### PR TITLE
Introduce group based processing for 5G uplink MU-MIMO and a MU-MIMO physical simulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2043,6 +2043,19 @@ target_link_libraries(nr_srssim PRIVATE
   m pthread ITTI dl nr_ue_phy_meas physim_common softmodem_common
   )
 
+add_executable(nr_ulsim_mu_mimo
+  ${OPENAIR1_DIR}/SIMULATION/NR_PHY/ulsim_mu_mimo.c
+  ${NFAPI_USER_DIR}/nfapi.c
+  ${NFAPI_USER_DIR}/gnb_ind_vars.c
+  ${PHY_INTERFACE_DIR}/queue_t.c
+  )
+
+target_link_libraries(nr_ulsim_mu_mimo PRIVATE
+  -Wl,--start-group UTIL SIMU PHY_NR_COMMON PHY_NR PHY_NR_UE SCHED_NR_LIB SCHED_NR_UE_LIB MAC_UE_NR MAC_NR_COMMON CONFIG_LIB L2_NR -Wl,--end-group
+  m pthread ${T_LIB} ITTI dl nr_ue_phy_meas physim_common softmodem_common NR_L2_UE
+  )
+target_link_libraries(nr_ulsim_mu_mimo PRIVATE asn1_nr_rrc_hdrs asn1_lte_rrc_hdrs)
+
 if(ENABLE_CHANNEL_SIM_CUDA)
   if (TARGET oai_cuda_lib)
       target_link_libraries(nr_dlsim PRIVATE oai_cuda_lib)
@@ -2100,7 +2113,7 @@ if (${T_TRACER})
         nr-uesoftmodem dlsim dlsim_tm4 dlsim_tm7
         ulsim pbchsim scansim mbmssim pdcchsim pucchsim prachsim
         syncsim nr_ulsim nr_dlsim nr_dlschsim nr_pbchsim nr_pucchsim
-        nr_ulschsim ldpctest polartest smallblocktest nr_srssim
+        nr_ulschsim ldpctest polartest smallblocktest nr_srssim nr_ulsim_mu_mimo
         #all "add_library" definitions
         ITTI lte_rrc nr_rrc s1ap x2ap m2ap m3ap f1ap
         params_libconfig

--- a/ci-scripts/docker/Dockerfile.physim.ubuntu
+++ b/ci-scripts/docker/Dockerfile.physim.ubuntu
@@ -26,4 +26,4 @@ RUN cmake -GNinja -DENABLE_PHYSIM_TESTS=ON \
         -DCMAKE_C_FLAGS=-Werror -DCMAKE_CXX_FLAGS=-Werror \
         -DPHYSIM_CHECK_FILES="ThresholdsGracehopper.cmake" \
         .. && \
-    ninja ldpctest polartest smallblocktest nr_pbchsim nr_dlschsim nr_ulschsim nr_dlsim nr_ulsim nr_pucchsim nr_prachsim nr_psbchsim nr_srssim
+    ninja ldpctest polartest smallblocktest nr_pbchsim nr_dlschsim nr_ulschsim nr_dlsim nr_ulsim nr_ulsim_mu_mimo nr_pucchsim nr_prachsim nr_psbchsim nr_srssim

--- a/cmake_targets/build_oai
+++ b/cmake_targets/build_oai
@@ -284,7 +284,7 @@ function main() {
             SIMUS_PHY=1
             CMAKE_CMD="$CMAKE_CMD -DENABLE_PHYSIM_TESTS=ON"
             # TODO: fix: dlsim_tm4 pucchsim prachsim pdcchsim pbchsim mbmssim
-            TARGET_LIST="$TARGET_LIST dlsim ulsim ldpctest polartest smallblocktest nr_pbchsim nr_dlschsim nr_ulschsim nr_dlsim nr_ulsim nr_pucchsim nr_prachsim nr_psbchsim nr_srssim"
+            TARGET_LIST="$TARGET_LIST dlsim ulsim ldpctest polartest smallblocktest nr_pbchsim nr_dlschsim nr_ulschsim nr_dlsim nr_ulsim nr_pucchsim nr_prachsim nr_psbchsim nr_srssim nr_ulsim_mu_mimo"
             echo_info "Will compile dlsim, ulsim, ..."
             shift;;
        -V | --vcd)

--- a/openair1/PHY/NR_TRANSPORT/nr_transport_proto.h
+++ b/openair1/PHY/NR_TRANSPORT/nr_transport_proto.h
@@ -92,12 +92,13 @@ void free_gNB_dlsch(NR_gNB_DLSCH_t *dlsch, uint16_t N_RB, const NR_DL_FRAME_PARM
     @param frame Frame number
     @param slot Slot number
 */
-int nr_rx_pusch_tp(PHY_VARS_gNB *gNB,
-                   NR_gNB_PUSCH *pusch_vars,
-                   const nfapi_nr_pusch_pdu_t *rel15_ul,
-                   uint32_t *ret_unav_res,
-                   uint32_t frame,
-                   uint8_t slot);
+int nr_rx_pusch_group_tp(PHY_VARS_gNB *gNB,
+                         NR_gNB_PUSCH **pusch_vars,
+                         const nfapi_nr_pusch_pdu_t **rel15_ul,
+                         uint32_t **ret_unav_res,
+                         uint8_t group_size,
+                         uint32_t frame,
+                         uint8_t slot);
 
 /*!
 \brief This function implements the idft transform precoding in PUSCH

--- a/openair1/PHY/NR_TRANSPORT/nr_transport_proto.h
+++ b/openair1/PHY/NR_TRANSPORT/nr_transport_proto.h
@@ -112,7 +112,9 @@ void reset_active_ulsch(PHY_VARS_gNB *gNB, int frame);
 void nr_fill_ulsch(PHY_VARS_gNB *gNB,
                    int frame,
                    int slot,
-                   nfapi_nr_pusch_pdu_t *ulsch_pdu);
+                   nfapi_nr_pusch_pdu_t *ulsch_pdu,
+                   int16_t mu_group_idx,
+                   uint8_t mu_group_size);
 
 void nr_schedule_rx_prach(PHY_VARS_gNB *gNB, int SFN, int Slot, nfapi_nr_prach_pdu_t *prach_pdu);
 

--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch.c
@@ -89,8 +89,12 @@ static void dump_pusch_pdu(int instance, int frame, int slot, nfapi_nr_pusch_pdu
         pusch_pdu->pusch_data.num_cb);
 }
 
-
-void nr_fill_ulsch(PHY_VARS_gNB *gNB, int frame, int slot, nfapi_nr_pusch_pdu_t *ulsch_pdu)
+void nr_fill_ulsch(PHY_VARS_gNB *gNB,
+                   int frame,
+                   int slot,
+                   nfapi_nr_pusch_pdu_t *ulsch_pdu,
+                   int16_t mu_group_idx,
+                   uint8_t mu_group_size)
 {
   dump_pusch_pdu(gNB->Mod_id, frame, slot, ulsch_pdu);
   LOG_D(NR_PHY,
@@ -101,7 +105,11 @@ void nr_fill_ulsch(PHY_VARS_gNB *gNB, int frame, int slot, nfapi_nr_pusch_pdu_t 
         ulsch_pdu->pusch_data.harq_process_id,
         ulsch_pdu->pusch_data.new_data_indicator);
 
-  NR_gNB_PUSCH_job_t pusch = {.frame = frame, .slot = slot, .pusch_pdu = *ulsch_pdu};
+  NR_gNB_PUSCH_job_t pusch = {.frame = frame,
+                              .slot = slot,
+                              .pusch_pdu = *ulsch_pdu,
+                              .mu_group_idx = mu_group_idx,
+                              .mu_group_size = mu_group_size};
   if (gNB->common_vars.beam_id) {
     int fapi_beam_idx = ulsch_pdu->beamforming.prgs_list[0].dig_bf_interface_list[0].beam_idx;
     int bitmap = SL_to_bitmap(ulsch_pdu->start_symbol_index, ulsch_pdu->nr_of_symbols);

--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
@@ -19,6 +19,8 @@
 #include <sys/time.h>
 #include "openair1/SCHED_NR/sched_nr.h"
 
+#define NR_MAX_PUSCH_SCRAMBLING_STACK_BYTES (2 * 1024 * 1024) // 2MB
+
 #if T_TRACER
 static void copy_c16_data_to_slot_memory(c16_t *src, c16_t *dst_slot, int nb_re_pusch, int symbol)
 {
@@ -335,7 +337,6 @@ typedef struct puschSymbolProc_s {
   int startSymbol;
   int numSymbols;
   int16_t *llr;
-  int16_t *scramblingSequence;
   uint32_t nvar;
   int beam_nb;
   time_stats_t pusch_extr;
@@ -348,6 +349,11 @@ typedef struct puschSymbolProc_s {
   task_ans_t *ans;
   c16_t *pusch_ch_est_dmrs_interpl_slot_mem;
   c16_t *rxFext_slot_mem;
+  uint8_t group_size;
+  const nfapi_nr_pusch_pdu_t **rel15_ul_group;
+  NR_gNB_PUSCH **pusch_vars_group;
+  int16_t **scrambling_sequences;
+  int *layer_offsets;
 } puschSymbolProc_t;
 
 static void nr_pusch_symbol_processing(void *arg)
@@ -387,28 +393,50 @@ static void nr_pusch_symbol_processing(void *arg)
              &rdata->ulsch_llr);
 
     int nb_re_pusch = pusch_vars->ul_valid_re_per_slot[symbol];
-    // layer de-mapping
-    start_meas(&rdata->ul_demap);
-    int16_t *llr_ptr = llrs[0];
-    if (rel15_ul->nrOfLayers != 1) {
-      llr_ptr = &rdata->llr[pusch_vars->llr_offset[symbol] * rel15_ul->nrOfLayers];
-      nr_layer_demapping(rel15_ul->nrOfLayers, rel15_ul->qam_mod_order, nb_re_pusch, llrss, llr_ptr);
+    for (int u = 0; u < rdata->group_size; u++) {
+      NR_gNB_PUSCH *ue_pusch_vars = rdata->pusch_vars_group[u];
+      const nfapi_nr_pusch_pdu_t *ue_pdu = rdata->rel15_ul_group[u];
+      int16_t *ue_scrambling_seq = rdata->scrambling_sequences[u];
+
+      const int ue_layers = ue_pdu->nrOfLayers;
+      const int qam = ue_pdu->qam_mod_order;
+      const int layer_off = rdata->layer_offsets[u];
+
+      ue_pusch_vars->llr_offset[symbol] = pusch_vars->llr_offset[symbol];
+      ue_pusch_vars->ul_valid_re_per_slot[symbol] = nb_re_pusch;
+
+      const int sym_bit_offset = ue_pusch_vars->llr_offset[symbol] * ue_layers;
+      int16_t *llr_dest = &ue_pusch_vars->llr[sym_bit_offset];
+      int16_t *s_seq = &ue_scrambling_seq[sym_bit_offset];
+
+      const int n = nb_re_pusch * ue_layers * qam;
+      const int16_t *src;
+
+      // demapping: bring elements into order such that unscrambling is a linear operation
+      // e.g., from "RE0-l0, RE1-l0, ..., REn-l0, RE0-l1, ..." to "RE0-l0, Re0-l1, RE1-l0, ..."
+      // Each REn-ln = q LLRs (q = QAM order {2,4,6,8}, one LLR/bit).
+      start_meas(&rdata->ul_demap);
+      if (ue_layers == 1) {
+        // no demapping needed
+        src = llrss[layer_off];
+      } else {
+        nr_layer_demapping(ue_layers, qam, nb_re_pusch, &llrss[layer_off], llr_dest);
+        src = llr_dest;
+      }
+      stop_meas(&rdata->ul_demap);
+
+      // unscrambling
+      start_meas(&rdata->ul_unscram);
+      int k = 0;
+      for (; k + 16 <= n; k += 16) {
+        simde__m256i a = simde_mm256_loadu_si256((const simde__m256i *)(src + k));
+        simde__m256i b = simde_mm256_loadu_si256((const simde__m256i *)(s_seq + k));
+        simde_mm256_storeu_si256((simde__m256i *)(llr_dest + k), simde_mm256_mullo_epi16(a, b));
+      }
+      for (; k < n; k++)
+        llr_dest[k] = src[k] * s_seq[k];
+      stop_meas(&rdata->ul_unscram);
     }
-    stop_meas(&rdata->ul_demap);
-    // unscrambling
-    start_meas(&rdata->ul_unscram);
-    int16_t *llr16 = (int16_t*)&rdata->llr[pusch_vars->llr_offset[symbol] * rel15_ul->nrOfLayers];
-    int16_t *s = rdata->scramblingSequence + pusch_vars->llr_offset[symbol] * rel15_ul->nrOfLayers;
-    const int end = nb_re_pusch * rel15_ul->qam_mod_order * rel15_ul->nrOfLayers;
-    int i = 0;
-    for (; (i + 8) <= end; i += 8) {
-      simde__m128i llr128 = simde_mm_loadu_si128((simde__m128i *)&llr_ptr[i]);
-      simde__m128i s128 = simde_mm_loadu_si128((simde__m128i *)&s[i]);
-      simde_mm_storeu_si128(llr16 + i, simde_mm_mullo_epi16(llr128, s128));
-    }
-    for (; i < end; i++)
-      llr16[i] = llr_ptr[i] * s[i];
-    stop_meas(&rdata->ul_unscram);
   }
 
   // Task running in // completed
@@ -438,26 +466,37 @@ static uint32_t average_u32(const uint32_t *x, uint16_t size)
   return (uint32_t)(sum_x / size);
 }
 
-int nr_rx_pusch_tp(PHY_VARS_gNB *gNB,
-                   NR_gNB_PUSCH *pusch_vars,
-                   const nfapi_nr_pusch_pdu_t *rel15_ul,
-                   uint32_t *ret_unav_res,
-                   uint32_t frame,
-                   uint8_t slot)
+int nr_rx_pusch_group_tp(PHY_VARS_gNB *gNB,
+                         NR_gNB_PUSCH **pusch_vars_group,
+                         const nfapi_nr_pusch_pdu_t **rel15_ul_group,
+                         uint32_t **ret_unav_res_group,
+                         uint8_t group_size,
+                         uint32_t frame,
+                         uint8_t slot)
 {
+  // This is a reference pdu since all the UEs in the group have same resource related parameters.
+  const nfapi_nr_pusch_pdu_t *rel15_ul_ref = rel15_ul_group[0];
   NR_DL_FRAME_PARMS *frame_parms = &gNB->frame_parms;
-  const nfapi_nr_spatial_stream_index_t *p = &rel15_ul->param_v4;
+  const nfapi_nr_spatial_stream_index_t *p = &rel15_ul_ref->param_v4;
   uint16_t ant_port_start = get_first_ant_idx(gNB->enable_analog_das,
                                               frame_parms->nb_antennas_tx / gNB->common_vars.num_beams_period,
-                                              rel15_ul->beamforming.prgs_list[0].dig_bf_interface_list[0].beam_idx,
+                                              rel15_ul_ref->beamforming.prgs_list[0].dig_bf_interface_list[0].beam_idx,
                                               p->numSpatialStreamIndices > 0 ? p->spatialStreamIndices[0] : 0);
 
-  uint32_t bwp_start_subcarrier = ((rel15_ul->rb_start + rel15_ul->bwp_start) * NR_NB_SC_PER_RB + frame_parms->first_carrier_offset) % frame_parms->ofdm_symbol_size;
-  LOG_D(PHY,"pusch %d.%d : bwp_start_subcarrier %d, rb_start %d, first_carrier_offset %d\n", frame,slot,bwp_start_subcarrier, rel15_ul->rb_start, frame_parms->first_carrier_offset);
-  LOG_D(PHY,"pusch %d.%d : ul_dmrs_symb_pos %x\n",frame,slot,rel15_ul->ul_dmrs_symb_pos);
+  uint32_t bwp_start_subcarrier =
+      ((rel15_ul_ref->rb_start + rel15_ul_ref->bwp_start) * NR_NB_SC_PER_RB + frame_parms->first_carrier_offset)
+      % frame_parms->ofdm_symbol_size;
+  LOG_D(PHY,
+        "pusch %d.%d : bwp_start_subcarrier %d, rb_start %d, first_carrier_offset %d\n",
+        frame,
+        slot,
+        bwp_start_subcarrier,
+        rel15_ul_ref->rb_start,
+        frame_parms->first_carrier_offset);
+  LOG_D(PHY, "pusch %d.%d : ul_dmrs_symb_pos %x\n", frame, slot, rel15_ul_ref->ul_dmrs_symb_pos);
 
   // Memories to store data for data recording
-  int buffer_length_slot = rel15_ul->rb_size * NR_NB_SC_PER_RB * 14; // 14 OFDM Symbols per slot
+  int buffer_length_slot = rel15_ul_ref->rb_size * NR_NB_SC_PER_RB * NR_SYMBOLS_PER_SLOT;
   // data recording application supports only a single layer.
   // nb_rx_ant (= frame_parms->nb_antennas_rx) is limited to 1 for data recording application.
   // int nb_layer (= rel15_ul->nrOfLayers) is limited to 1 for data recording application.
@@ -489,44 +528,92 @@ int nr_rx_pusch_tp(PHY_VARS_gNB *gNB,
     memset(rxFext_slot_mem, 0, sizeof(c16_t) * buffer_length_slot * 1 * 1);
 #endif
 
+  // Create a virtual multi layer pdu by accumulating the layers over UEs in the group and storing dmrs ports for joint processing
+  uint32_t combined_dmrs_ports = 0;
+  int total_layers = 0;
+  int layer_offset[group_size];
+  for (int u = 0; u < group_size; u++) {
+    const nfapi_nr_pusch_pdu_t *p = rel15_ul_group[u];
+    combined_dmrs_ports |= p->dmrs_ports;
+    layer_offset[u] = total_layers;
+    total_layers += rel15_ul_group[u]->nrOfLayers;
+  }
+  AssertFatal(total_layers <= NR_MAX_NB_LAYERS,
+              "MU-MIMO group total_layers=%d > NR_MAX_NB_LAYERS=%d\n",
+              total_layers,
+              NR_MAX_NB_LAYERS);
+
+  nfapi_nr_pusch_pdu_t joint_pdu = *rel15_ul_ref;
+  joint_pdu.nrOfLayers = total_layers;
+  joint_pdu.dmrs_ports = combined_dmrs_ports;
+
+  NR_gNB_PUSCH *joint_pv = pusch_vars_group[0];
+  LOG_D(PHY,
+        "%4u.%u MU-MIMO joint RX: %d UEs, %d total layers, rb_start=%u rb_size=%u qam=%u\n",
+        frame,
+        slot,
+        group_size,
+        total_layers,
+        rel15_ul_ref->rb_start,
+        rel15_ul_ref->rb_size,
+        rel15_ul_ref->qam_mod_order);
+
   //----------------------------------------------------------
   //------------------- Channel estimation -------------------
   //----------------------------------------------------------
   start_meas(&gNB->ulsch_channel_estimation_stats);
   int max_ch = 0;
   uint32_t nvar = 0;
-  int end_symbol = rel15_ul->start_symbol_index + rel15_ul->nr_of_symbols;
+  int end_symbol = rel15_ul_ref->start_symbol_index + rel15_ul_ref->nr_of_symbols;
   uint8_t dmrs_symb_idx = 0;
-  for (uint8_t symbol = rel15_ul->start_symbol_index; symbol < end_symbol; symbol++) {
-    uint8_t dmrs_symbol_flag = (rel15_ul->ul_dmrs_symb_pos >> symbol) & 0x01;
+  for (uint8_t symbol = rel15_ul_ref->start_symbol_index; symbol < end_symbol; symbol++) {
+    uint8_t dmrs_symbol_flag = (rel15_ul_ref->ul_dmrs_symb_pos >> symbol) & 0x01;
     LOG_D(PHY, "symbol %d, dmrs_symbol_flag :%d\n", symbol, dmrs_symbol_flag);
-
     if (dmrs_symbol_flag == 1) {
-      for (int nl = 0; nl < rel15_ul->nrOfLayers; nl++) {
-        uint32_t nvar_tmp = 0;
-        nr_pusch_channel_estimation(gNB,
-                                    slot,
-                                    nl,
-                                    get_dmrs_port(nl, rel15_ul->dmrs_ports),
-                                    dmrs_symb_idx,
-                                    symbol,
-                                    pusch_vars,
-                                    ant_port_start,
-                                    bwp_start_subcarrier,
-                                    rel15_ul,
-                                    &max_ch,
-                                    &nvar_tmp,
-                                    pusch_dmrs_slot_mem,
-                                    pusch_ch_est_dmrs_pos_slot_mem);
-        nvar += nvar_tmp;
+      for (int u = 0; u < group_size; u++) {
+        const nfapi_nr_pusch_pdu_t *p = rel15_ul_group[u];
+        for (int nl = 0; nl < p->nrOfLayers; nl++) {
+          int global_layer = layer_offset[u] + nl;
+          uint32_t nvar_tmp = 0;
+          nr_pusch_channel_estimation(gNB,
+                                      slot,
+                                      global_layer,
+                                      get_dmrs_port(nl, p->dmrs_ports),
+                                      dmrs_symb_idx,
+                                      symbol,
+                                      joint_pv,
+                                      ant_port_start,
+                                      bwp_start_subcarrier,
+                                      &joint_pdu,
+                                      &max_ch,
+                                      &nvar_tmp,
+                                      pusch_dmrs_slot_mem,
+                                      pusch_ch_est_dmrs_pos_slot_mem);
+          nvar += nvar_tmp;
+        }
       }
       dmrs_symb_idx++;
     }
   }
 
   if (dmrs_symb_idx > 0)
-    nvar /= (dmrs_symb_idx * rel15_ul->nrOfLayers);
+    nvar /= (dmrs_symb_idx * total_layers);
 
+  // averaging time domain channel estimates
+  // Change to joint processing
+  const uint8_t num_sp_streams = rel15_ul_ref->param_v4.numSpatialStreamIndices;
+  if (gNB->chest_time == 1)
+    nr_chest_time_domain_avg(frame_parms,
+                             joint_pv->ul_ch_estimates,
+                             rel15_ul_ref->nr_of_symbols,
+                             rel15_ul_ref->start_symbol_index,
+                             rel15_ul_ref->ul_dmrs_symb_pos, // change needed ?
+                             rel15_ul_ref->rb_size,
+                             total_layers,
+                             num_sp_streams);
+
+  // ULSCH signal and noise power measurements
+  // This is same for all the UEs in the group
   allocCast2D(n0_subband_power,
               unsigned int,
               gNB->measurements.n0_subband_power,
@@ -534,18 +621,17 @@ int nr_rx_pusch_tp(PHY_VARS_gNB *gNB,
               frame_parms->N_RB_UL,
               false);
 
-  const uint8_t num_sp_streams = rel15_ul->param_v4.numSpatialStreamIndices;
-  int start_sc = (rel15_ul->bwp_start + rel15_ul->rb_start) * NR_NB_SC_PER_RB;
+  int start_sc = (rel15_ul_ref->bwp_start + rel15_ul_ref->rb_start) * NR_NB_SC_PER_RB;
   int middle_sc = frame_parms->ofdm_symbol_size - frame_parms->first_carrier_offset;
-  int end_sc = (start_sc + rel15_ul->rb_size * NR_NB_SC_PER_RB - 1) % frame_parms->ofdm_symbol_size;
+  int end_sc = (start_sc + rel15_ul_ref->rb_size * NR_NB_SC_PER_RB - 1) % frame_parms->ofdm_symbol_size;
   for (int aa_pusch = 0; aa_pusch < num_sp_streams; aa_pusch++) {
     const int aarx = ant_port_start + aa_pusch;
-    DevAssert(aarx < sizeofArray(pusch_vars->ulsch_power));
-    pusch_vars->ulsch_power[aa_pusch] = 0;
-    pusch_vars->ulsch_noise_power[aa_pusch] = 0;
+    DevAssert(aarx < sizeofArray(joint_pv->ulsch_power));
+    joint_pv->ulsch_power[aa_pusch] = 0;
+    joint_pv->ulsch_noise_power[aa_pusch] = 0;
     int64_t symb_energy = 0;
 
-    for (uint8_t symbol = rel15_ul->start_symbol_index; symbol < end_symbol; symbol++) {
+    for (uint8_t symbol = rel15_ul_ref->start_symbol_index; symbol < end_symbol; symbol++) {
       int offset0 = ((slot % RU_RX_SLOT_DEPTH) * frame_parms->symbols_per_slot + symbol) * frame_parms->ofdm_symbol_size;
       int offset = offset0 + (frame_parms->first_carrier_offset + start_sc) % frame_parms->ofdm_symbol_size;
       c16_t *ul_ch = &gNB->common_vars.rxdataF[aarx][offset];
@@ -553,84 +639,81 @@ int nr_rx_pusch_tp(PHY_VARS_gNB *gNB,
         int64_t symb_energy_aux = signal_energy_nodc(ul_ch, middle_sc - start_sc) * (middle_sc - start_sc);
         ul_ch = &gNB->common_vars.rxdataF[aarx][offset0];
         symb_energy_aux += (signal_energy_nodc(ul_ch, end_sc + 1) * (end_sc + 1));
-        symb_energy += symb_energy_aux / (rel15_ul->rb_size * NR_NB_SC_PER_RB);
+        symb_energy += symb_energy_aux / (rel15_ul_ref->rb_size * NR_NB_SC_PER_RB);
       } else {
-        symb_energy += signal_energy_nodc(ul_ch, rel15_ul->rb_size * NR_NB_SC_PER_RB);
+        symb_energy += signal_energy_nodc(ul_ch, rel15_ul_ref->rb_size * NR_NB_SC_PER_RB);
       }
     }
-    pusch_vars->ulsch_power[aa_pusch] += (symb_energy / rel15_ul->nr_of_symbols);
+    joint_pv->ulsch_power[aa_pusch] += (symb_energy / rel15_ul_ref->nr_of_symbols);
 
-    pusch_vars->ulsch_noise_power[aa_pusch] +=
-        average_u32(&n0_subband_power[aarx][rel15_ul->bwp_start + rel15_ul->rb_start], rel15_ul->rb_size);
+    joint_pv->ulsch_noise_power[aa_pusch] +=
+        average_u32(&n0_subband_power[aarx][rel15_ul_ref->bwp_start + rel15_ul_ref->rb_start], rel15_ul_ref->rb_size);
 
-    LOG_D(PHY,
+    LOG_D(NR_PHY,
           "aa %d, bwp_start%d, rb_start %d, rb_size %d: ulsch_power %d, ulsch_noise_power %d\n",
           aarx,
-          rel15_ul->bwp_start,
-          rel15_ul->rb_start,
-          rel15_ul->rb_size,
-          pusch_vars->ulsch_power[aa_pusch],
-          pusch_vars->ulsch_noise_power[aa_pusch]);
+          rel15_ul_ref->bwp_start,
+          rel15_ul_ref->rb_start,
+          rel15_ul_ref->rb_size,
+          joint_pv->ulsch_power[aa_pusch],
+          joint_pv->ulsch_noise_power[aa_pusch]);
   }
-
-  // averaging time domain channel estimates
-  if (gNB->chest_time == 1)
-    nr_chest_time_domain_avg(frame_parms,
-                             pusch_vars->ul_ch_estimates,
-                             rel15_ul->nr_of_symbols,
-                             rel15_ul->start_symbol_index,
-                             rel15_ul->ul_dmrs_symb_pos,
-                             rel15_ul->rb_size,
-                             rel15_ul->nrOfLayers,
-                             num_sp_streams);
-
   stop_meas(&gNB->ulsch_channel_estimation_stats);
 
   start_meas(&gNB->rx_pusch_init_stats);
 
-  // Scrambling initialization
-  int number_dmrs_symbols = 0;
-  for (int l = rel15_ul->start_symbol_index; l < end_symbol; l++)
-    number_dmrs_symbols += ((rel15_ul->ul_dmrs_symb_pos)>>l) & 0x01;
-  int nb_re_dmrs;
-  if (rel15_ul->dmrs_config_type == pusch_dmrs_type1)
-    nb_re_dmrs = 6*rel15_ul->num_dmrs_cdm_grps_no_data;
-  else
-    nb_re_dmrs = 4*rel15_ul->num_dmrs_cdm_grps_no_data;
-
+  // Calculate number of unavailable resources due to PTRS
+  // This is assumed to be same for all the UEs (same PTRS configuration for all UEs)
   uint32_t unav_res = 0;
-  if (rel15_ul->pdu_bit_map & PUSCH_PDU_BITMAP_PUSCH_PTRS) {
+  if (rel15_ul_ref->pdu_bit_map & PUSCH_PDU_BITMAP_PUSCH_PTRS) {
     uint16_t ptrsSymbPos = 0;
     set_ptrs_symb_idx(&ptrsSymbPos,
-                      rel15_ul->nr_of_symbols,
-                      rel15_ul->start_symbol_index,
-                      1 << rel15_ul->pusch_ptrs.ptrs_time_density,
-                      rel15_ul->ul_dmrs_symb_pos);
-    int ptrsSymbPerSlot = get_ptrs_symbols_in_slot(ptrsSymbPos, rel15_ul->start_symbol_index, rel15_ul->nr_of_symbols);
-    int n_ptrs = (rel15_ul->rb_size + rel15_ul->pusch_ptrs.ptrs_freq_density - 1) / rel15_ul->pusch_ptrs.ptrs_freq_density;
+                      rel15_ul_ref->nr_of_symbols,
+                      rel15_ul_ref->start_symbol_index,
+                      1 << rel15_ul_ref->pusch_ptrs.ptrs_time_density,
+                      rel15_ul_ref->ul_dmrs_symb_pos);
+    int ptrsSymbPerSlot = get_ptrs_symbols_in_slot(ptrsSymbPos, rel15_ul_ref->start_symbol_index, rel15_ul_ref->nr_of_symbols);
+    int n_ptrs =
+        (rel15_ul_ref->rb_size + rel15_ul_ref->pusch_ptrs.ptrs_freq_density - 1) / rel15_ul_ref->pusch_ptrs.ptrs_freq_density;
     unav_res = n_ptrs * ptrsSymbPerSlot;
   }
 
-  // get how many bit in a slot //
-  int G = nr_get_G(rel15_ul->rb_size,
-                   rel15_ul->nr_of_symbols,
-                   nb_re_dmrs,
-                   number_dmrs_symbols, // number of dmrs symbols irrespective of single or double symbol dmrs
-                   unav_res,
-                   rel15_ul->qam_mod_order,
-                   rel15_ul->nrOfLayers);
-  *ret_unav_res = unav_res;
+  // Scrambling initialization
+  int number_dmrs_symbols =
+      count_bits64_with_mask(rel15_ul_ref->ul_dmrs_symb_pos, rel15_ul_ref->start_symbol_index, rel15_ul_ref->nr_of_symbols);
+  int factor = rel15_ul_ref->dmrs_config_type == pusch_dmrs_type1 ? 6 : 4;
+  int nb_re_dmrs = factor * rel15_ul_ref->num_dmrs_cdm_grps_no_data;
 
-  // initialize scrambling sequence //
-  int16_t scramblingSequence[G + 96] __attribute__((aligned(64)));
+  int max_G = 0;
+  for (int u = 0; u < group_size; u++) {
+    const nfapi_nr_pusch_pdu_t *p = rel15_ul_group[u];
+    int G_u = nr_get_G(p->rb_size, p->nr_of_symbols, nb_re_dmrs, number_dmrs_symbols, unav_res, p->qam_mod_order, p->nrOfLayers);
+    if (G_u > max_G)
+      max_G = G_u;
+  }
 
-  nr_codeword_unscrambling_init(scramblingSequence, G, 0, rel15_ul->data_scrambling_id, rel15_ul->rnti);
+  const uint64_t num_scrambling_bytes = group_size * (max_G + 96) * sizeof(int16_t);
+  AssertFatal(num_scrambling_bytes <= NR_MAX_PUSCH_SCRAMBLING_STACK_BYTES,
+              "scrambling_sequences stack buffer %" PRIu64 " bytes exceeds %d MB limit : group_size %d, max_G %d\n",
+              num_scrambling_bytes,
+              NR_MAX_PUSCH_SCRAMBLING_STACK_BYTES >> 20,
+              group_size,
+              max_G);
 
-  // first the computation of channel levels
+  int16_t scrambling_sequences[group_size][max_G + 96] __attribute__((aligned(32)));
+  int16_t *scrambling_sequences_arr[group_size];
 
+  for (int u = 0; u < group_size; u++) {
+    scrambling_sequences_arr[u] = scrambling_sequences[u];
+    const nfapi_nr_pusch_pdu_t *p = rel15_ul_group[u];
+    int G_u = nr_get_G(p->rb_size, p->nr_of_symbols, nb_re_dmrs, number_dmrs_symbols, unav_res, p->qam_mod_order, p->nrOfLayers);
+    nr_codeword_unscrambling_init(scrambling_sequences_arr[u], G_u, 0, p->data_scrambling_id, p->rnti);
+  }
+
+  // Computation of channel levels
   int nb_re_pusch = 0, meas_symbol = -1;
-  for(meas_symbol = rel15_ul->start_symbol_index; meas_symbol < end_symbol; meas_symbol++) 
-    if ((nb_re_pusch = get_nb_re_pusch(frame_parms, rel15_ul, meas_symbol)) > 0)
+  for (meas_symbol = rel15_ul_ref->start_symbol_index; meas_symbol < end_symbol; meas_symbol++)
+    if ((nb_re_pusch = get_nb_re_pusch(frame_parms, &joint_pdu, meas_symbol)) > 0)
       break;
 
   AssertFatal(nb_re_pusch > 0 && meas_symbol >= 0,
@@ -645,80 +728,81 @@ int nr_rx_pusch_tp(PHY_VARS_gNB *gNB,
   nb_re_pusch = ceil_mod(nb_re_pusch, 16);
   int dmrs_symbol;
   if (gNB->chest_time == 0)
-    dmrs_symbol = get_valid_dmrs_idx_for_channel_est(rel15_ul->ul_dmrs_symb_pos, meas_symbol);
+    dmrs_symbol = get_valid_dmrs_idx_for_channel_est(rel15_ul_ref->ul_dmrs_symb_pos, meas_symbol);
   else // average of channel estimates stored in first symbol
-    dmrs_symbol = get_next_dmrs_symbol_in_slot(rel15_ul->ul_dmrs_symb_pos, rel15_ul->start_symbol_index, end_symbol);
+    dmrs_symbol = get_next_dmrs_symbol_in_slot(rel15_ul_ref->ul_dmrs_symb_pos, rel15_ul_ref->start_symbol_index, end_symbol);
   int size_est = nb_re_pusch * frame_parms->symbols_per_slot;
-  __attribute__((aligned(32))) int ul_ch_estimates_ext[rel15_ul->nrOfLayers * num_sp_streams][size_est];
+  __attribute__((aligned(32))) int ul_ch_estimates_ext[total_layers * num_sp_streams][size_est];
   memset(ul_ch_estimates_ext, 0, sizeof(ul_ch_estimates_ext));
-  int buffer_length = rel15_ul->rb_size * NR_NB_SC_PER_RB;
+  int buffer_length = rel15_ul_ref->rb_size * NR_NB_SC_PER_RB;
   c16_t temp_rxFext[num_sp_streams][buffer_length] __attribute__((aligned(32)));
   for (int aarx = 0; aarx < num_sp_streams; aarx++)
-    for (int nl = 0; nl < rel15_ul->nrOfLayers; nl++) {
+    for (int nl = 0; nl < total_layers; nl++) {
       start_meas(&gNB->pusch_extraction_stats);
       nr_ulsch_extract_rbs(gNB->common_vars.rxdataF[ant_port_start + aarx],
-                           (c16_t *)pusch_vars->ul_ch_estimates[nl * num_sp_streams + aarx],
+                           (c16_t *)joint_pv->ul_ch_estimates[nl * num_sp_streams + aarx],
                            temp_rxFext[aarx],
                            (c16_t *)&ul_ch_estimates_ext[nl * num_sp_streams + aarx][meas_symbol * nb_re_pusch],
                            soffset + meas_symbol * frame_parms->ofdm_symbol_size,
                            dmrs_symbol * frame_parms->ofdm_symbol_size,
-                           (rel15_ul->ul_dmrs_symb_pos >> meas_symbol) & 0x01, 
-                           rel15_ul,
+                           (rel15_ul_ref->ul_dmrs_symb_pos >> meas_symbol) & 0x01,
+                           &joint_pdu,
                            frame_parms);
       stop_meas(&gNB->pusch_extraction_stats);
     }
 
-  uint8_t shift_ch_ext = rel15_ul->nrOfLayers > 1 ? log2_approx(max_ch >> 11) : 0;
+  uint8_t shift_ch_ext = total_layers > 1 ? log2_approx(max_ch >> 11) : 0;
 
   //----------------------------------------------------------
   //--------------------- Channel Scaling --------------------
   //----------------------------------------------------------
-  nr_scale_channel(size_est, ul_ch_estimates_ext, meas_symbol, nb_re_pusch, rel15_ul->nrOfLayers, num_sp_streams, shift_ch_ext);
+  nr_scale_channel(size_est, ul_ch_estimates_ext, meas_symbol, nb_re_pusch, total_layers, num_sp_streams, shift_ch_ext);
 
-  int avg[num_sp_streams * rel15_ul->nrOfLayers];
-  nr_channel_level(meas_symbol,
-                   size_est,
-                   (c16_t(*)[size_est])ul_ch_estimates_ext,
-                   num_sp_streams,
-                   rel15_ul->nrOfLayers,
-                   avg,
-                   nb_re_pusch);
+  int avg[num_sp_streams * total_layers];
+  nr_channel_level(meas_symbol, size_est, (c16_t(*)[size_est])ul_ch_estimates_ext, num_sp_streams, total_layers, avg, nb_re_pusch);
 
   int avgs = 0;
-  for (int nl = 0; nl < rel15_ul->nrOfLayers; nl++)
+  for (int nl = 0; nl < total_layers; nl++)
     for (int aarx = 0; aarx < num_sp_streams; aarx++)
       avgs = cmax(avgs, avg[nl * num_sp_streams + aarx]);
 
-  if (rel15_ul->nrOfLayers == 2 && rel15_ul->qam_mod_order > 6)
-    pusch_vars->log2_maxh = (log2_approx(avgs) >> 1) - 3; // for MMSE
-  else if (rel15_ul->nrOfLayers == 2)
-    pusch_vars->log2_maxh = (log2_approx(avgs) >> 1) - 2 + log2_approx(num_sp_streams >> 1);
+  if (total_layers == 2 && rel15_ul_ref->qam_mod_order > 6)
+    joint_pv->log2_maxh = (log2_approx(avgs) >> 1) - 3; // for MMSE
+  else if (total_layers == 2)
+    joint_pv->log2_maxh = (log2_approx(avgs) >> 1) - 2 + log2_approx(num_sp_streams >> 1);
   else
-    pusch_vars->log2_maxh = (log2_approx(avgs) >> 1) + 1 + log2_approx(num_sp_streams >> 1);
+    joint_pv->log2_maxh = (log2_approx(avgs) >> 1) + 1 + log2_approx(num_sp_streams >> 1);
 
-  if (pusch_vars->log2_maxh < 0)
-    pusch_vars->log2_maxh = 0;
+  if (joint_pv->log2_maxh < 0)
+    joint_pv->log2_maxh = 0;
 
   stop_meas(&gNB->rx_pusch_init_stats);
 
   start_meas(&gNB->rx_pusch_symbol_processing_stats);
   int numSymbols = gNB->num_pusch_symbols_per_thread;
   int total_res = 0;
-  int const loop_iter = CEILIDIV(rel15_ul->nr_of_symbols, numSymbols);
+  int const loop_iter = CEILIDIV(rel15_ul_ref->nr_of_symbols, numSymbols);
   puschSymbolProc_t arr[loop_iter];
   task_ans_t ans;
   init_task_ans(&ans, loop_iter);
 
   int sz_arr = 0;
-  for(uint8_t task_index = 0; task_index < loop_iter; task_index++) {
-    int symbol = task_index * numSymbols + rel15_ul->start_symbol_index;
+  for (uint8_t task_index = 0; task_index < loop_iter; task_index++) {
+    int symbol = task_index * numSymbols + rel15_ul_ref->start_symbol_index;
     int res_per_task = 0;
     for (int s = 0; s < numSymbols && s + symbol < end_symbol; s++) {
-      pusch_vars->ul_valid_re_per_slot[symbol+s] = get_nb_re_pusch(frame_parms,rel15_ul,symbol+s);
-      pusch_vars->llr_offset[symbol+s] = ((symbol+s) == rel15_ul->start_symbol_index) ? 
-                                         0 : 
-                                         pusch_vars->llr_offset[symbol+s-1] + pusch_vars->ul_valid_re_per_slot[symbol+s-1] * rel15_ul->qam_mod_order;
-      res_per_task += pusch_vars->ul_valid_re_per_slot[symbol + s];
+      int curr_sym = symbol + s;
+      joint_pv->ul_valid_re_per_slot[curr_sym] = get_nb_re_pusch(frame_parms, &joint_pdu, curr_sym);
+      if (curr_sym == rel15_ul_ref->start_symbol_index) {
+        joint_pv->llr_offset[curr_sym] = 0;
+      } else {
+        int prev_sym = curr_sym - 1;
+        int prev_offset = joint_pv->llr_offset[prev_sym];
+        int prev_re = joint_pv->ul_valid_re_per_slot[prev_sym];
+        int mod_order = rel15_ul_ref->qam_mod_order;
+        joint_pv->llr_offset[curr_sym] = prev_offset + (prev_re * mod_order);
+      }
+      res_per_task += joint_pv->ul_valid_re_per_slot[curr_sym];
     }
     total_res += res_per_task;
     if (res_per_task > 0) {
@@ -728,14 +812,13 @@ int nr_rx_pusch_tp(PHY_VARS_gNB *gNB,
 
       rdata->gNB = gNB;
       rdata->frame_parms = frame_parms;
-      rdata->rel15_ul = rel15_ul;
+      rdata->rel15_ul = &joint_pdu;
       rdata->slot = slot;
       rdata->startSymbol = symbol;
       // Last task processes remainder symbols
-      rdata->numSymbols = task_index == loop_iter - 1 ? rel15_ul->nr_of_symbols - (loop_iter - 1) * numSymbols : numSymbols;
-      rdata->pusch_vars = pusch_vars;
-      rdata->llr = pusch_vars->llr;
-      rdata->scramblingSequence = scramblingSequence;
+      rdata->numSymbols = task_index == loop_iter - 1 ? rel15_ul_ref->nr_of_symbols - (loop_iter - 1) * numSymbols : numSymbols;
+      rdata->pusch_vars = joint_pv;
+      rdata->llr = joint_pv->llr;
       rdata->nvar = nvar;
       rdata->ant_port_start = ant_port_start;
       rdata->rxFext_slot_mem = rxFext_slot_mem;
@@ -745,8 +828,13 @@ int nr_rx_pusch_tp(PHY_VARS_gNB *gNB,
       reset_meas(&rdata->ulsch_llr);
       reset_meas(&rdata->ul_demap);
       reset_meas(&rdata->ul_unscram);
+      rdata->group_size = group_size;
+      rdata->rel15_ul_group = rel15_ul_group;
+      rdata->pusch_vars_group = pusch_vars_group;
+      rdata->scrambling_sequences = scrambling_sequences_arr;
+      rdata->layer_offsets = layer_offset;
 
-      if (rel15_ul->pdu_bit_map & PUSCH_PDU_BITMAP_PUSCH_PTRS) {
+      if (rel15_ul_ref->pdu_bit_map & PUSCH_PDU_BITMAP_PUSCH_PTRS) {
         nr_pusch_symbol_processing(rdata);
       } else {
         task_t t = {.func = &nr_pusch_symbol_processing, .args = rdata};
@@ -760,36 +848,44 @@ int nr_rx_pusch_tp(PHY_VARS_gNB *gNB,
   } // symbol loop
 
 #if T_TRACER
-  int dmrs_port = get_dmrs_port(0, rel15_ul->dmrs_ports);
+  int dmrs_port = get_dmrs_port(0, rel15_ul_ref->dmrs_ports);
 
-  log_ul_fd_dmrs(frame, slot, frame_parms, rel15_ul,
-                 number_dmrs_symbols, dmrs_port,
+  log_ul_fd_dmrs(frame,
+                 slot,
+                 frame_parms,
+                 rel15_ul_ref,
+                 number_dmrs_symbols,
+                 dmrs_port,
                  (const c16_t *)(&(pusch_dmrs_slot_mem[0])),
-                 rel15_ul->rb_size * NR_NB_SC_PER_RB * rel15_ul->nr_of_symbols * 4);
+                 rel15_ul_ref->rb_size * NR_NB_SC_PER_RB * rel15_ul_ref->nr_of_symbols * 4);
 
-  log_ul_fd_chan_est_dmrs_pos(frame, slot, frame_parms, rel15_ul,
-                              number_dmrs_symbols, dmrs_port,
+  log_ul_fd_chan_est_dmrs_pos(frame,
+                              slot,
+                              frame_parms,
+                              rel15_ul_ref,
+                              number_dmrs_symbols,
+                              dmrs_port,
                               (const c16_t *)(&(pusch_ch_est_dmrs_pos_slot_mem[0])),
-                              rel15_ul->rb_size * NR_NB_SC_PER_RB * rel15_ul->nr_of_symbols * 4);
+                              rel15_ul_ref->rb_size * NR_NB_SC_PER_RB * rel15_ul_ref->nr_of_symbols * 4);
 
   log_ul_fd_pusch_iq(frame,
                      slot,
                      frame_parms,
-                     rel15_ul,
+                     rel15_ul_ref,
                      number_dmrs_symbols,
                      dmrs_port,
                      (const c16_t *)(&(rxFext_slot_mem[0])),
-                     rel15_ul->rb_size * NR_NB_SC_PER_RB * rel15_ul->nr_of_symbols * num_sp_streams * 4);
+                     rel15_ul_ref->rb_size * NR_NB_SC_PER_RB * rel15_ul_ref->nr_of_symbols * num_sp_streams * 4);
 
   log_ul_fd_chan_est_dmrs_interpl(
       frame,
       slot,
       frame_parms,
-      rel15_ul,
+      rel15_ul_ref,
       number_dmrs_symbols,
       dmrs_port,
       (const c16_t *)pusch_ch_est_dmrs_interpl_slot_mem,
-      rel15_ul->rb_size * NR_NB_SC_PER_RB * rel15_ul->nr_of_symbols * num_sp_streams * rel15_ul->nrOfLayers * 4);
+      rel15_ul_ref->rb_size * NR_NB_SC_PER_RB * rel15_ul_ref->nr_of_symbols * num_sp_streams * total_layers * 4);
 #endif
 
   join_task_ans(&ans);
@@ -802,27 +898,42 @@ int nr_rx_pusch_tp(PHY_VARS_gNB *gNB,
     merge_meas(&gNB->ulsch_layer_demapping_stats, &rdata->ul_demap);
     merge_meas(&gNB->ulsch_unscrambling_stats, &rdata->ul_unscram);
   }
+  for (int u = 0; u < group_size; u++) {
+    NR_gNB_PUSCH *pv = pusch_vars_group[u];
+    // Copy unavailable resources per UE
+    *ret_unav_res_group[u] = unav_res;
+    // Copy power measurements per UE
+    pv->ulsch_power_tot = 0;
+    pv->ulsch_noise_power_tot = 0;
+    for (int aarx = 0; aarx < num_sp_streams; aarx++) {
+      pv->ulsch_power[aarx] = joint_pv->ulsch_power[aarx];
+      pv->ulsch_noise_power[aarx] = joint_pv->ulsch_noise_power[aarx];
+      pv->ulsch_power_tot += pv->ulsch_power[aarx];
+      pv->ulsch_noise_power_tot += pv->ulsch_noise_power[aarx];
+    }
+  }
   stop_meas(&gNB->rx_pusch_symbol_processing_stats);
 
   // Copy the data to the scope. This cannot be performed in one call to gNBscopeCopy because the data is not contiguous in the
   // buffer due to reference symbol extraction and padding. The gNBscopeCopy call is broken up into steps: trylock, copy, unlock.
   metadata mt = {.slot = slot, .frame = frame};
   if (gNBTryLockScopeData(gNB, gNBPuschRxIq, sizeof(c16_t), 1, total_res, &mt)) {
-    int buffer_length = ceil_mod(rel15_ul->rb_size * NR_NB_SC_PER_RB, 16);
+    int buffer_length = ceil_mod(rel15_ul_ref->rb_size * NR_NB_SC_PER_RB, 16);
     size_t offset = 0;
-    for (uint8_t symbol = rel15_ul->start_symbol_index; symbol < (rel15_ul->start_symbol_index + rel15_ul->nr_of_symbols);
+    for (uint8_t symbol = rel15_ul_ref->start_symbol_index;
+         symbol < (rel15_ul_ref->start_symbol_index + rel15_ul_ref->nr_of_symbols);
          symbol++) {
       gNBscopeCopyUnsafe(gNB,
                          gNBPuschRxIq,
-                         &pusch_vars->rxdataF_comp[0][symbol * buffer_length],
-                         sizeof(c16_t) * pusch_vars->ul_valid_re_per_slot[symbol],
+                         &pusch_vars_group[0]->rxdataF_comp[0][symbol * buffer_length],
+                         sizeof(c16_t) * pusch_vars_group[0]->ul_valid_re_per_slot[symbol],
                          offset,
-                         symbol - rel15_ul->start_symbol_index);
-      offset += sizeof(c16_t) * pusch_vars->ul_valid_re_per_slot[symbol];
+                         symbol - rel15_ul_ref->start_symbol_index);
+      offset += sizeof(c16_t) * pusch_vars_group[0]->ul_valid_re_per_slot[symbol];
     }
     gNBunlockScopeData(gNB, gNBPuschRxIq)
   }
-  uint32_t total_llrs = total_res * rel15_ul->qam_mod_order * rel15_ul->nrOfLayers;
-  gNBscopeCopyWithMetadata(gNB, gNBPuschLlr, pusch_vars->llr, sizeof(c16_t), 1, total_llrs, 0, &mt);
+  uint32_t total_llrs = total_res * rel15_ul_ref->qam_mod_order * rel15_ul_ref->nrOfLayers;
+  gNBscopeCopyWithMetadata(gNB, gNBPuschLlr, pusch_vars_group[0]->llr, sizeof(c16_t), 1, total_llrs, 0, &mt);
   return 0;
 }

--- a/openair1/PHY/defs_gNB.h
+++ b/openair1/PHY/defs_gNB.h
@@ -181,6 +181,11 @@ typedef struct {
   uint32_t slot;
   /// ULSCH PDU
   nfapi_nr_pusch_pdu_t pusch_pdu;
+  // Multi-User (MU) group index
+  // -1 : unallocated
+  int16_t mu_group_idx;
+  // 1 for Single-User (SU) and > 1 is MU
+  uint8_t mu_group_size;
 } NR_gNB_PUSCH_job_t;
 
 typedef struct {

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -2924,7 +2924,7 @@ uint8_t nr_mmse_2layers(c16_t **rxdataF_comp,
 
   // Add noise_var such that: H^h * H + noise_var * I
   if (noise_var != 0) {
-    simde__m128i nvar_128i = simde_mm_set1_epi32(noise_var);
+    simde__m128i nvar_128i = simde_mm_set1_epi32(noise_var >> shift);
     simde__m128i *af_mf_00_128i = (simde__m128i *)af_mf_00;
     simde__m128i *af_mf_11_128i = (simde__m128i *)af_mf_11;
     for (int k = 0; k < 3 * nb_rb_0; k++) {

--- a/openair1/SCHED_NR/phy_procedures_nr_gNB.c
+++ b/openair1/SCHED_NR/phy_procedures_nr_gNB.c
@@ -958,6 +958,38 @@ static void handle_pucch(PHY_VARS_gNB *gNB, c16_t **rxdataF, const NR_gNB_PUCCH_
   }
 }
 
+#ifdef DEBUG_RXDATA
+static void dump_pusch_rx_data(PHY_VARS_gNB *gNB, NR_gNB_ULSCH_t *ulsch, const nfapi_nr_pusch_pdu_t *pdu)
+{
+  NR_DL_FRAME_PARMS *frame_parms = &gNB->frame_parms;
+  RU_t *ru = gNB->RU_list[0];
+  int slot_offset = get_samples_slot_timestamp(frame_parms, ulsch->slot);
+  slot_offset -= ru->N_TA_offset;
+  int32_t sample_offset = gNB->common_vars.debugBuff_sample_offset;
+  int16_t *buf = (int16_t *)&gNB->common_vars.debugBuff[sample_offset];
+  buf[0] = (int16_t)ulsch->rnti;
+  buf[1] = (int16_t)pdu->rb_size;
+  buf[2] = (int16_t)pdu->rb_start;
+  buf[3] = (int16_t)pdu->nr_of_symbols;
+  buf[4] = (int16_t)pdu->start_symbol_index;
+  buf[5] = (int16_t)pdu->mcs_index;
+  buf[6] = (int16_t)pdu->pusch_data.rv_index;
+  buf[7] = (int16_t)ulsch->harq_pid;
+  memcpy(&gNB->common_vars.debugBuff[gNB->common_vars.debugBuff_sample_offset + 4],
+         &ru->common.rxdata[0][slot_offset],
+         get_samples_per_slot(ulsch->slot, frame_parms) * sizeof(int32_t));
+  gNB->common_vars.debugBuff_sample_offset += (get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 4);
+  if (gNB->common_vars.debugBuff_sample_offset > ((get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 2) * 20)) {
+    FILE *f = fopen("rxdata_buff.raw", "w");
+    if (f == NULL)
+      exit(1);
+    fwrite((int16_t *)gNB->common_vars.debugBuff, 2, (get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 4) * 20 * 2, f);
+    fclose(f);
+    exit(-1);
+  }
+}
+#endif
+
 static void handle_pusch_rx_group_trigger(PHY_VARS_gNB *gNB,
                                           NR_gNB_PUSCH **pusch_vars_group,
                                           NR_gNB_ULSCH_t **ulsch_group,
@@ -971,36 +1003,7 @@ static void handle_pusch_rx_group_trigger(PHY_VARS_gNB *gNB,
     const nfapi_nr_pusch_pdu_t *pdu = &ulsch_harq->ulsch_pdu;
 
 #ifdef DEBUG_RXDATA
-    RU_t *ru = gNB->RU_list[0];
-    int slot_offset = frame_parms->get_samples_slot_timestamp(ulsch->slot, frame_parms, 0);
-    slot_offset -= ru->N_TA_offset;
-    int32_t sample_offset = gNB->common_vars.debugBuff_sample_offset;
-    int16_t buf = (int16_t *)&gNB->common_vars.debugBuff[offset];
-    buf[0] = (int16_t)ulsch->rnti;
-    buf[1] = (int16_t)pdu->rb_size;
-    buf[2] = (int16_t)pdu->rb_start;
-    buf[3] = (int16_t)pdu->nr_of_symbols;
-    buf[4] = (int16_t)pdu->start_symbol_index;
-    buf[5] = (int16_t)pdu->mcs_index;
-    buf[6] = (int16_t)pdu->pusch_data.rv_index;
-    buf[7] = (int16_t)ulsch->harq_pid;
-    memcpy(&gNB->common_vars.debugBuff[gNB->common_vars.debugBuff_sample_offset + 4],
-           &ru->common.rxdata[0][slot_offset],
-           frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) * sizeof(int32_t));
-    gNB->common_vars.debugBuff_sample_offset += (frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 4);
-    if (gNB->common_vars.debugBuff_sample_offset
-        > ((frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 2) * 20)) {
-      FILE *f;
-      f = fopen("rxdata_buff.raw", "w");
-      if (f == NULL)
-        exit(1);
-      fwrite((int16_t *)gNB->common_vars.debugBuff,
-             2,
-             (frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 4) * 20 * 2,
-             f);
-      fclose(f);
-      exit(-1);
-    }
+    dump_pusch_rx_data(gNB, ulsch, pdu);
 #endif
 
     start_meas(&gNB->rx_pusch_stats);

--- a/openair1/SCHED_NR/phy_procedures_nr_gNB.c
+++ b/openair1/SCHED_NR/phy_procedures_nr_gNB.c
@@ -28,6 +28,13 @@
 //#define DEBUG_RXDATA
 //#define SRS_IND_DEBUG
 
+typedef struct {
+  int jobs[MAX_UL_PDUS_PER_SLOT][MAX_UL_PDUS_PER_SLOT];
+  uint8_t size[MAX_UL_PDUS_PER_SLOT];
+  int16_t active_groups[MAX_UL_PDUS_PER_SLOT];
+  int n_active_groups;
+} NR_MU_MIMO_job_groups_t;
+
 static void nr_fill_indication(const PHY_VARS_gNB *gNB,
                                int frame,
                                int slot_rx,
@@ -951,54 +958,62 @@ static void handle_pucch(PHY_VARS_gNB *gNB, c16_t **rxdataF, const NR_gNB_PUCCH_
   }
 }
 
-static void handle_pusch_rx_trigger(PHY_VARS_gNB *gNB, NR_gNB_PUSCH *pusch_vars, NR_gNB_ULSCH_t *ulsch)
+static void handle_pusch_rx_group_trigger(PHY_VARS_gNB *gNB,
+                                          NR_gNB_PUSCH **pusch_vars_group,
+                                          NR_gNB_ULSCH_t **ulsch_group,
+                                          int group_size)
 {
-  NR_UL_gNB_HARQ_t *ulsch_harq = ulsch->harq_process;
-  AssertFatal(ulsch_harq != NULL, "harq_pid %d is not allocated\n", ulsch->harq_pid);
-  const nfapi_nr_pusch_pdu_t *pdu = &ulsch_harq->ulsch_pdu;
+  for (int u = 0; u < group_size; u++) {
+    NR_gNB_PUSCH *pusch_vars = pusch_vars_group[u];
+    NR_gNB_ULSCH_t *ulsch = ulsch_group[u];
+    NR_UL_gNB_HARQ_t *ulsch_harq = ulsch->harq_process;
+    AssertFatal(ulsch_harq != NULL, "harq_pid %d is not allocated\n", ulsch->harq_pid);
+    const nfapi_nr_pusch_pdu_t *pdu = &ulsch_harq->ulsch_pdu;
 
 #ifdef DEBUG_RXDATA
-  RU_t *ru = gNB->RU_list[0];
-  int slot_offset = frame_parms->get_samples_slot_timestamp(ulsch->slot, frame_parms, 0);
-  slot_offset -= ru->N_TA_offset;
-  int32_t sample_offset = gNB->common_vars.debugBuff_sample_offset;
-  int16_t buf = (int16_t *)&gNB->common_vars.debugBuff[offset];
-  buf[0] = (int16_t)ulsch->rnti;
-  buf[1] = (int16_t)pdu->rb_size;
-  buf[2] = (int16_t)pdu->rb_start;
-  buf[3] = (int16_t)pdu->nr_of_symbols;
-  buf[4] = (int16_t)pdu->start_symbol_index;
-  buf[5] = (int16_t)pdu->mcs_index;
-  buf[6] = (int16_t)pdu->pusch_data.rv_index;
-  buf[7] = (int16_t)ulsch->harq_pid;
-  memcpy(&gNB->common_vars.debugBuff[gNB->common_vars.debugBuff_sample_offset + 4],
-         &ru->common.rxdata[0][slot_offset],
-         frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) * sizeof(int32_t));
-  gNB->common_vars.debugBuff_sample_offset += (frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 4);
-  if (gNB->common_vars.debugBuff_sample_offset > ((frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 2) * 20)) {
-    FILE *f;
-    f = fopen("rxdata_buff.raw", "w");
-    if (f == NULL)
-      exit(1);
-    fwrite((int16_t *)gNB->common_vars.debugBuff,
-           2,
-           (frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 4) * 20 * 2,
-           f);
-    fclose(f);
-    exit(-1);
-  }
+    RU_t *ru = gNB->RU_list[0];
+    int slot_offset = frame_parms->get_samples_slot_timestamp(ulsch->slot, frame_parms, 0);
+    slot_offset -= ru->N_TA_offset;
+    int32_t sample_offset = gNB->common_vars.debugBuff_sample_offset;
+    int16_t buf = (int16_t *)&gNB->common_vars.debugBuff[offset];
+    buf[0] = (int16_t)ulsch->rnti;
+    buf[1] = (int16_t)pdu->rb_size;
+    buf[2] = (int16_t)pdu->rb_start;
+    buf[3] = (int16_t)pdu->nr_of_symbols;
+    buf[4] = (int16_t)pdu->start_symbol_index;
+    buf[5] = (int16_t)pdu->mcs_index;
+    buf[6] = (int16_t)pdu->pusch_data.rv_index;
+    buf[7] = (int16_t)ulsch->harq_pid;
+    memcpy(&gNB->common_vars.debugBuff[gNB->common_vars.debugBuff_sample_offset + 4],
+           &ru->common.rxdata[0][slot_offset],
+           frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) * sizeof(int32_t));
+    gNB->common_vars.debugBuff_sample_offset += (frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 4);
+    if (gNB->common_vars.debugBuff_sample_offset
+        > ((frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 2) * 20)) {
+      FILE *f;
+      f = fopen("rxdata_buff.raw", "w");
+      if (f == NULL)
+        exit(1);
+      fwrite((int16_t *)gNB->common_vars.debugBuff,
+             2,
+             (frame_parms->get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 4) * 20 * 2,
+             f);
+      fclose(f);
+      exit(-1);
+    }
 #endif
 
-  start_meas(&gNB->rx_pusch_stats);
-  nr_rx_pusch_tp(gNB, pusch_vars, pdu, &ulsch->unav_res, ulsch->frame, ulsch->slot);
-  pusch_vars->ulsch_power_tot = 0;
-  pusch_vars->ulsch_noise_power_tot = 0;
-  const uint8_t num_sp_streams = pdu->param_v4.numSpatialStreamIndices;
-  for (int aarx = 0; aarx < num_sp_streams; aarx++) {
-    pusch_vars->ulsch_power_tot += pusch_vars->ulsch_power[aarx];
-    pusch_vars->ulsch_noise_power_tot += pusch_vars->ulsch_noise_power[aarx];
+    start_meas(&gNB->rx_pusch_stats);
+    nr_rx_pusch_tp(gNB, pusch_vars, pdu, &ulsch->unav_res, ulsch->frame, ulsch->slot);
+    pusch_vars->ulsch_power_tot = 0;
+    pusch_vars->ulsch_noise_power_tot = 0;
+    const uint8_t num_sp_streams = pdu->param_v4.numSpatialStreamIndices;
+    for (int aarx = 0; aarx < num_sp_streams; aarx++) {
+      pusch_vars->ulsch_power_tot += pusch_vars->ulsch_power[aarx];
+      pusch_vars->ulsch_noise_power_tot += pusch_vars->ulsch_noise_power[aarx];
+    }
+    stop_meas(&gNB->rx_pusch_stats);
   }
-  stop_meas(&gNB->rx_pusch_stats);
 }
 
 static bool pusch_signal_detected(PHY_VARS_gNB *gNB, NR_gNB_PUSCH *pusch_vars, NR_gNB_ULSCH_t *ulsch)
@@ -1130,6 +1145,24 @@ static int handle_pusch_job_trigger(PHY_VARS_gNB *gNB, const NR_gNB_PUSCH_job_t 
   return ULSCH_id;
 }
 
+static NR_MU_MIMO_job_groups_t group_pusch_jobs(PHY_VARS_gNB *gNB, NR_gNB_PUSCH_job_t *pusch, int n_pusch_jobs)
+{
+  NR_MU_MIMO_job_groups_t groups = {0};
+  for (int i = 0; i < n_pusch_jobs; ++i) {
+    int ULSCH_id = handle_pusch_job_trigger(gNB, &pusch[i]);
+    if (ULSCH_id < 0) {
+      continue;
+    }
+    int g = pusch[i].mu_group_idx;
+    AssertFatal(g >= 0, "Ungrouped ULSCH_id %d\n", ULSCH_id);
+    if (groups.size[g] == 0) {
+      groups.active_groups[groups.n_active_groups++] = g;
+    }
+    groups.jobs[g][groups.size[g]++] = ULSCH_id;
+  }
+  return groups;
+}
+
 int phy_procedures_gNB_uespec_RX(PHY_VARS_gNB *gNB, int frame_rx, int slot_rx, NR_UL_IND_t *UL_INFO)
 {
   /* those variables to log T_GNB_PHY_PUCCH_PUSCH_IQ only when we try to decode */
@@ -1198,25 +1231,43 @@ int phy_procedures_gNB_uespec_RX(PHY_VARS_gNB *gNB, int frame_rx, int slot_rx, N
   UL_INFO->rx_ind.pdu_list = UL_INFO->rx_pdu_list;
   int ulsch_idx_to_decode[MAX_UL_PDUS_PER_SLOT];
   int num_pusch = 0;
-  for (int i = 0; i < n_pusch_jobs; ++i) {
-    int ULSCH_id = handle_pusch_job_trigger(gNB, &pusch[i]);
-    if (ULSCH_id < 0)
-      continue;
-    NR_gNB_PUSCH *pusch_vars = &gNB->pusch_vars[ULSCH_id];
-    NR_gNB_ULSCH_t *ulsch = &gNB->ulsch[ULSCH_id];
-    handle_pusch_rx_trigger(gNB, pusch_vars, ulsch);
 
-    if (pusch_signal_detected(gNB, pusch_vars, ulsch) || get_softmodem_params()->phy_test) {
-      ulsch_idx_to_decode[num_pusch++] = ULSCH_id;
-    } else {
-      AssertFatal(ulsch->harq_process != NULL, "harq_pid %d is not allocated\n", ulsch->harq_pid);
-      const nfapi_nr_pusch_pdu_t *pdu = &ulsch->harq_process->ulsch_pdu;
-      NR_gNB_PHY_STATS_t *stats = get_phy_stats(gNB, ulsch->rnti);
-      nfapi_nr_crc_t *crc = &UL_INFO->crc_ind.crc_list[UL_INFO->crc_ind.number_crcs++];
-      nfapi_nr_rx_data_pdu_t *rx = &UL_INFO->rx_ind.pdu_list[UL_INFO->rx_ind.number_of_pdus++];
-      nr_fill_indication(gNB, ulsch->frame, ulsch->slot, pusch_vars, pdu, stats, NULL, 1, crc, rx);
-      pusch_DTX++;
-      gNBdumpScopeData(gNB, ulsch->slot, ulsch->frame, "ULSCH_DTX");
+  // Group the jobs using group index
+  NR_MU_MIMO_job_groups_t pusch_groups = group_pusch_jobs(gNB, pusch, n_pusch_jobs);
+
+  for (int i = 0; i < pusch_groups.n_active_groups; i++) {
+    int g = pusch_groups.active_groups[i];
+    int gsz = pusch_groups.size[g];
+    AssertFatal(gsz == 1, "Cannot handle group size > 1\n");
+
+    NR_gNB_PUSCH *pusch_vars_group[gsz];
+    NR_gNB_ULSCH_t *ulsch_group[gsz];
+    // store pusch vars and ulsch pdu for group based processing
+    for (int u = 0; u < gsz; u++) {
+      int ulsch_id = pusch_groups.jobs[g][u];
+      pusch_vars_group[u] = &gNB->pusch_vars[ulsch_id];
+      ulsch_group[u] = &gNB->ulsch[ulsch_id];
+    }
+
+    handle_pusch_rx_group_trigger(gNB, pusch_vars_group, ulsch_group, gsz);
+
+    for (int u = 0; u < gsz; u++) {
+      int ULSCH_id = pusch_groups.jobs[g][u];
+      NR_gNB_PUSCH *pusch_vars = &gNB->pusch_vars[ULSCH_id];
+      NR_gNB_ULSCH_t *ulsch = &gNB->ulsch[ULSCH_id];
+
+      if (pusch_signal_detected(gNB, pusch_vars, ulsch) || get_softmodem_params()->phy_test) {
+        ulsch_idx_to_decode[num_pusch++] = ULSCH_id;
+      } else {
+        AssertFatal(ulsch->harq_process != NULL, "harq_pid %d is not allocated\n", ulsch->harq_pid);
+        const nfapi_nr_pusch_pdu_t *pdu = &ulsch->harq_process->ulsch_pdu;
+        NR_gNB_PHY_STATS_t *stats = get_phy_stats(gNB, ulsch->rnti);
+        nfapi_nr_crc_t *crc = &UL_INFO->crc_ind.crc_list[UL_INFO->crc_ind.number_crcs++];
+        nfapi_nr_rx_data_pdu_t *rx = &UL_INFO->rx_ind.pdu_list[UL_INFO->rx_ind.number_of_pdus++];
+        nr_fill_indication(gNB, ulsch->frame, ulsch->slot, pusch_vars, pdu, stats, NULL, 1, crc, rx);
+        pusch_DTX++;
+        gNBdumpScopeData(gNB, ulsch->slot, ulsch->frame, "ULSCH_DTX");
+      }
     }
   }
 
@@ -1230,7 +1281,7 @@ int phy_procedures_gNB_uespec_RX(PHY_VARS_gNB *gNB, int frame_rx, int slot_rx, N
   if (num_pusch > 0) {
     int ret_nr_ulsch_procedures = nr_ulsch_procedures(gNB, frame_rx, slot_rx, ulsch_idx_to_decode, num_pusch, UL_INFO);
     if (ret_nr_ulsch_procedures != 0)
-      LOG_E(PHY,"Error in nr_ulsch_procedures, returned %d\n",ret_nr_ulsch_procedures);
+      LOG_E(NR_PHY, "Error in nr_ulsch_procedures, returned %d\n", ret_nr_ulsch_procedures);
   }
 
   /* Do ULSCH decoding time measurement only when number of PUSCH is limited to 1
@@ -1271,6 +1322,19 @@ void nr_save_ul_tti_req(PHY_VARS_gNB *gNB, nfapi_nr_ul_tti_request_t *UL_tti_req
   int frame = UL_tti_req->SFN;
   int slot = UL_tti_req->Slot;
 
+  int16_t pdu_group_idx[MAX_UL_PDUS_PER_SLOT] = {[0 ... MAX_UL_PDUS_PER_SLOT - 1] = -1};
+  uint8_t pdu_group_size[MAX_UL_PDUS_PER_SLOT] = {0};
+  for (int g = 0; g < UL_tti_req->n_group; g++) {
+    const nfapi_nr_ul_tti_request_number_of_groups_t *grp = &UL_tti_req->groups_list[g];
+    for (int u = 0; u < grp->n_ue; u++) {
+      int pdu_idx = grp->ue_list[u].pdu_idx;
+      if (pdu_idx >= 0 && pdu_idx < UL_tti_req->n_pdus) {
+        pdu_group_idx[pdu_idx] = g;
+        pdu_group_size[pdu_idx] = grp->n_ue;
+      }
+    }
+  }
+
   for (int i = 0; i < UL_tti_req->n_pdus; i++) {
     int type = UL_tti_req->pdus_list[i].pdu_type;
     LOG_D(NR_PHY,
@@ -1282,7 +1346,12 @@ void nr_save_ul_tti_req(PHY_VARS_gNB *gNB, nfapi_nr_ul_tti_request_t *UL_tti_req
           UL_tti_req->Slot);
     switch (type) {
       case NFAPI_NR_UL_CONFIG_PUSCH_PDU_TYPE:
-        nr_fill_ulsch(gNB, UL_tti_req->SFN, UL_tti_req->Slot, &UL_tti_req->pdus_list[i].pusch_pdu);
+        nr_fill_ulsch(gNB,
+                      UL_tti_req->SFN,
+                      UL_tti_req->Slot,
+                      &UL_tti_req->pdus_list[i].pusch_pdu,
+                      pdu_group_idx[i],
+                      pdu_group_size[i]);
         break;
       case NFAPI_NR_UL_CONFIG_PUCCH_PDU_TYPE:
         nr_fill_pucch(gNB, UL_tti_req->SFN, UL_tti_req->Slot, &UL_tti_req->pdus_list[i].pucch_pdu);

--- a/openair1/SCHED_NR/phy_procedures_nr_gNB.c
+++ b/openair1/SCHED_NR/phy_procedures_nr_gNB.c
@@ -959,31 +959,33 @@ static void handle_pucch(PHY_VARS_gNB *gNB, c16_t **rxdataF, const NR_gNB_PUCCH_
 }
 
 #ifdef DEBUG_RXDATA
-static void dump_pusch_rx_data(PHY_VARS_gNB *gNB, NR_gNB_ULSCH_t *ulsch, const nfapi_nr_pusch_pdu_t *pdu)
+static void dump_pusch_rx_data(PHY_VARS_gNB *gNB, const nfapi_nr_pusch_pdu_t *pdu, uint8_t slot, int ue_idx)
 {
   NR_DL_FRAME_PARMS *frame_parms = &gNB->frame_parms;
   RU_t *ru = gNB->RU_list[0];
-  int slot_offset = get_samples_slot_timestamp(frame_parms, ulsch->slot);
+  int slot_offset = get_samples_slot_timestamp(frame_parms, slot);
   slot_offset -= ru->N_TA_offset;
   int32_t sample_offset = gNB->common_vars.debugBuff_sample_offset;
   int16_t *buf = (int16_t *)&gNB->common_vars.debugBuff[sample_offset];
-  buf[0] = (int16_t)ulsch->rnti;
+  buf[0] = (int16_t)pdu->rnti;
   buf[1] = (int16_t)pdu->rb_size;
   buf[2] = (int16_t)pdu->rb_start;
   buf[3] = (int16_t)pdu->nr_of_symbols;
   buf[4] = (int16_t)pdu->start_symbol_index;
   buf[5] = (int16_t)pdu->mcs_index;
   buf[6] = (int16_t)pdu->pusch_data.rv_index;
-  buf[7] = (int16_t)ulsch->harq_pid;
+  buf[7] = (int16_t)pdu->pusch_data.harq_process_id;
   memcpy(&gNB->common_vars.debugBuff[gNB->common_vars.debugBuff_sample_offset + 4],
          &ru->common.rxdata[0][slot_offset],
-         get_samples_per_slot(ulsch->slot, frame_parms) * sizeof(int32_t));
-  gNB->common_vars.debugBuff_sample_offset += (get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 4);
-  if (gNB->common_vars.debugBuff_sample_offset > ((get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 2) * 20)) {
-    FILE *f = fopen("rxdata_buff.raw", "w");
+         get_samples_per_slot(slot, frame_parms) * sizeof(int32_t));
+  gNB->common_vars.debugBuff_sample_offset += (get_samples_per_slot(slot, frame_parms) + 1000 + 4);
+  if (gNB->common_vars.debugBuff_sample_offset > ((get_samples_per_slot(slot, frame_parms) + 1000 + 2) * 20)) {
+    char fname[64];
+    snprintf(fname, sizeof(fname), "rxdata_buff_ue%d.raw", ue_idx);
+    FILE *f = fopen(fname, "w");
     if (f == NULL)
       exit(1);
-    fwrite((int16_t *)gNB->common_vars.debugBuff, 2, (get_samples_per_slot(ulsch->slot, frame_parms) + 1000 + 4) * 20 * 2, f);
+    fwrite((int16_t *)gNB->common_vars.debugBuff, 2, (get_samples_per_slot(slot, frame_parms) + 1000 + 4) * 20 * 2, f);
     fclose(f);
     exit(-1);
   }
@@ -992,31 +994,22 @@ static void dump_pusch_rx_data(PHY_VARS_gNB *gNB, NR_gNB_ULSCH_t *ulsch, const n
 
 static void handle_pusch_rx_group_trigger(PHY_VARS_gNB *gNB,
                                           NR_gNB_PUSCH **pusch_vars_group,
-                                          NR_gNB_ULSCH_t **ulsch_group,
-                                          int group_size)
+                                          const nfapi_nr_pusch_pdu_t **ulsch_pdu_group,
+                                          uint32_t **ret_unav_res_group,
+                                          int group_size,
+                                          uint32_t frame,
+                                          uint8_t slot)
 {
-  for (int u = 0; u < group_size; u++) {
-    NR_gNB_PUSCH *pusch_vars = pusch_vars_group[u];
-    NR_gNB_ULSCH_t *ulsch = ulsch_group[u];
-    NR_UL_gNB_HARQ_t *ulsch_harq = ulsch->harq_process;
-    AssertFatal(ulsch_harq != NULL, "harq_pid %d is not allocated\n", ulsch->harq_pid);
-    const nfapi_nr_pusch_pdu_t *pdu = &ulsch_harq->ulsch_pdu;
-
 #ifdef DEBUG_RXDATA
-    dump_pusch_rx_data(gNB, ulsch, pdu);
+  // Dumping only ue index 0 for now
+  int ue_idx = 0;
+  const nfapi_nr_pusch_pdu_t *pdu = ulsch_pdu_group[ue_idx];
+  dump_pusch_rx_data(gNB, pdu, slot, ue_idx);
 #endif
 
-    start_meas(&gNB->rx_pusch_stats);
-    nr_rx_pusch_tp(gNB, pusch_vars, pdu, &ulsch->unav_res, ulsch->frame, ulsch->slot);
-    pusch_vars->ulsch_power_tot = 0;
-    pusch_vars->ulsch_noise_power_tot = 0;
-    const uint8_t num_sp_streams = pdu->param_v4.numSpatialStreamIndices;
-    for (int aarx = 0; aarx < num_sp_streams; aarx++) {
-      pusch_vars->ulsch_power_tot += pusch_vars->ulsch_power[aarx];
-      pusch_vars->ulsch_noise_power_tot += pusch_vars->ulsch_noise_power[aarx];
-    }
-    stop_meas(&gNB->rx_pusch_stats);
-  }
+  start_meas(&gNB->rx_pusch_stats);
+  nr_rx_pusch_group_tp(gNB, pusch_vars_group, ulsch_pdu_group, ret_unav_res_group, group_size, frame, slot);
+  stop_meas(&gNB->rx_pusch_stats);
 }
 
 static bool pusch_signal_detected(PHY_VARS_gNB *gNB, NR_gNB_PUSCH *pusch_vars, NR_gNB_ULSCH_t *ulsch)
@@ -1241,18 +1234,19 @@ int phy_procedures_gNB_uespec_RX(PHY_VARS_gNB *gNB, int frame_rx, int slot_rx, N
   for (int i = 0; i < pusch_groups.n_active_groups; i++) {
     int g = pusch_groups.active_groups[i];
     int gsz = pusch_groups.size[g];
-    AssertFatal(gsz == 1, "Cannot handle group size > 1\n");
-
+    AssertFatal(gsz <= NR_MAX_NB_LAYERS, "Cannot handle group size > %d\n", NR_MAX_NB_LAYERS);
     NR_gNB_PUSCH *pusch_vars_group[gsz];
-    NR_gNB_ULSCH_t *ulsch_group[gsz];
+    const nfapi_nr_pusch_pdu_t *ulsch_pdu_group[gsz];
+    uint32_t *unav_res_group[gsz];
     // store pusch vars and ulsch pdu for group based processing
     for (int u = 0; u < gsz; u++) {
       int ulsch_id = pusch_groups.jobs[g][u];
       pusch_vars_group[u] = &gNB->pusch_vars[ulsch_id];
-      ulsch_group[u] = &gNB->ulsch[ulsch_id];
+      ulsch_pdu_group[u] = &gNB->ulsch[ulsch_id].harq_process->ulsch_pdu;
+      unav_res_group[u] = &gNB->ulsch[ulsch_id].unav_res;
     }
 
-    handle_pusch_rx_group_trigger(gNB, pusch_vars_group, ulsch_group, gsz);
+    handle_pusch_rx_group_trigger(gNB, pusch_vars_group, ulsch_pdu_group, unav_res_group, gsz, frame_rx, slot_rx);
 
     for (int u = 0; u < gsz; u++) {
       int ULSCH_id = pusch_groups.jobs[g][u];

--- a/openair1/SCHED_NR/phy_procedures_nr_gNB.c
+++ b/openair1/SCHED_NR/phy_procedures_nr_gNB.c
@@ -951,7 +951,7 @@ static void handle_pucch(PHY_VARS_gNB *gNB, c16_t **rxdataF, const NR_gNB_PUCCH_
   }
 }
 
-static bool handle_pusch_decode_trigger(PHY_VARS_gNB *gNB, NR_gNB_PUSCH *pusch_vars, NR_gNB_ULSCH_t *ulsch, NR_UL_IND_t *UL_INFO, int *pusch_DTX)
+static void handle_pusch_rx_trigger(PHY_VARS_gNB *gNB, NR_gNB_PUSCH *pusch_vars, NR_gNB_ULSCH_t *ulsch)
 {
   NR_UL_gNB_HARQ_t *ulsch_harq = ulsch->harq_process;
   AssertFatal(ulsch_harq != NULL, "harq_pid %d is not allocated\n", ulsch->harq_pid);
@@ -998,42 +998,32 @@ static bool handle_pusch_decode_trigger(PHY_VARS_gNB *gNB, NR_gNB_PUSCH *pusch_v
     pusch_vars->ulsch_power_tot += pusch_vars->ulsch_power[aarx];
     pusch_vars->ulsch_noise_power_tot += pusch_vars->ulsch_noise_power[aarx];
   }
-  if (dB_fixed_x10(pusch_vars->ulsch_power_tot) < dB_fixed_x10(pusch_vars->ulsch_noise_power_tot) + gNB->pusch_thres) {
-    NR_gNB_PHY_STATS_t *stats = get_phy_stats(gNB, ulsch->rnti);
+  stop_meas(&gNB->rx_pusch_stats);
+}
 
-    LOG_D(PHY,
-          "PUSCH not detected in %d.%d (%d,%d,%d)\n",
-          ulsch->frame,
-          ulsch->slot,
-          dB_fixed_x10(pusch_vars->ulsch_power_tot),
-          dB_fixed_x10(pusch_vars->ulsch_noise_power_tot),
-          gNB->pusch_thres);
+static bool pusch_signal_detected(PHY_VARS_gNB *gNB, NR_gNB_PUSCH *pusch_vars, NR_gNB_ULSCH_t *ulsch)
+{
+  const bool detected =
+      dB_fixed_x10(pusch_vars->ulsch_power_tot) >= dB_fixed_x10(pusch_vars->ulsch_noise_power_tot) + gNB->pusch_thres;
+
+  LOG_D(NR_PHY,
+        "PUSCH %s in %d.%d (%d,%d,%d)\n",
+        detected ? "detected" : "not detected",
+        ulsch->frame,
+        ulsch->slot,
+        dB_fixed_x10(pusch_vars->ulsch_power_tot),
+        dB_fixed_x10(pusch_vars->ulsch_noise_power_tot),
+        gNB->pusch_thres);
+
+  if (detected) {
+    pusch_vars->DTX = 0;
+  } else {
+    NR_gNB_PHY_STATS_t *stats = get_phy_stats(gNB, ulsch->rnti);
     pusch_vars->ulsch_power_tot = pusch_vars->ulsch_noise_power_tot;
     pusch_vars->DTX = 1;
     if (stats)
       stats->ulsch_stats.DTX++;
-    if (!get_softmodem_params()->phy_test) {
-      /* in case of phy_test mode, we still want to decode to measure execution time.
-         Therefore, we don't yet call nr_fill_indication, it will be called later */
-      nfapi_nr_crc_t *crc = &UL_INFO->crc_ind.crc_list[UL_INFO->crc_ind.number_crcs++];
-      nfapi_nr_rx_data_pdu_t *rx = &UL_INFO->rx_ind.pdu_list[UL_INFO->rx_ind.number_of_pdus++];
-      nr_fill_indication(gNB, ulsch->frame, ulsch->slot, pusch_vars, pdu, stats, NULL, 1, crc, rx);
-      (*pusch_DTX)++;
-      gNBdumpScopeData(gNB, ulsch->slot, ulsch->frame, "ULSCH_DTX");
-      return false;
-    }
-  } else {
-    LOG_D(PHY,
-          "PUSCH detected in %d.%d (%d,%d,%d)\n",
-          ulsch->frame,
-          ulsch->slot,
-          dB_fixed_x10(pusch_vars->ulsch_power_tot),
-          dB_fixed_x10(pusch_vars->ulsch_noise_power_tot),
-          gNB->pusch_thres);
-
-    pusch_vars->DTX = 0;
   }
-  stop_meas(&gNB->rx_pusch_stats);
 
   return true;
 }
@@ -1214,8 +1204,20 @@ int phy_procedures_gNB_uespec_RX(PHY_VARS_gNB *gNB, int frame_rx, int slot_rx, N
       continue;
     NR_gNB_PUSCH *pusch_vars = &gNB->pusch_vars[ULSCH_id];
     NR_gNB_ULSCH_t *ulsch = &gNB->ulsch[ULSCH_id];
-    if (handle_pusch_decode_trigger(gNB, pusch_vars, ulsch, UL_INFO, &pusch_DTX))
+    handle_pusch_rx_trigger(gNB, pusch_vars, ulsch);
+
+    if (pusch_signal_detected(gNB, pusch_vars, ulsch) || get_softmodem_params()->phy_test) {
       ulsch_idx_to_decode[num_pusch++] = ULSCH_id;
+    } else {
+      AssertFatal(ulsch->harq_process != NULL, "harq_pid %d is not allocated\n", ulsch->harq_pid);
+      const nfapi_nr_pusch_pdu_t *pdu = &ulsch->harq_process->ulsch_pdu;
+      NR_gNB_PHY_STATS_t *stats = get_phy_stats(gNB, ulsch->rnti);
+      nfapi_nr_crc_t *crc = &UL_INFO->crc_ind.crc_list[UL_INFO->crc_ind.number_crcs++];
+      nfapi_nr_rx_data_pdu_t *rx = &UL_INFO->rx_ind.pdu_list[UL_INFO->rx_ind.number_of_pdus++];
+      nr_fill_indication(gNB, ulsch->frame, ulsch->slot, pusch_vars, pdu, stats, NULL, 1, crc, rx);
+      pusch_DTX++;
+      gNBdumpScopeData(gNB, ulsch->slot, ulsch->frame, "ULSCH_DTX");
+    }
   }
 
   /* Do ULSCH decoding time measurement only when number of PUSCH is limited to 1

--- a/openair1/SCHED_NR/phy_procedures_nr_gNB.c
+++ b/openair1/SCHED_NR/phy_procedures_nr_gNB.c
@@ -1268,25 +1268,13 @@ int phy_procedures_gNB_uespec_RX(PHY_VARS_gNB *gNB, int frame_rx, int slot_rx, N
     }
   }
 
-  /* Do ULSCH decoding time measurement only when number of PUSCH is limited to 1
-   * (valid for unitary physical simulators). ULSCH processing lopp is then executed
-   * only once, which ensures exactly one start and stop of the ULSCH decoding time
-   * measurement per processed TB.*/
-  if (gNB->max_nb_pusch == 1)
-    start_meas(&gNB->ulsch_decoding_stats);
-
+  start_meas(&gNB->ulsch_decoding_stats);
   if (num_pusch > 0) {
     int ret_nr_ulsch_procedures = nr_ulsch_procedures(gNB, frame_rx, slot_rx, ulsch_idx_to_decode, num_pusch, UL_INFO);
     if (ret_nr_ulsch_procedures != 0)
       LOG_E(NR_PHY, "Error in nr_ulsch_procedures, returned %d\n", ret_nr_ulsch_procedures);
   }
-
-  /* Do ULSCH decoding time measurement only when number of PUSCH is limited to 1
-   * (valid for unitary physical simulators). ULSCH processing loop is then executed
-   * only once, which ensures exactly one start and stop of the ULSCH decoding time
-   * measurement per processed TB.*/
-  if (gNB->max_nb_pusch == 1)
-    stop_meas(&gNB->ulsch_decoding_stats);
+  stop_meas(&gNB->ulsch_decoding_stats);
 
   UL_INFO->srs_ind.sfn = frame_rx;
   UL_INFO->srs_ind.slot = slot_rx;

--- a/openair1/SIMULATION/NR_PHY/ulsim.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim.c
@@ -1326,6 +1326,12 @@ int main(int argc, char *argv[])
           srs_pdu->beamforming.prg_size = 1;
         }
 
+        // Fill FAPI PUSCH groups for 1 UE
+        UL_tti_req->n_group = 1;
+        nfapi_nr_ul_tti_request_number_of_groups_t *group = &UL_tti_req->groups_list[0];
+        group->n_ue = 1;
+        group->ue_list[0].pdu_idx = 0;
+
         /* load FAPI into RX of L1 */
         nr_save_ul_tti_req(gNB, &Sched_INFO->UL_tti_req);
 

--- a/openair1/SIMULATION/NR_PHY/ulsim.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim.c
@@ -723,13 +723,13 @@ int main(int argc, char *argv[])
                         &tx_bandwidth,
                         &rx_bandwidth);
 
-  RC.gNB = (PHY_VARS_gNB **) malloc(sizeof(PHY_VARS_gNB *));
-  RC.gNB[0] = calloc(1,sizeof(PHY_VARS_gNB));
+  RC.gNB = (PHY_VARS_gNB **)malloc_or_fail(sizeof(PHY_VARS_gNB *));
+  RC.gNB[0] = calloc_or_fail(1, sizeof(PHY_VARS_gNB));
   gNB = RC.gNB[0];
   gNB->ofdm_offset_divisor = UINT_MAX;
   gNB->num_pusch_symbols_per_thread = 1;
   gNB->dmrs_num_antennas_per_thread = num_antennas_per_thread;
-  gNB->RU_list[0] = calloc(1, sizeof(**gNB->RU_list));
+  gNB->RU_list[0] = calloc_or_fail(1, sizeof(**gNB->RU_list));
   gNB->RU_list[0]->rfdevice.openair0_cfg = openair0_cfg;
 
   if (setAffinity == false)
@@ -751,11 +751,11 @@ int main(int argc, char *argv[])
   AssertFatal((gNB->if_inst = NR_IF_Module_init(0)) != NULL, "Cannot register interface");
   gNB->if_inst->NR_PHY_config_req = nr_phy_config_request;
 
-  s_interleaved = malloc(n_tx * sizeof(float *));
-  r_re = malloc(n_rx * sizeof(float *));
-  r_im = malloc(n_rx * sizeof(float *));
+  s_interleaved = malloc_or_fail(n_tx * sizeof(float *));
+  r_re = malloc_or_fail(n_rx * sizeof(float *));
+  r_im = malloc_or_fail(n_rx * sizeof(float *));
 
-  NR_ServingCellConfigCommon_t *scc = calloc(1,sizeof(*scc));;
+  NR_ServingCellConfigCommon_t *scc = calloc_or_fail(1, sizeof(*scc));
   prepare_scc(scc);
   uint64_t ssb_bitmap;
   fill_scc_sim(scc, &ssb_bitmap, N_RB_DL, N_RB_DL, mu, mu);
@@ -851,9 +851,9 @@ int main(int argc, char *argv[])
 
   /* no RU: need to have rxdata */
   c16_t **rxdata;
-  rxdata = malloc(n_rx * sizeof(*rxdata));
+  rxdata = malloc_or_fail(n_rx * sizeof(*rxdata));
   for (int i = 0; i < n_rx; ++i)
-    rxdata[i] = calloc(gNB->frame_parms.samples_per_frame, sizeof(**rxdata));
+    rxdata[i] = calloc_or_fail(gNB->frame_parms.samples_per_frame, sizeof(**rxdata));
 
   NR_BWP_Uplink_t *ubwp=secondaryCellGroup->spCellConfig->spCellConfigDedicated->uplinkConfig->uplinkBWP_ToAddModList->list.array[0];
 
@@ -891,7 +891,7 @@ int main(int argc, char *argv[])
                           &d_channel_coeffs_gpu);
   if (use_cuda) {
     int num_links = n_tx * n_rx;
-    h_channel_coeffs = (float *)malloc(num_links * UE2gNB->channel_length * sizeof(float2));
+    h_channel_coeffs = (float *)malloc_or_fail(num_links * UE2gNB->channel_length * sizeof(float2));
   }
 #endif
 
@@ -899,7 +899,7 @@ int main(int argc, char *argv[])
   printf("Pre-allocating padded host memory for the CPU channel pipeline...\n");
   const int max_padding_alloc = 256 - 1;
   size_t padded_tx_alloc_bytes = n_tx * (num_samples_alloc + max_padding_alloc) * 2 * sizeof(float);
-  h_tx_sig_pinned = malloc(padded_tx_alloc_bytes);
+  h_tx_sig_pinned = malloc_or_fail(padded_tx_alloc_bytes);
   if (h_tx_sig_pinned == NULL) {
     printf("Error: Failed to allocate host buffer for CPU path\n");
     exit(-1);
@@ -907,9 +907,9 @@ int main(int argc, char *argv[])
 #endif
 
   // Configure UE
-  nrPHY_vars_UE_g = malloc(sizeof(PHY_VARS_NR_UE **));
-  nrPHY_vars_UE_g[0] = malloc(sizeof(PHY_VARS_NR_UE *));
-  PHY_VARS_NR_UE *UE = calloc(1, sizeof(PHY_VARS_NR_UE));
+  nrPHY_vars_UE_g = malloc_or_fail(sizeof(PHY_VARS_NR_UE **));
+  nrPHY_vars_UE_g[0] = malloc_or_fail(sizeof(PHY_VARS_NR_UE *));
+  PHY_VARS_NR_UE *UE = calloc_or_fail(1, sizeof(PHY_VARS_NR_UE));
   nrPHY_vars_UE_g[0][0] = UE;
   UE->frame_parms = gNB->frame_parms;
   UE->frame_parms.nb_antennas_tx = n_tx;
@@ -1076,17 +1076,17 @@ int main(int argc, char *argv[])
   unsigned int available_bits = nr_get_G(nb_rb, nb_symb_sch, nb_re_dmrs, number_dmrs_symbols, unav_res, mod_order, precod_nbr_layers);
   uint8_t cw_buf[available_bits];
   memset(cw_buf, 0, available_bits);
-  UE->phy_sim_test_buf = calloc(1, (available_bits + 7) / 8);
+  UE->phy_sim_test_buf = calloc_or_fail(1, (available_bits + 7) / 8);
   printf("[ULSIM]: VALUE OF G: %u, TBS: %u\n", available_bits, TBS);
 
   int frame_length_complex_samples = gNB->frame_parms.samples_per_subframe * NR_NUMBER_OF_SUBFRAMES_PER_FRAME;
   for (int aatx = 0; aatx < n_tx; aatx++) {
-    s_interleaved[aatx] = calloc(1, frame_length_complex_samples * 2 * sizeof(float));
+    s_interleaved[aatx] = calloc_or_fail(1, frame_length_complex_samples * 2 * sizeof(float));
   }
 
   for (int aarx = 0; aarx < n_rx; aarx++) {
-    r_re[aarx] = calloc(1, frame_length_complex_samples * sizeof(float));
-    r_im[aarx] = calloc(1, frame_length_complex_samples * sizeof(float));
+    r_re[aarx] = calloc_or_fail(1, frame_length_complex_samples * sizeof(float));
+    r_im[aarx] = calloc_or_fail(1, frame_length_complex_samples * sizeof(float));
   }
 
   //for (int i=0;i<16;i++) printf("%f\n",gaussdouble(0.0,1.0));
@@ -1282,7 +1282,7 @@ int main(int argc, char *argv[])
         pusch_pdu->pusch_data.num_cb = 0;
         pusch_pdu->pusch_ptrs.ptrs_time_density = ptrs_time_density;
         pusch_pdu->pusch_ptrs.ptrs_freq_density = ptrs_freq_density;
-        pusch_pdu->pusch_ptrs.ptrs_ports_list = (nfapi_nr_ptrs_ports_t *)malloc(2 * sizeof(nfapi_nr_ptrs_ports_t));
+        pusch_pdu->pusch_ptrs.ptrs_ports_list = (nfapi_nr_ptrs_ports_t *)malloc_or_fail(2 * sizeof(nfapi_nr_ptrs_ports_t));
         pusch_pdu->pusch_ptrs.ptrs_ports_list[0].ptrs_re_offset = 0;
         pusch_pdu->maintenance_parms_v3.ldpcBaseGraph = get_BG(TBS, code_rate);
         pusch_pdu->param_v4.numSpatialStreamIndices = conf.pusch_AntennaPorts;
@@ -1377,7 +1377,8 @@ int main(int argc, char *argv[])
         pusch_config_pdu->pusch_data.harq_process_id = harq_pid;
         pusch_config_pdu->pusch_ptrs.ptrs_time_density = ptrs_time_density;
         pusch_config_pdu->pusch_ptrs.ptrs_freq_density = ptrs_freq_density;
-        pusch_config_pdu->pusch_ptrs.ptrs_ports_list = (nfapi_nr_ue_ptrs_ports_t *)malloc(2 * sizeof(nfapi_nr_ue_ptrs_ports_t));
+        pusch_config_pdu->pusch_ptrs.ptrs_ports_list =
+            (nfapi_nr_ue_ptrs_ports_t *)malloc_or_fail(2 * sizeof(nfapi_nr_ue_ptrs_ports_t));
         pusch_config_pdu->pusch_ptrs.ptrs_ports_list[0].ptrs_re_offset = 0;
         pusch_config_pdu->transform_precoding = transform_precoding;
         // if transform precoding is enabled
@@ -1501,7 +1502,7 @@ int main(int argc, char *argv[])
             random_channel(UE2gNB, 0);
             int num_links = UE2gNB->nb_tx * UE2gNB->nb_rx;
             if (h_channel_coeffs == NULL) {
-              h_channel_coeffs = (float *)malloc(num_links * 256 * sizeof(float2));
+              h_channel_coeffs = (float *)malloc_or_fail(num_links * 256 * sizeof(float2));
             }
 
             for (int link = 0; link < num_links; link++) {
@@ -1537,7 +1538,7 @@ int main(int argc, char *argv[])
           } else
 #endif
           {
-            float **tx_sig_for_cpu = malloc(n_tx * sizeof(float *));
+            float **tx_sig_for_cpu = malloc_or_fail(n_tx * sizeof(float *));
             float *h_tx_ptr = (float *)h_tx_sig_pinned;
             const int padding_len = UE2gNB->channel_length - 1;
             const int padded_slot_length = slot_length + padding_len;

--- a/openair1/SIMULATION/NR_PHY/ulsim_mu_mimo.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim_mu_mimo.c
@@ -1,0 +1,1530 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include <limits.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <bits/getopt_core.h>
+#include "common/utils/nr/nr_common.h"
+#include "common/utils/var_array.h"
+#define inMicroS(a) (((double)(a)) / (get_cpu_freq_GHz() * 1000.0))
+#include "SIMULATION/LTE_PHY/common_sim.h"
+#include "common/utils/assertions.h"
+#include "executables/softmodem-common.h"
+#include "NR_BCCH-BCH-Message.h"
+#include "NR_MAC_COMMON/nr_mac.h"
+#include "NR_MAC_COMMON/nr_mac_common.h"
+#include "NR_MAC_UE/mac_defs.h"
+#include "NR_MAC_gNB/nr_mac_gNB.h"
+#include "NR_PHY_INTERFACE/NR_IF_Module.h"
+#include "NR_ReconfigurationWithSync.h"
+#include "NR_ServingCellConfig.h"
+#include "NR_UE-NR-Capability.h"
+#include "PHY/CODING/nrLDPC_coding/nrLDPC_coding_interface.h"
+#include "PHY/INIT/nr_phy_init.h"
+#include "PHY/MODULATION/nr_modulation.h"
+#include "PHY/NR_REFSIG/dmrs_nr.h"
+#include "PHY/NR_REFSIG/ul_ref_seq_nr.h"
+#include "PHY/NR_TRANSPORT/nr_transport_common_proto.h"
+#include "PHY/NR_TRANSPORT/nr_ulsch.h"
+#include "PHY/NR_UE_TRANSPORT/nr_transport_ue.h"
+#include "PHY/TOOLS/tools_defs.h"
+#include "PHY/defs_RU.h"
+#include "PHY/defs_gNB.h"
+#include "PHY/defs_nr_UE.h"
+#include "PHY/defs_nr_common.h"
+#include "PHY/impl_defs_nr.h"
+#include "PHY/phy_vars_nr_ue.h"
+#include "SCHED_NR/sched_nr.h"
+#include "SCHED_NR_UE/defs.h"
+#include "SCHED_NR_UE/fapi_nr_ue_l1.h"
+#include "asn_internal.h"
+#include "common/config/config_load_configmodule.h"
+#include "common/ngran_types.h"
+#include "common/openairinterface5g_limits.h"
+#include "common/ran_context.h"
+#include "common/utils/LOG/log.h"
+#include "common/utils/bits.h"
+#include "common/utils/T/T.h"
+#include "common/utils/threadPool/thread-pool.h"
+#include "common_lib.h"
+#include "e1ap_messages_types.h"
+#include "executables/nr-uesoftmodem.h"
+#include "fapi_nr_ue_constants.h"
+#include "fapi_nr_ue_interface.h"
+#include "nfapi_interface.h"
+#include "nfapi_nr_interface_scf.h"
+#include "nr_ue_phy_meas.h"
+#include "openair1/SIMULATION/NR_PHY/nr_unitary_defs.h"
+#include "openair1/SIMULATION/TOOLS/sim.h"
+#include "openair2/LAYER2/NR_MAC_UE/mac_proto.h"
+#include "openair2/LAYER2/NR_MAC_gNB/mac_proto.h"
+#include "openair2/LAYER2/NR_MAC_gNB/nr_radio_config.h"
+#include "time_meas.h"
+#include "utils.h"
+
+// #define DEBUG_ULSIM
+
+#define MAX_NUM_UE 2
+
+const char *__asan_default_options()
+{
+  /* don't do leak checking in nr_ulsim, not finished yet */
+  return "detect_leaks=0";
+}
+PHY_VARS_gNB *gNB;
+PHY_VARS_NR_UE *UE[MAX_NUM_UE];
+RAN_CONTEXT_t RC;
+char *uecap_file;
+int64_t uplink_frequency_offset[MAX_NUM_CCs][4];
+
+double cpuf;
+// uint8_t nfapi_mode = 0;
+uint64_t downlink_frequency[MAX_NUM_CCs][4];
+THREAD_STRUCT thread_struct;
+nfapi_ue_release_request_body_t release_rntis;
+
+// Fixme: Uniq dirty DU instance, by global var, datamodel need better management
+instance_t DUuniqInstance = 0;
+instance_t CUuniqInstance = 0;
+
+// NTN cellSpecificKoffset-r17, but in slots for DL SCS
+unsigned int NTN_UE_Koffset = 0;
+
+void nr_derive_key_ng_ran_star(uint16_t pci, uint64_t nr_arfcn_dl, const uint8_t key[32], uint8_t *key_ng_ran_star)
+{
+}
+
+/* this is a hack, but necessary for E2 agent. We compile in all of RRC
+ * (because of CMakeLists.txt), but we don't need it (only nr_radio_config.c).
+ * however, if E2 agent is defined, the following functions are used in
+ * rrc_gNB.c, but defined in RAN functions. In order to avoid pulling this in
+ * here as well, only provide a prototype (and abort if they are ever called). */
+void signal_rrc_msg(void /*const nr_rrc_class_e nr_channel, const uint32_t rrc_msg_id, const byte_array_t rrc_ba*/)
+{
+  abort();
+}
+void signal_rrc_state_changed_to(void /* const gNB_RRC_UE_t *rrc_ue_context, const rrc_state_e2sm_rc_e rrc_state */)
+{
+  abort();
+}
+void signal_ue_id(void /* const gNB_RRC_UE_t *rrc_ue_context, const uint16_t class, const uint32_t msg_id */)
+{
+  abort();
+}
+
+extern void fix_scd(NR_ServingCellConfig_t *scd); // forward declaration
+
+void e1_bearer_context_setup(const e1ap_bearer_setup_req_t *req)
+{
+  abort();
+}
+void e1_bearer_context_modif(const e1ap_bearer_mod_req_t *req)
+{
+  abort();
+}
+void e1_bearer_release_cmd(const e1ap_bearer_release_cmd_t *cmd)
+{
+  abort();
+}
+
+int8_t nr_rrc_RA_succeeded(const module_id_t mod_id, const uint8_t gNB_index)
+{
+  return 0;
+}
+
+void nr_derive_key(int alg_type, uint8_t alg_id, const uint8_t key[32], uint8_t out[16])
+{
+  (void)alg_type;
+}
+
+void processSlotTX(void *arg)
+{
+}
+
+nrUE_params_t nrUE_params;
+
+nrUE_params_t *get_nrUE_params(void)
+{
+  return &nrUE_params;
+}
+// needed for some functions
+uint16_t n_rnti = 0x1234;
+openair0_config_t openair0_cfg[MAX_CARDS];
+
+configmodule_interface_t *uniqCfg = NULL;
+int main(int argc, char *argv[])
+{
+  stop = false;
+  __attribute__((unused)) struct sigaction oldaction;
+  sigaction(SIGINT, &sigint_action, &oldaction);
+
+  int i;
+  double SNR, snr0 = -2.0, snr1 = 2.0;
+  double snr_step = .2;
+  uint8_t snr1set = 0;
+  int slot = 8, frame = 1;
+  float ***s_interleaved, **r_re, **r_im;
+  float **r_re_tmp, **r_im_tmp;
+  int trial, n_trials = 1, delay = 0;
+  double maxDoppler = 0.0;
+  uint8_t n_tx = 1, n_rx = 1;
+  channel_desc_t *UE2gNB[MAX_NUM_UE];
+  uint8_t extended_prefix_flag = 0;
+  SCM_t channel_model = AWGN; // Rayleigh1_anticorr;
+  corr_level_t corr_level = CORR_LEVEL_LOW;
+  uint16_t N_RB_DL = 106, N_RB_UL = 106, mu = 1;
+  uint8_t length_dmrs = pusch_len1;
+
+  int loglvl = OAILOG_WARNING;
+  uint16_t nb_symb_sch = 12;
+  int start_symbol = 0;
+  uint16_t nb_rb = 50;
+  int Imcs = 9;
+  uint8_t precod_nbr_layers = 1;
+  int tx_offset;
+  double txlev[MAX_NUM_UE] = {0};
+  double sigma;
+  int start_rb = 0;
+  int print_perf = 0;
+  cpuf = get_cpu_freq_GHz();
+  bool no_phase_pre_comp = false;
+  int rv_index = 0;
+  float eff_tp_check = 100;
+  uint8_t max_rounds = 4;
+  int chest_type[2] = {0};
+  int modify_dmrs = 0;
+  int dmrs_arg[4] = {-1, -1, -1, -1}; // Invalid values
+  uint8_t NUM_UE = 1;
+
+  uint8_t transform_precoding = transformPrecoder_disabled; // 0 - ENABLE, 1 - DISABLE
+  uint8_t num_dmrs_cdm_grps_no_data = 1;
+  uint8_t mcs_table = 0;
+  int ilbrm = 0;
+
+  double DS_TDL = .03;
+  int threadCnt = 0;
+  int max_ldpc_iterations = 5;
+  int num_antennas_per_thread = 1;
+  uint32_t log_format = 0;
+  int threequarter_fs = 0;
+
+  if ((uniqCfg = load_configmodule(argc, argv, CONFIG_ENABLECMDLINEONLY)) == 0) {
+    exit_fun("[NR_ULSIM] Error, configuration module init failed\n");
+  }
+  int ul_proc_error = 0; // uplink processing checking status flag
+  randominit();
+
+  /* initialize the sin-cos table */
+  InitSinLUT();
+
+  int c;
+  bool setAffinity = false;
+  char gNBthreads[128] = "n";
+
+  void *h_tx_sig_pinned = NULL;
+
+  while ((c = getopt(argc, argv, "--:O:a:b:c:d:ef:g:h:i:jk:l:m:n:o::p:q:r:s:t:u:v:w:y:z:A:C:F:G:H:I:M:N:PR:S:T:U:L:ZW:E:X:Y:"))
+         != -1) {
+    /* ignore long options starting with '--', option '-O' and their arguments that are handled by configmodule */
+    /* with this opstring getopt returns 1 for non-option arguments, refer to 'man 3 getopt' */
+    if (c == 1 || c == '-' || c == 'O')
+      continue;
+
+    printf("handling optarg %c\n", c);
+    switch (c) {
+      case 'a':
+        start_symbol = atoi(optarg);
+        AssertFatal(start_symbol >= 0 && start_symbol < 13, "start_symbol %d is not in 0..12\n", start_symbol);
+        break;
+
+      case 'b':
+        nb_symb_sch = atoi(optarg);
+        AssertFatal(nb_symb_sch > 0 && nb_symb_sch < 15, "start_symbol %d is not in 1..14\n", nb_symb_sch);
+        break;
+
+      case 'c':
+        n_rnti = atoi(optarg);
+        AssertFatal(n_rnti > 0 && n_rnti <= 65535, "Illegal n_rnti %x\n", n_rnti);
+        break;
+
+      case 'd':
+        delay = atoi(optarg);
+        break;
+
+      case 'g':
+
+        switch ((char)*optarg) {
+          case 'A':
+            channel_model = TDL_A;
+            DS_TDL = 0.030; // 30 ns
+            printf("Channel model: TDLA30\n");
+            break;
+          case 'B':
+            channel_model = TDL_B;
+            DS_TDL = 0.100; // 100ns
+            printf("Channel model: TDLB100\n");
+            break;
+          case 'C':
+            channel_model = TDL_C;
+            DS_TDL = 0.300; // 300 ns
+            printf("Channel model: TDLC300\n");
+            break;
+          default:
+            printf("Unsupported channel model!\n");
+            exit(-1);
+        }
+
+        if (optarg[1] == ',') {
+          switch (optarg[2]) {
+            case 'l':
+              corr_level = CORR_LEVEL_LOW;
+              break;
+            case 'm':
+              corr_level = CORR_LEVEL_MEDIUM;
+              break;
+            case 'h':
+              corr_level = CORR_LEVEL_HIGH;
+              break;
+            default:
+              printf("Invalid correlation level!\n");
+          }
+        }
+
+        if (optarg[3] == ',') {
+          maxDoppler = atoi(&optarg[4]);
+          printf("Maximum Doppler Frequency: %.0f Hz\n", maxDoppler);
+        }
+        break;
+
+      case 'i':
+        i = 0;
+        do {
+          chest_type[i >> 1] = atoi(&optarg[i]);
+          i += 2;
+        } while (optarg[i - 1] == ',');
+        break;
+
+      case 'j':
+        log_format |= MATLAB_RAW;
+        break;
+
+      case 'k':
+        printf("Setting threequarter_fs_flag\n");
+        threequarter_fs = 1;
+        break;
+
+      case 'l':
+        length_dmrs = atoi(optarg);
+        AssertFatal(length_dmrs == 1 || length_dmrs == 2, "Illegal PUSCH DMRS length %d\n", length_dmrs);
+        printf("PUSCH DMRS length %d\n", length_dmrs);
+        break;
+
+      case 'm':
+        Imcs = atoi(optarg);
+        break;
+
+      case 'W':
+        precod_nbr_layers = atoi(optarg);
+        AssertFatal(precod_nbr_layers > 0 && precod_nbr_layers <= NR_MAX_NB_LAYERS,
+                    "Number of layers per UE %d should be less than or equal to %d\n",
+                    precod_nbr_layers,
+                    NR_MAX_NB_LAYERS);
+        break;
+
+      case 'n':
+        n_trials = atoi(optarg);
+        break;
+
+      case 'p':
+        extended_prefix_flag = 1;
+        break;
+
+      case 'q':
+        mcs_table = atoi(optarg);
+        break;
+
+      case 'r':
+        nb_rb = atoi(optarg);
+        break;
+
+      case 's':
+        snr0 = atof(optarg);
+        printf("Setting SNR0 to %f\n", snr0);
+        break;
+
+      case 'C':
+        threadCnt = atoi(optarg);
+        break;
+
+      case 'u':
+        mu = atoi(optarg);
+        break;
+
+      case 'v':
+        max_rounds = atoi(optarg);
+        AssertFatal(max_rounds > 0 && max_rounds < 16, "Unsupported number of rounds %d, should be in [1,16]\n", max_rounds);
+        break;
+
+      case 'w':
+        start_rb = atoi(optarg);
+        break;
+
+      case 't':
+        eff_tp_check = atof(optarg);
+        break;
+
+      case 'y':
+        n_tx = atoi(optarg);
+        if ((n_tx == 0) || (n_tx > 4)) {
+          printf("Unsupported number of tx antennas %d\n", n_tx);
+          exit(-1);
+        }
+        break;
+
+      case 'z':
+        n_rx = atoi(optarg);
+        if ((n_rx == 0) || (n_rx > 8)) {
+          printf("Unsupported number of rx antennas %d\n", n_rx);
+          exit(-1);
+        }
+        break;
+
+      case 'A':
+        num_antennas_per_thread = atoi(optarg);
+        break;
+
+      case 'H':
+        slot = atoi(optarg);
+        break;
+
+      case 'I':
+        max_ldpc_iterations = atoi(optarg);
+        break;
+
+      case 'M':
+        ilbrm = atoi(optarg);
+        break;
+
+      case 'N':
+        NUM_UE = atoi(optarg);
+        AssertFatal(NUM_UE > 0 && NUM_UE <= MAX_NUM_UE, "Unsupported number of UEs %d\n", NUM_UE);
+        break;
+
+      case 'R':
+        N_RB_DL = atoi(optarg);
+        N_RB_UL = N_RB_DL;
+        break;
+
+      case 'S':
+        snr1 = atof(optarg);
+        snr1set = 1;
+        printf("Setting SNR1 to %f\n", snr1);
+        break;
+
+      case 'P':
+        print_perf = 1;
+        cpu_meas_enabled = 1;
+        break;
+
+      case 'L':
+        loglvl = atoi(optarg);
+        break;
+
+      case 'U':
+        modify_dmrs = 1;
+        i = 0;
+        do {
+          dmrs_arg[i >> 1] = atoi(&optarg[i]);
+          i += 2;
+        } while (optarg[i - 1] == ',');
+        break;
+
+      case 'Y':
+        threadCnt = sizeof(gNBthreads) - 1;
+        strncpy(gNBthreads, optarg, threadCnt);
+        gNBthreads[threadCnt] = 0;
+        setAffinity = true;
+        break;
+
+      case 'Z':
+        transform_precoding = transformPrecoder_enabled;
+        num_dmrs_cdm_grps_no_data = 2;
+        mcs_table = 3;
+        printf("NOTE: TRANSFORM PRECODING (SC-FDMA) is ENABLED in UPLINK (0 - ENABLE, 1 - DISABLE) : %d \n", transform_precoding);
+        break;
+
+      default:
+      case 'h':
+        printf("%s -h(elp)\n", argv[0]);
+        printf("-a ULSCH starting symbol\n");
+        printf("-b ULSCH number of symbols\n");
+        printf("-c RNTI\n");
+        printf("-d Introduce delay in terms of number of samples\n");
+        printf(
+            "-g Channel model configuration. Arguments list: Number of arguments = 3, {Channel model: [A] TDLA30, [B] TDLB100, [C] "
+            "TDLC300}, {Correlation: [l] Low, [m] Medium, [h] High}, {Maximum Doppler shift} e.g. -g A,l,10\n");
+        printf("-h This message\n");
+        printf(
+            "-i Change channel estimation technique. Arguments list: Number of arguments=2, Frequency domain {0:Linear "
+            "interpolation, 1:PRB based averaging}, Time domain {0:Estimates of last DMRS symbol, 1:Average of DMRS symbols}. e.g. "
+            "-i 1,0\n");
+        printf("-j Save signal buffers in binary format.");
+        printf("-k 3/4 sampling\n");
+        printf("-l PUSCH DMRS length: 1 or 2\n");
+        printf("-m MCS value\n");
+        printf("-n Number of trials to simulate\n");
+        printf("-p Use extended prefix mode\n");
+        printf("-q MCS table\n");
+        printf("-r Number of allocated resource blocks for PUSCH\n");
+        printf("-s Starting SNR, runs from SNR0 to SNR0 + 10 dB if ending SNR isn't given\n");
+        printf("-S Ending SNR, runs from SNR0 to SNR1\n");
+        printf("-t Acceptable effective throughput (in percentage)\n");
+        printf("-u Set the numerology\n");
+        printf("-v Set the max rounds\n");
+        printf("-w Start PRB for PUSCH\n");
+        printf("-y Number of TX antennas used per UE\n");
+        printf("-z Number of RX antennas used at gNB\n");
+        printf("-A Number of antennas per thread for PUSCH channel estimation\n");
+        printf("-C Specify the number of threads for the simulation\n");
+        printf("-H Slot number\n");
+        printf("-I Maximum LDPC decoder iterations\n");
+        printf("-L <log level, 0(errors), 1(warning), 2(info) 3(debug) 4 (trace)>\n");
+        printf("-M Use limited buffer rate-matching\n");
+        printf("-N Number of UEs\n");
+        printf("-P Print ULSCH performances\n");
+        printf("-R Maximum number of available resorce blocks (N_RB_DL)\n");
+        printf(
+            "-U Change DMRS Config, arguments list: Number of arguments=4, DMRS Mapping Type{0=A,1=B}, DMRS AddPos{0:3}, DMRS "
+            "Config Type{1,2}, Number of CDM groups without data{1,2,3} e.g. -U 0,2,0,1 \n");
+        printf("-W Number of layers for PUSCH per UE\n");
+        printf("-Z If -Z is used, SC-FDMA or transform precoding is enabled in Uplink \n");
+        exit(-1);
+        break;
+    }
+  }
+
+  AssertFatal(precod_nbr_layers <= min(n_tx, n_rx),
+              "Number of layers %d cannot be more than min(n_tx %d, n_rx %d)\n",
+              precod_nbr_layers,
+              n_tx,
+              n_rx);
+  uint8_t total_layers = precod_nbr_layers * NUM_UE;
+  AssertFatal(total_layers <= NR_MAX_NB_LAYERS,
+              "Total number of layers %d cannot be more than NR_MAX_NB_LAYERS %d\n",
+              total_layers,
+              NR_MAX_NB_LAYERS);
+  AssertFatal(total_layers <= n_rx, "Total number of layers %d cannot be more than n_rx %d\n", total_layers, n_rx);
+
+  logInit();
+  set_glog(loglvl);
+
+  get_softmodem_params()->phy_test = 1;
+  get_softmodem_params()->do_ra = 0;
+
+  if (snr1set == 0)
+    snr1 = snr0 + 10;
+
+  double sampling_frequency, tx_bandwidth, rx_bandwidth;
+  get_samplerate_and_bw(mu, N_RB_DL, threequarter_fs, &sampling_frequency, &tx_bandwidth, &rx_bandwidth);
+
+  RC.gNB = (PHY_VARS_gNB **)malloc_or_fail(sizeof(PHY_VARS_gNB *));
+  RC.gNB[0] = calloc_or_fail(1, sizeof(PHY_VARS_gNB));
+  gNB = RC.gNB[0];
+  gNB->ofdm_offset_divisor = UINT_MAX;
+  gNB->num_pusch_symbols_per_thread = 1;
+  gNB->dmrs_num_antennas_per_thread = num_antennas_per_thread;
+  gNB->RU_list[0] = calloc_or_fail(1, sizeof(**gNB->RU_list));
+  gNB->RU_list[0]->rfdevice.openair0_cfg = openair0_cfg;
+
+  if (setAffinity == false)
+    initFloatingCoresTpool(threadCnt, &gNB->threadPool, false, "gNB-tpool");
+  else
+    initNamedTpool(gNBthreads, &gNB->threadPool, true, "gNB-tpool");
+
+  NR_UL_IND_t UL_INFO = {0};
+  UL_INFO.crc_ind.crc_list = UL_INFO.crc_pdu_list;
+  UL_INFO.rx_ind.pdu_list = UL_INFO.rx_pdu_list;
+  UL_INFO.rx_ind.number_of_pdus = 0;
+  UL_INFO.crc_ind.number_crcs = 0;
+  gNB->max_ldpc_iterations = max_ldpc_iterations;
+  gNB->pusch_thres = -20;
+  gNB->frame_parms.N_RB_DL = N_RB_DL;
+  gNB->frame_parms.N_RB_UL = N_RB_UL;
+  gNB->frame_parms.Ncp = extended_prefix_flag ? NR_EXTENDED : NR_NORMAL;
+
+  AssertFatal((gNB->if_inst = NR_IF_Module_init(0)) != NULL, "Cannot register interface");
+  gNB->if_inst->NR_PHY_config_req = nr_phy_config_request;
+
+  s_interleaved = calloc_or_fail(NUM_UE, sizeof(float **));
+  for (int u = 0; u < NUM_UE; u++) {
+    s_interleaved[u] = malloc_or_fail(n_tx * sizeof(float *));
+  }
+  r_re = malloc_or_fail(n_rx * sizeof(float *));
+  r_im = malloc_or_fail(n_rx * sizeof(float *));
+  r_re_tmp = malloc_or_fail(n_rx * sizeof(float *));
+  r_im_tmp = malloc_or_fail(n_rx * sizeof(float *));
+
+  NR_ServingCellConfigCommon_t *scc = calloc_or_fail(1, sizeof(*scc));
+  prepare_scc(scc);
+  uint64_t ssb_bitmap;
+  fill_scc_sim(scc, &ssb_bitmap, N_RB_DL, N_RB_DL, mu, mu);
+  fix_scc(scc, ssb_bitmap);
+
+  frame_structure_t frame_structure = {0};
+  frame_type_t frame_type = TDD;
+  config_frame_structure(mu,
+                         scc->tdd_UL_DL_ConfigurationCommon,
+                         get_tdd_period_idx(scc->tdd_UL_DL_ConfigurationCommon),
+                         frame_type,
+                         &frame_structure);
+  AssertFatal(is_ul_slot(slot, &frame_structure), "The slot selected is not UL. Can't run ULSIM\n");
+
+  // TODO do a UECAP for phy-sim
+  const nr_mac_config_t conf = {.pdsch_AntennaPorts = {.N1 = 1, .N2 = 1, .XP = 1},
+                                .pusch_AntennaPorts = n_rx,
+                                .minRXTXTIME = 0,
+                                .do_CSIRS = 0,
+                                .do_SRS = 0,
+                                .num_dlharq = 16,
+                                .num_ulharq = 16,
+                                .force_256qam_off = false,
+                                .timer_config.sr_ProhibitTimer = 0,
+                                .timer_config.sr_TransMax = 64,
+                                .timer_config.sr_ProhibitTimer_v1700 = 0,
+                                .timer_config.t300 = 400,
+                                .timer_config.t301 = 400,
+                                .timer_config.t310 = 2000,
+                                .timer_config.n310 = 10,
+                                .timer_config.t311 = 3000,
+                                .timer_config.n311 = 1,
+                                .timer_config.t319 = 400,
+                                .spatial_stream_index = {0, 1, 2, 3, 4, 5, 6, 7}};
+  const nr_rlc_configuration_t rlc_config = {.srb =
+                                                 {
+                                                     .t_poll_retransmit = 45,
+                                                     .t_reassembly = 35,
+                                                     .t_status_prohibit = 0,
+                                                     .poll_pdu = -1,
+                                                     .poll_byte = -1,
+                                                     .max_retx_threshold = 8,
+                                                     .sn_field_length = 12,
+                                                 },
+                                             .drb_am =
+                                                 {
+                                                     .t_poll_retransmit = 45,
+                                                     .t_reassembly = 15,
+                                                     .t_status_prohibit = 15,
+                                                     .poll_pdu = 64,
+                                                     .poll_byte = 1024 * 500,
+                                                     .max_retx_threshold = 32,
+                                                     .sn_field_length = 18,
+                                                 },
+                                             .drb_um = {
+                                                 .t_reassembly = 15,
+                                                 .sn_field_length = 12,
+                                             }};
+
+  RC.nb_nr_macrlc_inst = 1;
+  mac_top_init_gNB(ngran_gNB, scc, &conf, &rlc_config);
+  RC.nrmac[0]->beam_info = (NR_beam_info_t){.beams_per_period = 1};
+  nr_mac_config_scc(RC.nrmac[0], scc, &conf);
+
+  NR_UE_NR_Capability_t *UE_Capability_nr = CALLOC(1, sizeof(NR_UE_NR_Capability_t));
+  prepare_sim_uecap(UE_Capability_nr, scc, mu, N_RB_UL, 0, mcs_table);
+  rnti_t rnti = 0x1234;
+  int uid = 0;
+  int ssb_index = 0;
+  NR_CellGroupConfig_t *secondaryCellGroup = get_default_secondaryCellGroup(scc, UE_Capability_nr, 0, 1, &conf, uid, ssb_index);
+  secondaryCellGroup->spCellConfig->reconfigurationWithSync = get_reconfiguration_with_sync(rnti, uid, scc, frame);
+
+  NR_BCCH_BCH_Message_t *mib = get_new_MIB_NR(scc);
+
+  // UE dedicated configuration
+  for (int u = 0; u < NUM_UE; u++) {
+    nr_mac_add_test_ue(RC.nrmac[0], n_rnti + u, secondaryCellGroup);
+  }
+  gNB->frame_parms.nb_antennas_tx = 1;
+  gNB->frame_parms.nb_antennas_rx = n_rx;
+  nfapi_nr_config_request_scf_t *cfg = &gNB->gNB_config;
+  cfg->carrier_config.num_tx_ant.value = 1;
+  cfg->carrier_config.num_rx_ant.value = n_rx;
+
+  gNB->chest_freq = chest_type[0];
+  gNB->chest_time = chest_type[1];
+  if (gNB->if_inst) {
+    gNB->if_inst->sl_ahead = 6;
+  }
+
+  phy_init_nr_gNB(gNB);
+  /* RU handles rxdataF, and gNB just has a pointer. Here, we don't have an RU,
+   * so we need to allocate that memory as well. */
+  for (i = 0; i < n_rx; i++)
+    gNB->common_vars.rxdataF[i] = malloc16_clear(gNB->frame_parms.samples_per_frame_wCP * sizeof(int32_t));
+  N_RB_DL = gNB->frame_parms.N_RB_DL;
+
+  /* no RU: need to have rxdata */
+  c16_t **rxdata;
+  rxdata = malloc_or_fail(n_rx * sizeof(*rxdata));
+  for (int i = 0; i < n_rx; ++i)
+    rxdata[i] = calloc_or_fail(gNB->frame_parms.samples_per_frame, sizeof(**rxdata));
+
+  NR_BWP_Uplink_t *ubwp =
+      secondaryCellGroup->spCellConfig->spCellConfigDedicated->uplinkConfig->uplinkBWP_ToAddModList->list.array[0];
+
+  // Configure channel model
+  for (int u = 0; u < NUM_UE; u++) {
+    UE2gNB[u] = new_channel_desc_scm(n_tx,
+                                     n_rx,
+                                     channel_model,
+                                     sampling_frequency / 1e6,
+                                     gNB->frame_parms.ul_CarrierFreq,
+                                     tx_bandwidth,
+                                     DS_TDL,
+                                     maxDoppler,
+                                     corr_level,
+                                     0,
+                                     delay,
+                                     0,
+                                     0);
+
+    if (UE2gNB[u] == NULL) {
+      printf("Problem generating channel model. Exiting.\n");
+      exit(-1);
+    }
+  }
+
+  const int num_samples_alloc = 153600;
+  printf("Pre-allocating padded host memory for the CPU channel pipeline...\n");
+  const int max_padding_alloc = 256 - 1;
+  size_t padded_tx_alloc_bytes = n_tx * (num_samples_alloc + max_padding_alloc) * 2 * sizeof(float);
+  h_tx_sig_pinned = malloc_or_fail(padded_tx_alloc_bytes);
+  if (h_tx_sig_pinned == NULL) {
+    printf("Error: Failed to allocate host buffer for CPU path\n");
+    exit(-1);
+  }
+
+  // Configure UE
+  NR_UE_MAC_INST_t *UE_mac[MAX_NUM_UE];
+  nrPHY_vars_UE_g = malloc_or_fail(NUM_UE * sizeof(PHY_VARS_NR_UE **));
+  for (int u = 0; u < NUM_UE; u++) {
+    nrPHY_vars_UE_g[u] = malloc_or_fail(sizeof(PHY_VARS_NR_UE *));
+    UE[u] = calloc_or_fail(1, sizeof(PHY_VARS_NR_UE));
+    nrPHY_vars_UE_g[u][0] = UE[u];
+    UE[u]->frame_parms = gNB->frame_parms;
+    UE[u]->frame_parms.nb_antennas_tx = n_tx;
+    UE[u]->frame_parms.nb_antennas_rx = 0;
+    UE[u]->nrLDPC_coding_interface = gNB->nrLDPC_coding_interface;
+
+    if (init_nr_ue_signal(UE[u], 1) != 0) {
+      printf("Error at UE NR initialisation\n");
+      exit(-1);
+    }
+
+    init_nr_ue_transport(UE[u]);
+
+    UE_mac[u] = nr_l2_init_ue(u, mu);
+    ue_init_config_request(UE_mac[u], get_slots_per_frame_from_scs(mu));
+    UE[u]->if_inst = nr_ue_if_module_init(u);
+    UE[u]->if_inst->scheduled_response = nr_ue_scheduled_response;
+    UE[u]->if_inst->phy_config_request = nr_ue_phy_config_request;
+    UE[u]->if_inst->dl_indication = nr_ue_dl_indication;
+    UE[u]->if_inst->ul_indication = nr_ue_ul_indication;
+    UE[u]->no_phase_pre_comp = no_phase_pre_comp;
+    UE_mac[u]->if_module = nr_ue_if_module_init(u);
+    nr_ue_phy_config_request(&UE_mac[u]->phy_config);
+  }
+
+  initFloatingCoresTpool(threadCnt, &nrUE_params.Tpool, false, "UE-tpool");
+
+  unsigned char harq_pid = 0;
+
+  NR_Sched_Rsp_t *Sched_INFO = malloc16_clear(sizeof(*Sched_INFO));
+  memset((void *)Sched_INFO, 0, sizeof(*Sched_INFO));
+  nfapi_nr_ul_tti_request_t *UL_tti_req = &Sched_INFO->UL_tti_req;
+
+  time_stats_t channel_stats = {0};
+  time_stats_t noise_stats = {0};
+  uint32_t errors_decoding = 0;
+
+  uint16_t pdu_bit_map = PUSCH_PDU_BITMAP_PUSCH_DATA;
+
+  unsigned char mod_order = nr_get_Qm_ul(Imcs, mcs_table);
+  uint16_t code_rate = nr_get_code_rate_ul(Imcs, mcs_table);
+
+  uint8_t mapping_type = typeB; // Default Values
+  pusch_dmrs_type_t dmrs_config_type = pusch_dmrs_type1; // Default Values
+  pusch_dmrs_AdditionalPosition_t add_pos = pusch_dmrs_pos0; // Default Values
+
+  /* validate parameters othwerwise default values are used */
+  /* -U flag can be used to set DMRS parameters*/
+  if (modify_dmrs) {
+    if (dmrs_arg[0] == 0)
+      mapping_type = typeA;
+    else if (dmrs_arg[0] == 1)
+      mapping_type = typeB;
+    /* Additional DMRS positions */
+    if (dmrs_arg[1] >= 0 && dmrs_arg[1] <= 3)
+      add_pos = dmrs_arg[1];
+    /* DMRS Conf Type 1 or 2 */
+    if (dmrs_arg[2] == 1)
+      dmrs_config_type = pusch_dmrs_type1;
+    else if (dmrs_arg[2] == 2)
+      dmrs_config_type = pusch_dmrs_type2;
+    num_dmrs_cdm_grps_no_data = dmrs_arg[3];
+  }
+
+  uint16_t l_prime_mask =
+      get_l_prime(nb_symb_sch, mapping_type, add_pos, length_dmrs, start_symbol, NR_MIB__dmrs_TypeA_Position_pos2);
+  int number_dmrs_symbols = count_bits64_with_mask(l_prime_mask, start_symbol, nb_symb_sch);
+  uint8_t nb_re_dmrs = (dmrs_config_type == pusch_dmrs_type1) ? 6 : 4;
+
+  uint32_t tbslbrm = 0;
+  if (ilbrm)
+    tbslbrm = nr_compute_tbslbrm(mcs_table, N_RB_UL, precod_nbr_layers);
+
+  if ((UE[0]->frame_parms.nb_antennas_tx == 4) && (precod_nbr_layers == 4))
+    num_dmrs_cdm_grps_no_data = 2;
+
+  if (transform_precoding == transformPrecoder_enabled) {
+    int index = get_index_for_dmrs_lowpapr_seq((NR_NB_SC_PER_RB / 2) * nb_rb);
+    AssertFatal(index >= 0,
+                "Num RBs not configured according to 3GPP 38.211 section 6.3.1.4. For PUSCH with transform precoding, num RBs "
+                "cannot be multiple of any other primenumber other than 2,3,5\n");
+
+    dmrs_config_type = pusch_dmrs_type1;
+    nb_re_dmrs = 6;
+
+    printf("[ULSIM]: TRANSFORM PRECODING ENABLED. Num RBs: %d, index for DMRS_SEQ: %d\n", nb_rb, index);
+  }
+
+  nb_re_dmrs = nb_re_dmrs * num_dmrs_cdm_grps_no_data;
+  unsigned int TBS =
+      nr_compute_tbs(mod_order, code_rate, nb_rb, nb_symb_sch, nb_re_dmrs * number_dmrs_symbols, 0, 0, precod_nbr_layers);
+
+  printf("[ULSIM]: length_dmrs: %u, l_prime_mask: %u	number_dmrs_symbols: %u, mapping_type: %u add_pos: %d \n",
+         length_dmrs,
+         l_prime_mask,
+         number_dmrs_symbols,
+         mapping_type,
+         add_pos);
+  printf("[ULSIM]: CDM groups: %u, dmrs_config_type: %d, num_rbs: %u, nb_symb_sch: %u, start_symbol %u\n",
+         num_dmrs_cdm_grps_no_data,
+         dmrs_config_type,
+         nb_rb,
+         nb_symb_sch,
+         start_symbol);
+  printf("[ULSIM]: MCS: %d, mod order: %u, code_rate: %u\n", Imcs, mod_order, code_rate);
+
+  uint8_t ulsch_input_buffer[MAX_NUM_UE][TBS / 8];
+
+  for (int u = 0; u < NUM_UE; u++) {
+    ulsch_input_buffer[u][0] = 0x31;
+    for (i = 1; i < TBS / 8; i++) {
+      ulsch_input_buffer[u][i] = (uint8_t)rand();
+    }
+  }
+
+  double ts = 1.0 / (gNB->frame_parms.subcarrier_spacing * gNB->frame_parms.ofdm_symbol_size);
+
+  if (n_trials == 1)
+    max_rounds = 1;
+
+  printf("\n");
+
+  uint32_t unav_res = 0;
+  unsigned int available_bits =
+      nr_get_G(nb_rb, nb_symb_sch, nb_re_dmrs, number_dmrs_symbols, unav_res, mod_order, precod_nbr_layers);
+  uint8_t cw_buf[available_bits];
+  memset(cw_buf, 0, available_bits);
+  printf("[ULSIM]: VALUE OF G: %u, TBS: %u\n", available_bits, TBS);
+  int frame_length_complex_samples = gNB->frame_parms.samples_per_subframe * NR_NUMBER_OF_SUBFRAMES_PER_FRAME;
+
+  for (int u = 0; u < NUM_UE; u++) {
+    UE[u]->phy_sim_test_buf = calloc_or_fail(1, (available_bits + 7) / 8);
+    for (int aatx = 0; aatx < n_tx; aatx++) {
+      s_interleaved[u][aatx] = calloc_or_fail(1, frame_length_complex_samples * 2 * sizeof(float));
+    }
+  }
+
+  for (int aarx = 0; aarx < n_rx; aarx++) {
+    r_re[aarx] = calloc_or_fail(1, frame_length_complex_samples * sizeof(float));
+    r_im[aarx] = calloc_or_fail(1, frame_length_complex_samples * sizeof(float));
+    r_re_tmp[aarx] = calloc_or_fail(1, frame_length_complex_samples * sizeof(float));
+    r_im_tmp[aarx] = calloc_or_fail(1, frame_length_complex_samples * sizeof(float));
+  }
+
+  int slot_offset = get_samples_slot_timestamp(&gNB->frame_parms, slot);
+  int slot_length = slot_offset - get_samples_slot_timestamp(&gNB->frame_parms, slot - 1);
+
+  fapi_nr_ul_config_request_t ul_config[MAX_NUM_UE] = {0};
+  nr_phy_data_tx_t phy_data[MAX_NUM_UE] = {0};
+  UE_nr_rxtx_proc_t UE_proc[MAX_NUM_UE] = {0};
+
+  int ret = 1;
+  for (SNR = snr0; SNR <= snr1 && !stop; SNR += snr_step) {
+    varArray_t *table_rx = initVarArray(1000, sizeof(double));
+
+    reset_meas(&gNB->phy_proc_rx);
+    reset_meas(&gNB->rx_pusch_stats);
+    reset_meas(&gNB->rx_pusch_init_stats);
+    reset_meas(&gNB->rx_pusch_symbol_processing_stats);
+    reset_meas(&gNB->pusch_extraction_stats);
+    reset_meas(&gNB->pusch_channel_compensation_stats);
+    reset_meas(&gNB->ulsch_llr_stats);
+    reset_meas(&gNB->ulsch_layer_demapping_stats);
+    reset_meas(&gNB->ulsch_unscrambling_stats);
+    reset_meas(&gNB->ulsch_decoding_stats);
+    reset_meas(&gNB->ts_deinterleave);
+    reset_meas(&gNB->ts_rate_unmatch);
+    reset_meas(&gNB->ts_ldpc_decode);
+    reset_meas(&gNB->ulsch_channel_estimation_stats);
+    reset_meas(&gNB->pusch_channel_estimation_antenna_processing_stats);
+    for (int u = 0; u < NUM_UE; u++)
+      init_nr_ue_phy_cpu_stats(&UE[u]->phy_cpu_stats);
+
+    uint32_t errors_scrambling[MAX_NUM_UE][16] = {0};
+    int n_errors[MAX_NUM_UE][16] = {0};
+    int round_trials[MAX_NUM_UE][16] = {0};
+    double blerStats[MAX_NUM_UE][16] = {0};
+    double berStats[MAX_NUM_UE][16] = {0};
+
+    uint64_t sum_pusch_delay[MAX_NUM_UE] = {0};
+    int min_pusch_delay[MAX_NUM_UE];
+    int max_pusch_delay[MAX_NUM_UE];
+    int delay_pusch_est_count[MAX_NUM_UE] = {0};
+    for (int u = 0; u < NUM_UE; u++) {
+      min_pusch_delay[u] = INT_MAX;
+      max_pusch_delay[u] = INT_MIN;
+    }
+
+    int n_false_positive[MAX_NUM_UE] = {0};
+    double effRate[MAX_NUM_UE] = {0};
+    double effTP[MAX_NUM_UE] = {0};
+    float roundStats[MAX_NUM_UE] = {0};
+    for (trial = 0; trial < n_trials && !stop; trial++) {
+      uint8_t round = 0;
+      int ue_crc_status[MAX_NUM_UE];
+      int ue_rounds[MAX_NUM_UE] = {0};
+      for (int u = 0; u < NUM_UE; u++) {
+        ue_crc_status[u] = 1;
+      }
+
+      while (round < max_rounds && !stop) {
+        int active_ues = 0;
+        for (int u = 0; u < NUM_UE; u++) {
+          if (ue_crc_status[u]) {
+            active_ues++;
+            ue_rounds[u]++;
+          }
+        }
+        if (active_ues == 0)
+          break;
+
+        rv_index = nr_get_rv(round % 4);
+
+        /// gNB UL PDUs
+        UL_tti_req->SFN = frame;
+        UL_tti_req->Slot = slot;
+        UL_tti_req->n_pdus = NUM_UE;
+
+        // Fill FAPI PUSCH groups
+        UL_tti_req->n_group = 1;
+        nfapi_nr_ul_tti_request_number_of_groups_t *group = &UL_tti_req->groups_list[0];
+        group->n_ue = NUM_UE;
+
+        for (int u = 0; u < NUM_UE; u++) {
+          if (ue_crc_status[u] == 1) {
+            round_trials[u][round]++;
+          }
+          group->ue_list[u].pdu_idx = u;
+
+          nfapi_nr_ul_tti_request_number_of_pdus_t *pdu_element0 = &UL_tti_req->pdus_list[u];
+          pdu_element0->pdu_type = NFAPI_NR_UL_CONFIG_PUSCH_PDU_TYPE;
+          pdu_element0->pdu_size = sizeof(nfapi_nr_pusch_pdu_t);
+
+          nfapi_nr_pusch_pdu_t *pusch_pdu = &pdu_element0->pusch_pdu;
+          memset(pusch_pdu, 0, sizeof(nfapi_nr_pusch_pdu_t));
+
+          int abwp_size = NRRIV2BW(ubwp->bwp_Common->genericParameters.locationAndBandwidth, 275);
+          int abwp_start = NRRIV2PRBOFFSET(ubwp->bwp_Common->genericParameters.locationAndBandwidth, 275);
+          pusch_pdu->bwp_start = abwp_start;
+          pusch_pdu->bwp_size = abwp_size;
+          pusch_pdu->pusch_data.tb_size = TBS >> 3;
+          pusch_pdu->pdu_bit_map = pdu_bit_map;
+          pusch_pdu->rnti = n_rnti + u;
+          pusch_pdu->mcs_index = Imcs;
+          pusch_pdu->mcs_table = mcs_table;
+          pusch_pdu->target_code_rate = code_rate;
+          pusch_pdu->qam_mod_order = mod_order;
+          pusch_pdu->transform_precoding = transform_precoding;
+          pusch_pdu->data_scrambling_id = *scc->physCellId;
+          pusch_pdu->nrOfLayers = precod_nbr_layers;
+          pusch_pdu->ul_dmrs_symb_pos = l_prime_mask;
+          pusch_pdu->dmrs_config_type = dmrs_config_type;
+          pusch_pdu->ul_dmrs_scrambling_id = *scc->physCellId;
+          pusch_pdu->scid = 0;
+          // Set orthogonal DMRS
+          pusch_pdu->dmrs_ports = ((1 << precod_nbr_layers) - 1) << (u * precod_nbr_layers);
+          pusch_pdu->num_dmrs_cdm_grps_no_data = num_dmrs_cdm_grps_no_data;
+          pusch_pdu->resource_alloc = 1;
+          pusch_pdu->rb_start = start_rb;
+          pusch_pdu->rb_size = nb_rb;
+          pusch_pdu->vrb_to_prb_mapping = 0;
+          pusch_pdu->frequency_hopping = 0;
+          pusch_pdu->uplink_frequency_shift_7p5khz = 0;
+          pusch_pdu->start_symbol_index = start_symbol;
+          pusch_pdu->nr_of_symbols = nb_symb_sch;
+          pusch_pdu->maintenance_parms_v3.tbSizeLbrmBytes = tbslbrm;
+          pusch_pdu->pusch_data.rv_index = rv_index;
+          pusch_pdu->pusch_data.harq_process_id = 0;
+          pusch_pdu->pusch_data.new_data_indicator = round == 0 ? true : false;
+          pusch_pdu->pusch_data.num_cb = 0;
+          pusch_pdu->maintenance_parms_v3.ldpcBaseGraph = get_BG(TBS, code_rate);
+          pusch_pdu->param_v4.numSpatialStreamIndices = conf.pusch_AntennaPorts;
+          memcpy(pusch_pdu->param_v4.spatialStreamIndices, conf.spatial_stream_index, sizeof(conf.spatial_stream_index));
+
+          // if transform precoding is enabled
+          if (transform_precoding == transformPrecoder_enabled) {
+            pusch_pdu->dfts_ofdm.low_papr_group_number = *scc->physCellId % 30; // U as defined in 38.211 section 6.4.1.1.1.2
+            pusch_pdu->dfts_ofdm.low_papr_sequence_number = 0; // V as defined in 38.211 section 6.4.1.1.1.2
+            pusch_pdu->num_dmrs_cdm_grps_no_data = num_dmrs_cdm_grps_no_data;
+          }
+        }
+
+        /* load FAPI into RX of L1 */
+        nr_save_ul_tti_req(gNB, &Sched_INFO->UL_tti_req);
+
+        for (int aarx = 0; aarx < n_rx; aarx++) {
+          memset(r_re[aarx], 0, frame_length_complex_samples * sizeof(float));
+          memset(r_im[aarx], 0, frame_length_complex_samples * sizeof(float));
+        }
+        double txlev_sum = 0;
+        for (int u = 0; u < NUM_UE; u++) {
+          UE[u]->ul_harq_processes[harq_pid].round = round;
+          UE_proc[u].nr_slot_tx = slot;
+          UE_proc[u].frame_tx = frame;
+          UE_proc[u].gNB_id = 0;
+
+          // --------- setting parameters for UE --------
+          nr_scheduled_response_t scheduled_response = {.module_id = u,
+                                                        .ul_config = &ul_config[u],
+                                                        .phy_data = (void *)&phy_data[u]};
+
+          ul_config[u].slot = slot;
+          ul_config[u].number_pdus = 1;
+
+          fapi_nr_ul_config_request_pdu_t *ul_config0 = &ul_config[u].ul_config_list[0];
+          ul_config0->pdu_type = FAPI_NR_UL_CONFIG_TYPE_PUSCH;
+          nfapi_nr_ue_pusch_pdu_t *pusch_config_pdu = &ul_config0->pusch_config_pdu;
+          // Config UL TX PDU
+          pusch_config_pdu->tx_request_body.fapiTxPdu = ulsch_input_buffer[u];
+          pusch_config_pdu->tx_request_body.pdu_length = TBS / 8;
+          pusch_config_pdu->rnti = n_rnti + u;
+          pusch_config_pdu->pdu_bit_map = pdu_bit_map;
+          pusch_config_pdu->qam_mod_order = mod_order;
+          pusch_config_pdu->rb_size = nb_rb;
+          pusch_config_pdu->rb_start = start_rb;
+          pusch_config_pdu->nr_of_symbols = nb_symb_sch;
+          pusch_config_pdu->start_symbol_index = start_symbol;
+          pusch_config_pdu->ul_dmrs_symb_pos = l_prime_mask;
+          pusch_config_pdu->dmrs_config_type = dmrs_config_type;
+          pusch_config_pdu->mcs_index = Imcs;
+          pusch_config_pdu->mcs_table = mcs_table;
+          pusch_config_pdu->num_dmrs_cdm_grps_no_data = num_dmrs_cdm_grps_no_data;
+          pusch_config_pdu->nrOfLayers = precod_nbr_layers;
+          // set orthognal DMRS ports
+          pusch_config_pdu->dmrs_ports = ((1 << precod_nbr_layers) - 1) << (u * precod_nbr_layers);
+          pusch_config_pdu->target_code_rate = code_rate;
+          pusch_config_pdu->tbslbrm = tbslbrm;
+          pusch_config_pdu->ldpcBaseGraph = get_BG(TBS, code_rate);
+          pusch_config_pdu->pusch_data.tb_size = TBS / 8;
+          pusch_config_pdu->pusch_data.new_data_indicator = round == 0 ? true : false;
+          pusch_config_pdu->pusch_data.rv_index = rv_index;
+          pusch_config_pdu->pusch_data.harq_process_id = harq_pid;
+          pusch_config_pdu->transform_precoding = transform_precoding;
+          // if transform precoding is enabled
+          if (transform_precoding == transformPrecoder_enabled) {
+            pusch_config_pdu->dfts_ofdm.low_papr_group_number = *scc->physCellId % 30; // U as defined in 38.211 section 6.4.1.1.1.2
+            pusch_config_pdu->dfts_ofdm.low_papr_sequence_number = 0; // V as defined in 38.211 section 6.4.1.1.1.2
+            // pusch_config_pdu->pdu_bit_map |= PUSCH_PDU_BITMAP_DFTS_OFDM;
+            pusch_config_pdu->num_dmrs_cdm_grps_no_data = num_dmrs_cdm_grps_no_data;
+          }
+
+          for (int i = 0; i < (TBS / 8); i++) {
+            UE[u]->ul_harq_processes[harq_pid].payload_AB[i] = ulsch_input_buffer[u][i];
+          }
+
+          // set FAPI parameters for UE, put them in the scheduled response and call
+          nr_ue_scheduled_response(&scheduled_response);
+
+          /////////////////////////phy_procedures_nr_ue_TX///////////////////////
+          ///////////
+          int slot_start = get_samples_slot_timestamp(&UE[u]->frame_parms, slot);
+          c16_t *tx[UE[u]->frame_parms.nb_antennas_tx];
+          for (int i = 0; i < UE[u]->frame_parms.nb_antennas_tx; i++)
+            tx[i] = UE[u]->common_vars.txData[i] + slot_start;
+          phy_procedures_nrUE_TX(UE[u], &UE_proc[u], &phy_data[u], tx);
+
+          if (n_trials == 1) {
+            LOG_M("txsig0.m", "txs0", &UE[u]->common_vars.txData[0][slot_offset], slot_length, 1, 1 | log_format);
+            if (precod_nbr_layers > 1) {
+              LOG_M("txsig1.m", "txs1", &UE[u]->common_vars.txData[1][slot_offset], slot_length, 1, 1 | log_format);
+              if (precod_nbr_layers == 4) {
+                LOG_M("txsig2.m", "txs2", &UE[u]->common_vars.txData[2][slot_offset], slot_length, 1, 1 | log_format);
+                LOG_M("txsig3.m", "txs3", &UE[u]->common_vars.txData[3][slot_offset], slot_length, 1, 1 | log_format);
+              }
+            }
+          }
+          ///////////
+          ////////////////////////////////////////////////////
+          // Compute transmitter energy level
+          tx_offset = get_samples_slot_timestamp(&gNB->frame_parms, slot);
+          int symbol_offset = tx_offset + 5 * gNB->frame_parms.ofdm_symbol_size + 4 * gNB->frame_parms.nb_prefix_samples
+                              + gNB->frame_parms.nb_prefix_samples0;
+          int symbol_length = gNB->frame_parms.ofdm_symbol_size + gNB->frame_parms.nb_prefix_samples;
+          txlev[u] = compute_tx_energy_level(UE[u]->common_vars.txData,
+                                             UE[u]->frame_parms.nb_antennas_tx,
+                                             symbol_offset,
+                                             symbol_length,
+                                             n_trials);
+
+          txlev_sum += txlev[u];
+
+          for (int aa = 0; aa < UE[u]->frame_parms.nb_antennas_tx; aa++) {
+            for (i = 0; i < slot_length; i++) {
+              s_interleaved[u][aa][2 * i] = (float)UE[u]->common_vars.txData[aa][slot_offset + i].r;
+              s_interleaved[u][aa][2 * i + 1] = (float)UE[u]->common_vars.txData[aa][slot_offset + i].i;
+            }
+          }
+
+          const int padding_len = UE2gNB[u]->channel_length - 1;
+          const int padded_slot_length = slot_length + padding_len;
+          float *h_tx_ptr = (float *)h_tx_sig_pinned;
+          size_t total_padded_bytes_for_slot = n_tx * padded_slot_length * 2 * sizeof(float);
+          memset(h_tx_ptr, 0, total_padded_bytes_for_slot);
+
+          for (int j = 0; j < n_tx; j++) {
+            float *data_start_ptr = h_tx_ptr + (j * padded_slot_length + padding_len) * 2;
+            memcpy(data_start_ptr, s_interleaved[u][j], slot_length * 2 * sizeof(float));
+          }
+
+          float **tx_sig_for_cpu = malloc_or_fail(n_tx * sizeof(float *));
+          for (int j = 0; j < n_tx; j++) {
+            tx_sig_for_cpu[j] = h_tx_ptr + (j * padded_slot_length + padding_len) * 2;
+          }
+
+          for (int aarx = 0; aarx < n_rx; aarx++) {
+            memset(r_re_tmp[aarx], 0, frame_length_complex_samples * sizeof(float));
+            memset(r_im_tmp[aarx], 0, frame_length_complex_samples * sizeof(float));
+          }
+
+          start_meas(&channel_stats);
+          multipath_channel_float(UE2gNB[u], tx_sig_for_cpu, r_re_tmp, r_im_tmp, slot_length, 0, (n_trials == 1) ? 1 : 0);
+          // Add interference from multiple UEs
+          add_rx_signals(r_re, r_im, r_re_tmp, r_im_tmp, n_rx, slot_length);
+          stop_meas(&channel_stats);
+
+          free(tx_sig_for_cpu);
+        }
+
+        sigma =
+            compute_noise_variance(txlev_sum, gNB->frame_parms.ofdm_symbol_size, nb_rb, NUM_UE * precod_nbr_layers, SNR, n_trials);
+        start_meas(&noise_stats);
+        add_noise_float(rxdata,
+                        (const float **)r_re,
+                        (const float **)r_im,
+                        (float)sigma,
+                        slot_length,
+                        slot_offset,
+                        ts,
+                        delay,
+                        false,
+                        gNB->frame_parms.nb_antennas_rx);
+        stop_meas(&noise_stats);
+
+        //----------------------------------------------------------
+        //------------------- gNB phy procedures -------------------
+        //----------------------------------------------------------
+        UL_INFO.rx_ind.number_of_pdus = 0;
+        UL_INFO.crc_ind.number_crcs = 0;
+
+        //----------- OFDM Demodulation and RX rotation--------------------------
+        bool was_symbol_used[14] = {0};
+        int offset = (slot & 3) * gNB->frame_parms.symbols_per_slot * gNB->frame_parms.ofdm_symbol_size;
+        for (int i = 0; i < 14; i++) {
+          was_symbol_used[i] = true;
+        }
+        nr_ofdm_demod_and_rx_rotation(rxdata,
+                                      gNB->common_vars.rxdataF,
+                                      &gNB->frame_parms,
+                                      gNB->frame_parms.nb_antennas_rx,
+                                      slot,
+                                      offset,
+                                      link_type_ul,
+                                      was_symbol_used);
+
+        ul_proc_error = phy_procedures_gNB_uespec_RX(gNB, frame, slot, &UL_INFO);
+
+        if (n_trials == 1 && round == 0) {
+          LOG_M("rxsig0.m", "rx0", &rxdata[0][slot_offset], slot_length, 1, 1 | log_format);
+          LOG_M("rxsigF0.m", "rxsF0", gNB->common_vars.rxdataF[0], 14 * gNB->frame_parms.ofdm_symbol_size, 1, 1 | log_format);
+          if (precod_nbr_layers > 1) {
+            LOG_M("rxsig1.m", "rx1", &rxdata[1][slot_offset], slot_length, 1, 1);
+            LOG_M("rxsigF1.m", "rxsF1", gNB->common_vars.rxdataF[1], 14 * gNB->frame_parms.ofdm_symbol_size, 1, 1 | log_format);
+            if (precod_nbr_layers == 4) {
+              LOG_M("rxsig2.m", "rx2", &rxdata[2][slot_offset], slot_length, 1, 1);
+              LOG_M("rxsig3.m", "rx3", &rxdata[3][slot_offset], slot_length, 1, 1);
+              LOG_M("rxsigF2.m", "rxsF2", gNB->common_vars.rxdataF[2], 14 * gNB->frame_parms.ofdm_symbol_size, 1, 1 | log_format);
+              LOG_M("rxsigF3.m", "rxsF3", gNB->common_vars.rxdataF[3], 14 * gNB->frame_parms.ofdm_symbol_size, 1, 1 | log_format);
+            }
+          }
+        }
+
+        for (int u = 0; u < NUM_UE; u++) {
+          NR_gNB_PUSCH *pusch_vars = &gNB->pusch_vars[u];
+          nfapi_nr_ul_tti_request_number_of_pdus_t *pdu_element0 = &UL_tti_req->pdus_list[u];
+          nfapi_nr_pusch_pdu_t *pusch_pdu = &pdu_element0->pusch_pdu;
+
+          if (n_trials == 1 && round == 0) {
+            __attribute__((unused)) int off = ((nb_rb & 1) == 1) ? 4 : 0;
+
+            LOG_M("chestF0.m",
+                  "chF0",
+                  &pusch_vars->ul_ch_estimates[0][start_symbol * gNB->frame_parms.ofdm_symbol_size],
+                  gNB->frame_parms.ofdm_symbol_size,
+                  1,
+                  1 | log_format);
+
+            LOG_M("rxsigF0_comp.m",
+                  "rxsF0_comp",
+                  &pusch_vars->rxdataF_comp[0][start_symbol * (off + (NR_NB_SC_PER_RB * pusch_pdu->rb_size))],
+                  nb_symb_sch * (off + (NR_NB_SC_PER_RB * pusch_pdu->rb_size)),
+                  1,
+                  1 | log_format);
+
+            if (precod_nbr_layers == 2) {
+              LOG_M("chestF3.m",
+                    "chF3",
+                    &pusch_vars->ul_ch_estimates[3][start_symbol * gNB->frame_parms.ofdm_symbol_size],
+                    gNB->frame_parms.ofdm_symbol_size,
+                    1,
+                    1 | log_format);
+
+              LOG_M("rxsigF2_comp.m",
+                    "rxsF2_comp",
+                    &pusch_vars->rxdataF_comp[2][start_symbol * (off + (NR_NB_SC_PER_RB * pusch_pdu->rb_size))],
+                    nb_symb_sch * (off + (NR_NB_SC_PER_RB * pusch_pdu->rb_size)),
+                    1,
+                    1 | log_format);
+            }
+
+            if (precod_nbr_layers == 4) {
+              LOG_M("chestF5.m",
+                    "chF5",
+                    &pusch_vars->ul_ch_estimates[5][start_symbol * gNB->frame_parms.ofdm_symbol_size],
+                    gNB->frame_parms.ofdm_symbol_size,
+                    1,
+                    1 | log_format);
+              LOG_M("chestF10.m",
+                    "chF10",
+                    &pusch_vars->ul_ch_estimates[10][start_symbol * gNB->frame_parms.ofdm_symbol_size],
+                    gNB->frame_parms.ofdm_symbol_size,
+                    1,
+                    1 | log_format);
+              LOG_M("chestF15.m",
+                    "chF15",
+                    &pusch_vars->ul_ch_estimates[15][start_symbol * gNB->frame_parms.ofdm_symbol_size],
+                    gNB->frame_parms.ofdm_symbol_size,
+                    1,
+                    1 | log_format);
+
+              LOG_M("rxsigF4_comp.m",
+                    "rxsF4_comp",
+                    &pusch_vars->rxdataF_comp[4][start_symbol * (off + (NR_NB_SC_PER_RB * pusch_pdu->rb_size))],
+                    nb_symb_sch * (off + (NR_NB_SC_PER_RB * pusch_pdu->rb_size)),
+                    1,
+                    1 | log_format);
+              LOG_M("rxsigF8_comp.m",
+                    "rxsF8_comp",
+                    &pusch_vars->rxdataF_comp[8][start_symbol * (off + (NR_NB_SC_PER_RB * pusch_pdu->rb_size))],
+                    nb_symb_sch * (off + (NR_NB_SC_PER_RB * pusch_pdu->rb_size)),
+                    1,
+                    1 | log_format);
+              LOG_M("rxsigF12_comp.m",
+                    "rxsF12_comp",
+                    &pusch_vars->rxdataF_comp[12][start_symbol * (off + (NR_NB_SC_PER_RB * pusch_pdu->rb_size))],
+                    nb_symb_sch * (off + (NR_NB_SC_PER_RB * pusch_pdu->rb_size)),
+                    1,
+                    1 | log_format);
+            }
+
+            LOG_M("rxsigF0_llr.m",
+                  "rxsF0_llr",
+                  &pusch_vars->llr[0],
+                  precod_nbr_layers * (nb_symb_sch - 1) * NR_NB_SC_PER_RB * pusch_pdu->rb_size * mod_order,
+                  1,
+                  0 | log_format);
+          }
+
+          //----------------------------------------------------------
+          //----------------- count and print errors -----------------
+          //----------------------------------------------------------
+
+          NR_gNB_ULSCH_t *ulsch_gNB = &gNB->ulsch[u];
+          if (ue_crc_status[u] == 1) {
+            if ((ulsch_gNB->last_iteration_cnt >= ulsch_gNB->max_ldpc_iterations) || ul_proc_error > 0) {
+              n_errors[u][round]++;
+            }
+
+            for (i = 0; i < available_bits; i++) {
+              const uint8_t current_bit = (UE[u]->ul_harq_processes[harq_pid].f[i / 8] >> (i & 7)) & 1;
+              if (((current_bit == 0) && (pusch_vars->llr[i] <= 0)) || ((current_bit == 1) && (pusch_vars->llr[i] >= 0))) {
+                errors_scrambling[u][round]++;
+              }
+            }
+          }
+
+          if (ue_crc_status[u] == 1) {
+            sum_pusch_delay[u] += pusch_vars->delay.est_delay;
+            min_pusch_delay[u] = min(pusch_vars->delay.est_delay, min_pusch_delay[u]);
+            max_pusch_delay[u] = max(pusch_vars->delay.est_delay, max_pusch_delay[u]);
+            delay_pusch_est_count[u]++;
+
+            if ((ulsch_gNB->last_iteration_cnt >= ulsch_gNB->max_ldpc_iterations) || ul_proc_error > 0) {
+              ue_crc_status[u] = 1;
+            } else {
+              ue_crc_status[u] = 0;
+            }
+          }
+        }
+
+        if (n_trials == 1) {
+          printf("end of round %d rv_index %d\n", round, rv_index);
+        }
+        round++;
+      } // round
+
+      for (int u = 0; u < NUM_UE; u++) {
+        int ue_final_error_flag = ue_crc_status[u];
+        if (n_trials == 1 && errors_scrambling[u][0] > 0) {
+          printf(
+              "\x1B[31m"
+              "[UE %d][frame %d][trial %d]\tnumber of errors in unscrambling = %u\n"
+              "\x1B[0m",
+              u,
+              frame,
+              trial,
+              errors_scrambling[u][0]);
+        }
+
+        errors_decoding = 0;
+        for (i = 0; i < TBS; i++) {
+          uint8_t estimated_output_bit = (gNB->ulsch[u].harq_process->b[i / 8] & (1 << (i & 7))) >> (i & 7);
+          uint8_t test_input_bit = (UE[u]->ul_harq_processes[harq_pid].payload_AB[i / 8] & (1 << (i & 7))) >> (i & 7);
+
+          if (estimated_output_bit != test_input_bit) {
+            errors_decoding++;
+          }
+        }
+        if (errors_decoding > 0 && ue_final_error_flag == 0) {
+          n_false_positive[u]++;
+          if (n_trials == 1)
+            printf(
+                "\x1B[31m"
+                "[UE %d][frame %d][trial %d]\tnumber of errors in decoding     = %u\n"
+                "\x1B[0m",
+                u,
+                frame,
+                trial,
+                errors_decoding);
+        }
+        roundStats[u] += ((float)ue_rounds[u]);
+        if (!ue_final_error_flag)
+          effRate[u] += ((double)TBS) / (double)ue_rounds[u];
+      }
+    } // trial loop
+
+    int ues_passed = 0;
+    for (int u = 0; u < NUM_UE; u++) {
+      roundStats[u] /= ((float)n_trials);
+      effRate[u] /= (double)n_trials;
+
+      // -------csv file-------
+
+      // adding values into file
+      printf("*****************************************\n");
+      printf("[UE %d] SNR %f: n_errors (%d/%d", u, SNR, n_errors[u][0], round_trials[u][0]);
+      for (int r = 1; r < max_rounds; r++)
+        printf(",%d/%d", n_errors[u][r], round_trials[u][r]);
+      printf(") (negative CRC), false_positive %d/%d, errors_scrambling (%u/%u",
+             n_false_positive[u],
+             n_trials,
+             errors_scrambling[u][0],
+             available_bits * round_trials[u][0]);
+      for (int r = 1; r < max_rounds; r++)
+        printf(",%u/%u", errors_scrambling[u][r], available_bits * round_trials[u][r]);
+      printf(")\n");
+      printf("\n");
+
+      for (int r = 0; r < max_rounds; r++) {
+        if (round_trials[u][r] > 0) {
+          blerStats[u][r] = (double)n_errors[u][r] / round_trials[u][r];
+          berStats[u][r] = (double)errors_scrambling[u][r] / available_bits / round_trials[u][r];
+        } else {
+          blerStats[u][r] = 0.0;
+          berStats[u][r] = 0.0;
+        }
+      }
+      effTP[u] = effRate[u] / (double)TBS * (double)100;
+      printf("SNR %f: Channel BLER (%e", SNR, blerStats[u][0]);
+      for (int r = 1; r < max_rounds; r++)
+        printf(",%e", blerStats[u][r]);
+      printf(" Channel BER (%e", berStats[u][0]);
+      for (int r = 1; r < max_rounds; r++)
+        printf(",%e", berStats[u][r]);
+
+      printf(") Avg round %.2f, Eff Rate %.4f bits/slot, Eff Throughput %.2f, TBS %u bits/slot\n",
+             roundStats[u],
+             effRate[u],
+             effTP[u],
+             TBS);
+
+      if (delay_pusch_est_count[u] > 0) {
+        double av_delay = (double)sum_pusch_delay[u] / (2 * delay_pusch_est_count[u]);
+        printf("DMRS-PUSCH delay estimation: min %i, max %i, average %2.1f\n",
+               min_pusch_delay[u] >> 1,
+               max_pusch_delay[u] >> 1,
+               av_delay);
+      }
+
+      printf("*****************************************\n");
+      printf("\n");
+      if ((float)effTP[u] >= eff_tp_check) {
+        ues_passed++;
+      }
+    }
+
+    FILE *fd = fopen("nr_ulsim.log", "w");
+    if (fd == NULL) {
+      printf("Problem with filename %s\n", "nr_ulsim.log");
+      exit(-1);
+    }
+    dump_pusch_stats(fd, gNB);
+    fclose(fd);
+
+    if (print_perf == 1) {
+      printf("UE TX\n");
+      for (int u = 0; u < NUM_UE; u++) {
+        for (int i = PHY_PROC_TX; i <= OFDM_MOD_STATS; i++) {
+          printStatIndent(&UE[u]->phy_cpu_stats.cpu_time_stats[i], UE[u]->phy_cpu_stats.cpu_time_stats[i].meas_name);
+        }
+      }
+
+      printf("\ngNB RX\n");
+      printDistribution(&gNB->phy_proc_rx, table_rx, "Total PHY proc rx");
+      printStatIndent(&gNB->rx_pusch_stats, "RX PUSCH time");
+      printStatIndent2(&gNB->ulsch_channel_estimation_stats, "ULSCH channel estimation time");
+      printStatIndent3(&gNB->pusch_channel_estimation_antenna_processing_stats, "Antenna Processing time");
+      printStatIndent2(&gNB->rx_pusch_init_stats, "RX PUSCH Initialization time");
+      printStatIndent2(&gNB->rx_pusch_symbol_processing_stats, "RX PUSCH Symbol Processing time");
+      gNB->pusch_extraction_stats.trials = gNB->rx_pusch_symbol_processing_stats.trials;
+      printStatIndent3(&gNB->pusch_extraction_stats, "RX PUSCH extraction");
+      gNB->pusch_channel_compensation_stats.trials = gNB->rx_pusch_symbol_processing_stats.trials;
+      printStatIndent3(&gNB->pusch_channel_compensation_stats, "RX PUSCH channel compensation");
+      gNB->ulsch_llr_stats.trials = gNB->rx_pusch_symbol_processing_stats.trials;
+      printStatIndent3(&gNB->ulsch_llr_stats, "RX PUSCH LLR");
+      gNB->ulsch_layer_demapping_stats.trials = gNB->rx_pusch_symbol_processing_stats.trials;
+      printStatIndent3(&gNB->ulsch_layer_demapping_stats, "RX PUSCH layer demapping");
+      gNB->ulsch_unscrambling_stats.trials = gNB->rx_pusch_symbol_processing_stats.trials;
+      printStatIndent3(&gNB->ulsch_unscrambling_stats, "RX PUSCH unscrambling");
+      printStatIndent(&gNB->ulsch_decoding_stats, "ULSCH total decoding time");
+      gNB->ts_deinterleave.trials = n_trials;
+      printStatIndent2(&gNB->ts_deinterleave, "ULSCH segment deinterleaving time");
+      gNB->ts_rate_unmatch.trials = n_trials;
+      printStatIndent2(&gNB->ts_rate_unmatch, "ULSCH segment rate matching time");
+      gNB->ts_ldpc_decode.trials = n_trials;
+      printStatIndent2(&gNB->ts_ldpc_decode, "ULSCH segments decoding time");
+      printStatIndent(&channel_stats, "Multipath Channel (CPU)");
+      printStatIndent(&noise_stats, "Add Noise (CPU)");
+      printf("\n");
+    }
+
+    freeVarArray(table_rx);
+
+    if (n_trials == 1)
+      break;
+    if (ues_passed == NUM_UE) {
+      printf("*************\n");
+      printf("PUSCH test OK\n");
+      printf("*************\n");
+      ret = 0;
+      break;
+    }
+  } // SNR loop
+  printf("\n");
+  printf(
+      "Num RB:\t%d\n"
+      "Num symbols:\t%d\n"
+      "MCS:\t%d\n"
+      "DMRS config type:\t%d\n"
+      "DMRS add pos:\t%d\n"
+      "PUSCH mapping type:\t%d\n"
+      "DMRS length:\t%d\n"
+      "DMRS CDM gr w/o data:\t%d\n",
+      nb_rb,
+      nb_symb_sch,
+      Imcs,
+      dmrs_config_type,
+      add_pos,
+      mapping_type,
+      length_dmrs,
+      num_dmrs_cdm_grps_no_data);
+
+  free_MIB_NR(mib);
+
+  free_nrLDPC_coding_interface(&gNB->nrLDPC_coding_interface);
+
+  for (int u = 0; u < NUM_UE; u++) {
+    free_and_zero(UE[u]->phy_sim_test_buf);
+    for (int aatx = 0; aatx < n_tx; aatx++) {
+      free_and_zero(s_interleaved[u][aatx]);
+    }
+    free_and_zero(s_interleaved[u]);
+  }
+  free_and_zero(s_interleaved);
+  for (int aarx = 0; aarx < n_rx; aarx++) {
+    free_and_zero(r_re[aarx]);
+    free_and_zero(r_im[aarx]);
+    free_and_zero(r_re_tmp[aarx]);
+    free_and_zero(r_im_tmp[aarx]);
+  }
+  free_and_zero(r_re);
+  free_and_zero(r_im);
+  free_and_zero(r_re_tmp);
+  free_and_zero(r_im_tmp);
+
+  for (int u = 0; u < NUM_UE; u++) {
+    free_channel_desc_scm(UE2gNB[u]);
+  }
+
+  for (int i = 0; i < n_rx; ++i) {
+    free_and_zero(rxdata[i]);
+  }
+  free_and_zero(rxdata);
+
+  for (int u = 0; u < NUM_UE; u++) {
+    free_and_zero(UE[u]);
+    free_and_zero(nrPHY_vars_UE_g[u]);
+  }
+  free_and_zero(nrPHY_vars_UE_g);
+  free_and_zero(h_tx_sig_pinned);
+
+  return ret;
+}

--- a/openair1/SIMULATION/TOOLS/multipath_channel.c
+++ b/openair1/SIMULATION/TOOLS/multipath_channel.c
@@ -373,3 +373,45 @@ void multipath_channel_float(channel_desc_t *desc,
 }
 
 #endif
+
+// \f$\mathbf{y} = y + \mathbf{x}\f$
+#ifdef CHANNEL_SSE
+void __attribute__((no_sanitize_address)) add_rx_signals(float **y_re,
+                                                         float **y_im,
+                                                         float **x_re,
+                                                         float **x_im,
+                                                         int n_rx,
+                                                         int length)
+{
+  for (int aarx = 0; aarx < n_rx; aarx++) {
+    int i = 0;
+    for (; i <= length - 4; i += 4) {
+      // Add real values
+      simde__m128 vec_re_x = simde_mm_loadu_ps(&x_re[aarx][i]);
+      simde__m128 vec_re_y = simde_mm_loadu_ps(&y_re[aarx][i]);
+      simde_mm_storeu_ps(&y_re[aarx][i], simde_mm_add_ps(vec_re_y, vec_re_x));
+
+      // Add imaginary values
+      simde__m128 vec_im_x = simde_mm_loadu_ps(&x_im[aarx][i]);
+      simde__m128 vec_im_y = simde_mm_loadu_ps(&y_im[aarx][i]);
+      simde_mm_storeu_ps(&y_im[aarx][i], simde_mm_add_ps(vec_im_y, vec_im_x));
+    }
+
+    // Add remaining samples
+    for (; i < length; i++) {
+      y_re[aarx][i] += x_re[aarx][i];
+      y_im[aarx][i] += x_im[aarx][i];
+    }
+  }
+}
+#else
+void add_rx_signals(float **y_re, float **y_im, float **x_re, float **x_im, int n_rx, int length)
+{
+  for (int aarx = 0; aarx < n_rx; aarx++) {
+    for (int i = 0; i < length; i++) {
+      y_re[aarx][i] += x_re[aarx][i];
+      y_im[aarx][i] += x_im[aarx][i];
+    }
+  }
+}
+#endif

--- a/openair1/SIMULATION/TOOLS/sim.h
+++ b/openair1/SIMULATION/TOOLS/sim.h
@@ -429,6 +429,8 @@ void add_noise_float(c16_t **rxdata,
                      bool apply_phase_noise,
                      const uint8_t nb_antennas_rx);
 
+void add_rx_signals(float **y_re, float **y_im, float **x_re, float **x_im, int n_rx, int length);
+
 /*
 \fn double compute_pbch_sinr(channel_desc_t *desc,
                              channel_desc_t *desc_i1,

--- a/openair1/SIMULATION/tests/CMakeLists.txt
+++ b/openair1/SIMULATION/tests/CMakeLists.txt
@@ -267,11 +267,11 @@ add_physim_test(physim.5g.nr_ulsim.3gpp.test28 "3GPP G-FR1-A4-27, PUSCH Type B, 
 ######                           nr_ulsim_mu_mimo unit test                   ######
 ####################################################################################
 
-add_physim_test(physim.5g.nr_ulsim_mu_mimo.test1 "UEs 2 MCS 2 PRBs 106 SNR 1.7" nr_ulsim_mu_mimo -n300 -b14 -I15 -i 0,1 -g B,l -t90 -u 1 -m2 -R106 -r106 -U 1,1,1,2 -W1 -y1 -z2 -s1.7 -S1.7 -N2)
-add_physim_test(physim.5g.nr_ulsim_mu_mimo.test2 "UEs 2 MCS 2 PRBs 106 SNR -2.1" nr_ulsim_mu_mimo -n300 -b14 -I15 -i 0,1 -g B,l -t90 -u 1 -m2 -R106 -r106 -U 1,1,1,2 -W1 -y1 -z4 -s-2.1 -S-2.1 -N2)
-add_physim_test(physim.5g.nr_ulsim_mu_mimo.test3 "UEs 2 MCS 16 PRBs 217 SNR 18.7" nr_ulsim_mu_mimo -n300 -b14 -I15 -i 0,1 -g C,l -t90 -u 1 -m16 -R217 -r217 -U 1,1,1,2 -W1 -y1 -z2 -s18.7 -S18.7 -N2)
-add_physim_test(physim.5g.nr_ulsim_mu_mimo.test4 "UEs 2 MCS 16 PRBs 273 SNR 11.2" nr_ulsim_mu_mimo -n300 -b14 -I15 -i 0,1 -g C,l -t90 -u 1 -m16 -R273 -r273 -U 1,1,1,2 -W1 -y1 -z4 -s11.2 -S11.2 -N2)
-add_physim_test(physim.5g.nr_ulsim_mu_mimo.test5 "UEs 2 MCS 27 PRBs 106 SNR 30 QAM 256 " nr_ulsim_mu_mimo -n300 -b14 -I15 -i 0,1 -g C,l -t65 -u 1 -m27 -q1 -R106 -r106 -U 1,1,1,2 -W1 -y1 -z4 -s30 -S30 -N2)
+add_physim_test(physim.5g.nr_ulsim_mu_mimo.test1 "UEs 2 MCS 2 PRBs 106 SNR 1.7" nr_ulsim_mu_mimo -P -n300 -b14 -I15 -i 0,1 -g B,l -t90 -u 1 -m2 -R106 -r106 -U 1,1,1,2 -W1 -y1 -z2 -s1.7 -S1.7 -N2)
+add_physim_test(physim.5g.nr_ulsim_mu_mimo.test2 "UEs 2 MCS 2 PRBs 106 SNR -2.1" nr_ulsim_mu_mimo -P -n300 -b14 -I15 -i 0,1 -g B,l -t90 -u 1 -m2 -R106 -r106 -U 1,1,1,2 -W1 -y1 -z4 -s-2.1 -S-2.1 -N2)
+add_physim_test(physim.5g.nr_ulsim_mu_mimo.test3 "UEs 2 MCS 16 PRBs 217 SNR 18.7" nr_ulsim_mu_mimo -P -n300 -b14 -I15 -i 0,1 -g C,l -t90 -u 1 -m16 -R217 -r217 -U 1,1,1,2 -W1 -y1 -z2 -s18.7 -S18.7 -N2)
+add_physim_test(physim.5g.nr_ulsim_mu_mimo.test4 "UEs 2 MCS 16 PRBs 273 SNR 11.2" nr_ulsim_mu_mimo -P -n300 -b14 -I15 -i 0,1 -g C,l -t90 -u 1 -m16 -R273 -r273 -U 1,1,1,2 -W1 -y1 -z4 -s11.2 -S11.2 -N2)
+add_physim_test(physim.5g.nr_ulsim_mu_mimo.test5 "UEs 2 MCS 27 PRBs 106 SNR 30 QAM 256 " nr_ulsim_mu_mimo -P -n300 -b14 -I15 -i 0,1 -g C,l -t65 -u 1 -m27 -q1 -R106 -r106 -U 1,1,1,2 -W1 -y1 -z4 -s30 -S30 -N2)
 
 
 ####################################################################################

--- a/openair1/SIMULATION/tests/CMakeLists.txt
+++ b/openair1/SIMULATION/tests/CMakeLists.txt
@@ -264,6 +264,17 @@ add_physim_test(physim.5g.nr_ulsim.3gpp.test27 "3GPP G-FR1-A4-27, PUSCH Type B, 
 add_physim_test(physim.5g.nr_ulsim.3gpp.test28 "3GPP G-FR1-A4-27, PUSCH Type B, 40 MHz BW, 30 kHz SCS, 4 RX Antennas Requirements Test, 2 layers" nr_ulsim -P -n300 -b14 -I15 -i 0,1 -g C,l -t70 -u 1 -m16 -R106 -r106 -U 1,1,1,2 -W2 -y2 -z4 -s11.2 -S11.2)
 
 ####################################################################################
+######                           nr_ulsim_mu_mimo unit test                   ######
+####################################################################################
+
+add_physim_test(physim.5g.nr_ulsim_mu_mimo.test1 "UEs 2 MCS 2 PRBs 106 SNR 1.7" nr_ulsim_mu_mimo -n300 -b14 -I15 -i 0,1 -g B,l -t90 -u 1 -m2 -R106 -r106 -U 1,1,1,2 -W1 -y1 -z2 -s1.7 -S1.7 -N2)
+add_physim_test(physim.5g.nr_ulsim_mu_mimo.test2 "UEs 2 MCS 2 PRBs 106 SNR -2.1" nr_ulsim_mu_mimo -n300 -b14 -I15 -i 0,1 -g B,l -t90 -u 1 -m2 -R106 -r106 -U 1,1,1,2 -W1 -y1 -z4 -s-2.1 -S-2.1 -N2)
+add_physim_test(physim.5g.nr_ulsim_mu_mimo.test3 "UEs 2 MCS 16 PRBs 217 SNR 18.7" nr_ulsim_mu_mimo -n300 -b14 -I15 -i 0,1 -g C,l -t90 -u 1 -m16 -R217 -r217 -U 1,1,1,2 -W1 -y1 -z2 -s18.7 -S18.7 -N2)
+add_physim_test(physim.5g.nr_ulsim_mu_mimo.test4 "UEs 2 MCS 16 PRBs 273 SNR 11.2" nr_ulsim_mu_mimo -n300 -b14 -I15 -i 0,1 -g C,l -t90 -u 1 -m16 -R273 -r273 -U 1,1,1,2 -W1 -y1 -z4 -s11.2 -S11.2 -N2)
+add_physim_test(physim.5g.nr_ulsim_mu_mimo.test5 "UEs 2 MCS 27 PRBs 106 SNR 30 QAM 256 " nr_ulsim_mu_mimo -n300 -b14 -I15 -i 0,1 -g C,l -t65 -u 1 -m27 -q1 -R106 -r106 -U 1,1,1,2 -W1 -y1 -z4 -s30 -S30 -N2)
+
+
+####################################################################################
 ######                           nr_prachsim unit test                        ######
 ####################################################################################
 

--- a/openair1/SIMULATION/tests/ThresholdsGracehopper.cmake
+++ b/openair1/SIMULATION/tests/ThresholdsGracehopper.cmake
@@ -123,3 +123,9 @@ check_threshold_variance(physim.5g.ldpctest.test19 "Encoding time mean:" AVG 8 A
 check_threshold_variance(physim.5g.ldpctest.test19 "Decoding time mean:" AVG 48 ABS_VAR 10)
 check_threshold_variance(physim.5g.ldpctest.test20 "Encoding time mean:" AVG 10 ABS_VAR 2)
 check_threshold_variance(physim.5g.ldpctest.test20 "Decoding time mean:" AVG 57 ABS_VAR 12)
+
+check_threshold_variance(physim.5g.nr_ulsim_mu_mimo.test1 "ULSCH total decoding time" AVG 475 ABS_VAR 95)
+check_threshold_variance(physim.5g.nr_ulsim_mu_mimo.test2 "ULSCH total decoding time" AVG 420 ABS_VAR 84)
+check_threshold_variance(physim.5g.nr_ulsim_mu_mimo.test3 "ULSCH total decoding time" AVG 2814 ABS_VAR 563)
+check_threshold_variance(physim.5g.nr_ulsim_mu_mimo.test4 "ULSCH total decoding time" AVG 3840 ABS_VAR 768)
+check_threshold_variance(physim.5g.nr_ulsim_mu_mimo.test5 "ULSCH total decoding time" AVG 3187 ABS_VAR 637)

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler.c
@@ -115,6 +115,20 @@ static void copy_ul_tti_req(nfapi_nr_ul_tti_request_t *to, nfapi_nr_ul_tti_reque
     to->groups_list[i] = from->groups_list[i];
 }
 
+static void nr_fill_pusch_fapi_groups(nfapi_nr_ul_tti_request_t *UL_tti_req)
+{
+  // Single User MIMO
+  UL_tti_req->n_group = 0;
+  for (int i = 0; i < UL_tti_req->n_pdus; i++) {
+    if (UL_tti_req->pdus_list[i].pdu_type != NFAPI_NR_UL_CONFIG_PUSCH_PDU_TYPE)
+      continue;
+    nfapi_nr_ul_tti_request_number_of_groups_t *group = &UL_tti_req->groups_list[UL_tti_req->n_group];
+    group->n_ue = 0;
+    group->ue_list[group->n_ue++].pdu_idx = i;
+    UL_tti_req->n_group++;
+  }
+}
+
 void gNB_dlsch_ulsch_scheduler(module_id_t module_idP, frame_t frame, slot_t slot, NR_Sched_Rsp_t *sched_info)
 {
   protocol_ctxt_t ctxt = {0};
@@ -232,6 +246,8 @@ void gNB_dlsch_ulsch_scheduler(module_id_t module_idP, frame_t frame, slot_t slo
   AssertFatal(MAX_NUM_CCs == 1, "only 1 CC supported\n");
   const int current_index = ul_buffer_index(frame, slot, slots_frame, gNB->UL_tti_req_ahead_size);
   copy_ul_tti_req(&sched_info->UL_tti_req, &gNB->UL_tti_req_ahead[0][current_index]);
+
+  nr_fill_pusch_fapi_groups(&sched_info->UL_tti_req);
 
   stop_meas(&gNB->gNB_scheduler);
   NR_SCHED_UNLOCK(&gNB->sched_lock);

--- a/openair2/NR_PHY_INTERFACE/NR_IF_Module.c
+++ b/openair2/NR_PHY_INTERFACE/NR_IF_Module.c
@@ -486,6 +486,7 @@ void reset_sched_response(NR_Sched_Rsp_t *sched_response, int frame, int slot, i
   UL_tti_req->SFN = frame;
   UL_tti_req->Slot = slot;
   UL_tti_req->n_pdus = 0;
+  UL_tti_req->n_group = 0;
 
   nfapi_nr_tx_data_request_t *TX_req = &sched_response->TX_req;
   TX_req->SFN = frame;

--- a/tools/packages/packages.cmake
+++ b/tools/packages/packages.cmake
@@ -222,7 +222,7 @@ if(PACKAGING_PHYSIM)
     --------------------------------------------------------
     Coding focused: polartest, smallblocktest, ldpctest
     Downlink PHY: nr_dlschsim, nr_psbchsim, nr_dlsim
-    Uplink PHY: nr_pucchsim nr_prachsim nr_ulschsim nr_ulsim
+    Uplink PHY: nr_pucchsim nr_prachsim nr_ulschsim nr_ulsim nr_ulsim_mu_mimo
     --------------------------------------------------------
     polartest: test polar codes which are used in 5G control channels, validates encoding, decoding and error correction performance*
     smallblocktest: generic test for small channel coding blocks, validates encoding and decoding for small transport blocks
@@ -233,7 +233,8 @@ if(PACKAGING_PHYSIM)
     nr_dlsim: simulates NR downlink, including multiple downlink channels and measurements of BLER/throughput
     nr_prachsim: simulates the Physical Random Access Channel, including UE initial access, preamble detection and timing alignment
     nr_ulschsim: simulates the Uplink Shared Channel, including LDPC encoding, modulation, transmission and decoding
-    nr_ulsim: simulates the NR uplink simulation, including PUCCH, PUSCH and PRACH")
+    nr_ulsim: simulates the NR uplink simulation, including PUCCH, PUSCH and PRACH
+    nr_ulsim_mu_mimo: simulates the NR uplink simulation with PUSCH multi user MIMO")
 
   if(PACKAGING_RPM)
     set(CPACK_RPM_PACKAGE_OAI-PHYSIM_SUMMARY "OpenAirInterface PhySim package")
@@ -254,7 +255,7 @@ if(PACKAGING_PHYSIM)
   install(FILES "${CMAKE_SOURCE_DIR}/doc/physical-simulators.md" DESTINATION share/doc/ COMPONENT oai-physim)
 
   #Add the targets to the package
-  install(TARGETS polartest smallblocktest ldpctest nr_dlschsim nr_psbchsim nr_pucchsim nr_dlsim nr_prachsim nr_ulschsim nr_ulsim
+  install(TARGETS polartest smallblocktest ldpctest nr_dlschsim nr_psbchsim nr_pucchsim nr_dlsim nr_prachsim nr_ulschsim nr_ulsim nr_ulsim_mu_mimo
         COMPONENT oai-physim
         RUNTIME DESTINATION /usr/bin
         LIBRARY DESTINATION /usr/lib


### PR DESCRIPTION
This MR introduces the baseband processing at the gNB required to support Uplink MU-MIMO gNB by updating ULSCH_id based processing to FAPI group-based joint processing. The PHY layer can now perform spatial demultiplexing for multiple UEs scheduled on the exact same time and frequency resources.

Additionally, this MR introduces a dedicated MU-MIMO physical simulator (nr_ulsim_mu_mimo) to validate the joint receiver's performance.

The simulator can be compiled with the other physical simulators using ./build_oai --phy_simulators

It can be run using the following: `sudo ./nr_ulsim_mu_mimo -n 300 -s 30 -S 30 -R 273 -W 1 -y 2 -z 2 -L 3 -N 2 -g C,l,10`

This is the following output:
```
*****************************************
[UE 0] SNR 30.000000: n_errors (4/300,0/10,0/0,0/0) (negative CRC), false_positive 0/300, errors_scrambling (30357/4140000,335/138000,0/0,0/0)

SNR 30.000000: Channel BLER (1.333333e-02,0.000000e+00,-nan,-nan Channel BER (7.332609e-03,2.427536e-03,-nan,-nan) Avg round 1.03, Eff Rate 9070.2667 bits/slot, Eff Throughput 98.33, TBS 9224 bits/slot
DMRS-PUSCH delay estimation: min 0, max 10, average 1.9
*****************************************

*****************************************
[UE 1] SNR 30.000000: n_errors (6/300,0/10,0/0,0/0) (negative CRC), false_positive 0/300, errors_scrambling (32485/4140000,1104/138000,0/0,0/0)

SNR 30.000000: Channel BLER (2.000000e-02,0.000000e+00,-nan,-nan Channel BER (7.846618e-03,8.000000e-03,-nan,-nan) Avg round 1.03, Eff Rate 9070.2667 bits/slot, Eff Throughput 98.33, TBS 9224 bits/slot
DMRS-PUSCH delay estimation: min 0, max 10, average 1.9
*****************************************

```