### PR TITLE
Improvements in UCI on PUSCH implementation at UE

### DIFF
--- a/common/utils/nr/nr_common.h
+++ b/common/utils/nr/nr_common.h
@@ -257,11 +257,9 @@ uint32_t nr_timer_remaining_time(const NR_timer_t *timer);
 
 int set_default_nta_offset(frequency_range_t freq_range, uint32_t samples_per_subframe);
 
-static inline int get_num_dmrs(uint16_t dmrs_mask )
+static inline int get_num_dmrs(uint16_t dmrs_mask)
 {
-  int num_dmrs=0;
-  for (int i=0;i<16;i++) num_dmrs+=((dmrs_mask>>i)&1);
-  return(num_dmrs);
+  return __builtin_popcount(dmrs_mask);
 }
 
 void warn_higher_threequarter_fs(const int n_rb, const int mu);

--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch.c
@@ -143,34 +143,6 @@ void reset_active_ulsch(PHY_VARS_gNB *gNB, int frame)
   }
 }
 
-void nr_ulsch_unscrambling(int16_t* llr, uint32_t size, uint32_t Nid, uint32_t n_RNTI)
-{
-  nr_codeword_unscrambling(llr, size, 0, Nid, n_RNTI);
-}
-
-void nr_ulsch_layer_demapping(int16_t *llr_cw, uint8_t Nl, uint8_t mod_order, uint32_t length, int16_t **llr_layers)
-{
-
-  switch (Nl) {
-    case 1:
-      memcpy((void*)llr_cw, (void*)llr_layers[0], (length)*sizeof(int16_t));
-      break;
-    case 2:
-    case 3:
-    case 4:
-      for (int i=0; i<(length/Nl/mod_order); i++) {
-        for (int l=0; l<Nl; l++) {
-          for (int m=0; m<mod_order; m++) {
-            llr_cw[i*Nl*mod_order+l*mod_order+m] = llr_layers[l][i*mod_order+m];
-          }
-        }
-      }
-      break;
-  default:
-    AssertFatal(0, "Not supported number of layers %d\n", Nl);
-  }
-}
-
 void dump_pusch_stats(FILE *fd, PHY_VARS_gNB *gNB)
 {
   for (int i = 0; i < MAX_MOBILES_PER_GNB; i++) {

--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch.h
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch.h
@@ -34,18 +34,6 @@ int nr_ulsch_decoding(PHY_VARS_gNB *phy_vars_gNB,
                       int *ULSCH_ids,
                       int nb_pusch);
 
-/*! \brief Perform PUSCH unscrambling. TS 38.211 V15.4.0 subclause 6.3.1.1
-  @param llr, Pointer to llr bits
-  @param size, length of llr bits
-  @param q, codeword index (0,1)
-  @param Nid, cell id
-  @param n_RNTI, CRNTI
-*/
-
-void nr_ulsch_unscrambling(int16_t* llr, uint32_t size, uint32_t Nid, uint32_t n_RNTI);
-
-void nr_ulsch_layer_demapping(int16_t *llr_cw, uint8_t Nl, uint8_t mod_order, uint32_t length, int16_t **llr_layers);
-
 void dump_pusch_stats(FILE *fd,PHY_VARS_gNB *gNB);
 
 NR_gNB_SCH_STATS_t *get_ulsch_stats(PHY_VARS_gNB *gNB,NR_gNB_ULSCH_t *ulsch);

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
@@ -15,16 +15,6 @@
 #include "PHY/CODING/nrPolar_tools/nr_polar_psbch_defs.h"
 #include "common/utils/bits.h"
 
-typedef enum {
-  BIT_TYPE_ULSCH = 0, // Default: UL-SCH data
-  BIT_TYPE_ACK = 1, // HARQ-ACK bit
-  BIT_TYPE_ACK_RESERVED = 2, // Reserved for HARQ-ACK (punctured)
-  BIT_TYPE_ACK_ULSCH = 3,
-  BIT_TYPE_CSI1 = 4, // CSI Part 1 bit
-  BIT_TYPE_CSI2 = 5, // CSI Part 2 bit
-  BIT_TYPE_PLACEHOLDER
-} uci_on_pusch_bit_type_t;
-
 // Specifies the data that should be copied to the scope during PDSCH RX
 typedef struct pdsch_scope_req_s {
   bool copy_chanest_to_scope;

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
@@ -15,16 +15,14 @@
 #include "PHY/CODING/nrPolar_tools/nr_polar_psbch_defs.h"
 #include "common/utils/bits.h"
 
-#define NR_PUSCH_x 2 // UCI placeholder bit TS 38.212 V15.4.0 subclause 5.3.3.1
-#define NR_PUSCH_y 3 // UCI placeholder bit
-
 typedef enum {
   BIT_TYPE_ULSCH = 0, // Default: UL-SCH data
   BIT_TYPE_ACK = 1, // HARQ-ACK bit
   BIT_TYPE_ACK_RESERVED = 2, // Reserved for HARQ-ACK (punctured)
   BIT_TYPE_ACK_ULSCH = 3,
   BIT_TYPE_CSI1 = 4, // CSI Part 1 bit
-  BIT_TYPE_CSI2 = 5 // CSI Part 2 bit
+  BIT_TYPE_CSI2 = 5, // CSI Part 2 bit
+  BIT_TYPE_PLACEHOLDER
 } uci_on_pusch_bit_type_t;
 
 // Specifies the data that should be copied to the scope during PDSCH RX
@@ -101,22 +99,6 @@ int nr_ulsch_encoding(PHY_VARS_NR_UE *ue,
                       unsigned int *G,
                       int nb_ulsch,
                       uint8_t *ULSCH_ids);
-
-/*! \brief Perform PUSCH scrambling. TS 38.211 V15.4.0 subclause 6.3.1.1
-  @param[in] in Pointer to input bits
-  @param[in] size of input bits
-  @param[in] Nid cell id
-  @param[in] n_RNTI CRNTI
-  @param[in] uci_on_pusch whether UCI placeholder bits need to be scrambled (true -> no optimized scrambling)
-  @param[out] out the scrambled bits
-*/
-void nr_pusch_codeword_scrambling(uint8_t *in,
-                                  uint32_t size,
-                                  uint32_t Nid,
-                                  uint32_t n_RNTI,
-                                  bool uci_on_pusch,
-                                  const uci_on_pusch_bit_type_t *template,
-                                  uint32_t *out);
 
 /** \brief Alternative entry point to UE uplink shared channels procedures.
     It handles all the HARQ processes in only one call.

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_transport_ue.h
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_transport_ue.h
@@ -117,7 +117,8 @@ typedef struct {
 
 typedef struct {
   uint16_t Q_dash_ACK; // number of coded HARQ-ACK symbols
-  uint16_t E_uci_ACK; // number of coded HARQ-ACK bits
+  uint16_t E_uci_ACK; // number of coded HARQ-ACK bits (including reserved ones)
+  uint16_t E_uci_ACK_actual; // actual number of coded HARQ-ACK bits
   uint16_t Q_dash_CSI1; // number of coded CSI part 1 symbols
   uint16_t E_uci_CSI1; // number of coded CSI part 1 bits
   uint16_t Q_dash_CSI2; // number of coded CSI part 2 symbols

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_transport_ue.h
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_transport_ue.h
@@ -60,6 +60,7 @@ typedef struct {
   int     Nid_cell;
   /// bit mask of PT-RS ofdm symbol indicies
   uint16_t ptrs_symbols;
+  int n_ptrs;
 } NR_UE_ULSCH_t;
 
 typedef struct {
@@ -117,13 +118,12 @@ typedef struct {
 typedef struct {
   uint16_t Q_dash_ACK; // number of coded HARQ-ACK symbols
   uint16_t E_uci_ACK; // number of coded HARQ-ACK bits
-  uint16_t Q_dash_ACK_rvd; // number of coded HARQ-ACK symbols reserved
-  uint16_t E_uci_ACK_rvd; // number of coded HARQ-ACK bits reserved
   uint16_t Q_dash_CSI1; // number of coded CSI part 1 symbols
   uint16_t E_uci_CSI1; // number of coded CSI part 1 bits
   uint16_t Q_dash_CSI2; // number of coded CSI part 2 symbols
   uint16_t E_uci_CSI2; // number of coded CSI part 2 bits
   uint32_t G_ulsch; // bit capacity of ULSCH
+  int O_ack;
 } rate_match_info_uci_t;
 
 #endif

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -548,9 +548,9 @@ static double get_alpha_scaling_value(uint8_t alpha_scaling)
 }
 
 /*
- * This function gets the CRC size of UCI
+ * This function gets the CRC size of UCI according to 6.3.1.2.1 of 38.212
  */
-static int get_crc_uci(const uint16_t ouci)
+static int get_crc_uci(const uint32_t ouci)
 {
   int L = 0;
   if (ouci > 19) {
@@ -558,37 +558,35 @@ static int get_crc_uci(const uint16_t ouci)
   } else if (ouci > 11) {
     L = 6;
   } else {
-    L = 0; // no ACK/NACK
+    L = 0;
   }
-
   return L;
 }
 
-static uint16_t get_Qd(const uint16_t oack,
+static uint32_t get_Qd(const uint32_t ouci,
                        double beta,
                        double alpha,
-                       const uint32_t sumKr,
+                       const uint32_t eff_bits,
                        const uint32_t s1,
                        const uint32_t s2,
                        const uint32_t sub)
 {
-  if (oack == 0)
+  // as described in section 6.3.2.4.1 of 38.212
+  if (ouci == 0)
     return 0;
-
-  uint16_t first_term = ceil(((double)oack + get_crc_uci(oack)) * (double)beta * s1 / sumKr);
-  uint16_t second_term = ceil(alpha * s2) - sub;
-
+  uint32_t first_term = ceil(((double)ouci + get_crc_uci(ouci)) * (double)beta * s1 / eff_bits);
+  uint32_t second_term = ceil(alpha * s2) - sub;
   return (first_term < second_term) ? first_term : second_term;
 }
 
 /*
  * This function calculates the rate matching information for UCI multiplexing with PUSCH
  */
-static rate_match_info_uci_t calc_rate_match_info_uci(const nfapi_nr_ue_pusch_pdu_t *pusch_pdu,
+static rate_match_info_uci_t calc_rate_match_info_uci(const NR_UE_ULSCH_t *ulsch_ue,
                                                       const NR_UL_UE_HARQ_t *harq_process_ul_ue,
-                                                      const uint8_t nlqm,
                                                       unsigned int *G)
 {
+  const nfapi_nr_ue_pusch_pdu_t *pusch_pdu = &ulsch_ue->pusch_pdu;
   // get beta offset
   uint8_t beta_offset_index = pusch_pdu->pusch_uci.beta_offset_harq_ack;
   double beta = get_beta_offset_harq_ack(beta_offset_index);
@@ -598,60 +596,44 @@ static rate_match_info_uci_t calc_rate_match_info_uci(const nfapi_nr_ue_pusch_pd
   double alpha = get_alpha_scaling_value(alpha_scaling);
 
   // Calculate sumKr (total bits in all code blocks)
-  uint32_t sumKr = 0;
-  if (harq_process_ul_ue->C == 0) {
-    sumKr = 0;
-  } else if (harq_process_ul_ue->C == 1) {
-    sumKr = harq_process_ul_ue->K;
-  } else {
-    sumKr = harq_process_ul_ue->K * harq_process_ul_ue->C;
-  }
+  uint32_t sumKr = harq_process_ul_ue->K * harq_process_ul_ue->C;
 
-  // Calculate s1: total number of non-DMRS REs in allocation
-  uint16_t nb_rb = pusch_pdu->rb_size;
-  uint8_t start_symbol = pusch_pdu->start_symbol_index;
-  uint8_t number_of_symbols = pusch_pdu->nr_of_symbols;
   uint16_t ul_dmrs_symb_pos = pusch_pdu->ul_dmrs_symb_pos;
-
-  uint32_t s1 = 0;
-  for (int l = start_symbol; l < start_symbol + number_of_symbols; l++) {
-    if (!((ul_dmrs_symb_pos >> l) & 0x01)) {
-      s1 += nb_rb * NR_NB_SC_PER_RB;
-    }
-  }
+  // Calculate s1: total number of non-DMRS REs in allocation
+  int s1 = pusch_pdu->rb_size * NR_NB_SC_PER_RB * (pusch_pdu->nr_of_symbols - get_num_dmrs(ul_dmrs_symb_pos));
 
   // Calculate s2: number of non-DMRS REs after first DMRS symbol
-  int first_dmrs_symbol = -1;
-  for (int l = start_symbol; l < start_symbol + number_of_symbols; l++) {
-    if ((ul_dmrs_symb_pos >> l) & 0x01) {
-      first_dmrs_symbol = l;
-      break;
-    }
-  }
-  int l0 = -1;
-  if (first_dmrs_symbol >= 0 && first_dmrs_symbol < start_symbol + number_of_symbols - 1) {
-    l0 = first_dmrs_symbol + 1;
-  }
-  uint32_t s2 = 0;
-  for (int l = l0; l < start_symbol + number_of_symbols; l++) {
-    if (!((ul_dmrs_symb_pos >> l) & 0x01)) {
-      s2 += nb_rb * NR_NB_SC_PER_RB;
-    }
+  // __builtin_ctz returns the index of the first set bit
+  int first_dmrs_symbol = __builtin_ctz(ul_dmrs_symb_pos);
+  // mask with everything from (first_dmrs_symbol + 1) to the end
+  uint32_t range_mask = ((1U << pusch_pdu->nr_of_symbols) - 1) << pusch_pdu->start_symbol_index;
+  uint32_t post_dmrs_mask = range_mask & ~((1U << (first_dmrs_symbol + 1)) - 1);
+  // number of non-DMRS REs bits in that post-DMRS range
+  uint32_t non_dmrs_bits = post_dmrs_mask & ~ul_dmrs_symb_pos;
+  int num_non_dmrs_symbols = __builtin_popcount(non_dmrs_bits);
+  int s2 = num_non_dmrs_symbols * pusch_pdu->rb_size * NR_NB_SC_PER_RB;
+
+  if (ulsch_ue->ptrs_symbols) {
+    // for any OFDM symbol that does not carry DMRS of the PUSCH, M_UCI = M_PUSCH − M_PTRS
+    uint32_t non_dmrs_ptrs_mask = ulsch_ue->ptrs_symbols & ~ul_dmrs_symb_pos;
+    int ptrs_symb_in_alloc = __builtin_popcount(non_dmrs_ptrs_mask);
+    s1 -= (ptrs_symb_in_alloc * ulsch_ue->n_ptrs);
+    uint32_t ptrs_in_post_window = ulsch_ue->ptrs_symbols & post_dmrs_mask;
+    int num_ptrs_symbols_s2 = __builtin_popcount(ptrs_in_post_window);
+    s2 -= (num_ptrs_symbols_s2 * ulsch_ue->n_ptrs);
   }
 
-  uint16_t oack = pusch_pdu->pusch_uci.harq_ack_bit_length;
-  uint16_t oack_rvd = (oack <= 2) ? 2 : 0; // get the reserved bits when oACK <= 2 according to TS 38.212 section 6.2.7, step 1
 
   rate_match_info_uci_t rminfo = {0};
+  // if the number of HARQ-ACK information bits to be transmitted on PUSCH is 0, 1 or 2 bits
+  // the number of reserved resource elements for potential HARQ-ACK transmission is calculated using oack = 2
+  // according to TS 38.212 section 6.2.7, step 1
+  rminfo.O_ack = (pusch_pdu->pusch_uci.harq_ack_bit_length <= 2) ? 2 : pusch_pdu->pusch_uci.harq_ack_bit_length;
+  const int nlqm = pusch_pdu->nrOfLayers * pusch_pdu->qam_mod_order; // product of number of layers and modulation order
 
   // get the number of coded HARQ-ACK symbols and bits, TS 38.212 section 6.3.2.4.1.1
-  rminfo.Q_dash_ACK = get_Qd(oack, beta, alpha, sumKr, s1, s2, 0);
+  rminfo.Q_dash_ACK = get_Qd(rminfo.O_ack, beta, alpha, sumKr, s1, s2, 0);
   rminfo.E_uci_ACK = rminfo.Q_dash_ACK * nlqm;
-
-  if (oack_rvd > 0) {
-    rminfo.Q_dash_ACK_rvd = get_Qd(oack_rvd, beta, alpha, sumKr, s1, s2, 0);
-    rminfo.E_uci_ACK_rvd = rminfo.Q_dash_ACK_rvd * nlqm;
-  }
 
   // get beta offset for csi
   const double beta_csi1 = get_beta_offset_csi(pusch_pdu->pusch_uci.beta_offset_csi1);
@@ -668,16 +650,15 @@ static rate_match_info_uci_t calc_rate_match_info_uci(const nfapi_nr_ue_pusch_pd
   rminfo.E_uci_CSI2 = rminfo.Q_dash_CSI2 * nlqm;
 
   rminfo.G_ulsch = *G - (rminfo.E_uci_CSI1 + rminfo.E_uci_CSI2);
-  if (oack_rvd == 0) {
+  if (rminfo.O_ack > 2) {
     rminfo.G_ulsch -= rminfo.E_uci_ACK;
   }
 
   *G = rminfo.G_ulsch;
   LOG_D(PHY, "[UCI_RATE_MATCH] sumKr=%u, s1=%u, s2=%u, Final G_ulsch (output G): %u\n", sumKr, s1, s2, *G);
   LOG_D(PHY,
-        "[UCI_RATE_MATCH] rate matching info returned: E_uci_ACK=%u, E_uci_ACK_rvd=%u, E_uci_CSI1=%u, E_uci_CSI2=%u, G_ulsch=%u\n",
+        "[UCI_RATE_MATCH] rate matching info returned: E_uci_ACK=%u, E_uci_CSI1=%u, E_uci_CSI2=%u, G_ulsch=%u\n",
         rminfo.E_uci_ACK,
-        rminfo.E_uci_ACK_rvd,
         rminfo.E_uci_CSI1,
         rminfo.E_uci_CSI2,
         rminfo.G_ulsch);
@@ -685,13 +666,13 @@ static rate_match_info_uci_t calc_rate_match_info_uci(const nfapi_nr_ue_pusch_pd
   return rminfo;
 }
 
-static int initialize_mapping_resources(const nfapi_nr_ue_pusch_pdu_t *pusch_pdu,
+static int initialize_mapping_resources(const NR_UE_ULSCH_t *ulsch_ue,
                                         uint32_t *m_ulsch_initial,
                                         uint32_t *m_uci_current)
 {
-  if (!pusch_pdu || !m_ulsch_initial || !m_uci_current)
+  if (!m_ulsch_initial || !m_uci_current)
     return -1;
-
+  const nfapi_nr_ue_pusch_pdu_t *pusch_pdu = &ulsch_ue->pusch_pdu;
   const uint8_t n_pusch_sym_all = pusch_pdu->nr_of_symbols;
   const uint16_t ul_dmrs_symb_pos = pusch_pdu->ul_dmrs_symb_pos;
   const uint8_t dmrs_type = pusch_pdu->dmrs_config_type;
@@ -702,28 +683,26 @@ static int initialize_mapping_resources(const nfapi_nr_ue_pusch_pdu_t *pusch_pdu
   // Initialize resources per symbol for ULSCH and UCI
   for (uint8_t i = 0; i < n_pusch_sym_all; i++) {
     uint8_t absolute_symbol_idx = pusch_pdu->start_symbol_index + i;
-
+    bool is_ptrs = (ulsch_ue->ptrs_symbols >> absolute_symbol_idx) & 0x01;
+    int ptrs_overhead = is_ptrs ? ulsch_ue->n_ptrs : 0;
     if ((ul_dmrs_symb_pos >> absolute_symbol_idx) & 0x01) {
       // Calculate available data REs on DMRS symbols based on DMRS configuration
-
-      m_ulsch_initial[i] = pusch_pdu->rb_size * data_re_on_dmrs_sym_per_prb;
+      m_ulsch_initial[i] = pusch_pdu->rb_size * data_re_on_dmrs_sym_per_prb - ptrs_overhead;
       m_uci_current[i] = 0; // UCI is not mapped on DMRS symbols
-
     } else { // Not a DMRS symbol
-
-      m_ulsch_initial[i] = res_per_symbol_non_dmrs;
-      m_uci_current[i] = res_per_symbol_non_dmrs;
+      m_ulsch_initial[i] = res_per_symbol_non_dmrs - ptrs_overhead;
+      m_uci_current[i] = m_ulsch_initial[i];
     }
   }
-
   return 0;
 }
 
+// to compute the first non dmrs symbol and the first symbol after the first set of consecutive DMRS symbols
 static void get_first_uci_symbol(const uint8_t start_symbol,
                                  const uint8_t num_symbols,
                                  const uint16_t dmrs_map,
-                                 uint8_t *first_non_dmrs_sym,
-                                 uint8_t *dmrs_p1)
+                                 int *first_non_dmrs_sym,
+                                 int *after_dmrs_symb)
 {
   // First non-DMRS symbol
   const uint16_t last_sym = start_symbol + num_symbols;
@@ -735,15 +714,15 @@ static void get_first_uci_symbol(const uint8_t start_symbol,
   }
 
   // Symbol after first consequtive DMRS symbol
-  const uint8_t first_dmrs_sym = get_next_dmrs_symbol_in_slot(dmrs_map, start_symbol, last_sym);
-  *dmrs_p1 = first_dmrs_sym + 1;
-  while (is_dmrs_symbol(*dmrs_p1, dmrs_map) && *dmrs_p1 < last_sym) {
-    (*dmrs_p1)++;
+  const int first_dmrs_sym = get_next_dmrs_symbol_in_slot(dmrs_map, start_symbol, last_sym);
+  *after_dmrs_symb = first_dmrs_sym + 1;
+  while (is_dmrs_symbol(*after_dmrs_symb, dmrs_map) && *after_dmrs_symb < last_sym) {
+    (*after_dmrs_symb)++;
   }
 
   // Return relative symbol idx
   *first_non_dmrs_sym -= start_symbol;
-  *dmrs_p1 -= start_symbol;
+  *after_dmrs_symb -= start_symbol;
 }
 
 static inline bool skip_mapping_current_uci(const uci_on_pusch_bit_type_t template, const uci_on_pusch_bit_type_t uci_type_to_map)
@@ -879,14 +858,12 @@ static void map_overlapped_ack(uci_on_pusch_bit_type_t *template,
  */
 static void apply_template_to_codeword(uint8_t *codeword,
                                        const uci_on_pusch_bit_type_t *template,
+                                       rate_match_info_uci_t *rm_info,
                                        uint32_t codeword_len,
                                        const uint8_t *ulsch_bits,
                                        const uint64_t *cack,
                                        const uint64_t *csi1,
                                        const uint64_t *csi2,
-                                       uint16_t G_ack,
-                                       uint32_t G_csi1,
-                                       uint32_t G_csi2,
                                        uint32_t G_ulsch)
 {
   uint32_t ulsch_idx = 0;
@@ -899,7 +876,7 @@ static void apply_template_to_codeword(uint8_t *codeword,
       case BIT_TYPE_ACK:
       case BIT_TYPE_ACK_ULSCH:
       case BIT_TYPE_PLACEHOLDER:
-        if (G_ack > 0 && ack_idx < G_ack) {
+        if (rm_info->E_uci_ACK > 0 && ack_idx < rm_info->E_uci_ACK) {
           uint32_t word_idx = ack_idx / 64;
           uint32_t bit_in_word_idx = ack_idx % 64;
           codeword[i] = (cack[word_idx] >> bit_in_word_idx) & 1;
@@ -909,7 +886,7 @@ static void apply_template_to_codeword(uint8_t *codeword,
         }
         break;
       case BIT_TYPE_CSI1:
-        if (G_csi1 > 0 && csi1_idx < G_csi1) {
+        if (rm_info->E_uci_CSI1 > 0 && csi1_idx < rm_info->E_uci_CSI1) {
           uint32_t word_idx = csi1_idx / 64;
           uint32_t bit_in_word_idx = csi1_idx % 64;
           codeword[i] = (csi1[word_idx] >> bit_in_word_idx) & 1;
@@ -917,7 +894,7 @@ static void apply_template_to_codeword(uint8_t *codeword,
         }
         break;
       case BIT_TYPE_CSI2:
-        if (G_csi2 > 0 && csi2_idx < G_csi2) {
+        if (rm_info->E_uci_CSI2 > 0 && csi2_idx < rm_info->E_uci_CSI2) {
           uint32_t word_idx = csi2_idx / 64;
           uint32_t bit_in_word_idx = csi2_idx % 64;
           codeword[i] = (csi2[word_idx] >> bit_in_word_idx) & 1;
@@ -941,13 +918,10 @@ static void apply_template_to_codeword(uint8_t *codeword,
 /*
  * This function implements the UCI multiplexing on PUSCH according to TS 38.212 section 6.2.7.
  */
-static uci_on_pusch_bit_type_t *nr_data_control_mapping(const nfapi_nr_ue_pusch_pdu_t *pusch_pdu,
+static uci_on_pusch_bit_type_t *nr_data_control_mapping(const NR_UE_ULSCH_t *ulsch_ue,
                                                         uci_on_pusch_bit_type_t *template,
                                                         unsigned int G_ulsch,
-                                                        uint16_t G_ack,
-                                                        uint32_t G_ack_rvd,
-                                                        uint32_t G_csi1,
-                                                        uint32_t G_csi2,
+                                                        rate_match_info_uci_t *rm_info,
                                                         uint8_t *codeword,
                                                         uint32_t codeword_len,
                                                         const uint8_t *ulsch_bits,
@@ -955,8 +929,9 @@ static uci_on_pusch_bit_type_t *nr_data_control_mapping(const nfapi_nr_ue_pusch_
                                                         const uint64_t *csi1,
                                                         const uint64_t *csi2)
 {
-  if (!pusch_pdu || !codeword || codeword_len == 0 || !template)
+  if (!codeword || codeword_len == 0 || !template)
     return NULL;
+  const nfapi_nr_ue_pusch_pdu_t *pusch_pdu = &ulsch_ue->pusch_pdu;
   const uint8_t n_symbols = pusch_pdu->nr_of_symbols;
   if (n_symbols == 0 || n_symbols > NR_SYMBOLS_PER_SLOT)
     return NULL;
@@ -964,13 +939,13 @@ static uci_on_pusch_bit_type_t *nr_data_control_mapping(const nfapi_nr_ue_pusch_
   uint32_t m_ulsch_initial[NR_SYMBOLS_PER_SLOT] = {0};
   uint32_t m_uci_current[NR_SYMBOLS_PER_SLOT] = {0}; // This holds RE counts, not bit counts
 
-  if (initialize_mapping_resources(pusch_pdu, m_ulsch_initial, m_uci_current) != 0) {
+  if (initialize_mapping_resources(ulsch_ue, m_ulsch_initial, m_uci_current) != 0) {
     LOG_E(PHY, "Failed to initialize mapping resources\n");
     return NULL;
   }
 
-  uint8_t first_non_dmrs_sym = 0;
-  uint8_t l1_c = 0;
+  int first_non_dmrs_sym = 0;
+  int l1_c = 0;
   get_first_uci_symbol(pusch_pdu->start_symbol_index,
                        pusch_pdu->nr_of_symbols,
                        pusch_pdu->ul_dmrs_symb_pos,
@@ -988,9 +963,11 @@ static uci_on_pusch_bit_type_t *nr_data_control_mapping(const nfapi_nr_ue_pusch_
                                        .l1_c = l1_c,
                                        .m_uci_current = m_uci_current,
                                        .m_ulsch_initial = m_ulsch_initial};
-  if (G_ack_rvd > 0) {
+
+  int G_ack = rm_info->E_uci_ACK;
+  if (rm_info->O_ack == 2) {
     map_arg.uci_type_to_map = BIT_TYPE_ACK_RESERVED;
-    map_arg.G_uci = G_ack_rvd;
+    map_arg.G_uci = G_ack;
     map_arg.resv_ack_pos_symb = positions_by_sym;
     map_arg.resv_ack_count_symb = count_by_sym;
     map_uci_common(map_arg);
@@ -1002,20 +979,20 @@ static uci_on_pusch_bit_type_t *nr_data_control_mapping(const nfapi_nr_ue_pusch_
 
   // CSI part 1
   map_arg.uci_type_to_map = BIT_TYPE_CSI1;
-  map_arg.G_uci = G_csi1;
+  map_arg.G_uci = rm_info->E_uci_CSI1;
   map_arg.resv_ack_pos_symb = NULL;
   map_arg.resv_ack_count_symb = NULL;
   map_uci_common(map_arg);
   // CSI part 2
   map_arg.uci_type_to_map = BIT_TYPE_CSI2;
-  map_arg.G_uci = G_csi2;
+  map_arg.G_uci = rm_info->E_uci_CSI2;
   map_uci_common(map_arg);
 
-  if (G_ack > 0 && G_ack_rvd > 0) {
+  if (G_ack > 0 && rm_info->O_ack == 2) {
     map_overlapped_ack(template, G_ack, l1_c, pusch_pdu, positions_by_sym, count_by_sym);
   }
 
-  apply_template_to_codeword(codeword, template, codeword_len, ulsch_bits, cack, csi1, csi2, G_ack, G_csi1, G_csi2, G_ulsch);
+  apply_template_to_codeword(codeword, template, rm_info, codeword_len, ulsch_bits, cack, csi1, csi2, G_ulsch);
 
   return template;
 }
@@ -1072,17 +1049,15 @@ void nr_ue_ulsch_procedures(PHY_VARS_NR_UE *UE,
 
   unsigned int K_ptrs = 0, k_RE_ref = 0;
   uint32_t unav_res = 0;
+  ulsch_ue->ptrs_symbols = 0;
   if (pusch_pdu->pdu_bit_map & PUSCH_PDU_BITMAP_PUSCH_PTRS) {
     K_ptrs = pusch_pdu->pusch_ptrs.ptrs_freq_density;
     k_RE_ref = pusch_pdu->pusch_ptrs.ptrs_ports_list[0].ptrs_re_offset;
     uint8_t L_ptrs = 1 << pusch_pdu->pusch_ptrs.ptrs_time_density;
-
-    ulsch_ue->ptrs_symbols = 0;
-
     set_ptrs_symb_idx(&ulsch_ue->ptrs_symbols, number_of_symbols, start_symbol, L_ptrs, ul_dmrs_symb_pos);
-    int n_ptrs = (nb_rb + K_ptrs - 1) / K_ptrs;
+    ulsch_ue->n_ptrs = (nb_rb + K_ptrs - 1) / K_ptrs;
     int ptrsSymbPerSlot = get_ptrs_symbols_in_slot(ulsch_ue->ptrs_symbols, start_symbol, number_of_symbols);
-    unav_res = n_ptrs * ptrsSymbPerSlot;
+    unav_res = ulsch_ue->n_ptrs * ptrsSymbPerSlot;
   }
 
   G[pusch_id] = nr_get_G(nb_rb, number_of_symbols, nb_dmrs_re_per_rb, number_dmrs_symbols, unav_res, mod_order, Nl);
@@ -1110,18 +1085,17 @@ void nr_ue_ulsch_procedures(PHY_VARS_NR_UE *UE,
   /////////////////////////ULSCH coding/////////////////////////
 
   rate_match_info_uci_t rm_info = {0};
-  const uint8_t nl_qm = Nl * mod_order; // product of number of layers and modulation order
-  if(nr_ulsch_pre_encoding(UE, &phy_data->ulsch, frame, slot, G, 1, ULSCH_ids) != 0) {
+  if(nr_ulsch_pre_encoding(UE, ulsch_ue, frame, slot, G, 1, ULSCH_ids) != 0) {
     LOG_E(PHY, "Error pre-encoding\n");
     return;
   }
 
   bool uci_present = (pusch_pdu->pusch_uci.harq_ack_bit_length != 0) || (pusch_pdu->pusch_uci.csi_payload.p1_bits != 0);
   if (uci_present) {
-    rm_info = calc_rate_match_info_uci(pusch_pdu, harq_process_ul_ue, nl_qm, &G[pusch_id]);
+    rm_info = calc_rate_match_info_uci(ulsch_ue, harq_process_ul_ue, &G[pusch_id]);
   }
 
-  if (nr_ulsch_encoding(UE, &phy_data->ulsch, frame, slot, G, 1, ULSCH_ids) == -1) {
+  if (nr_ulsch_encoding(UE, ulsch_ue, frame, slot, G, 1, ULSCH_ids) == -1) {
     stop_meas_nr_ue_phy(UE, PUSCH_PROC_STATS);
     return;
   }
@@ -1150,11 +1124,10 @@ void nr_ue_ulsch_procedures(PHY_VARS_NR_UE *UE,
                     &b_ack[0]);
 
     LOG_D(PHY,
-          "[UCI_ON_PUSCH] G_ulsch=%u (updated G[pusch_id]), G_ack=%u (M_bit), G_ack_rvd=%u, total_len=%u "
+          "[UCI_ON_PUSCH] G_ulsch=%u (updated G[pusch_id]), G_ack=%u (M_bit), total_len=%u "
           "(G_initial_total_pusch_bits).\n",
           G[pusch_id],
           rm_info.E_uci_ACK,
-          rm_info.E_uci_ACK_rvd,
           G_initial_total_pusch_bits);
   }
 
@@ -1181,13 +1154,10 @@ void nr_ue_ulsch_procedures(PHY_VARS_NR_UE *UE,
   if (uci_present) {
     uint8_t temp_codeword[G_initial_total_pusch_bits];
     start_meas_nr_ue_phy(UE, UCI_ON_PUSCH_MAPPING);
-    nr_data_control_mapping(pusch_pdu,
+    nr_data_control_mapping(ulsch_ue,
                             template_buffer,
                             G[pusch_id],
-                            rm_info.E_uci_ACK,
-                            rm_info.E_uci_ACK_rvd,
-                            rm_info.E_uci_CSI1,
-                            rm_info.E_uci_CSI2,
+                            &rm_info,
                             temp_codeword,
                             G_initial_total_pusch_bits,
                             harq_process_ul_ue->f,

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -915,8 +915,6 @@ static void apply_template_to_codeword(uint8_t *codeword,
   for (uint32_t i = 0; i < codeword_len; i++) {
     switch (template[i]) {
       case BIT_TYPE_ACK:
-      case BIT_TYPE_ACK_RESERVED_CSI2:
-      case BIT_TYPE_ACK_PLACEHOLDER_CSI2:
         if (rm_info->E_uci_ACK > 0 && ack_idx < rm_info->E_uci_ACK) {
           WRITE_BIT(codeword, i, READ_PACKED(cack, ack_idx));
           ack_idx++;
@@ -930,6 +928,16 @@ static void apply_template_to_codeword(uint8_t *codeword,
           if (G_ulsch > 0 && ulsch_idx < G_ulsch)
             ulsch_idx++;
         }
+        break;
+      case BIT_TYPE_ACK_RESERVED_CSI2:
+      case BIT_TYPE_ACK_PLACEHOLDER_CSI2:
+        if (rm_info->E_uci_ACK > 0 && ack_idx < rm_info->E_uci_ACK) {
+          WRITE_BIT(codeword, i, READ_PACKED(cack, ack_idx));
+          ack_idx++;
+        }
+        // advance csi2_idx for punctured CSI2 bits
+        if (rm_info->E_uci_CSI2 > 0 && csi2_idx < rm_info->E_uci_CSI2)
+          csi2_idx++;
         break;
       case BIT_TYPE_CSI1:
         if (rm_info->E_uci_CSI1 > 0 && csi1_idx < rm_info->E_uci_CSI1) {
@@ -946,7 +954,7 @@ static void apply_template_to_codeword(uint8_t *codeword,
       case BIT_TYPE_ULSCH:
       default:
         if (G_ulsch > 0 && ulsch_idx < G_ulsch) {
-          WRITE_BIT(codeword, i, (ulsch_bits[ulsch_idx/8] >> (ulsch_idx%8)) & 1);
+          WRITE_BIT(codeword, i, (ulsch_bits[ulsch_idx / 8] >> (ulsch_idx % 8)) & 1);
           ulsch_idx++;
         }
         break;

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -42,6 +42,8 @@ typedef enum {
   BIT_TYPE_ACK_PLACEHOLDER = 3, // Reserved for HARQ-ACK placeholders (not scrambled)
   BIT_TYPE_CSI1 = 4, // CSI Part 1 bit
   BIT_TYPE_CSI2 = 5, // CSI Part 2 bit
+  BIT_TYPE_ACK_RESERVED_CSI2,
+  BIT_TYPE_ACK_PLACEHOLDER_CSI2
 } uci_on_pusch_bit_type_t;
 
 static void nr_pusch_codeword_scrambling(uint8_t *in,
@@ -63,7 +65,7 @@ static void nr_pusch_codeword_scrambling(uint8_t *in,
     uint32_t word_idx = i / 32;
     uint32_t bit_idx  = i % 32;
     uint32_t bit = (in[i / 8] >> (i % 8)) & 1;
-    if (template[i] != BIT_TYPE_ACK_PLACEHOLDER)
+    if (template[i] != BIT_TYPE_ACK_PLACEHOLDER && template[i] != BIT_TYPE_ACK_PLACEHOLDER_CSI2)
       bit ^= (seq[word_idx] >> bit_idx) & 1;
     out[word_idx] |= (bit << bit_idx);
   }
@@ -878,7 +880,10 @@ static void map_overlapped_ack(uci_on_pusch_bit_type_t *template,
     for (uint32_t i = 0; i < num_reserved_bits_on_sym && ack_bits_marked < G_ack; i += d_factor_re) {
       uint32_t pos = reserved_indices_on_this_sym[i];
       int bit_in_group = pos % Qm;
-      template[pos] = (bit_in_group >= placeholder_start) ? BIT_TYPE_ACK_PLACEHOLDER : BIT_TYPE_ACK_RESERVED;
+      if (template[pos] == BIT_TYPE_ULSCH) // puncturing ULSCH
+        template[pos] = (bit_in_group >= placeholder_start) ? BIT_TYPE_ACK_PLACEHOLDER : BIT_TYPE_ACK_RESERVED;
+      else  // puncturing CSIp2
+        template[pos] = (bit_in_group >= placeholder_start) ? BIT_TYPE_ACK_PLACEHOLDER_CSI2 : BIT_TYPE_ACK_RESERVED_CSI2;
       ack_bits_marked++;
     }
   }
@@ -910,12 +915,19 @@ static void apply_template_to_codeword(uint8_t *codeword,
   for (uint32_t i = 0; i < codeword_len; i++) {
     switch (template[i]) {
       case BIT_TYPE_ACK:
+      case BIT_TYPE_ACK_RESERVED_CSI2:
+      case BIT_TYPE_ACK_PLACEHOLDER_CSI2:
+        if (rm_info->E_uci_ACK > 0 && ack_idx < rm_info->E_uci_ACK) {
+          WRITE_BIT(codeword, i, READ_PACKED(cack, ack_idx));
+          ack_idx++;
+        }
+        break;
       case BIT_TYPE_ACK_RESERVED:
       case BIT_TYPE_ACK_PLACEHOLDER:
         if (rm_info->E_uci_ACK > 0 && ack_idx < rm_info->E_uci_ACK) {
           WRITE_BIT(codeword, i, READ_PACKED(cack, ack_idx));
           ack_idx++;
-          if (template[i] != BIT_TYPE_ACK && G_ulsch > 0 && ulsch_idx < G_ulsch)
+          if (G_ulsch > 0 && ulsch_idx < G_ulsch)
             ulsch_idx++;
         }
         break;

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -49,6 +49,7 @@ typedef enum {
 static void nr_pusch_codeword_scrambling(uint8_t *in,
                                          uint32_t size,
                                          uint32_t Nid,
+                                         uint32_t A,
                                          uint32_t n_RNTI,
                                          const uci_on_pusch_bit_type_t *template,
                                          uint32_t *out)
@@ -67,6 +68,11 @@ static void nr_pusch_codeword_scrambling(uint8_t *in,
     uint32_t bit = (in[i / 8] >> (i % 8)) & 1;
     if (template[i] != BIT_TYPE_ACK_PLACEHOLDER && template[i] != BIT_TYPE_ACK_PLACEHOLDER_CSI2)
       bit ^= (seq[word_idx] >> bit_idx) & 1;
+    else if (A == 1 && (template[i - 1] == BIT_TYPE_ACK_RESERVED || template[i - 1] == BIT_TYPE_ACK_RESERVED_CSI2)) {
+      uint32_t last_word_idx = (i - 1) / 32;
+      uint32_t last_bit_idx  = (i - 1) % 32;
+      bit ^= (seq[last_word_idx] >> last_bit_idx) & 1;
+    }
     out[word_idx] |= (bit << bit_idx);
   }
 }
@@ -1265,6 +1271,7 @@ void nr_ue_ulsch_procedures(PHY_VARS_NR_UE *UE,
   nr_pusch_codeword_scrambling(harq_process_ul_ue->f,
                                available_bits,
                                pusch_pdu->data_scrambling_id,
+                               pusch_pdu->pusch_uci.harq_ack_bit_length,
                                rnti,
                                uci_mapping_template,
                                scrambled_output);

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -35,6 +35,15 @@
 //#define DEBUG_MAC_PDU
 //#define DEBUG_DFT_IDFT
 
+typedef enum {
+  BIT_TYPE_ULSCH = 0, // Default: UL-SCH data
+  BIT_TYPE_ACK = 1, // HARQ-ACK bit
+  BIT_TYPE_ACK_RESERVED = 2, // Reserved for HARQ-ACK data (punctured)
+  BIT_TYPE_ACK_PLACEHOLDER = 3, // Reserved for HARQ-ACK placeholders (not scrambled)
+  BIT_TYPE_CSI1 = 4, // CSI Part 1 bit
+  BIT_TYPE_CSI2 = 5, // CSI Part 2 bit
+} uci_on_pusch_bit_type_t;
+
 static void nr_pusch_codeword_scrambling(uint8_t *in,
                                          uint32_t size,
                                          uint32_t Nid,
@@ -54,7 +63,7 @@ static void nr_pusch_codeword_scrambling(uint8_t *in,
     uint32_t word_idx = i / 32;
     uint32_t bit_idx  = i % 32;
     uint32_t bit = (in[i / 8] >> (i % 8)) & 1;
-    if (template[i] != BIT_TYPE_PLACEHOLDER)
+    if (template[i] != BIT_TYPE_ACK_PLACEHOLDER)
       bit ^= (seq[word_idx] >> bit_idx) & 1;
     out[word_idx] |= (bit << bit_idx);
   }
@@ -816,11 +825,19 @@ static void map_uci_common(struct map_uci_common_arg p)
 
 /*
  * Maps HARQ-ACK bits when O_ACK <= 2 (overlapped ACK/ULSCH case).
- * Marks each reserved bit position as either BIT_TYPE_ACK_ULSCH (real data bit)
- * or BIT_TYPE_PLACEHOLDER (x/y position), based on its position within the
- * Qm-bit modulation group:
- *   A=1: pos 0 is data, pos 1+ are placeholders (y at pos 1, x at pos 2+)
- *   A=2: pos 0,1 are data, pos 2+ are placeholders (x only)
+ *
+ * The template already has BIT_TYPE_ACK_RESERVED positions marked by map_uci_common,
+ * some of which may have been overwritten by CSI2 mapping.
+ *
+ * This function:
+ * 1. Resets all non-CSI2 reserved positions back to BIT_TYPE_ULSCH
+ * 2. Selects a subset of reserved positions for actual ACK placement,
+ *    marking them as BIT_TYPE_ACK_RESERVED (real ACK bit) or
+ *    BIT_TYPE_ACK_PLACEHOLDER (resolved x/y bit, not scrambled), based
+ *    on their position within the Qm-bit modulation group:
+ *      A=1: pos 0 is real ACK, pos 1+ are placeholders (y at pos 1, x at pos 2+)
+ *      A=2: pos 0,1 are real ACK, pos 2+ are placeholders (x only)
+ *
  */
 static void map_overlapped_ack(uci_on_pusch_bit_type_t *template,
                                uint16_t G_ack,
@@ -829,23 +846,28 @@ static void map_overlapped_ack(uci_on_pusch_bit_type_t *template,
                                uint32_t positions_by_sym[][MAX_UCI_CODED_BITS],
                                const uint32_t *count_by_sym)
 {
-  // First placeholder position within a Qm-bit group:
-  //   A=1: pos 1 (y), pos 2+ (x)
-  //   A=2: pos 2+ (x only, pos 0 and 1 are always real data bits)
   const int placeholder_start = (pusch_pdu->pusch_uci.harq_ack_bit_length == 1) ? 1 : 2;
+  const int Qm = pusch_pdu->qam_mod_order;
   uint32_t ack_bits_marked = 0;
   for (uint8_t sym_iter = l1_c; sym_iter < pusch_pdu->nr_of_symbols && ack_bits_marked < G_ack; sym_iter++) {
     const uint32_t num_reserved_bits_on_sym = count_by_sym[sym_iter];
-    if (num_reserved_bits_on_sym > 0) {
-      const uint32_t num_ack_remaining = G_ack - ack_bits_marked;
-      const uint32_t d_factor_re = get_d_factor_re(num_ack_remaining, num_reserved_bits_on_sym);
-      const uint32_t *reserved_indices_on_this_sym = positions_by_sym[sym_iter];
-      for (uint32_t i = 0; i < num_reserved_bits_on_sym && ack_bits_marked < G_ack; i += d_factor_re) {
-        uint32_t pos_to_mark = reserved_indices_on_this_sym[i];
-        int bit_in_group = pos_to_mark % pusch_pdu->qam_mod_order;
-        template[pos_to_mark] = (bit_in_group >= placeholder_start) ? BIT_TYPE_PLACEHOLDER : BIT_TYPE_ACK_ULSCH;
-        ack_bits_marked++;
-      }
+    if (num_reserved_bits_on_sym == 0)
+      continue;
+    const uint32_t *reserved_indices_on_this_sym = positions_by_sym[sym_iter];
+    // pass 1: reset all non-CSI2 reserved positions to ULSCH
+    for (uint32_t i = 0; i < num_reserved_bits_on_sym; i++) {
+      uint32_t pos = reserved_indices_on_this_sym[i];
+      if (template[pos] != BIT_TYPE_CSI2)
+        template[pos] = BIT_TYPE_ULSCH;
+    }
+    // pass 2: mark selected positions as ACK_RESERVED or PLACEHOLDER
+    const uint32_t num_ack_remaining = G_ack - ack_bits_marked;
+    const uint32_t d_factor_re = get_d_factor_re(num_ack_remaining, num_reserved_bits_on_sym);
+    for (uint32_t i = 0; i < num_reserved_bits_on_sym && ack_bits_marked < G_ack; i += d_factor_re) {
+      uint32_t pos = reserved_indices_on_this_sym[i];
+      int bit_in_group = pos % Qm;
+      template[pos] = (bit_in_group >= placeholder_start) ? BIT_TYPE_ACK_PLACEHOLDER : BIT_TYPE_ACK_RESERVED;
+      ack_bits_marked++;
     }
   }
 }
@@ -876,8 +898,8 @@ static void apply_template_to_codeword(uint8_t *codeword,
   for (uint32_t i = 0; i < codeword_len; i++) {
     switch (template[i]) {
       case BIT_TYPE_ACK:
-      case BIT_TYPE_ACK_ULSCH:
-      case BIT_TYPE_PLACEHOLDER:
+      case BIT_TYPE_ACK_RESERVED:
+      case BIT_TYPE_ACK_PLACEHOLDER:
         if (rm_info->E_uci_ACK > 0 && ack_idx < rm_info->E_uci_ACK) {
           WRITE_BIT(codeword, i, READ_PACKED(cack, ack_idx));
           ack_idx++;
@@ -897,7 +919,6 @@ static void apply_template_to_codeword(uint8_t *codeword,
           csi2_idx++;
         }
         break;
-      case BIT_TYPE_ACK_RESERVED:
       case BIT_TYPE_ULSCH:
       default:
         if (G_ulsch > 0 && ulsch_idx < G_ulsch) {

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -998,12 +998,12 @@ static uci_on_pusch_bit_type_t *nr_data_control_mapping(const NR_UE_ULSCH_t *uls
   }
 
   int first_non_dmrs_sym = 0;
-  int l1_c = 0;
+  int first_symb_after_dmrs = 0;
   get_first_uci_symbol(pusch_pdu->start_symbol_index,
                        pusch_pdu->nr_of_symbols,
                        pusch_pdu->ul_dmrs_symb_pos,
                        &first_non_dmrs_sym,
-                       &l1_c);
+                       &first_symb_after_dmrs);
 
   memset(template, 0, codeword_len * sizeof(uci_on_pusch_bit_type_t));
 
@@ -1013,7 +1013,7 @@ static uci_on_pusch_bit_type_t *nr_data_control_mapping(const NR_UE_ULSCH_t *uls
   struct map_uci_common_arg map_arg = {.template = template,
                                        .n_symbols = pusch_pdu->nr_of_symbols,
                                        .nlqm = pusch_pdu->qam_mod_order * pusch_pdu->nrOfLayers,
-                                       .l1_c = l1_c,
+                                       .l1_c = first_symb_after_dmrs,
                                        .m_uci_current = m_uci_current,
                                        .m_ulsch_initial = m_ulsch_initial};
 
@@ -1035,6 +1035,7 @@ static uci_on_pusch_bit_type_t *nr_data_control_mapping(const NR_UE_ULSCH_t *uls
   map_arg.G_uci = rm_info->E_uci_CSI1;
   map_arg.resv_ack_pos_symb = positions_by_sym;
   map_arg.resv_ack_count_symb = count_by_sym;
+  map_arg.l1_c = first_non_dmrs_sym;
   map_uci_common(map_arg);
   // CSI part 2
   map_arg.uci_type_to_map = BIT_TYPE_CSI2;
@@ -1042,7 +1043,7 @@ static uci_on_pusch_bit_type_t *nr_data_control_mapping(const NR_UE_ULSCH_t *uls
   map_uci_common(map_arg);
 
   if (rm_info->O_ack == 2) {
-    map_overlapped_ack(template, rm_info->E_uci_ACK_actual, l1_c, pusch_pdu, positions_by_sym, count_by_sym);
+    map_overlapped_ack(template, rm_info->E_uci_ACK_actual, first_symb_after_dmrs, pusch_pdu, positions_by_sym, count_by_sym);
   }
 
   apply_template_to_codeword(codeword, template, rm_info, codeword_len, ulsch_bits, cack, csi1, csi2, G_ulsch);

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -638,9 +638,14 @@ static rate_match_info_uci_t calc_rate_match_info_uci(const NR_UE_ULSCH_t *ulsch
   rminfo.O_ack = (pusch_pdu->pusch_uci.harq_ack_bit_length <= 2) ? 2 : pusch_pdu->pusch_uci.harq_ack_bit_length;
   const int nlqm = pusch_pdu->nrOfLayers * pusch_pdu->qam_mod_order; // product of number of layers and modulation order
 
-  // get the number of coded HARQ-ACK symbols and bits, TS 38.212 section 6.3.2.4.1.1
+  // get the number of coded HARQ-ACK symbols and bits, TS 38.212 section 6.3.2.4.1.1 (considering reservetion)
   rminfo.Q_dash_ACK = get_Qd(rminfo.O_ack, beta, alpha, sumKr, s1, s2, 0);
   rminfo.E_uci_ACK = rminfo.Q_dash_ACK * nlqm;
+  // actual number of coded HARQ-ACK bits to place
+  if (pusch_pdu->pusch_uci.harq_ack_bit_length <= 2) {
+    uint16_t Q_dash_ACK_actual = get_Qd(pusch_pdu->pusch_uci.harq_ack_bit_length, beta, alpha, sumKr, s1, s2, 0);
+    rminfo.E_uci_ACK_actual = Q_dash_ACK_actual * nlqm;
+  }
 
   // get beta offset for csi
   const double beta_csi1 = get_beta_offset_csi(pusch_pdu->pusch_uci.beta_offset_csi1);
@@ -849,7 +854,7 @@ static void map_overlapped_ack(uci_on_pusch_bit_type_t *template,
   const int placeholder_start = (pusch_pdu->pusch_uci.harq_ack_bit_length == 1) ? 1 : 2;
   const int Qm = pusch_pdu->qam_mod_order;
   uint32_t ack_bits_marked = 0;
-  for (uint8_t sym_iter = l1_c; sym_iter < pusch_pdu->nr_of_symbols && ack_bits_marked < G_ack; sym_iter++) {
+  for (uint8_t sym_iter = l1_c; sym_iter < pusch_pdu->nr_of_symbols; sym_iter++) {
     const uint32_t num_reserved_bits_on_sym = count_by_sym[sym_iter];
     if (num_reserved_bits_on_sym == 0)
       continue;
@@ -861,7 +866,9 @@ static void map_overlapped_ack(uci_on_pusch_bit_type_t *template,
         template[pos] = BIT_TYPE_ULSCH;
     }
     // pass 2: mark selected positions as ACK_RESERVED or PLACEHOLDER
-    const uint32_t num_ack_remaining = G_ack - ack_bits_marked;
+    const int32_t num_ack_remaining = G_ack - ack_bits_marked;
+    if (num_ack_remaining <= 0)
+      continue;
     const uint32_t d_factor_re = get_d_factor_re(num_ack_remaining, num_reserved_bits_on_sym);
     for (uint32_t i = 0; i < num_reserved_bits_on_sym && ack_bits_marked < G_ack; i += d_factor_re) {
       uint32_t pos = reserved_indices_on_this_sym[i];
@@ -1003,8 +1010,8 @@ static uci_on_pusch_bit_type_t *nr_data_control_mapping(const NR_UE_ULSCH_t *uls
   map_arg.G_uci = rm_info->E_uci_CSI2;
   map_uci_common(map_arg);
 
-  if (G_ack > 0 && rm_info->O_ack == 2) {
-    map_overlapped_ack(template, G_ack, l1_c, pusch_pdu, positions_by_sym, count_by_sym);
+  if (rm_info->O_ack == 2) {
+    map_overlapped_ack(template, rm_info->E_uci_ACK_actual, l1_c, pusch_pdu, positions_by_sym, count_by_sym);
   }
 
   apply_template_to_codeword(codeword, template, rm_info, codeword_len, ulsch_bits, cack, csi1, csi2, G_ulsch);

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -35,75 +35,31 @@
 //#define DEBUG_MAC_PDU
 //#define DEBUG_DFT_IDFT
 
-//extern int32_t uplink_counter;
-
-static void nr_pusch_codeword_scrambling_uci(uint8_t *in,
-                                             uint32_t size,
-                                             uint32_t Nid,
-                                             uint32_t n_RNTI,
-                                             const uci_on_pusch_bit_type_t *template,
-                                             uint32_t *out)
+static void nr_pusch_codeword_scrambling(uint8_t *in,
+                                         uint32_t size,
+                                         uint32_t Nid,
+                                         uint32_t n_RNTI,
+                                         const uci_on_pusch_bit_type_t *template,
+                                         uint32_t *out)
 {
+  // no UCI on PUSCH -> optimized scrambling
+  if (template == NULL) {
+    nr_codeword_scrambling(in, size, 0, Nid, n_RNTI, out);
+    return;
+  }
+
   uint32_t *seq = gold_cache((n_RNTI << 15) + Nid, (size + 31) / 32);
   uint32_t num_words = (size + 31) / 32;
-
-  // Step 1: Initial general scrambling
-  // First convert unpacked input to bit-packed words
-  uint32_t in_words[num_words];
-  memset(in_words, 0, num_words * sizeof(uint32_t));
+  memset(out, 0, num_words * sizeof(uint32_t));
 
   for (uint32_t i = 0; i < size; i++) {
     uint32_t word_idx = i / 32;
-    uint32_t bit_idx = i % 32;
-    if (in[i] & 1) {
-      in_words[word_idx] |= (1U << bit_idx);
-    }
+    uint32_t bit_idx  = i % 32;
+    uint32_t bit = (in[i] & 1);
+    if (template[i] != BIT_TYPE_PLACEHOLDER)
+      bit ^= (seq[word_idx] >> bit_idx) & 1;
+    out[word_idx] |= (bit << bit_idx);
   }
-
-  for (uint32_t i = 0; i < num_words; i++) {
-    out[i] = in_words[i] ^ seq[i];
-  }
-
-  // According to 38.211 6.3.1.1
-  for (uint32_t i = 0; i < size; i++) {
-    if (template[i] == BIT_TYPE_ACK_ULSCH) {
-      // Step 2: Overwrite/Correct positions for UCI bits including placeholders X, Y when O_ACK <= 2
-      uint32_t pos = i;
-      uint32_t idx = pos / 32;
-      uint32_t b_idx = pos % 32;
-
-      if (in[pos] == NR_PUSCH_y) {
-        // Clear bit
-        out[idx] &= ~(1U << b_idx);
-        if (b_idx > 0) {
-          // Y depends on the final value of the previous bit in the same word.
-          // This previous bit could be an ACK (already corrected) or ULSCH (from initial scramble).
-          out[idx] |= ((out[idx] >> (b_idx - 1)) & 1) << b_idx;
-        } else if (idx > 0) {
-          // Y depends on the last bit of the previous word.
-          out[idx] |= ((out[idx - 1] >> 31) & 1);
-        }
-      } else if (in[pos] == NR_PUSCH_x) {
-        out[idx] |= (1U << b_idx);
-      }
-    }
-  }
-}
-
-void nr_pusch_codeword_scrambling(uint8_t *in,
-                                  uint32_t size,
-                                  uint32_t Nid,
-                                  uint32_t n_RNTI,
-                                  bool uci_on_pusch,
-                                  const uci_on_pusch_bit_type_t *template,
-                                  uint32_t *out)
-{
-  if (uci_on_pusch)
-    // in buffer is in byte-packed format
-    nr_pusch_codeword_scrambling_uci(in, size, Nid, n_RNTI, template, out);
-  else
-    // in buffer is in bit-packed format
-    nr_codeword_scrambling(in, size, 0, Nid, n_RNTI, out);
 }
 
 /*
@@ -882,37 +838,41 @@ static void map_uci_common(struct map_uci_common_arg p)
 }
 
 /*
- * This function maps the HARQ-ACK bits when O_ACK <= 2
+ * Maps HARQ-ACK bits when O_ACK <= 2 (overlapped ACK/ULSCH case).
+ * Marks each reserved bit position as either BIT_TYPE_ACK_ULSCH (real data bit)
+ * or BIT_TYPE_PLACEHOLDER (x/y position), based on its position within the
+ * Qm-bit modulation group:
+ *   A=1: pos 0 is data, pos 1+ are placeholders (y at pos 1, x at pos 2+)
+ *   A=2: pos 0,1 are data, pos 2+ are placeholders (x only)
  */
 static void map_overlapped_ack(uci_on_pusch_bit_type_t *template,
                                uint16_t G_ack,
                                uint8_t l1_c,
-                               uint8_t n_symbols,
+                               const nfapi_nr_ue_pusch_pdu_t *pusch_pdu,
                                uint32_t positions_by_sym[][MAX_UCI_CODED_BITS],
                                const uint32_t *count_by_sym)
 {
+  // First placeholder position within a Qm-bit group:
+  //   A=1: pos 1 (y), pos 2+ (x)
+  //   A=2: pos 2+ (x only, pos 0 and 1 are always real data bits)
+  const int placeholder_start = (pusch_pdu->pusch_uci.harq_ack_bit_length == 1) ? 1 : 2;
   uint32_t ack_bits_marked = 0;
-
-  for (uint8_t sym_iter = l1_c; sym_iter < n_symbols && ack_bits_marked < G_ack; sym_iter++) {
+  for (uint8_t sym_iter = l1_c; sym_iter < pusch_pdu->nr_of_symbols && ack_bits_marked < G_ack; sym_iter++) {
     const uint32_t num_reserved_bits_on_sym = count_by_sym[sym_iter];
-
     if (num_reserved_bits_on_sym > 0) {
       const uint32_t num_ack_remaining = G_ack - ack_bits_marked;
-
-      // This d-factor is calculated for stepping through the list of *reserved bits*.
       const uint32_t d_factor_re = get_d_factor_re(num_ack_remaining, num_reserved_bits_on_sym);
-
       const uint32_t *reserved_indices_on_this_sym = positions_by_sym[sym_iter];
-
       for (uint32_t i = 0; i < num_reserved_bits_on_sym && ack_bits_marked < G_ack; i += d_factor_re) {
         uint32_t pos_to_mark = reserved_indices_on_this_sym[i];
-        template[pos_to_mark] = BIT_TYPE_ACK_ULSCH;
-
+        int bit_in_group = pos_to_mark % pusch_pdu->qam_mod_order;
+        template[pos_to_mark] = (bit_in_group >= placeholder_start) ? BIT_TYPE_PLACEHOLDER : BIT_TYPE_ACK_ULSCH;
         ack_bits_marked++;
       }
     }
   }
 }
+
 
 /*
  * Applies the template to build the final codeword
@@ -937,23 +897,17 @@ static void apply_template_to_codeword(uint8_t *codeword,
   for (uint32_t i = 0; i < codeword_len; i++) {
     switch (template[i]) {
       case BIT_TYPE_ACK:
+      case BIT_TYPE_ACK_ULSCH:
+      case BIT_TYPE_PLACEHOLDER:
         if (G_ack > 0 && ack_idx < G_ack) {
           uint32_t word_idx = ack_idx / 64;
           uint32_t bit_in_word_idx = ack_idx % 64;
           codeword[i] = (cack[word_idx] >> bit_in_word_idx) & 1;
           ack_idx++;
-        }
-        break;
-
-      case BIT_TYPE_ACK_ULSCH:
-        if (G_ack > 0 && ack_idx < G_ack) {
-          codeword[i] = ((const uint8_t *)cack)[ack_idx++];
-          if (G_ulsch > 0 && ulsch_idx < G_ulsch) {
+          if (template[i] != BIT_TYPE_ACK && G_ulsch > 0 && ulsch_idx < G_ulsch)
             ulsch_idx++;
-          }
         }
         break;
-
       case BIT_TYPE_CSI1:
         if (G_csi1 > 0 && csi1_idx < G_csi1) {
           uint32_t word_idx = csi1_idx / 64;
@@ -962,7 +916,6 @@ static void apply_template_to_codeword(uint8_t *codeword,
           csi1_idx++;
         }
         break;
-
       case BIT_TYPE_CSI2:
         if (G_csi2 > 0 && csi2_idx < G_csi2) {
           uint32_t word_idx = csi2_idx / 64;
@@ -971,7 +924,6 @@ static void apply_template_to_codeword(uint8_t *codeword,
           csi2_idx++;
         }
         break;
-
       case BIT_TYPE_ACK_RESERVED:
       case BIT_TYPE_ULSCH:
       default:
@@ -1060,7 +1012,7 @@ static uci_on_pusch_bit_type_t *nr_data_control_mapping(const nfapi_nr_ue_pusch_
   map_uci_common(map_arg);
 
   if (G_ack > 0 && G_ack_rvd > 0) {
-    map_overlapped_ack(template, G_ack, l1_c, n_symbols, positions_by_sym, count_by_sym);
+    map_overlapped_ack(template, G_ack, l1_c, pusch_pdu, positions_by_sym, count_by_sym);
   }
 
   apply_template_to_codeword(codeword, template, codeword_len, ulsch_bits, cack, csi1, csi2, G_ack, G_csi1, G_csi2, G_ulsch);
@@ -1193,7 +1145,6 @@ void nr_ue_ulsch_procedures(PHY_VARS_NR_UE *UE,
     nr_uci_encoding(pusch_pdu->pusch_uci.harq_payload,
                     pusch_pdu->pusch_uci.harq_ack_bit_length,
                     pucch_pdu->prb_size,
-                    true,
                     rm_info.E_uci_ACK,
                     mod_order,
                     &b_ack[0]);
@@ -1213,7 +1164,6 @@ void nr_ue_ulsch_procedures(PHY_VARS_NR_UE *UE,
     nr_uci_encoding(pusch_pdu->pusch_uci.csi_payload.part1_payload,
                     pusch_pdu->pusch_uci.csi_payload.p1_bits,
                     pucch_pdu->prb_size,
-                    true,
                     rm_info.E_uci_CSI1,
                     mod_order,
                     &b_csi1[0]);
@@ -1223,7 +1173,6 @@ void nr_ue_ulsch_procedures(PHY_VARS_NR_UE *UE,
       nr_uci_encoding(pusch_pdu->pusch_uci.csi_payload.part2_payload,
                       pusch_pdu->pusch_uci.csi_payload.p2_bits,
                       pucch_pdu->prb_size,
-                      true,
                       rm_info.E_uci_CSI2,
                       mod_order,
                       &b_csi2[0]);
@@ -1300,7 +1249,6 @@ void nr_ue_ulsch_procedures(PHY_VARS_NR_UE *UE,
                                available_bits,
                                pusch_pdu->data_scrambling_id,
                                rnti,
-                               uci_present,
                                uci_mapping_template,
                                scrambled_output);
   if (UE->phy_sim_test_buf) {

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -778,9 +778,6 @@ struct map_uci_common_arg {
 
 static void map_uci_common(struct map_uci_common_arg p)
 {
-  DevAssert((p.resv_ack_count_symb && p.resv_ack_pos_symb && (p.uci_type_to_map == BIT_TYPE_ACK_RESERVED))
-            || (!p.resv_ack_count_symb && !p.resv_ack_pos_symb && (p.uci_type_to_map != BIT_TYPE_ACK_RESERVED)));
-
   uint32_t symbol_start_bit_idx[NR_SYMBOLS_PER_SLOT] = {0};
   for (uint8_t s = 1; s < p.n_symbols; s++) {
     symbol_start_bit_idx[s] = symbol_start_bit_idx[s - 1] + (p.m_ulsch_initial[s - 1] * p.nlqm);
@@ -791,15 +788,15 @@ static void map_uci_common(struct map_uci_common_arg p)
 
   uint32_t total_placed = 0;
   for (uint8_t sym = p.l1_c; sym < p.n_symbols && total_placed < p.G_uci; sym++) {
-    const uint32_t uci_re_on_sym = p.m_uci_current[sym];
-
+    uint32_t uci_re_on_sym = p.m_uci_current[sym];
+    if (p.uci_type_to_map == BIT_TYPE_CSI1 && p.resv_ack_count_symb) // need to remove reserved res
+      uci_re_on_sym -= p.resv_ack_count_symb[sym] / p.nlqm;
     if (uci_re_on_sym <= 0) {
       continue;
     }
 
     const uint32_t remaining_to_place = p.G_uci - total_placed;
     const uint32_t num_re_to_select = ceil((double)remaining_to_place / p.nlqm);
-
     uint32_t d_factor_re = get_d_factor_re(num_re_to_select, uci_re_on_sym);
     uint32_t re_offset = 0;
     uint32_t *cur_sym_resv_ack_pos = p.resv_ack_pos_symb[sym];
@@ -813,17 +810,25 @@ static void map_uci_common(struct map_uci_common_arg p)
         if (total_placed >= p.G_uci) {
           break;
         }
-
         uint32_t bit_offset_in_sym = (re_offset * p.nlqm) + bit_in_re;
         uint32_t cw_idx = symbol_start_bit_idx[sym] + bit_offset_in_sym;
         p.template[cw_idx] = p.uci_type_to_map;
         if (p.uci_type_to_map == BIT_TYPE_ACK_RESERVED) {
           cur_sym_resv_ack_pos[p.resv_ack_count_symb[sym]++] = cw_idx;
         }
-
         total_placed++;
       }
-      re_offset += d_factor_re;
+      if (p.uci_type_to_map == BIT_TYPE_CSI1 && p.resv_ack_pos_symb) {
+        uint32_t prev_re_offset = re_offset;
+        re_offset += d_factor_re;
+        for (uint32_t i = 0; i < p.resv_ack_count_symb[sym] / p.nlqm; i++) {
+          uint32_t resv_re = (p.resv_ack_pos_symb[sym][i * p.nlqm] - symbol_start_bit_idx[sym]) / p.nlqm;
+          if (resv_re > prev_re_offset && resv_re <= re_offset)
+            re_offset++;
+        }
+      } else {
+        re_offset += d_factor_re;
+      }
     }
   }
 }
@@ -1002,8 +1007,8 @@ static uci_on_pusch_bit_type_t *nr_data_control_mapping(const NR_UE_ULSCH_t *uls
   // CSI part 1
   map_arg.uci_type_to_map = BIT_TYPE_CSI1;
   map_arg.G_uci = rm_info->E_uci_CSI1;
-  map_arg.resv_ack_pos_symb = NULL;
-  map_arg.resv_ack_count_symb = NULL;
+  map_arg.resv_ack_pos_symb = positions_by_sym;
+  map_arg.resv_ack_count_symb = count_by_sym;
   map_uci_common(map_arg);
   // CSI part 2
   map_arg.uci_type_to_map = BIT_TYPE_CSI2;

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -47,15 +47,13 @@ static void nr_pusch_codeword_scrambling(uint8_t *in,
     nr_codeword_scrambling(in, size, 0, Nid, n_RNTI, out);
     return;
   }
-
   uint32_t *seq = gold_cache((n_RNTI << 15) + Nid, (size + 31) / 32);
   uint32_t num_words = (size + 31) / 32;
   memset(out, 0, num_words * sizeof(uint32_t));
-
   for (uint32_t i = 0; i < size; i++) {
     uint32_t word_idx = i / 32;
     uint32_t bit_idx  = i % 32;
-    uint32_t bit = (in[i] & 1);
+    uint32_t bit = (in[i / 8] >> (i % 8)) & 1;
     if (template[i] != BIT_TYPE_PLACEHOLDER)
       bit ^= (seq[word_idx] >> bit_idx) & 1;
     out[word_idx] |= (bit << bit_idx);
@@ -856,6 +854,9 @@ static void map_overlapped_ack(uci_on_pusch_bit_type_t *template,
 /*
  * Applies the template to build the final codeword
  */
+#define WRITE_BIT(cw, i, bit) do { if (bit) (cw)[(i) / 8] |= (1 << ((i) % 8)); } while(0)
+#define READ_PACKED(arr, idx) (((arr)[(idx) / 64] >> ((idx) % 64)) & 1ULL)
+
 static void apply_template_to_codeword(uint8_t *codeword,
                                        const uci_on_pusch_bit_type_t *template,
                                        rate_match_info_uci_t *rm_info,
@@ -870,6 +871,7 @@ static void apply_template_to_codeword(uint8_t *codeword,
   uint32_t ack_idx = 0;
   uint32_t csi1_idx = 0;
   uint32_t csi2_idx = 0;
+  memset(codeword, 0, (codeword_len + 7) / 8);
 
   for (uint32_t i = 0; i < codeword_len; i++) {
     switch (template[i]) {
@@ -877,9 +879,7 @@ static void apply_template_to_codeword(uint8_t *codeword,
       case BIT_TYPE_ACK_ULSCH:
       case BIT_TYPE_PLACEHOLDER:
         if (rm_info->E_uci_ACK > 0 && ack_idx < rm_info->E_uci_ACK) {
-          uint32_t word_idx = ack_idx / 64;
-          uint32_t bit_in_word_idx = ack_idx % 64;
-          codeword[i] = (cack[word_idx] >> bit_in_word_idx) & 1;
+          WRITE_BIT(codeword, i, READ_PACKED(cack, ack_idx));
           ack_idx++;
           if (template[i] != BIT_TYPE_ACK && G_ulsch > 0 && ulsch_idx < G_ulsch)
             ulsch_idx++;
@@ -887,17 +887,13 @@ static void apply_template_to_codeword(uint8_t *codeword,
         break;
       case BIT_TYPE_CSI1:
         if (rm_info->E_uci_CSI1 > 0 && csi1_idx < rm_info->E_uci_CSI1) {
-          uint32_t word_idx = csi1_idx / 64;
-          uint32_t bit_in_word_idx = csi1_idx % 64;
-          codeword[i] = (csi1[word_idx] >> bit_in_word_idx) & 1;
+          WRITE_BIT(codeword, i, READ_PACKED(csi1, csi1_idx));
           csi1_idx++;
         }
         break;
       case BIT_TYPE_CSI2:
         if (rm_info->E_uci_CSI2 > 0 && csi2_idx < rm_info->E_uci_CSI2) {
-          uint32_t word_idx = csi2_idx / 64;
-          uint32_t bit_in_word_idx = csi2_idx % 64;
-          codeword[i] = (csi2[word_idx] >> bit_in_word_idx) & 1;
+          WRITE_BIT(codeword, i, READ_PACKED(csi2, csi2_idx));
           csi2_idx++;
         }
         break;
@@ -905,9 +901,7 @@ static void apply_template_to_codeword(uint8_t *codeword,
       case BIT_TYPE_ULSCH:
       default:
         if (G_ulsch > 0 && ulsch_idx < G_ulsch) {
-          uint32_t byte_idx = ulsch_idx / 8;
-          uint32_t bit_in_byte_idx = ulsch_idx % 8;
-          codeword[i] = (ulsch_bits[byte_idx] >> bit_in_byte_idx) & 1;
+          WRITE_BIT(codeword, i, (ulsch_bits[ulsch_idx/8] >> (ulsch_idx%8)) & 1);
           ulsch_idx++;
         }
         break;
@@ -1152,7 +1146,7 @@ void nr_ue_ulsch_procedures(PHY_VARS_NR_UE *UE,
   }
 
   if (uci_present) {
-    uint8_t temp_codeword[G_initial_total_pusch_bits];
+    uint8_t temp_codeword[(G_initial_total_pusch_bits + 7) / 8];
     start_meas_nr_ue_phy(UE, UCI_ON_PUSCH_MAPPING);
     nr_data_control_mapping(ulsch_ue,
                             template_buffer,
@@ -1165,7 +1159,7 @@ void nr_ue_ulsch_procedures(PHY_VARS_NR_UE *UE,
                             b_csi1,
                             b_csi2);
     stop_meas_nr_ue_phy(UE, UCI_ON_PUSCH_MAPPING);
-    memcpy(harq_process_ul_ue->f, temp_codeword, G_initial_total_pusch_bits);
+    memcpy(harq_process_ul_ue->f, temp_codeword, (G_initial_total_pusch_bits + 7) / 8);
     uci_mapping_template = template_buffer;
   }
 

--- a/openair1/PHY/NR_UE_TRANSPORT/pucch_nr.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/pucch_nr.c
@@ -535,198 +535,108 @@ static inline void nr_pucch2_3_4_scrambling(uint16_t M_bit, uint16_t rnti, uint1
 #endif
 }
 
-void nr_uci_encoding(uint64_t payload, uint8_t nr_bit, uint8_t nrofPRB, bool uci_on_pusch, uint16_t E, uint8_t Qm, uint64_t *b)
+/*
+ * Build a tiled pattern of N bits repeated to fill the required output words,
+ * and write it into b[]. Tiling only covers ceil(E/64) word. N <= 32
+ */
+static inline void fill_pattern(uint64_t *b, uint64_t pattern, int N, uint16_t E)
+{
+  int nwords = (E + 63) / 64;
+  memset(b, 0, nwords * sizeof(uint64_t));
+  int ncopies = (E + N - 1) / N;
+  for (int k = 0; k < ncopies; k++) {
+    int bit = k * N;
+    int w = bit / 64;
+    int shift = bit % 64;
+    b[w] |= pattern << shift;
+    if (shift > 0 && shift + N > 64 && w + 1 < nwords)
+      b[w + 1] |= pattern >> (64 - shift);
+  }
+}
+
+void nr_uci_encoding(uint64_t payload, uint8_t nr_bit, uint8_t nrofPRB, uint16_t E, uint8_t Qm, uint64_t *b)
 {
   /*
    * Implementing TS 38.212 Subclause 6.3.1.2 and 6.3.2
    *
+   * For A<=11, encoding and rate matching are combined: each branch builds
+   * the base N-bit codeword as a pattern and fills E output bits directly
+   * via fill_pattern().
+   *
+   * For A>=12, polar_encoder_fast handles encoding and rate matching internally.
+   *
+   * Output b[] is always a packed bitfield: bit i is at b[i/64] position (i%64).
+   *
+   * Placeholder values from Table 5.3.3.2-1 are resolved at encoding time:
+   *   x -> 1
+   *   y -> b(i-1)  (previous output bit; only appears in the A=1 case)
    */
-  // A is the payload size, to be provided in function call
   uint8_t A = nr_bit;
-  // L is the CRC size
-  // uint8_t L;
-  // E is the rate matching output sequence length as given in TS 38.212 subclause 6.3.1.4.1
-  // int I_seg;
+
 #ifdef DEBUG_NR_PUCCH_TX
   printf("\t\t [nr_uci_encoding] start function with encoding A=%d bits into M_bit=%d (where nrofPRB=%d)\n", A, E, nrofPRB);
 #endif
 
-  // For A=1 case (single bit UCI)
+  memset(b, 0, 8 * sizeof(uint64_t));
   if (A == 1) {
-    uint8_t uci_bit_val = payload & 1; // Extract the single UCI bit
-    uint64_t pattern_word;
-    uint8_t *b_bytes = (uint8_t *)b; // Access b as bytes to set individual special values
-
+    uint8_t uci_bit = payload & 1;
     if (Qm == 1) {
-      // For BPSK, just repeat the input bit
-      pattern_word = uci_bit_val ? 0xFFFFFFFFFFFFFFFFULL : 0x0000000000000000ULL;
-      for (int i = 0; i < 8; i++) {
-        b[i] = pattern_word;
-      }
+      // N=1: repeat the single UCI bit
+      // b is already zeroed by memset, when uci_bit=0 we don't need to do anything
+      if (uci_bit)
+        for (int i = 0; i < (E + 63) / 64; i++)
+          b[i] = 0xFFFFFFFFFFFFFFFFULL;
     } else {
-      // For higher order modulation (QPSK, etc.), use placeholder values
-      memset(b, 0, 8 * sizeof(uint64_t));
-
-      // Fill the entire output with the pattern
-      for (int i = 0; i < E; i++) {
-        switch (i % Qm) {
-          case 0:
-            // First bit in each group is actual UCI bit
-            b_bytes[i] = uci_bit_val;
-            LOG_D(PHY,
-                  "[UCI_ENCODING_A1_QAM_LOOP] i=%d, i%%Qm=%d (case 0), writing uci_bit_val %d to b_bytes[%d]\n",
-                  i,
-                  i % Qm,
-                  uci_bit_val,
-                  i);
-            break;
-          case 1:
-            b_bytes[i] = NR_PUSCH_y;
-            LOG_D(PHY,
-                  "[UCI_ENCODING_A1_QAM_LOOP] i=%d, i%%Qm=%d (case 1), writing NR_PUSCH_y (0x%02X) to b_bytes[%d]\n",
-                  i,
-                  i % Qm,
-                  NR_PUSCH_y,
-                  i);
-            break;
-          default:
-            b_bytes[i] = NR_PUSCH_x;
-            break;
-        }
-      }
+      // N=Qm: build one resolved symbol group per Table 5.3.3.2-1:
+      //   pos 0:  c0      (UCI bit)
+      //   pos 1:  y       -> b(i-1) = uci_bit
+      //   pos 2+: x       -> 1
+      // Resolved pattern: [uci_bit, uci_bit, 1, 1, ..., 1]
+      uint64_t pattern = uci_bit ? 0x3ULL : 0x0ULL; // bits 0 and 1
+      if (Qm > 2)
+        pattern |= ((1ULL << (Qm - 2)) - 1) << 2;   // bits 2..Qm-1 set to 1
+      fill_pattern(b, pattern, Qm, E);
     }
-  }
-  // For A=2 case (two bits UCI)
-  else if (A == 2) {
-    uint8_t bit0 = (payload >> 0) & 1;
-    uint8_t bit1 = (payload >> 1) & 1;
-    uint8_t c2 = bit0 ^ bit1; // Parity bit (XOR of the two bits)
-    uint8_t *b_bytes = (uint8_t *)b;
-
+  } else if (A == 2) {
+    uint8_t c0 = (payload >> 0) & 1;
+    uint8_t c1 = (payload >> 1) & 1;
+    uint8_t c2 = c0 ^ c1;
     if (Qm == 1) {
-      // For BPSK, output is [bit0, bit1, c2]
-      uint64_t pattern = (bit0) | (bit1 << 1) | (c2 << 2);
-      // Repeat this 3-bit pattern to fill the output
-      pattern |= pattern << 3;
-      pattern |= pattern << 6;
-      pattern |= pattern << 12;
-      pattern |= pattern << 24;
-      pattern |= pattern << 48;
-
-      for (int i = 0; i < 8; i++) {
-        b[i] = pattern;
-      }
+      // N=3: base codeword [c0 c1 c2]
+      uint64_t pattern = (uint64_t)c0 | ((uint64_t)c1 << 1) | ((uint64_t)c2 << 2);
+      fill_pattern(b, pattern, 3, E);
     } else {
-      // For higher order modulation (Qm>=2), using patterns from Table 5.3.3.2-1
-      // Pattern: 3 groups of Qm bits each = 3*Qm total length
-      memset(b, 0, 8 * sizeof(uint64_t));
-
-      for (int i = 0; i < E; i++) {
-        int pos_in_pattern = i % (3 * Qm);
-        int group = pos_in_pattern / Qm;
-        int pos_in_group = pos_in_pattern % Qm;
-        uint8_t val_to_write;
-
-        if (pos_in_group == 0) {
-          if (group == 0)
-            val_to_write = bit0;
-          else if (group == 1)
-            val_to_write = c2;
-          else
-            val_to_write = bit1;
-        } else if (pos_in_group == 1) {
-          if (group == 0)
-            val_to_write = bit1;
-          else if (group == 1)
-            val_to_write = bit0;
-          else
-            val_to_write = c2;
-        } else {
-          // Positions 2 and beyond are x placeholders
-          val_to_write = NR_PUSCH_x;
-        }
-
-        b_bytes[i] = val_to_write;
+      // N=3*Qm: one full period per Table 5.3.3.2-1.
+      // Each group of Qm bits:
+      //   pos 0:   data bit (c0, c2, c1 for groups 0, 1, 2)
+      //   pos 1:   data bit (c1, c0, c2 for groups 0, 1, 2)
+      //   pos 2+:  x -> 1
+      // Note: Table 5.3.3.2-1 contains no y placeholders for A=2.
+      uint8_t data[3][2] = {{c0, c1}, {c2, c0}, {c1, c2}};
+      uint64_t pattern = 0;
+      for (int group = 0; group < 3; group++) {
+        int base = group * Qm;
+        if (data[group][0])
+          pattern |= (1ULL << (base + 0));
+        if (data[group][1])
+          pattern |= (1ULL << (base + 1));
+        for (int p = 2; p < Qm; p++)
+          pattern |= (1ULL << (base + p));            // x -> 1
       }
+      fill_pattern(b, pattern, 3 * Qm, E);
     }
   } else if (A <= 11) {
-    // procedure in subclause 6.3.1.2.2 (UCI encoded by channel coding of small block lengths -> subclause 6.3.1.3.2)
-    // CRC bits are not attached, and coding small block lengths (subclause 5.3.3)
-    uint64_t b0 = encodeSmallBlock(payload, A);
-    if (uci_on_pusch) {
-      b[0] = b0;
-      for (int i = 1; i < 8; i++) {
-        b[i] = 0;
-      }
-    } else {
-      // repetition for rate-matching up to 16 PRB
-      b[0] = b0 | (b0<<32);
-      b[1] = b[0];
-      b[2] = b[0];
-      b[3] = b[0];
-      b[4] = b[0];
-      b[5] = b[0];
-      b[6] = b[0];
-      b[7] = b[0];
-      AssertFatal(nrofPRB<=16,"Number of PRB >16\n");
-    }
-  } else if (A >= 12) {
-    // Encoder reversal
+    // Small block encoder produces a 32-bit codeword (TS 38.212 subclause 5.3.3).
+    // Rate match by tiling the 32-bit codeword across E output bits.
+    uint64_t pattern = (uint32_t)encodeSmallBlock(payload, A);
+    fill_pattern(b, pattern, 32, E);
+  } else { // A >= 12
+    // Polar encoder handles encoding and rate matching internally
     payload = reverse_bits(payload, A);
-
-    polar_encoder_fast(&payload, b, 0,0,
-                       NR_POLAR_UCI_PUCCH_MESSAGE_TYPE, 
-                       A, 
-                       nrofPRB);
-  }
-
-  if (uci_on_pusch) {
-    // Rate matching for HARQ ACK following 38.212 section 5.4.3
-    uint64_t output[8] = {0}; // Assuming max 512 bits (8 words of 64 bits)
-    uint16_t N;
-    if (nr_bit <= 2) {
-      // For A=1 (BPSK), N=1. For A=2 (QPSK), N=3
-      N = (nr_bit == 1) ? 1 : 3;
-    } else if (nr_bit <= 11) {
-      // For 3 <= A <= 11, the small block encoder produces a 32-bit codeword
-      N = 32;
-    } else {
-      // For polar-coded UCI, output depends on nrofPRB
-      N = 16 * nrofPRB;
-    }
-
-    if ((nr_bit == 1 || nr_bit == 2) && Qm > 1) {
-      LOG_D(PHY,
-            "[UCI_ENCODING_RM] Bypassing bit-wise rate matching for A=%d, Qm=%d. 'b' (length %d bytes) is assumed to be already "
-            "final.\n",
-            nr_bit,
-            Qm,
-            E);
-    } else {
-      if (N == 0) {
-        LOG_W(PHY, "HARQ-ACK rate matching with encoded_length=0 but E_uci_ack=%d\n", E);
-        return;
-      }
-
-      // Rate matching with single loop for both repetition and puncturing
-      for (int i = 0; i < E; i++) {
-        int src_bit = i % N; // Modulo for cyclic repetition
-        int src_word = src_bit / 64;
-        int src_bit_pos = src_bit % 64;
-        int dst_word = i / 64;
-        int dst_bit_pos = i % 64;
-
-        if ((b[src_word] >> src_bit_pos) & 1ULL)
-          output[dst_word] |= (1ULL << dst_bit_pos);
-      }
-
-      for (int i = 0; i < (E + 63) / 64; i++) {
-        b[i] = output[i];
-      }
-    }
+    polar_encoder_fast(&payload, b, 0, 0, NR_POLAR_UCI_PUCCH_MESSAGE_TYPE, A, nrofPRB);
   }
 }
-//#if 0
+
 void nr_generate_pucch2(c16_t **txdataF,
                         const NR_DL_FRAME_PARMS *frame_parms,
                         const int16_t amp16,
@@ -740,7 +650,7 @@ void nr_generate_pucch2(c16_t **txdataF,
   uint64_t b[16] = {0}; // limit to 1024-bit encoded length
   // M_bit is the number of bits of block b (payload after encoding)
   uint16_t M_bit = nr_pucch_output_sequence_length(pucch_pdu->format_type, pucch_pdu->nr_of_symbols, pucch_pdu->prb_size, 0, 0, 0);
-  nr_uci_encoding(pucch_pdu->payload, pucch_pdu->n_bit, pucch_pdu->prb_size, false, M_bit, 0, &b[0]);
+  nr_uci_encoding(pucch_pdu->payload, pucch_pdu->n_bit, pucch_pdu->prb_size, M_bit, 0, &b[0]);
   /*
    * Implementing TS 38.211
    * Subclauses 6.3.2.5.1 Scrambling (PUCCH format 2)
@@ -910,7 +820,7 @@ void nr_generate_pucch2(c16_t **txdataF,
     }
   }
 }
-//#if 0
+
 void nr_generate_pucch3_4(c16_t **txdataF,
                           const NR_DL_FRAME_PARMS *frame_parms,
                           const int16_t amp16,
@@ -957,7 +867,7 @@ void nr_generate_pucch3_4(c16_t **txdataF,
                                           is_pi_over_2_bpsk_enabled,
                                           add_dmrs);
 
-  nr_uci_encoding(pucch_pdu->payload, pucch_pdu->n_bit, nrofPRB, false, M_bit, 0, b);
+  nr_uci_encoding(pucch_pdu->payload, pucch_pdu->n_bit, nrofPRB, M_bit, 0, b);
   /*
    * Implementing TS 38.211
    * Subclauses 6.3.2.6.1 Scrambling (PUCCH formats 3 and 4)

--- a/openair1/PHY/NR_UE_TRANSPORT/pucch_nr.h
+++ b/openair1/PHY/NR_UE_TRANSPORT/pucch_nr.h
@@ -42,7 +42,7 @@ void nr_generate_pucch3_4(c16_t **txdataF,
                           const int nr_slot_tx,
                           const fapi_nr_ul_config_pucch_pdu *pucch_pdu);
 
-void nr_uci_encoding(uint64_t payload, uint8_t nr_bit, uint8_t nrofPRB, bool uci_on_pusch, uint16_t E, uint8_t Qm, uint64_t *b);
+void nr_uci_encoding(uint64_t payload, uint8_t nr_bit, uint8_t nrofPRB, uint16_t E, uint8_t Qm, uint64_t *b);
 
 static const uint8_t list_of_prime_numbers[46] = {2,  3,  5,  7,  11, 13, 17, 19, 23, 29,
                                          31, 37, 41, 43, 47, 53, 59, 61, 67, 71,


### PR DESCRIPTION
This MR improves the implementation of UCI on PUSCH at UE side and fixes some issues found while testing and fixing the revised version.

Tested in ULSIM with MATLAB vectors provided by @sakthivelvelumani  in the following scenarios (bits)
- 2 ACK no CSI
- 7 CSI part1 no ACK no CSI part2
- 1 ACK 7 CSI part1 7 CSI part2
- 3 ACK 4 CSI part1 4 CSI part2
using the command line ./nr_ulsim -m 27 -u 1 -R 51 -r 51 -s 30 -o(path to the file containing the vector)

Closes #181 