### PR TITLE
Harmonize PUSCH CDM groups and port allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1339,13 +1339,6 @@ target_link_libraries(NR_L2_UE PRIVATE nr_rlc)
 target_link_libraries(NR_L2_UE PRIVATE asn1_nr_rrc_hdrs asn1_lte_rrc_hdrs nr_common nr_ue_power_procedures nr_ue_ra_procedures)
 target_link_libraries(NR_L2_UE PRIVATE nr_nas)
 
-add_library(MAC_NR_COMMON
-            ${OPENAIR2_DIR}/LAYER2/NR_MAC_COMMON/nr_mac_common.c
-            ${OPENAIR2_DIR}/LAYER2/NR_MAC_COMMON/nr_mac_common_tdd.c
-            ${OPENAIR2_DIR}/LAYER2/NR_MAC_COMMON/nr_compute_tbs_common.c
-)
-target_link_libraries(MAC_NR_COMMON PRIVATE asn1_nr_rrc_hdrs asn1_lte_rrc_hdrs)
-
 include_directories("${OPENAIR2_DIR}/NR_UE_PHY_INTERFACE")
 include_directories("${OPENAIR2_DIR}/LAYER2")
 include_directories("${OPENAIR1_DIR}/SCHED_NR_UE")

--- a/openair1/PHY/NR_ESTIMATION/nr_ul_channel_estimation.c
+++ b/openair1/PHY/NR_ESTIMATION/nr_ul_channel_estimation.c
@@ -241,6 +241,14 @@ static void nr_pusch_antenna_processing(void *arg)
         }
       }
 
+      // Align the channel estimates for the delta shift
+      if (delta != 0) {
+        c16_t *ul_ch_base = &ul_ch_estimates[nl * num_sp_streams + antenna][symbol_offset];
+        memmove(&ul_ch_base[delta], ul_ch_base, (nb_rb_pusch * 12 - delta) * sizeof(c16_t));
+        for (int d = 0; d < delta; d++)
+          ul_ch_base[d] = ul_ch_base[delta];
+      }
+
     } else if (pusch_pdu->dmrs_config_type == pusch_dmrs_type2
                && chest_freq == 0) { // pusch_dmrs_type2  |p_r,p_l,d,d,d,d,p_r,p_l,d,d,d,d|
       LOG_D(PHY, "PUSCH estimation DMRS type 2, Freq-domain interpolation\n");

--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
@@ -84,6 +84,15 @@ static void nr_ulsch_extract_rbs(c16_t* const rxdataF,
                                  NR_DL_FRAME_PARMS *frame_parms)
 {
   uint8_t delta = 0;
+  if (is_dmrs_symbol) {
+    uint8_t max_cdm = (pusch_pdu->dmrs_config_type == pusch_dmrs_type1 ? 2 : 3);
+    AssertFatal(pusch_pdu->num_dmrs_cdm_grps_no_data <= max_cdm,
+                "cdm group no data %d cannot be greater than %d\n",
+                pusch_pdu->num_dmrs_cdm_grps_no_data,
+                max_cdm);
+    int first_port = get_dmrs_port(0, pusch_pdu->dmrs_ports);
+    delta = get_delta(first_port, pusch_pdu->dmrs_config_type);
+  }
   int start_re = (frame_parms->first_carrier_offset + (pusch_pdu->rb_start + pusch_pdu->bwp_start) * NR_NB_SC_PER_RB)%frame_parms->ofdm_symbol_size;
   int nb_re_pusch = NR_NB_SC_PER_RB * pusch_pdu->rb_size;
   c16_t *rxF = &rxdataF[rxoffset];

--- a/openair2/LAYER2/CMakeLists.txt
+++ b/openair2/LAYER2/CMakeLists.txt
@@ -2,4 +2,5 @@
 
 add_subdirectory(nr_rlc)
 add_subdirectory(nr_pdcp)
+add_subdirectory(NR_MAC_COMMON)
 add_subdirectory(NR_MAC_UE)

--- a/openair2/LAYER2/NR_MAC_COMMON/CMakeLists.txt
+++ b/openair2/LAYER2/NR_MAC_COMMON/CMakeLists.txt
@@ -4,3 +4,7 @@ add_library(MAC_NR_COMMON
             nr_compute_tbs_common.c
 )
 target_link_libraries(MAC_NR_COMMON PRIVATE asn1_nr_rrc_hdrs asn1_lte_rrc_hdrs)
+
+if(ENABLE_TESTS)
+  add_subdirectory(tests)
+endif()

--- a/openair2/LAYER2/NR_MAC_COMMON/CMakeLists.txt
+++ b/openair2/LAYER2/NR_MAC_COMMON/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(MAC_NR_COMMON
+            nr_mac_common.c
+            nr_mac_common_tdd.c
+            nr_compute_tbs_common.c
+)
+target_link_libraries(MAC_NR_COMMON PRIVATE asn1_nr_rrc_hdrs asn1_lte_rrc_hdrs)

--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
@@ -4324,8 +4324,7 @@ int get_f3_dmrs_symbols(NR_PUCCH_Resource_t *pucchres, NR_PUCCH_Config_t *pucch_
   return f3_dmrs_symbols;
 }
 
-uint16_t compute_pucch_prb_size(uint8_t format,
-                                uint8_t nr_prbs,
+uint16_t compute_pucch_prb_size(uint8_t nr_prbs,
                                 uint16_t O_csi,
                                 uint16_t O_ack,
                                 uint8_t O_sr,

--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
@@ -2592,6 +2592,73 @@ int get_dci_antenna_ports_val(uint8_t rank, uint16_t dmrs_ports, uint8_t cdm, in
   return val ? val - 1 : -1;
 }
 
+// Returns 0 on success, -1 on invalid val. Fills cdm groups, dmrs port mask, front load symbols.
+int decode_dci_antenna_ports_val(uint8_t rank,
+                                 const long *dmrs_type,
+                                 long tp,
+                                 uint8_t val,
+                                 uint8_t *cdm,
+                                 uint16_t *dmrs_ports,
+                                 int *front_load)
+{
+  const dci_port_rev_t *tbl;
+  int size;
+
+  if (tp == NR_PUSCH_Config__transformPrecoder_enabled) {
+    tbl = lut_tp_rev;
+    size = sizeofArray(lut_tp_rev);
+  } else if (dmrs_type == NULL) {
+    switch (rank) {
+      case 1:
+        tbl = lut_rev_t1_r1;
+        size = sizeofArray(lut_rev_t1_r1);
+        break;
+      case 2:
+        tbl = lut_rev_t1_r2;
+        size = sizeofArray(lut_rev_t1_r2);
+        break;
+      case 3:
+        tbl = lut_rev_t1_r3;
+        size = sizeofArray(lut_rev_t1_r3);
+        break;
+      case 4:
+        tbl = lut_rev_t1_r4;
+        size = sizeofArray(lut_rev_t1_r4);
+        break;
+      default:
+        return -1;
+    }
+  } else {
+    switch (rank) {
+      case 1:
+        tbl = lut_rev_t2_r1;
+        size = sizeofArray(lut_rev_t2_r1);
+        break;
+      case 2:
+        tbl = lut_rev_t2_r2;
+        size = sizeofArray(lut_rev_t2_r2);
+        break;
+      case 3:
+        tbl = lut_rev_t2_r3;
+        size = sizeofArray(lut_rev_t2_r3);
+        break;
+      case 4:
+        tbl = lut_rev_t2_r4;
+        size = sizeofArray(lut_rev_t2_r4);
+        break;
+      default:
+        return -1;
+    }
+  }
+
+  if (val >= size)
+    return -1;
+  *cdm = tbl[val].cdm_groups;
+  *dmrs_ports = tbl[val].port_mask;
+  *front_load = tbl[val].num_front_load_symb;
+  return 0;
+}
+
 int srs_codebook_nb_res(NR_SRS_Config_t *srs_config)
 {
   int count = 0;

--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
@@ -2438,6 +2438,160 @@ static int binomial(int n, int k)
   return c;
 }
 
+// Type 1 (Tables 7.3.1.1.2-8 to 7.3.1.1.2-15)
+// The array indices are in the order [Number of front-loaded symbols - 1][CDM_groups_no_data - 1][DMRS_Port_Bitmask]
+// The LUTs are initialized with 0's
+// The +1 while storing the DCI antenna port value indicate a valid dci array index (The value at the other indices are 0 and is a
+// valid dci antenna port)
+const int8_t lut_t1_r1[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE1_DMRS_MASK] = {
+    [0][0][1] = 0 + 1,
+    [0][0][2] = 1 + 1,
+    [0][1][1] = 2 + 1,
+    [0][1][2] = 3 + 1,
+    [0][1][4] = 4 + 1,
+    [0][1][8] = 5 + 1,
+    [1][1][1] = 6 + 1,
+    [1][1][2] = 7 + 1,
+    [1][1][4] = 8 + 1,
+    [1][1][8] = 9 + 1,
+    [1][1][16] = 10 + 1,
+    [1][1][32] = 11 + 1,
+    [1][1][64] = 12 + 1,
+    [1][1][128] = 13 + 1,
+};
+
+const int8_t lut_t1_r2[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE1_DMRS_MASK] = {
+    [0][0][3] = 0 + 1,
+    [0][1][3] = 1 + 1,
+    [0][1][12] = 2 + 1,
+    [0][1][5] = 3 + 1,
+    [1][1][3] = 4 + 1,
+    [1][1][12] = 5 + 1,
+    [1][1][48] = 6 + 1,
+    [1][1][192] = 7 + 1,
+    [1][1][17] = 8 + 1,
+    [1][1][68] = 9 + 1,
+};
+
+const int8_t lut_t1_r3[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE1_DMRS_MASK] = {
+    [0][1][7] = 0 + 1,
+    [1][1][19] = 1 + 1,
+    [1][1][76] = 2 + 1,
+};
+
+const int8_t lut_t1_r4[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE1_DMRS_MASK] = {
+    [0][1][15] = 0 + 1,
+    [1][1][51] = 1 + 1,
+    [1][1][204] = 2 + 1,
+    [1][1][85] = 3 + 1,
+};
+
+// Type 2 (Tables 7.3.1.1.2-16 to 7.3.1.1.2-23)
+const int8_t lut_t2_r1[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE2_DMRS_MASK] = {
+    [0][0][1] = 0 + 1,    [0][0][2] = 1 + 1,    [0][1][1] = 2 + 1,     [0][1][2] = 3 + 1,     [0][1][4] = 4 + 1,
+    [0][1][8] = 5 + 1,    [0][2][1] = 6 + 1,    [0][2][2] = 7 + 1,     [0][2][4] = 8 + 1,     [0][2][8] = 9 + 1,
+    [0][2][16] = 10 + 1,  [0][2][32] = 11 + 1,  [1][2][1] = 12 + 1,    [1][2][2] = 13 + 1,    [1][2][4] = 14 + 1,
+    [1][2][8] = 15 + 1,   [1][2][16] = 16 + 1,  [1][2][32] = 17 + 1,   [1][2][64] = 18 + 1,   [1][2][128] = 19 + 1,
+    [1][2][256] = 20 + 1, [1][2][512] = 21 + 1, [1][2][1024] = 22 + 1, [1][2][2048] = 23 + 1, [1][0][1] = 24 + 1,
+    [1][0][2] = 25 + 1,   [1][0][64] = 26 + 1,  [1][0][128] = 27 + 1,
+};
+
+const int8_t lut_t2_r2[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE2_DMRS_MASK] = {
+    [0][0][3] = 0 + 1,    [0][1][3] = 1 + 1,    [0][1][12] = 2 + 1,    [0][2][3] = 3 + 1,    [0][2][12] = 4 + 1,
+    [0][2][48] = 5 + 1,   [0][1][5] = 6 + 1,    [1][2][3] = 7 + 1,     [1][2][12] = 8 + 1,   [1][2][48] = 9 + 1,
+    [1][2][192] = 10 + 1, [1][2][768] = 11 + 1, [1][2][3072] = 12 + 1, [1][0][3] = 13 + 1,   [1][0][192] = 14 + 1,
+    [1][1][3] = 15 + 1,   [1][1][12] = 16 + 1,  [1][1][192] = 17 + 1,  [1][1][768] = 18 + 1,
+};
+
+const int8_t lut_t2_r3[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE2_DMRS_MASK] = {
+    [0][1][7] = 0 + 1,
+    [0][2][7] = 1 + 1,
+    [0][2][56] = 2 + 1,
+    [1][2][67] = 3 + 1,
+    [1][2][268] = 4 + 1,
+    [1][2][1072] = 5 + 1,
+};
+
+const int8_t lut_t2_r4[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE2_DMRS_MASK] = {
+    [0][1][15] = 0 + 1,
+    [0][2][15] = 1 + 1,
+    [1][2][195] = 2 + 1,
+    [1][2][780] = 3 + 1,
+    [1][2][3120] = 4 + 1,
+};
+
+// Transform Precoding Enabled (Tables 7.3.1.1.2-6/7)
+const int8_t lut_tp[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE1_DMRS_MASK] = {
+    [0][1][1] = 0 + 1,
+    [0][1][2] = 1 + 1,
+    [0][1][4] = 2 + 1,
+    [0][1][8] = 3 + 1,
+    [1][1][1] = 4 + 1,
+    [1][1][2] = 5 + 1,
+    [1][1][4] = 6 + 1,
+    [1][1][8] = 7 + 1,
+    [1][1][16] = 8 + 1,
+    [1][1][32] = 9 + 1,
+    [1][1][64] = 10 + 1,
+    [1][1][128] = 11 + 1,
+};
+
+/**
+ * @brief Looksup DCI antenna_ports.val based on assigned dmrs ports, type, cdm groups, front load symbols and rank.
+ */
+int get_dci_antenna_ports_val(uint8_t rank, uint16_t dmrs_ports, uint8_t cdm, int dmrs_type, uint8_t front_load, int tp)
+{
+  if (rank < 1 || rank > 4 || cdm < 1 || cdm > 3 || front_load < 1 || front_load > 2)
+    return -1;
+
+  int f = front_load - 1, c = cdm - 1;
+  int val = 0;
+
+  if (tp == NR_PUSCH_Config__transformPrecoder_enabled) {
+    val = (dmrs_ports < MAX_TYPE1_DMRS_MASK) ? lut_tp[f][c][dmrs_ports] : 0;
+  } else if (dmrs_type == pusch_dmrs_type1) {
+    if (dmrs_ports >= MAX_TYPE1_DMRS_MASK)
+      return -1;
+    switch (rank) {
+      case 1:
+        val = lut_t1_r1[f][c][dmrs_ports];
+        break;
+      case 2:
+        val = lut_t1_r2[f][c][dmrs_ports];
+        break;
+      case 3:
+        val = lut_t1_r3[f][c][dmrs_ports];
+        break;
+      case 4:
+        val = lut_t1_r4[f][c][dmrs_ports];
+        break;
+      default:
+        return -1;
+    }
+  } else {
+    if (dmrs_ports >= MAX_TYPE2_DMRS_MASK)
+      return -1;
+    switch (rank) {
+      case 1:
+        val = lut_t2_r1[f][c][dmrs_ports];
+        break;
+      case 2:
+        val = lut_t2_r2[f][c][dmrs_ports];
+        break;
+      case 3:
+        val = lut_t2_r3[f][c][dmrs_ports];
+        break;
+      case 4:
+        val = lut_t2_r4[f][c][dmrs_ports];
+        break;
+      default:
+        return -1;
+    }
+  }
+
+  return val ? val - 1 : -1;
+}
+
 int srs_codebook_nb_res(NR_SRS_Config_t *srs_config)
 {
   int count = 0;

--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.h
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.h
@@ -59,6 +59,13 @@ static const uint16_t table_7_3_1_1_2_32[3][15] = {
     {0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 };
 
+#define MAX_FRONTLOAD_SYMB 2
+#define MAX_CDM_GROUPS 3
+#define MAX_TYPE1_DMRS_MASK 256
+#define MAX_TYPE2_DMRS_MASK 4096
+
+int get_dci_antenna_ports_val(uint8_t rank, uint16_t dmrs_ports, uint8_t cdm, int dmrs_type, uint8_t front_load, int tp);
+
 typedef enum {
   pusch_dmrs_pos0 = 0,
   pusch_dmrs_pos1 = 1,

--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.h
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.h
@@ -322,8 +322,7 @@ uint8_t get_pusch_nb_antenna_ports(NR_PUSCH_Config_t *pusch_Config,
                                    NR_SRS_Config_t *srs_config,
                                    dci_field_t srs_resource_indicator);
 
-uint16_t compute_pucch_prb_size(uint8_t format,
-                                uint8_t nr_prbs,
+uint16_t compute_pucch_prb_size(uint8_t nr_prbs,
                                 uint16_t O_csi,
                                 uint16_t O_ack,
                                 uint8_t O_sr,

--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.h
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.h
@@ -65,6 +65,79 @@ static const uint16_t table_7_3_1_1_2_32[3][15] = {
 #define MAX_TYPE2_DMRS_MASK 4096
 
 int get_dci_antenna_ports_val(uint8_t rank, uint16_t dmrs_ports, uint8_t cdm, int dmrs_type, uint8_t front_load, int tp);
+int decode_dci_antenna_ports_val(uint8_t rank,
+                                 const long *dmrs_type,
+                                 long tp,
+                                 uint8_t val,
+                                 uint8_t *cdm,
+                                 uint16_t *dmrs_ports,
+                                 int *front_load);
+
+typedef struct {
+  uint8_t cdm_groups;
+  uint16_t port_mask;
+  uint8_t num_front_load_symb;
+} dci_port_rev_t;
+
+// Type 1 UE reverse tables
+static const dci_port_rev_t lut_rev_t1_r1[] = {{1, 1, 1},
+                                               {1, 2, 1},
+                                               {2, 1, 1},
+                                               {2, 2, 1},
+                                               {2, 4, 1},
+                                               {2, 8, 1},
+                                               {2, 1, 2},
+                                               {2, 2, 2},
+                                               {2, 4, 2},
+                                               {2, 8, 2},
+                                               {2, 16, 2},
+                                               {2, 32, 2},
+                                               {2, 64, 2},
+                                               {2, 128, 2}};
+static const dci_port_rev_t lut_rev_t1_r2[] =
+    {{1, 3, 1}, {2, 3, 1}, {2, 12, 1}, {2, 5, 1}, {2, 3, 2}, {2, 12, 2}, {2, 48, 2}, {2, 192, 2}, {2, 17, 2}, {2, 68, 2}};
+static const dci_port_rev_t lut_rev_t1_r3[] = {{2, 7, 1}, {2, 19, 2}, {2, 76, 2}};
+static const dci_port_rev_t lut_rev_t1_r4[] = {{2, 15, 1}, {2, 51, 2}, {2, 204, 2}, {2, 85, 2}};
+
+// Type 2 UE reverse tables
+static const dci_port_rev_t lut_rev_t2_r1[] = {
+    {1, 1, 1},   {1, 2, 1},   {2, 1, 1},    {2, 2, 1},    {2, 4, 1}, {2, 8, 1}, {3, 1, 1},  {3, 2, 1},  {3, 4, 1},  {3, 8, 1},
+    {3, 16, 1},  {3, 32, 1},  {3, 1, 2},    {3, 2, 2},    {3, 4, 2}, {3, 8, 2}, {3, 16, 2}, {3, 32, 2}, {3, 64, 2}, {3, 128, 2},
+    {3, 256, 2}, {3, 512, 2}, {3, 1024, 2}, {3, 2048, 2}, {1, 1, 2}, {1, 2, 2}, {1, 64, 2}, {1, 128, 2}};
+static const dci_port_rev_t lut_rev_t2_r2[] = {{1, 3, 1},
+                                               {2, 3, 1},
+                                               {2, 12, 1},
+                                               {3, 3, 1},
+                                               {3, 12, 1},
+                                               {3, 48, 1},
+                                               {2, 5, 1},
+                                               {3, 3, 2},
+                                               {3, 12, 2},
+                                               {3, 48, 2},
+                                               {3, 192, 2},
+                                               {3, 768, 2},
+                                               {3, 3072, 2},
+                                               {1, 3, 2},
+                                               {1, 192, 2},
+                                               {2, 3, 2},
+                                               {2, 12, 2},
+                                               {2, 192, 2},
+                                               {2, 768, 2}};
+static const dci_port_rev_t lut_rev_t2_r3[] = {{2, 7, 1}, {3, 7, 1}, {3, 56, 1}, {3, 67, 2}, {3, 268, 2}, {3, 1072, 2}};
+static const dci_port_rev_t lut_rev_t2_r4[] = {{2, 15, 1}, {3, 15, 1}, {3, 195, 2}, {3, 780, 2}, {3, 3120, 2}};
+
+static const dci_port_rev_t lut_tp_rev[] = {{2, 1, 1},
+                                            {2, 2, 1},
+                                            {2, 4, 1},
+                                            {2, 8, 1},
+                                            {2, 1, 2},
+                                            {2, 2, 2},
+                                            {2, 4, 2},
+                                            {2, 8, 2},
+                                            {2, 16, 2},
+                                            {2, 32, 2},
+                                            {2, 64, 2},
+                                            {2, 128, 2}};
 
 typedef enum {
   pusch_dmrs_pos0 = 0,

--- a/openair2/LAYER2/NR_MAC_COMMON/tests/CMakeLists.txt
+++ b/openair2/LAYER2/NR_MAC_COMMON/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(test_lut_dmrs test_lut_dmrs.c)
+target_link_libraries(test_lut_dmrs PRIVATE
+    MAC_NR_COMMON
+    nr_common
+    asn1_nr_rrc_hdrs
+    minimal_lib m)
+add_dependencies(tests test_lut_dmrs)
+add_test(NAME test_lut_dmrs COMMAND test_lut_dmrs)

--- a/openair2/LAYER2/NR_MAC_COMMON/tests/test_lut_dmrs.c
+++ b/openair2/LAYER2/NR_MAC_COMMON/tests/test_lut_dmrs.c
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.h"
+#include "executables/softmodem-common.h"
+
+/* Forward LUTs: const (external linkage) in nr_mac_common.c, not in the header. */
+extern const int8_t lut_t1_r1[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE1_DMRS_MASK];
+extern const int8_t lut_t1_r2[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE1_DMRS_MASK];
+extern const int8_t lut_t1_r3[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE1_DMRS_MASK];
+extern const int8_t lut_t1_r4[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE1_DMRS_MASK];
+extern const int8_t lut_t2_r1[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE2_DMRS_MASK];
+extern const int8_t lut_t2_r2[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE2_DMRS_MASK];
+extern const int8_t lut_t2_r3[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE2_DMRS_MASK];
+extern const int8_t lut_t2_r4[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE2_DMRS_MASK];
+extern const int8_t lut_tp[MAX_FRONTLOAD_SYMB][MAX_CDM_GROUPS][MAX_TYPE1_DMRS_MASK];
+
+softmodem_params_t *get_softmodem_params(void)
+{
+  return NULL;
+}
+
+/* non-NULL is dmrs type 2 to the decoder */
+static long g_type2_marker = 1;
+
+#define TP_DIS NR_PUSCH_Config__transformPrecoder_disabled
+#define TP_EN NR_PUSCH_Config__transformPrecoder_enabled
+
+typedef struct {
+  const int8_t *lut;
+  int mask_dim;
+  uint8_t rank;
+  /* gNB encode side: pusch_dmrs_type1 / type2 */
+  int type;
+  /* decode side: NULL = type1, non-NULL = type2 */
+  const long *ue_type;
+  int tp;
+  const char *name;
+} lut_desc_t;
+
+/* Round-trip every live cell of one table: gNB encode reproduces val,
+ * decode reproduces (cdm, mask, fl). abort() on any mismatch. */
+static void check_lut(const lut_desc_t *t)
+{
+  int tested = 0;
+  for (int f = 0; f < MAX_FRONTLOAD_SYMB; f++) {
+    for (int c = 0; c < MAX_CDM_GROUPS; c++) {
+      for (int m = 0; m < t->mask_dim; m++) {
+        int8_t stored = t->lut[(f * MAX_CDM_GROUPS + c) * t->mask_dim + m];
+        /* empty cell */
+        if (stored == 0)
+          continue;
+        int val = stored - 1;
+        tested++;
+
+        int enc = get_dci_antenna_ports_val(t->rank, m, c + 1, t->type, f + 1, t->tp);
+        if (enc != val) {
+          fprintf(stderr, "FAIL %s encode: fl%d cdm%d mask%d -> %d, want %d\n", t->name, f + 1, c + 1, m, enc, val);
+          abort();
+        }
+
+        uint8_t dcdm = 0;
+        uint16_t dmask = 0;
+        int dfl = 0;
+        int ret = decode_dci_antenna_ports_val(t->rank, t->ue_type, (long)t->tp, (uint8_t)val, &dcdm, &dmask, &dfl);
+        if (ret != 0 || dcdm != c + 1 || dmask != m || dfl != f + 1) {
+          fprintf(stderr,
+                  "FAIL %s decode val%d: ret%d cdm%d mask%d fl%d, want cdm%d mask%d fl%d\n",
+                  t->name,
+                  val,
+                  ret,
+                  dcdm,
+                  dmask,
+                  dfl,
+                  c + 1,
+                  m,
+                  f + 1);
+          abort();
+        }
+      }
+    }
+  }
+  if (tested == 0) {
+    fprintf(stderr, "FAIL %s: no live entries\n", t->name);
+    abort();
+  }
+}
+
+static void check_invalid(void)
+{
+  if (get_dci_antenna_ports_val(0, 1, 1, pusch_dmrs_type1, 1, TP_DIS) != -1)
+    abort();
+  if (get_dci_antenna_ports_val(5, 1, 1, pusch_dmrs_type1, 1, TP_DIS) != -1)
+    abort();
+  if (get_dci_antenna_ports_val(1, 1, 0, pusch_dmrs_type1, 1, TP_DIS) != -1)
+    abort();
+  if (get_dci_antenna_ports_val(1, 1, 4, pusch_dmrs_type1, 1, TP_DIS) != -1)
+    abort();
+  if (get_dci_antenna_ports_val(1, 1, 1, pusch_dmrs_type1, 0, TP_DIS) != -1)
+    abort();
+  if (get_dci_antenna_ports_val(1, 1, 1, pusch_dmrs_type1, 3, TP_DIS) != -1)
+    abort();
+  if (get_dci_antenna_ports_val(1, 0x7, 1, pusch_dmrs_type1, 1, TP_DIS) != -1)
+    abort();
+
+  uint8_t cdm;
+  uint16_t mask;
+  int fl;
+  if (decode_dci_antenna_ports_val(1, NULL, TP_DIS, 14, &cdm, &mask, &fl) != -1)
+    abort();
+  if (decode_dci_antenna_ports_val(3, NULL, TP_DIS, 3, &cdm, &mask, &fl) != -1)
+    abort();
+}
+
+static void lut_test(void)
+{
+  const lut_desc_t tables[] = {
+      {(const int8_t *)lut_t1_r1, MAX_TYPE1_DMRS_MASK, 1, pusch_dmrs_type1, NULL, TP_DIS, "t1_r1"},
+      {(const int8_t *)lut_t1_r2, MAX_TYPE1_DMRS_MASK, 2, pusch_dmrs_type1, NULL, TP_DIS, "t1_r2"},
+      {(const int8_t *)lut_t1_r3, MAX_TYPE1_DMRS_MASK, 3, pusch_dmrs_type1, NULL, TP_DIS, "t1_r3"},
+      {(const int8_t *)lut_t1_r4, MAX_TYPE1_DMRS_MASK, 4, pusch_dmrs_type1, NULL, TP_DIS, "t1_r4"},
+      {(const int8_t *)lut_t2_r1, MAX_TYPE2_DMRS_MASK, 1, pusch_dmrs_type2, &g_type2_marker, TP_DIS, "t2_r1"},
+      {(const int8_t *)lut_t2_r2, MAX_TYPE2_DMRS_MASK, 2, pusch_dmrs_type2, &g_type2_marker, TP_DIS, "t2_r2"},
+      {(const int8_t *)lut_t2_r3, MAX_TYPE2_DMRS_MASK, 3, pusch_dmrs_type2, &g_type2_marker, TP_DIS, "t2_r3"},
+      {(const int8_t *)lut_t2_r4, MAX_TYPE2_DMRS_MASK, 4, pusch_dmrs_type2, &g_type2_marker, TP_DIS, "t2_r4"},
+      {(const int8_t *)lut_tp, MAX_TYPE1_DMRS_MASK, 1, pusch_dmrs_type1, NULL, TP_EN, "tp"},
+  };
+
+  for (unsigned i = 0; i < sizeof(tables) / sizeof(tables[0]); i++)
+    check_lut(&tables[i]);
+
+  check_invalid();
+}
+
+int main(void)
+{
+  lut_test();
+  printf("All LUT round-trip tests passed.\n");
+  return 0;
+}

--- a/openair2/LAYER2/NR_MAC_UE/mac_tables.c
+++ b/openair2/LAYER2/NR_MAC_UE/mac_tables.c
@@ -81,155 +81,6 @@ static const uint8_t table_7_3_1_1_2_2_3_4_5[64][20] = {
   {0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0}
 };
 
-static const uint8_t table_7_3_1_1_2_12[14][3] = {
-  {1,0,1},
-  {1,1,1},
-  {2,0,1},
-  {2,1,1},
-  {2,2,1},
-  {2,3,1},
-  {2,0,2},
-  {2,1,2},
-  {2,2,2},
-  {2,3,2},
-  {2,4,2},
-  {2,5,2},
-  {2,6,2},
-  {2,7,2}
-};
-
-static const uint8_t table_7_3_1_1_2_13[10][4] = {
-  {1,0,1,1},
-  {2,0,1,1},
-  {2,2,3,1},
-  {2,0,2,1},
-  {2,0,1,2},
-  {2,2,3,2},
-  {2,4,5,2},
-  {2,6,7,2},
-  {2,0,4,2},
-  {2,2,6,2}
-};
-
-static const uint8_t table_7_3_1_1_2_14[3][5] = {
-  {2,0,1,2,1},
-  {2,0,1,4,2},
-  {2,2,3,6,2}
-};
-
-static const uint8_t table_7_3_1_1_2_15[4][6] = {
-  {2,0,1,2,3,1},
-  {2,0,1,4,5,2},
-  {2,2,3,6,7,2},
-  {2,0,2,4,6,2}
-};
-
-static const uint8_t table_7_3_1_1_2_16[12][2] = {
-  {1,0},
-  {1,1},
-  {2,0},
-  {2,1},
-  {2,2},
-  {2,3},
-  {3,0},
-  {3,1},
-  {3,2},
-  {3,3},
-  {3,4},
-  {3,5}
-};
-
-static const uint8_t table_7_3_1_1_2_17[7][3] = {
-  {1,0,1},
-  {2,0,1},
-  {2,2,3},
-  {3,0,1},
-  {3,2,3},
-  {3,4,5},
-  {2,0,2}
-};
-
-static const uint8_t table_7_3_1_1_2_18[3][4] = {
-  {2,0,1,2},
-  {3,0,1,2},
-  {3,3,4,5}
-};
-
-static const uint8_t table_7_3_1_1_2_19[2][5] = {
-  {2,0,1,2,3},
-  {3,0,1,2,3}
-};
-
-static const uint8_t table_7_3_1_1_2_20[28][3] = {
-  {1,0,1},
-  {1,1,1},
-  {2,0,1},
-  {2,1,1},
-  {2,2,1},
-  {2,3,1},
-  {3,0,1},
-  {3,1,1},
-  {3,2,1},
-  {3,3,1},
-  {3,4,1},
-  {3,5,1},
-  {3,0,2},
-  {3,1,2},
-  {3,2,2},
-  {3,3,2},
-  {3,4,2},
-  {3,5,2},
-  {3,6,2},
-  {3,7,2},
-  {3,8,2},
-  {3,9,2},
-  {3,10,2},
-  {3,11,2},
-  {1,0,2},
-  {1,1,2},
-  {1,6,2},
-  {1,7,2}
-};
-
-static const uint8_t table_7_3_1_1_2_21[19][4] = {
-  {1,0,1,1},
-  {2,0,1,1},
-  {2,2,3,1},
-  {3,0,1,1},
-  {3,2,3,1},
-  {3,4,5,1},
-  {2,0,2,1},
-  {3,0,1,2},
-  {3,2,3,2},
-  {3,4,5,2},
-  {3,6,7,2},
-  {3,8,9,2},
-  {3,10,11,2},
-  {1,0,1,2},
-  {1,6,7,2},
-  {2,0,1,2},
-  {2,2,3,2},
-  {2,6,7,2},
-  {2,8,9,2}
-};
-
-static const uint8_t table_7_3_1_1_2_22[6][5] = {
-  {2,0,1,2,1},
-  {3,0,1,2,1},
-  {3,3,4,5,1},
-  {3,0,1,6,2},
-  {3,2,3,8,2},
-  {3,4,5,10,2}
-};
-
-static const uint8_t table_7_3_1_1_2_23[5][6] = {
-  {2,0,1,2,3,1},
-  {3,0,1,2,3,1},
-  {3,0,1,6,7,2},
-  {3,2,3,8,9,2},
-  {3,4,5,10,11,2}
-};
-
 static const uint8_t table_7_3_2_3_3_1[12][5] = {
   {1,1,0,0,0},
   {1,0,1,0,0},
@@ -475,107 +326,23 @@ void ul_ports_config(NR_UE_MAC_INST_t *mac,
         dmrs_type ? "type2" : "type1",
         val);
 
-  if ((transformPrecoder == NR_PUSCH_Config__transformPrecoder_enabled)
-       && (dmrs_type == NULL)
-       && (max_length == NULL)) { // tables 7.3.1.1.2-6
-    pusch_config_pdu->num_dmrs_cdm_grps_no_data = 2;
-    pusch_config_pdu->dmrs_ports = 1 << val;
+  int ret = decode_dci_antenna_ports_val(rank,
+                                         dmrs_type,
+                                         transformPrecoder,
+                                         val,
+                                         &pusch_config_pdu->num_dmrs_cdm_grps_no_data,
+                                         &pusch_config_pdu->dmrs_ports,
+                                         n_front_load_symb);
+  if (ret < 0) {
+    LOG_E(NR_MAC,
+          "invalid DCI antenna_ports val %d (rank %d type %d tp %s)\n",
+          val,
+          rank,
+          dmrs_type ? 2 : 1,
+          transformPrecoder == NR_PUSCH_Config__transformPrecoder_disabled ? "disabled" : "enabled");
+    return;
   }
-  if ((transformPrecoder == NR_PUSCH_Config__transformPrecoder_enabled)
-      && (dmrs_type == NULL)
-      && (max_length != NULL)) { // tables 7.3.1.1.2-7
-    pusch_config_pdu->num_dmrs_cdm_grps_no_data = 2; //TBC
-    pusch_config_pdu->dmrs_ports = 1 << ((val > 3) ? (val - 4) : (val));
-    *n_front_load_symb = (val > 3) ? 2 : 1;
-  }
-  if ((transformPrecoder == NR_PUSCH_Config__transformPrecoder_disabled)
-      && (dmrs_type == NULL)
-      && (max_length == NULL)) { // tables 7.3.1.1.2-8/9/10/11
-    if (rank == 1) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = (val > 1) ? 2 : 1;
-      pusch_config_pdu->dmrs_ports = 1 << ((val > 1) ? (val - 2) : (val));
-    }
-    if (rank == 2) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = (val > 0) ? 2 : 1;
-      pusch_config_pdu->dmrs_ports = (val > 1) ? ((val > 2) ? 0x5 : 0xc) : 0x3;
-    }
-    if (rank == 3) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = 2;
-      pusch_config_pdu->dmrs_ports = 0x7;  // ports 0-2
-    }
-    if (rank == 4) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = 2;
-      pusch_config_pdu->dmrs_ports = 0xf;  // ports 0-3
-    }
-  }
-  if ((transformPrecoder == NR_PUSCH_Config__transformPrecoder_disabled)
-      && (dmrs_type == NULL)
-      && (max_length != NULL)) { // tables 7.3.1.1.2-12/13/14/15
-    if (rank == 1) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_12[val][0];
-      pusch_config_pdu->dmrs_ports = 1 << table_7_3_1_1_2_12[val][1];
-      *n_front_load_symb = table_7_3_1_1_2_12[val][2];
-    }
-    if (rank == 2) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_13[val][0];
-      pusch_config_pdu->dmrs_ports = packBits(&table_7_3_1_1_2_13[val][1], 2);
-      *n_front_load_symb = table_7_3_1_1_2_13[val][3];
-    }
-    if (rank == 3) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_14[val][0];
-      pusch_config_pdu->dmrs_ports = packBits(&table_7_3_1_1_2_14[val][1], 3);
-      *n_front_load_symb = table_7_3_1_1_2_14[val][4];
-    }
-    if (rank == 4) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_15[val][0];
-      pusch_config_pdu->dmrs_ports = packBits(&table_7_3_1_1_2_15[val][1], 4);
-      *n_front_load_symb = table_7_3_1_1_2_15[val][5];
-    }
-  }
-  if ((transformPrecoder == NR_PUSCH_Config__transformPrecoder_disabled)
-      && (dmrs_type != NULL)
-      && (max_length == NULL)) { // tables 7.3.1.1.2-16/17/18/19
-    if (rank == 1) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_16[val][0];
-      pusch_config_pdu->dmrs_ports = 1 << table_7_3_1_1_2_16[val][1];
-    }
-    if (rank == 2) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_17[val][0];
-      pusch_config_pdu->dmrs_ports = packBits(&table_7_3_1_1_2_17[val][1], 2);
-    }
-    if (rank == 3) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_18[val][0];
-      pusch_config_pdu->dmrs_ports = packBits(&table_7_3_1_1_2_18[val][1], 3);
-    }
-    if (rank == 4) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_19[val][0];
-      pusch_config_pdu->dmrs_ports = packBits(&table_7_3_1_1_2_19[val][1], 4);
-    }
-  }
-  if ((transformPrecoder == NR_PUSCH_Config__transformPrecoder_disabled)
-      && (dmrs_type != NULL)
-      && (max_length != NULL)) { // tables 7.3.1.1.2-20/21/22/23
-    if (rank == 1) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_20[val][0];
-      pusch_config_pdu->dmrs_ports = 1 << table_7_3_1_1_2_20[val][1];
-      *n_front_load_symb = table_7_3_1_1_2_20[val][2];
-    }
-    if (rank == 2) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_21[val][0];
-      pusch_config_pdu->dmrs_ports = packBits(&table_7_3_1_1_2_21[val][1], 2);
-      *n_front_load_symb = table_7_3_1_1_2_21[val][3];
-    }
-    if (rank == 3) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_22[val][0];
-      pusch_config_pdu->dmrs_ports = packBits(&table_7_3_1_1_2_22[val][1], 3);
-      *n_front_load_symb = table_7_3_1_1_2_22[val][4];
-    }
-    if (rank == 4) {
-      pusch_config_pdu->num_dmrs_cdm_grps_no_data = table_7_3_1_1_2_23[val][0];
-      pusch_config_pdu->dmrs_ports = packBits(&table_7_3_1_1_2_23[val][1], 4);
-      *n_front_load_symb = table_7_3_1_1_2_23[val][5];
-    }
-  }
+
   LOG_D(NR_MAC,
         "num_dmrs_cdm_grps_no_data %d, dmrs_ports %d\n",
         pusch_config_pdu->num_dmrs_cdm_grps_no_data,

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
@@ -1788,8 +1788,7 @@ int nr_ue_configure_pucch(NR_UE_MAC_INST_t *mac,
         pucch_pdu->start_symbol_index = pucchres->format.choice.format2->startingSymbolIndex;
         pucch_pdu->data_scrambling_id = pusch_id != NULL ? *pusch_id : mac->physCellId;
         pucch_pdu->dmrs_scrambling_id = id0 != NULL ? *id0 : mac->physCellId;
-        pucch_pdu->prb_size = compute_pucch_prb_size(2,
-                                                     pucchres->format.choice.format2->nrofPRBs,
+        pucch_pdu->prb_size = compute_pucch_prb_size(pucchres->format.choice.format2->nrofPRBs,
                                                      pucch->csi_payload.p1_bits,
                                                      pucch->n_harq,
                                                      pucch->n_sr,
@@ -1824,8 +1823,7 @@ int nr_ue_configure_pucch(NR_UE_MAC_INST_t *mac,
           else
             f3_dmrs_symbols = 2<<pucch_pdu->add_dmrs_flag;
         }
-        pucch_pdu->prb_size = compute_pucch_prb_size(3,
-                                                     pucchres->format.choice.format3->nrofPRBs,
+        pucch_pdu->prb_size = compute_pucch_prb_size(pucchres->format.choice.format3->nrofPRBs,
                                                      pucch->csi_payload.p1_bits,
                                                      pucch->n_harq,
                                                      pucch->n_sr,

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
@@ -806,7 +806,7 @@ int nr_config_pusch_pdu(NR_UE_MAC_INST_t *mac,
   delta_pusch = 0; // set to 0 as a workaround for PHY not applying PUSCH tx power
 
   bool is_rar_tx_retx = rnti_type == TYPE_TC_RNTI_;
-
+  bool tp_enabled = pusch_config_pdu->transform_precoding == NR_PUSCH_Config__transformPrecoder_enabled;
   pusch_config_pdu->tx_power = get_pusch_tx_power_ue(mac,
                                                      pusch_config_pdu->rb_size,
                                                      pusch_config_pdu->rb_start,
@@ -819,7 +819,7 @@ int nr_config_pusch_pdu(NR_UE_MAC_INST_t *mac,
                                                      pusch_config_pdu->pusch_data.tb_size << 3,
                                                      delta_pusch,
                                                      is_rar_tx_retx,
-                                                     pusch_config_pdu->transform_precoding);
+                                                     tp_enabled);
 
   pusch_config_pdu->ldpcBaseGraph = get_BG(pusch_config_pdu->pusch_data.tb_size << 3, pusch_config_pdu->target_code_rate);
 
@@ -2607,6 +2607,7 @@ void nr_ue_ul_scheduler(NR_UE_MAC_INST_t *mac, nr_uplink_indication_t *ul_info)
           }
           // Getting IP traffic to be transmitted
           int tx_power = pdu->tx_power;
+          bool tp_enabled = pdu->transform_precoding == NR_PUSCH_Config__transformPrecoder_enabled;
           int P_CMAX = nr_get_Pcmax(mac->p_Max,
                                     mac->nr_band,
                                     mac->frame_structure.frame_type,
@@ -2616,7 +2617,7 @@ void nr_ue_ul_scheduler(NR_UE_MAC_INST_t *mac, nr_uplink_indication_t *ul_info)
                                     false,
                                     mac->current_UL_BWP->scs,
                                     mac->current_UL_BWP->BWPSize,
-                                    pdu->transform_precoding,
+                                    tp_enabled,
                                     pdu->rb_size,
                                     pdu->rb_start);
 

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_RA.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_RA.c
@@ -815,7 +815,7 @@ static void nr_generate_Msg3_retransmission(module_id_t module_idP,
   int buffer_index = ul_buffer_index(sched_frame, sched_slot, slots_frame, nr_mac->vrb_map_UL_size);
   uint16_t *vrb_map_UL = &nr_mac->common_channels[CC_id].vrb_map_UL[beam_ul.idx][buffer_index * MAX_BWP_SIZE];
 
-  NR_pusch_dmrs_t dmrs_info = get_ul_dmrs_params(scc, ul_bwp, &tda_info, 1);
+  NR_pusch_dmrs_t dmrs_info = get_ul_dmrs_params(scc, ul_bwp, &tda_info, 1, 0, 0);
   int num_dmrs_symb = count_bits64_with_mask(dmrs_info.ul_dmrs_symb_pos, tda_info.startSymbolIndex, tda_info.nrOfSymbols);
   int TBS = 0, mcsindex = 0, R = 0, Qm = 0;
   while(TBS < 7) {  // TBS for msg3 is 7 bytes (except for RRCResumeRequest1 currently not implemented)
@@ -1262,7 +1262,7 @@ nr_add_msg3(module_id_t module_idP, int CC_id, frame_t frameP, slot_t slotP, NR_
   future_ul_tti_req->pdus_list[future_ul_tti_req->n_pdus].pdu_size = sizeof(nfapi_nr_pusch_pdu_t);
 
   NR_tda_info_t tda_info = get_ul_tda_info(ul_bwp, 0, NR_SearchSpace__searchSpaceType_PR_common, TYPE_TC_RNTI_, ra->Msg3_tda_id);
-  NR_pusch_dmrs_t dmrs_info = get_ul_dmrs_params(scc, ul_bwp, &tda_info, 1);
+  NR_pusch_dmrs_t dmrs_info = get_ul_dmrs_params(scc, ul_bwp, &tda_info, 1, 0, 0);
   int num_dmrs_symb = count_bits64_with_mask(dmrs_info.ul_dmrs_symb_pos, tda_info.startSymbolIndex, tda_info.nrOfSymbols);
   int TBS = 0, mcsindex = 0, R = 0, Qm = 0;
   while(TBS < 7) {  // TBS for msg3 is 7 bytes (except for RRCResumeRequest1 currently not implemented)

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_phytest.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_phytest.c
@@ -310,7 +310,7 @@ void nr_ul_preprocessor_phytest(gNB_MAC_INST *nr_mac, post_process_pusch_t *pp_p
       // tpmi in post-process
       .time_domain_allocation = tda,
       .tda_info = tda_info,
-      .dmrs_info = get_ul_dmrs_params(scc, ul_bwp, &tda_info, target_ul_Nl),
+      .dmrs_info = get_ul_dmrs_params(scc, ul_bwp, &tda_info, target_ul_Nl, 0, 1),
       .bwp_info = get_pusch_bwp_start_size(UE),
       .ant_port_idx.numSpatialStreamIndices = nr_mac->radio_config.pusch_AntennaPorts,
   };

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -810,13 +810,13 @@ const NR_DMRS_UplinkConfig_t *get_DMRS_UplinkConfig(const NR_PUSCH_Config_t *pus
 NR_pusch_dmrs_t get_ul_dmrs_params(const NR_ServingCellConfigCommon_t *scc,
                                    const NR_UE_UL_BWP_t *ul_bwp,
                                    const NR_tda_info_t *tda_info,
-                                   const int Layers)
+                                   const int Layers,
+                                   const uint16_t dmrs_ports,
+                                   const uint8_t cdm_groups)
 {
   NR_pusch_dmrs_t dmrs = {0};
-  if (ul_bwp->transform_precoding && Layers < 3)
-    dmrs.num_dmrs_cdm_grps_no_data = ul_bwp->dci_format == NR_UL_DCI_FORMAT_0_1 || tda_info->nrOfSymbols <= 2 ? 1 : 2;
-  else
-    dmrs.num_dmrs_cdm_grps_no_data = 2;
+  dmrs.dmrs_ports = (dmrs_ports != 0) ? dmrs_ports : (uint16_t)((1 << Layers) - 1);
+  dmrs.num_dmrs_cdm_grps_no_data = (cdm_groups > 0) ? cdm_groups : 2;
 
   const NR_DMRS_UplinkConfig_t *NR_DMRS_UplinkConfig = get_DMRS_UplinkConfig(ul_bwp->pusch_Config, tda_info);
   dmrs.ptrsConfig = NR_DMRS_UplinkConfig

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -1609,8 +1609,7 @@ void nr_configure_pucch(nfapi_nr_pucch_pdu_t *pucch_pdu,
             pucch_pdu->start_symbol_index = pucchres->format.choice.format2->startingSymbolIndex;
             pucch_pdu->data_scrambling_id = pusch_id ? *pusch_id : *scc->physCellId;
             pucch_pdu->dmrs_scrambling_id = id0 ? *id0 : *scc->physCellId;
-            pucch_pdu->prb_size = compute_pucch_prb_size(2,
-                                                         pucchres->format.choice.format2->nrofPRBs,
+            pucch_pdu->prb_size = compute_pucch_prb_size(pucchres->format.choice.format2->nrofPRBs,
                                                          O_csi,
                                                          O_ack,
                                                          O_sr,
@@ -1635,8 +1634,7 @@ void nr_configure_pucch(nfapi_nr_pucch_pdu_t *pucch_pdu,
               pucch_pdu->add_dmrs_flag = pucchfmt->additionalDMRS ? 1 : 0;
             }
             int f3_dmrs_symbols = get_f3_dmrs_symbols(pucchres, pucch_Config);
-            pucch_pdu->prb_size = compute_pucch_prb_size(3,
-                                                         pucchres->format.choice.format3->nrofPRBs,
+            pucch_pdu->prb_size = compute_pucch_prb_size(pucchres->format.choice.format3->nrofPRBs,
                                                          O_csi,
                                                          O_ack,
                                                          O_sr,

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -1326,6 +1326,17 @@ static uint32_t compute_precoding_information(NR_PUSCH_Config_t *pusch_Config,
   return val;
 }
 
+static uint8_t get_pusch_front_load_symb(const nfapi_nr_pusch_pdu_t *pusch_pdu)
+{
+  // Detect if the scheduled DMRS uses 1 or 2 front-loaded symbols
+  // Consecutive bits signify a double-symbol DMRS
+  for (int i = 0; i < NR_SYMBOLS_PER_SLOT - 1; i++) {
+    if (((pusch_pdu->ul_dmrs_symb_pos >> i) & 0x3) == 0x3)
+      return 2;
+  }
+  return 1;
+}
+
 void config_uldci(const NR_UE_ServingCell_Info_t *sc_info,
                   const nfapi_nr_pusch_pdu_t *pusch_pdu,
                   dci_pdu_rel15_t *dci_pdu_rel15,
@@ -1386,9 +1397,25 @@ void config_uldci(const NR_UE_ServingCell_Info_t *sc_info,
                                                                                &pusch_pdu->nrOfLayers,
                                                                                tpmi);
 
-      // antenna_ports.val = 0 for transform precoder is disabled, dmrs-Type=1, maxLength=1, Rank=1/2/3/4
       // Antenna Ports
-      dci_pdu_rel15->antenna_ports.val = 0;
+      uint8_t front_load_symb = get_pusch_front_load_symb(pusch_pdu);
+      int antenna_ports_val = get_dci_antenna_ports_val(pusch_pdu->nrOfLayers,
+                                                        pusch_pdu->dmrs_ports,
+                                                        pusch_pdu->num_dmrs_cdm_grps_no_data,
+                                                        pusch_pdu->dmrs_config_type,
+                                                        front_load_symb,
+                                                        ul_bwp->transform_precoding);
+      if (antenna_ports_val < 0) {
+        LOG_E(NR_MAC,
+              "No DCI antenna_ports entry for rank=%d ports=0x%04x cdm=%d type=%d front load symbols %d\n",
+              pusch_pdu->nrOfLayers,
+              pusch_pdu->dmrs_ports,
+              pusch_pdu->num_dmrs_cdm_grps_no_data,
+              pusch_pdu->dmrs_config_type,
+              front_load_symb);
+        antenna_ports_val = 0;
+      }
+      dci_pdu_rel15->antenna_ports.val = (uint32_t)antenna_ports_val;
 
       // DMRS sequence initialization
       dci_pdu_rel15->dmrs_sequence_initialization.val = pusch_pdu->scid;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -1720,7 +1720,12 @@ uint16_t check_ul_retx_feasibility(const nr_ul_candidate_t *cand,
   NR_UE_UL_BWP_t *current_BWP = &cand->UE->current_UL_BWP;
   const NR_sched_pusch_t *retInfo = &sched_ctrl->ul_harq_processes[cand->retx_harq_pid].sched_pusch;
 
-  NR_pusch_dmrs_t dmrs_info = get_ul_dmrs_params(scc, current_BWP, tda_info, retInfo->nrOfLayers);
+  NR_pusch_dmrs_t dmrs_info = get_ul_dmrs_params(scc,
+                                                 current_BWP,
+                                                 tda_info,
+                                                 retInfo->nrOfLayers,
+                                                 retInfo->dmrs_info.dmrs_ports,
+                                                 retInfo->dmrs_info.num_dmrs_cdm_grps_no_data);
   uint32_t new_tbs;
   uint16_t new_rbSize;
   bool ok = nr_find_nb_rb(retInfo->Qm,
@@ -1783,7 +1788,12 @@ static int apply_ul_retransmission(gNB_MAC_INST *nrmac,
     new_sched.rbStart = cand->sched_pusch.rbStart;
   } else {
     /* TDA changed vs original retx: recompute DMRS and TB size for new TDA */
-    NR_pusch_dmrs_t dmrs_info = get_ul_dmrs_params(scc, current_BWP, tda_info, nrOfLayers);
+    NR_pusch_dmrs_t dmrs_info = get_ul_dmrs_params(scc,
+                                                   current_BWP,
+                                                   tda_info,
+                                                   nrOfLayers,
+                                                   retInfo->dmrs_info.dmrs_ports,
+                                                   retInfo->dmrs_info.num_dmrs_cdm_grps_no_data);
     new_sched.rbSize = check_sc_fdma_rbsize(current_BWP->transform_precoding, cand->sched_pusch.rbSize);
     new_sched.rbStart = cand->sched_pusch.rbStart;
     new_sched.tb_size = nr_compute_tbs(retInfo->Qm,
@@ -1849,7 +1859,12 @@ static int apply_ul_new_transmission(gNB_MAC_INST *nrmac,
   sched.ul_harq_pid = -1;
   sched.time_domain_allocation = tda;
   sched.tda_info = *tda_info;
-  sched.dmrs_info = get_ul_dmrs_params(scc, current_BWP, tda_info, sched.nrOfLayers);
+  sched.dmrs_info = get_ul_dmrs_params(scc,
+                                       current_BWP,
+                                       tda_info,
+                                       sched.nrOfLayers,
+                                       cand->sched_pusch.dmrs_info.dmrs_ports,
+                                       cand->sched_pusch.dmrs_info.num_dmrs_cdm_grps_no_data);
   sched.bwp_info = bi;
 
   // Map antenna ports for this UE
@@ -2096,7 +2111,7 @@ nfapi_nr_pusch_pdu_t *prepare_pusch_pdu(nfapi_nr_ul_tti_request_t *future_ul_tti
   pusch_pdu->nrOfLayers = sched_pusch->nrOfLayers;
   // DMRS
   pusch_pdu->num_dmrs_cdm_grps_no_data = sched_pusch->dmrs_info.num_dmrs_cdm_grps_no_data;
-  pusch_pdu->dmrs_ports = ((1 << sched_pusch->nrOfLayers) - 1);
+  pusch_pdu->dmrs_ports = sched_pusch->dmrs_info.dmrs_ports;
   pusch_pdu->ul_dmrs_symb_pos = sched_pusch->dmrs_info.ul_dmrs_symb_pos;
   pusch_pdu->dmrs_config_type = sched_pusch->dmrs_info.dmrs_config_type;
   pusch_pdu->scid = sched_pusch->dmrs_info.scid; // DMRS sequence initialization [TS38.211, sec 6.4.1.1.1]
@@ -2637,8 +2652,12 @@ bool nr_ul_check_phr(const nr_ul_sched_params_t *params,
 {
   NR_UE_UL_BWP_t *current_BWP = &cand->UE->current_UL_BWP;
   bool hasDeltaMCS = current_BWP->pusch_Config && current_BWP->pusch_Config->pusch_PowerControl->deltaMCS;
-  NR_pusch_dmrs_t dmrs_info =
-      get_ul_dmrs_params(params->scc, current_BWP, &cand->sched_pusch.tda_info, cand->sched_pusch.nrOfLayers);
+  NR_pusch_dmrs_t dmrs_info = get_ul_dmrs_params(params->scc,
+                                                 current_BWP,
+                                                 &cand->sched_pusch.tda_info,
+                                                 cand->sched_pusch.nrOfLayers,
+                                                 cand->sched_pusch.dmrs_info.dmrs_ports,
+                                                 cand->sched_pusch.dmrs_info.num_dmrs_cdm_grps_no_data);
   int n_dmrs = dmrs_info.N_PRB_DMRS * dmrs_info.num_dmrs_symb;
 
   /* Transient NR_sched_pusch_t scratchpad, feeds compute_ph_mcs_factor() which

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch_default_policies.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch_default_policies.c
@@ -227,6 +227,29 @@ static int compare_ul_pf_rb_ptrs(const void *a, const void *b)
   return (wa < wb) - (wa > wb);
 }
 
+static void nr_ul_port_select_default(const nr_ul_sched_params_t *params, nr_ul_candidate_t *cand)
+{
+  if (cand->is_retx) {
+    const NR_sched_pusch_t *retInfo = &cand->UE->UE_sched_ctrl.ul_harq_processes[cand->retx_harq_pid].sched_pusch;
+    cand->sched_pusch.dmrs_info = retInfo->dmrs_info;
+  } else {
+    int layers = cand->sched_pusch.nrOfLayers;
+    NR_UE_UL_BWP_t *current_BWP = &cand->UE->current_UL_BWP;
+    NR_tda_info_t *tda_info = &cand->sched_pusch.tda_info;
+    uint8_t cdm_groups;
+    if (current_BWP->transform_precoding == NR_PUSCH_Config__transformPrecoder_enabled) {
+      cdm_groups = 2;
+    } else if (current_BWP->dci_format == NR_UL_DCI_FORMAT_0_0) {
+      cdm_groups = (tda_info->nrOfSymbols <= 2) ? 1 : 2;
+    } else {
+      cdm_groups = (layers < 3) ? 1 : 2;
+    }
+    cand->sched_pusch.dmrs_info.dmrs_ports = (uint16_t)((1 << layers) - 1);
+    cand->sched_pusch.dmrs_info =
+        get_ul_dmrs_params(params->scc, current_BWP, tda_info, layers, cand->sched_pusch.dmrs_info.dmrs_ports, cdm_groups);
+  }
+}
+
 int nr_ul_proportional_fair(const nr_ul_sched_params_t *params, nr_ul_candidate_t *candidates, int n_candidates)
 {
   int n_scheduled = 0;
@@ -246,6 +269,8 @@ int nr_ul_proportional_fair(const nr_ul_sched_params_t *params, nr_ul_candidate_
     if (!cand->is_retx)
       continue;
 
+    nr_ul_port_select_default(params, cand);
+
     int rbStart;
     uint16_t *vrb_map = params->vrb_map_UL[cand->alloc_beam_idx];
     int block_len = find_largest_free_block(vrb_map, cand->alloc_slbitmap, cand->bwp_start, cand->bwp_size, &rbStart);
@@ -260,6 +285,8 @@ int nr_ul_proportional_fair(const nr_ul_sched_params_t *params, nr_ul_candidate_
     nr_ul_candidate_t *cand = order[j];
     if (cand->is_retx || !cand->sched_inactive)
       continue;
+
+    nr_ul_port_select_default(params, cand);
 
     uint16_t *vrb_map = params->vrb_map_UL[cand->alloc_beam_idx];
     int rbStart;
@@ -289,11 +316,12 @@ int nr_ul_proportional_fair(const nr_ul_sched_params_t *params, nr_ul_candidate_
     if (cand->is_retx || cand->sched_inactive)
       continue;
 
+    nr_ul_port_select_default(params, cand);
+
     // calculate the number of RBs that UE would like to have. Power limitation
     // is later
+    NR_pusch_dmrs_t dmrs_info = cand->sched_pusch.dmrs_info;
     NR_UE_UL_BWP_t *current_BWP = &cand->UE->current_UL_BWP;
-    NR_pusch_dmrs_t dmrs_info =
-        get_ul_dmrs_params(params->scc, current_BWP, &cand->sched_pusch.tda_info, cand->sched_pusch.nrOfLayers);
     uint16_t Rt;
     uint8_t Qt;
     update_ul_ue_R_Qm(cand->sched_pusch.mcs, current_BWP->mcs_table, current_BWP->pusch_Config, &Rt, &Qt);

--- a/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
@@ -281,7 +281,9 @@ const NR_DMRS_UplinkConfig_t *get_DMRS_UplinkConfig(const NR_PUSCH_Config_t *pus
 NR_pusch_dmrs_t get_ul_dmrs_params(const NR_ServingCellConfigCommon_t *scc,
                                    const NR_UE_UL_BWP_t *ul_bwp,
                                    const NR_tda_info_t *tda_info,
-                                   const int Layers);
+                                   const int Layers,
+                                   const uint16_t dmrs_ports,
+                                   const uint8_t cdm_groups);
 
 int get_spf(nfapi_nr_config_request_scf_t *cfg);
 

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -438,6 +438,7 @@ typedef struct NR_pusch_dmrs {
   uint8_t num_dmrs_symb;
   uint16_t ul_dmrs_symb_pos;
   uint8_t num_dmrs_cdm_grps_no_data;
+  uint16_t dmrs_ports;
   nfapi_nr_dmrs_type_e dmrs_config_type;
   int dmrs_scrambling_id;
   int pusch_identity;


### PR DESCRIPTION
In this PR,
 - We harmonize the PUSCH CDM groups no data and port allocation.
    - This can be extented as a custom policy from the scheduler. 
 - Channel estimation fixes related to the change in cdm group.
 - Harmonizes DCI antenna ports val across gNB and UE
   - Unit test introduced to validate the LUTs
 