### PR TITLE
Fix vrtsim antenna configs

### DIFF
--- a/ci-scripts/cls_containerize.py
+++ b/ci-scripts/cls_containerize.py
@@ -401,7 +401,7 @@ class Containerize():
 		# I would like to run it with --rm and mount the ctest result directory to avoid 'docker cp'
 		# below, but then permissions are messed up and we can't remove the directory without sudo
 		# making the next pipeline fail
-		ret = cmd.run(f'docker run -a STDOUT {runtime_opt} --workdir /oai-ran/build/ --env LD_LIBRARY_PATH=/oai-ran/build/ --name ran-unittests ran-unittests:{baseTag} ctest --no-label-summary -j$(nproc) {ctest_opt}')
+		ret = cmd.run(f'docker run -a STDOUT {runtime_opt} --shm-size=2g --workdir /oai-ran/build/ --env LD_LIBRARY_PATH=/oai-ran/build/ --name ran-unittests ran-unittests:{baseTag} ctest --no-label-summary -j$(nproc) {ctest_opt}')
 		cmd.run('docker cp ran-unittests:/oai-ran/build/Testing/Temporary/LastTest.log .')
 		archiveArtifact(cmd, ctx, f'{lSourcePath}/LastTest.log')
 		cmd.run('docker cp ran-unittests:/oai-ran/build/Testing/Temporary/LastTestsFailed.log .')

--- a/common/utils/shm_iq_channel/shm_td_iq_channel.c
+++ b/common/utils/shm_iq_channel/shm_td_iq_channel.c
@@ -40,6 +40,9 @@ typedef struct ShmTDIQChannel_s {
 
 ShmTDIQChannel *shm_td_iq_channel_create(const char *name, int num_tx_ant, int num_rx_ant)
 {
+  // Unlink any stale shared memory segment first to ensure we start fresh and reclaim space
+  shm_unlink(name);
+
   // Create shared memory segment
   int fd = shm_open(name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
   AssertFatal(fd != -1, "shm_open failed: %s\n", strerror(errno));
@@ -96,29 +99,48 @@ ShmTDIQChannel *shm_td_iq_channel_connect(const char *name, int timeout_in_secon
 {
   // Create shared memory segment
   int fd = -1;
-  while (timeout_in_seconds > 0 && fd == -1) {
+  double timeout_in_uS = timeout_in_seconds * 1000000.0;
+  while (timeout_in_uS > 0 && fd == -1) {
     for (int i = 0; i < 1000; i++) {
       fd = shm_open(name, O_RDWR, S_IRUSR | S_IWUSR);
       if (fd != -1) {
         break;
       }
       usleep(1000);
+      timeout_in_uS -= 1000;
     }
-    timeout_in_seconds--;
     if (fd == -1) {
       printf("Waiting for server to create shared memory segment\n");
     }
   }
   AssertFatal(fd != -1, "shm_open() failed: errno %d, %s", errno, strerror(errno));
 
+  // Map just the header first to wait for initialization
+  ShmTDIQChannelData *shm_ptr = mmap(NULL, sizeof(ShmTDIQChannelData), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  if (shm_ptr == MAP_FAILED) {
+    perror("mmap header");
+    exit(1);
+  }
+
+  // Wait until server initializes the segment
+  while (timeout_in_uS > 0 && shm_ptr->magic != SHM_MAGIC_NUMBER) {
+    usleep(1000);
+    timeout_in_uS -= 1000;
+  }
+  AssertFatal(shm_ptr->magic == SHM_MAGIC_NUMBER, "Timeout waiting for server to initialize shared memory segment\n");
+
+  // Now that it's initialized, ftruncate has finished, so we can get the actual size
   struct stat buf;
   fstat(fd, &buf);
   size_t total_size = buf.st_size;
 
-  // Map shared memory segment to address space
-  ShmTDIQChannelData *shm_ptr = mmap(NULL, total_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  // Unmap the temporary header mapping
+  munmap(shm_ptr, sizeof(ShmTDIQChannelData));
+
+  // Map the entire shared memory segment
+  shm_ptr = mmap(NULL, total_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   if (shm_ptr == MAP_FAILED) {
-    perror("mmap");
+    perror("mmap full");
     exit(1);
   }
 
@@ -134,10 +156,6 @@ ShmTDIQChannel *shm_td_iq_channel_connect(const char *name, int timeout_in_secon
   channel->nb_rx_ant = channel->data->num_antennas_tx;
   printf("\033[38;5;208mnb_tx_ant, nb_rx_ant: %d, %d\n\033[0m", channel->nb_tx_ant, channel->nb_rx_ant);
   channel->type = IQ_CHANNEL_TYPE_CLIENT;
-  while (shm_ptr->magic != SHM_MAGIC_NUMBER) {
-    printf("Waiting for server to initialize shared memory\n");
-    sleep(1);
-  }
   close(fd);
   return channel;
 }
@@ -238,7 +256,7 @@ int shm_td_iq_channel_wait(ShmTDIQChannel *channel, uint64_t timestamp, uint64_t
       fprintf(stderr, "Error: clock_gettime failed: %s\n", strerror(errno));
       return 1;
     }
-    
+
     ts.tv_sec += timeout_uS / 1000000; // Convert microseconds to seconds
     ts.tv_nsec += (timeout_uS % 1000000) * 1000; // Convert remaining microseconds to nanoseconds
 

--- a/radio/vrtsim/cirdb_provider.c
+++ b/radio/vrtsim/cirdb_provider.c
@@ -172,9 +172,7 @@ void cirdb_connect(int id,
 
   /* Selection request */
   int want_model_id = sel->want_model_id;
-  AssertFatal(want_model_id >= 0 && want_model_id <= 4,
-            "Invalid model_id=%d (valid: 0..4)\n",
-            want_model_id);
+  AssertFatal(want_model_id >= 0 && want_model_id <= 4, "Invalid model_id=%d (valid: 0..4)\n", want_model_id);
   float want_ds = (sel && sel->want_ds_ns > 0) ? sel->want_ds_ns : -1.0f;
   float want_speed = (sel && sel->want_speed_mps > 0) ? sel->want_speed_mps : -1.0f;
 

--- a/radio/vrtsim/cirdb_provider.c
+++ b/radio/vrtsim/cirdb_provider.c
@@ -31,7 +31,7 @@ typedef struct {
   channel_desc_t *ch; /* ch_ps points into taps_blob */
 } cirdb_buffer_t;
 
-typedef struct {
+typedef struct cirdb_provider_s {
   /* I/O */
   FILE *fh;
 
@@ -70,8 +70,6 @@ typedef struct {
   /* Bookkeeping of last step computed from elapsed time */
   int64_t last_step_applied; /* -1 until first update */
 } cirdb_g;
-
-static cirdb_g G;
 
 static inline void fread_exact(void *dst, size_t sz, FILE *fh)
 {
@@ -121,35 +119,39 @@ static void compact_L_out(struct complexf *dst,
 }
 
 /* Load snapshot index s into the next publication buffer and flip */
-static void load_snapshot_and_publish(uint32_t s)
+static void load_snapshot_and_publish(cirdb_g *G, uint32_t s)
 {
-  uint64_t stride = (uint64_t)G.n_tx * G.n_rx * G.L_full * sizeof(struct complexf);
-  uint64_t off = G.sel_offset + (uint64_t)s * stride;
+  uint64_t stride = (uint64_t)G->n_tx * G->n_rx * G->L_full * sizeof(struct complexf);
+  uint64_t off = G->sel_offset + (uint64_t)s * stride;
 
-  if (fseeko(G.fh, (off_t)off, SEEK_SET) != 0) {
+  if (fseeko(G->fh, (off_t)off, SEEK_SET) != 0) {
     LOG_E(HW, "CIRDB fseoko failed errno=%d\n", errno);
     abort();
   }
-  fread_exact(G.snapshot_tmp, (size_t)stride, G.fh);
+  fread_exact(G->snapshot_tmp, (size_t)stride, G->fh);
 
-  int next = (G.cur + 1) % NUM_TAPS_BUFFERS;
-  cirdb_buffer_t *buf = &G.bufs[next];
+  int next = (G->cur + 1) % NUM_TAPS_BUFFERS;
+  cirdb_buffer_t *buf = &G->bufs[next];
 
-  compact_L_out((struct complexf *)buf->taps_blob, (const struct complexf *)G.snapshot_tmp, G.n_tx, G.n_rx, G.L_full, G.L_out);
+  compact_L_out((struct complexf *)buf->taps_blob,
+                (const struct complexf *)G->snapshot_tmp,
+                G->n_tx,
+                G->n_rx,
+                G->L_full,
+                G->L_out);
 
-  point_channel_desc(buf->ch, (struct complexf *)buf->taps_blob, G.n_tx, G.n_rx, G.L_out);
+  point_channel_desc(buf->ch, (struct complexf *)buf->taps_blob, G->n_tx, G->n_rx, G->L_out);
 
-  *G.channel_desc_out = buf->ch;
-  G.cur = next;
+  *G->channel_desc_out = buf->ch;
+  G->cur = next;
 }
 
-void cirdb_connect(int id,
-                   int num_tx_antennas,
-                   int num_rx_antennas,
-                   const cirdb_select_opts_t *sel,
-                   channel_desc_t **channel_desc_out)
+cirdb_provider_t *cirdb_connect(int num_tx_antennas,
+                                int num_rx_antennas,
+                                const cirdb_select_opts_t *sel,
+                                channel_desc_t **channel_desc_out)
 {
-  (void)id;
+  cirdb_g G;
   memset(&G, 0, sizeof(G));
   G.channel_desc_out = channel_desc_out;
   G.num_tx = num_tx_antennas;
@@ -275,7 +277,7 @@ void cirdb_connect(int id,
   }
 
   if (G.S > 0) {
-    load_snapshot_and_publish(0);
+    load_snapshot_and_publish(&G, 0);
   }
 
   LOG_I(HW,
@@ -291,42 +293,49 @@ void cirdb_connect(int id,
         G.snapshot_dt_s,
         G.speed_mps,
         sel->want_aoa_deg);
+
+  cirdb_g *p = calloc_or_fail(1, sizeof(cirdb_g));
+  *p = G;
+  return p;
 }
 
-void cirdb_update(uint64_t ns_since_start)
+void cirdb_update(cirdb_provider_t *G, uint64_t ns_since_start)
 {
-  if (!G.channel_desc_out || !*G.channel_desc_out)
+  if (!G)
     return;
-  if (G.S <= 0)
+  if (!G->channel_desc_out || !*G->channel_desc_out)
+    return;
+  if (G->S <= 0)
     return;
 
-  double dt_s = (G.snapshot_dt_s > 0.0 ? G.snapshot_dt_s : 0.5);
+  double dt_s = (G->snapshot_dt_s > 0.0 ? G->snapshot_dt_s : 0.5);
   if (dt_s <= 0.0)
     dt_s = 0.5;
 
   double steps_f = (ns_since_start * 1e-9) / dt_s;
   int64_t step = (int64_t)(steps_f >= 0.0 ? steps_f : 0.0);
 
-  if (step != G.last_step_applied) {
-    uint32_t s = (uint32_t)(step % G.S);
-    load_snapshot_and_publish(s);
-    G.snap_idx = s;
-    G.last_step_applied = step;
+  if (step != G->last_step_applied) {
+    uint32_t s = (uint32_t)(step % G->S);
+    load_snapshot_and_publish(G, s);
+    G->snap_idx = s;
+    G->last_step_applied = step;
   }
 }
 
-void cirdb_stop(void)
+void cirdb_stop(cirdb_provider_t *G)
 {
+  if (!G)
+    return;
   for (int i = 0; i < NUM_TAPS_BUFFERS; i++) {
-    free(G.bufs[i].taps_blob);
-    if (G.bufs[i].ch) {
-      free(G.bufs[i].ch->ch_ps);
-      free(G.bufs[i].ch);
+    free(G->bufs[i].taps_blob);
+    if (G->bufs[i].ch) {
+      free(G->bufs[i].ch->ch_ps);
+      free(G->bufs[i].ch);
     }
   }
-  free(G.snapshot_tmp);
-  if (G.fh)
-    fclose(G.fh);
-  memset(&G, 0, sizeof(G));
-  G.last_step_applied = -1;
+  free(G->snapshot_tmp);
+  if (G->fh)
+    fclose(G->fh);
+  free(G);
 }

--- a/radio/vrtsim/cirdb_provider.h
+++ b/radio/vrtsim/cirdb_provider.h
@@ -28,17 +28,19 @@ typedef struct {
   float want_aoa_deg; /* degrees; TDL-D/E only; 0.0 = broadside default */
 } cirdb_select_opts_t;
 
+/* Opaque handle for CIRDB provider */
+typedef struct cirdb_provider_s cirdb_provider_t;
+
 /* Initialize provider and publish snapshot 0 through channel_desc_out. */
-void cirdb_connect(int id,
-                   int num_tx_antennas,
-                   int num_rx_antennas,
-                   const cirdb_select_opts_t *sel,
-                   channel_desc_t **channel_desc_out);
+cirdb_provider_t *cirdb_connect(int num_tx_antennas,
+                                int num_rx_antennas,
+                                const cirdb_select_opts_t *sel,
+                                channel_desc_t **channel_desc_out);
 
 /* Advance snapshot selection based on elapsed nanoseconds since the start. */
-void cirdb_update(uint64_t ns_since_start);
+void cirdb_update(cirdb_provider_t *provider, uint64_t ns_since_start);
 
 /* Tear down and free resources. */
-void cirdb_stop(void);
+void cirdb_stop(cirdb_provider_t *provider);
 
 #endif /* OAI_VRTSIM_CIRDB_PROVIDER_H */

--- a/radio/vrtsim/tests/CMakeLists.txt
+++ b/radio/vrtsim/tests/CMakeLists.txt
@@ -5,20 +5,17 @@ target_link_libraries(test_vrtsim PRIVATE vrtsim_static UTIL CONFIG_LIB GTest::g
 if (OAI_VRTSIM_TAPS_CLIENT)
   target_link_libraries(test_vrtsim PRIVATE taps_client nanomsg)
 endif()
-#add_dependencies(tests test_vrtsim)
-#add_test(NAME test_vrtsim
-#    COMMAND ./test_vrtsim)
+add_dependencies(tests test_vrtsim)
+add_test(NAME test_vrtsim COMMAND ./test_vrtsim)
 
 if (OAI_VRTSIM_TAPS_CLIENT)
   add_executable(test_vrtsim_taps test_vrtsim_taps.cpp)
   target_link_libraries(test_vrtsim_taps PRIVATE vrtsim_static UTIL CONFIG_LIB GTest::gtest dl shlib_loader taps_client nanomsg flatbuffers taps_api)
-  #add_dependencies(tests test_vrtsim_taps)
-  #add_test(NAME test_vrtsim_taps
-  #    COMMAND ./test_vrtsim_taps)
+  add_dependencies(tests test_vrtsim_taps)
+  add_test(NAME test_vrtsim_taps COMMAND ./test_vrtsim_taps)
 endif()
 
 add_executable(test_vrtsim_cirdb test_vrtsim_cirdb.cpp)
 target_link_libraries(test_vrtsim_cirdb PRIVATE vrtsim_static UTIL CONFIG_LIB GTest::gtest dl shlib_loader yaml-cpp)
-#add_dependencies(tests test_vrtsim_cirdb)
-#add_test(NAME test_vrtsim_cirdb
-#    COMMAND ./test_vrtsim_cirdb)
+add_dependencies(tests test_vrtsim_cirdb)
+add_test(NAME test_vrtsim_cirdb COMMAND ./test_vrtsim_cirdb)

--- a/radio/vrtsim/tests/test_vrtsim.cpp
+++ b/radio/vrtsim/tests/test_vrtsim.cpp
@@ -165,6 +165,205 @@ INSTANTIATE_TEST_SUITE_P(AntennaVariations,
                                            VRTSIMTestCase{8, 8, 2, 2, "2x2"},
                                            VRTSIMTestCase{1, 1, 2, 2, "2x2"}));
 
+struct VRTSIMMultiTestCase {
+  int server_tx;
+  int server_rx;
+  int num_ues;
+  std::vector<std::string> ue_antennas;
+};
+
+class VRTSIMMultiUETest : public ::testing::TestWithParam<VRTSIMMultiTestCase> {
+ protected:
+  configmodule_interface_t *cfg_server = nullptr;
+  std::vector<configmodule_interface_t *> cfg_clients;
+  openair0_device_t server_device = {0};
+  std::vector<openair0_device_t> client_devices;
+  openair0_config_t server_config = {0};
+  std::vector<openair0_config_t> client_configs;
+
+  void SetUp() override
+  {
+    const auto &param = GetParam();
+
+    // Setup server
+    std::vector<std::string> server_args_store = {"test_vrtsim",
+                                                  "--vrtsim.role",
+                                                  "server",
+                                                  "--vrtsim.disable-timing-thread",
+                                                  "1",
+                                                  "--vrtsim.num_ues",
+                                                  std::to_string(param.num_ues)};
+    for (int i = 0; i < param.num_ues; i++) {
+      server_args_store.push_back("--vrtsim.ue_config.[" + std::to_string(i) + "].antennas");
+      server_args_store.push_back(param.ue_antennas[i]);
+    }
+
+    std::vector<const char *> server_argv;
+    for (const auto &arg : server_args_store) {
+      server_argv.push_back(arg.c_str());
+    }
+
+    cfg_server = load_configmodule(server_argv.size(), (char **)server_argv.data(), CONFIG_ENABLECMDLINEONLY);
+    uniqCfg = cfg_server;
+    server_config.tx_num_channels = param.server_tx;
+    server_config.rx_num_channels = param.server_rx;
+    server_config.sample_rate = 30.72e6;
+    ASSERT_EQ(device_init(&server_device, &server_config), 0);
+    ASSERT_EQ(server_device.trx_start_func(&server_device), 0);
+
+    // Setup clients
+    client_devices.resize(param.num_ues);
+    client_configs.resize(param.num_ues);
+    cfg_clients.resize(param.num_ues);
+
+    for (int i = 0; i < param.num_ues; i++) {
+      std::vector<std::string> client_args_store = {"test_vrtsim", "--vrtsim.role", "client", "--vrtsim.ue_id", std::to_string(i)};
+      std::vector<const char *> client_argv;
+      for (const auto &arg : client_args_store) {
+        client_argv.push_back(arg.c_str());
+      }
+      cfg_clients[i] = load_configmodule(client_argv.size(), (char **)client_argv.data(), CONFIG_ENABLECMDLINEONLY);
+      uniqCfg = cfg_clients[i];
+
+      int client_tx = 0, client_rx = 0;
+      sscanf(param.ue_antennas[i].c_str(), "%dx%d", &client_tx, &client_rx);
+
+      client_configs[i].tx_num_channels = client_tx;
+      client_configs[i].rx_num_channels = client_rx;
+      client_configs[i].sample_rate = 30.72e6;
+      ASSERT_EQ(device_init(&client_devices[i], &client_configs[i]), 0);
+      ASSERT_EQ(client_devices[i].trx_start_func(&client_devices[i]), 0);
+    }
+  }
+
+  void TearDown() override
+  {
+    for (auto &client_device : client_devices) {
+      if (client_device.trx_end_func) {
+        client_device.trx_end_func(&client_device);
+      }
+    }
+    if (server_device.trx_end_func) {
+      server_device.trx_end_func(&server_device);
+    }
+    for (auto *cfg : cfg_clients) {
+      if (cfg) {
+        end_configmodule(cfg);
+      }
+    }
+    if (cfg_server) {
+      end_configmodule(cfg_server);
+    }
+  }
+};
+
+TEST_P(VRTSIMMultiUETest, TransparentChannel)
+{
+  const auto &param = GetParam();
+  const int nsamps = 1024;
+
+  // Prepare TX samples for each client (UL)
+  std::vector<std::vector<std::vector<c16_t>>> client_tx_samples(param.num_ues);
+  std::vector<std::vector<void *>> client_tx_ptrs(param.num_ues);
+  for (int u = 0; u < param.num_ues; u++) {
+    int client_tx = 0, client_rx = 0;
+    sscanf(param.ue_antennas[u].c_str(), "%dx%d", &client_tx, &client_rx);
+
+    client_tx_samples[u].resize(client_tx, std::vector<c16_t>(nsamps));
+    client_tx_ptrs[u].resize(client_tx);
+    for (int a = 0; a < client_tx; a++) {
+      for (int i = 0; i < nsamps; i++) {
+        client_tx_samples[u][a][i] = {(int16_t)(i + u * 1000 + a * 100), (int16_t) - (i + u * 1000 + a * 100)};
+      }
+      client_tx_ptrs[u][a] = client_tx_samples[u][a].data();
+    }
+  }
+
+  // Prepare TX samples for server (DL)
+  std::vector<std::vector<c16_t>> server_tx_samples(param.server_tx, std::vector<c16_t>(nsamps));
+  std::vector<void *> server_tx_ptrs(param.server_tx);
+  for (int a = 0; a < param.server_tx; a++) {
+    for (int i = 0; i < nsamps; i++) {
+      server_tx_samples[a][i] = {(int16_t)(i + a * 200), (int16_t)(i + a * 200 + 10)};
+    }
+    server_tx_ptrs[a] = server_tx_samples[a].data();
+  }
+
+  // All clients write at timestamp 0
+  for (int u = 0; u < param.num_ues; u++) {
+    int client_tx = 0, client_rx = 0;
+    sscanf(param.ue_antennas[u].c_str(), "%dx%d", &client_tx, &client_rx);
+    ASSERT_EQ(client_devices[u].trx_write_func(&client_devices[u], 0, client_tx_ptrs[u].data(), nsamps, client_tx, 0), nsamps);
+  }
+  // Server writes at timestamp 0
+  ASSERT_EQ(server_device.trx_write_func(&server_device, 0, server_tx_ptrs.data(), nsamps, param.server_tx, 0), nsamps);
+
+  // Server produces samples
+  vrtsim_produce_samples(&server_device, nsamps);
+
+  // Server reads from clients (UL combined) at timestamp 0
+  std::vector<std::vector<c16_t>> server_rx_samples(param.server_rx, std::vector<c16_t>(nsamps));
+  std::vector<void *> server_rx_ptrs(param.server_rx);
+  for (int a = 0; a < param.server_rx; a++) {
+    server_rx_ptrs[a] = server_rx_samples[a].data();
+  }
+
+  openair0_timestamp_t rx_ts;
+  ASSERT_EQ(server_device.trx_read_func(&server_device, &rx_ts, server_rx_ptrs.data(), nsamps, param.server_rx), nsamps);
+  EXPECT_EQ(rx_ts, 0);
+
+  // Verify UL combining (Order mapping)
+  for (int aarx = 0; aarx < param.server_rx; aarx++) {
+    for (int i = 0; i < nsamps; i++) {
+      int32_t expected_r = 0;
+      int32_t expected_i = 0;
+      for (int u = 0; u < param.num_ues; u++) {
+        int client_tx = 0, client_rx = 0;
+        sscanf(param.ue_antennas[u].c_str(), "%dx%d", &client_tx, &client_rx);
+        if (aarx < client_tx) {
+          expected_r += client_tx_samples[u][aarx][i].r;
+          expected_i += client_tx_samples[u][aarx][i].i;
+        }
+      }
+      int16_t sat_r = (int16_t)((expected_r > 32767) ? 32767 : (expected_r < -32768) ? -32768 : expected_r);
+      int16_t sat_i = (int16_t)((expected_i > 32767) ? 32767 : (expected_i < -32768) ? -32768 : expected_i);
+      EXPECT_EQ(server_rx_samples[aarx][i].r, sat_r) << "UL Mismatch at sample " << i << " rx_ant " << aarx;
+      EXPECT_EQ(server_rx_samples[aarx][i].i, sat_i) << "UL Mismatch at sample " << i << " rx_ant " << aarx;
+    }
+  }
+
+  // Each client reads from server (DL) at timestamp 0
+  for (int u = 0; u < param.num_ues; u++) {
+    int client_tx = 0, client_rx = 0;
+    sscanf(param.ue_antennas[u].c_str(), "%dx%d", &client_tx, &client_rx);
+
+    std::vector<std::vector<c16_t>> client_rx_samples(client_rx, std::vector<c16_t>(nsamps));
+    std::vector<void *> client_rx_ptrs(client_rx);
+    for (int a = 0; a < client_rx; a++) {
+      client_rx_ptrs[a] = client_rx_samples[a].data();
+    }
+
+    ASSERT_EQ(client_devices[u].trx_read_func(&client_devices[u], &rx_ts, client_rx_ptrs.data(), nsamps, client_rx), nsamps);
+    EXPECT_EQ(rx_ts, 0);
+
+    // Verify DL mapping for UE u
+    int num_dl_mapped = std::min(param.server_tx, client_rx);
+    for (int a = 0; a < num_dl_mapped; a++) {
+      for (int i = 0; i < nsamps; i++) {
+        EXPECT_EQ(client_rx_samples[a][i].r, server_tx_samples[a][i].r)
+            << "DL Mismatch UE " << u << " ant " << a << " sample " << i;
+        EXPECT_EQ(client_rx_samples[a][i].i, server_tx_samples[a][i].i)
+            << "DL Mismatch UE " << u << " ant " << a << " sample " << i;
+      }
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(MultiUEVariations,
+                         VRTSIMMultiUETest,
+                         ::testing::Values(VRTSIMMultiTestCase{2, 2, 2, {"2x2", "1x2"}},
+                                           VRTSIMMultiTestCase{2, 2, 2, {"1x2", "1x2"}}));
+
 int main(int argc, char **argv)
 {
   logInit();

--- a/radio/vrtsim/tests/test_vrtsim_cirdb.cpp
+++ b/radio/vrtsim/tests/test_vrtsim_cirdb.cpp
@@ -11,6 +11,8 @@
 #include <filesystem>
 #include <fstream>
 #include <tuple>
+#include <set>
+#include <utility>
 
 #include "common_lib.h"
 #include "common/config/config_userapi.h"
@@ -300,6 +302,339 @@ INSTANTIATE_TEST_SUITE_P(AntennaVariations,
                                            CIRDBAntParams(2, 2, 1, 1, "1x1"),
                                            CIRDBAntParams(4, 4, 2, 2, "2x2"),
                                            CIRDBAntParams(8, 8, 2, 2, "2x2")));
+
+struct CIRDBMultiUEParams {
+  int server_tx;
+  int server_rx;
+  int num_ues;
+  std::vector<std::string> ue_antennas;
+  CIRDBMultiUEParams(int s_tx, int s_rx, int n_ue, std::vector<std::string> ants)
+      : server_tx(s_tx), server_rx(s_rx), num_ues(n_ue), ue_antennas(ants)
+  {
+  }
+};
+
+class VRTSIMCIRDBMultiUETest : public ::testing::TestWithParam<CIRDBMultiUEParams> {
+ protected:
+  configmodule_interface_t *cfg_server = nullptr;
+  std::vector<configmodule_interface_t *> cfg_clients;
+  openair0_device_t server_device = {0};
+  std::vector<openair0_device_t> client_devices;
+  openair0_config_t server_config = {0};
+  std::vector<openair0_config_t> client_configs;
+  fs::path tmp_dir;
+  std::string shm_name;
+
+  void SetUp() override
+  {
+    const auto &p = GetParam();
+    std::string key = std::to_string(p.server_tx) + "_" + std::to_string(p.server_rx);
+    for (int i = 0; i < p.num_ues; i++) {
+      key += "_" + p.ue_antennas[i];
+    }
+    tmp_dir = fs::temp_directory_path() / ("vrtsim_cirdb_multi_test_" + key);
+    shm_name = "shm_cirdb_multi_" + key;
+
+    CIRDBProducer producer(tmp_dir);
+    // Add entries for both DL and UL directions, for both model IDs
+    // Collect all unique configurations of (n_tx, n_rx)
+    std::set<std::pair<int, int>> unique_configs;
+    for (int i = 0; i < p.num_ues; i++) {
+      int client_tx = 0, client_rx = 0;
+      sscanf(p.ue_antennas[i].c_str(), "%dx%d", &client_tx, &client_rx);
+      unique_configs.insert({p.server_tx, client_rx});
+      unique_configs.insert({client_tx, p.server_rx});
+    }
+
+    for (const auto &cfg : unique_configs) {
+      producer.add_entry(0, cfg.first, cfg.second, 8, 1, 30.72e6, 0.5, 10.0, 1.5);
+      producer.add_entry(1, cfg.first, cfg.second, 8, 1, 30.72e6, 0.5, 10.0, 1.5);
+    }
+    producer.write_files();
+  }
+
+  void TearDown() override
+  {
+    for (auto &client_device : client_devices) {
+      if (client_device.trx_end_func) {
+        client_device.trx_end_func(&client_device);
+      }
+    }
+    if (server_device.trx_end_func) {
+      server_device.trx_end_func(&server_device);
+    }
+    for (auto *cfg : cfg_clients) {
+      if (cfg) {
+        end_configmodule(cfg);
+      }
+    }
+    if (cfg_server) {
+      end_configmodule(cfg_server);
+    }
+    fs::remove_all(tmp_dir);
+    client_devices.clear();
+    client_configs.clear();
+    cfg_clients.clear();
+    cfg_server = nullptr;
+    server_device = {0};
+    uniqCfg = nullptr;
+  }
+};
+
+TEST_P(VRTSIMCIRDBMultiUETest, CIRDBDelayDL)
+{
+  const auto &param = GetParam();
+
+  // Setup Server
+  {
+    std::vector<std::string> server_args_store = {"test_vrtsim_cirdb",
+                                                  "--vrtsim.role",
+                                                  "server",
+                                                  "--vrtsim.shm_channel_name",
+                                                  shm_name.c_str(),
+                                                  "--vrtsim.disable-timing-thread",
+                                                  "1",
+                                                  "--vrtsim.cirdb",
+                                                  "1",
+                                                  "--vrtsim.cirdb-path",
+                                                  tmp_dir.c_str(),
+                                                  "--vrtsim.cirdb_model_id",
+                                                  "0",
+                                                  "--vrtsim.num_ues",
+                                                  std::to_string(param.num_ues)};
+    for (int i = 0; i < param.num_ues; i++) {
+      server_args_store.push_back("--vrtsim.ue_config.[" + std::to_string(i) + "].antennas");
+      server_args_store.push_back(param.ue_antennas[i]);
+    }
+
+    std::vector<const char *> server_argv;
+    for (const auto &arg : server_args_store) {
+      server_argv.push_back(arg.c_str());
+    }
+
+    cfg_server = load_configmodule(server_argv.size(), (char **)server_argv.data(), CONFIG_ENABLECMDLINEONLY);
+    uniqCfg = cfg_server;
+    server_config.tx_num_channels = param.server_tx;
+    server_config.rx_num_channels = param.server_rx;
+    server_config.sample_rate = 30.72e6;
+    ASSERT_EQ(device_init(&server_device, &server_config), 0);
+    ASSERT_EQ(server_device.trx_start_func(&server_device), 0);
+  }
+
+  // Setup Clients
+  client_devices.resize(param.num_ues);
+  client_configs.resize(param.num_ues);
+  cfg_clients.resize(param.num_ues);
+
+  for (int i = 0; i < param.num_ues; i++) {
+    std::vector<std::string> client_args_store = {"test_vrtsim_cirdb",
+                                                  "--vrtsim.role",
+                                                  "client",
+                                                  "--vrtsim.shm_channel_name",
+                                                  shm_name.c_str(),
+                                                  "--vrtsim.cirdb",
+                                                  "0",
+                                                  "--vrtsim.ue_id",
+                                                  std::to_string(i),
+                                                  "--vrtsim.ue_config.[" + std::to_string(i) + "].antennas",
+                                                  param.ue_antennas[i]};
+    std::vector<const char *> client_argv;
+    for (const auto &arg : client_args_store) {
+      client_argv.push_back(arg.c_str());
+    }
+    cfg_clients[i] = load_configmodule(client_argv.size(), (char **)client_argv.data(), CONFIG_ENABLECMDLINEONLY);
+    uniqCfg = cfg_clients[i];
+
+    int client_tx = 0, client_rx = 0;
+    sscanf(param.ue_antennas[i].c_str(), "%dx%d", &client_tx, &client_rx);
+
+    client_configs[i].tx_num_channels = client_tx;
+    client_configs[i].rx_num_channels = client_rx;
+    client_configs[i].sample_rate = 30.72e6;
+    ASSERT_EQ(device_init(&client_devices[i], &client_configs[i]), 0);
+    ASSERT_EQ(client_devices[i].trx_start_func(&client_devices[i]), 0);
+  }
+
+  const int nsamps = 1024;
+  // Prepare TX samples for Server (DL)
+  std::vector<std::vector<c16_t>> server_tx_samples(param.server_tx, std::vector<c16_t>(nsamps));
+  std::vector<void *> server_tx_ptrs(param.server_tx);
+  for (int ch = 0; ch < param.server_tx; ch++) {
+    for (int i = 0; i < nsamps; i++)
+      server_tx_samples[ch][i] = {(int16_t)(i + 1 + ch * 100), (int16_t) - (i + 1 + ch * 100)};
+    server_tx_ptrs[ch] = server_tx_samples[ch].data();
+  }
+  ASSERT_EQ(server_device.trx_write_func(&server_device, 0, server_tx_ptrs.data(), nsamps, param.server_tx, 0), nsamps);
+  vrtsim_produce_samples(&server_device, nsamps);
+
+  // Each client reads from server (DL) and checks delayed signal
+  for (int u = 0; u < param.num_ues; u++) {
+    int client_tx = 0, client_rx = 0;
+    sscanf(param.ue_antennas[u].c_str(), "%dx%d", &client_tx, &client_rx);
+
+    std::vector<std::vector<c16_t>> client_rx_samples(client_rx, std::vector<c16_t>(nsamps));
+    std::vector<void *> client_rx_ptrs(client_rx);
+    for (int ch = 0; ch < client_rx; ch++)
+      client_rx_ptrs[ch] = client_rx_samples[ch].data();
+    openair0_timestamp_t rx_ts;
+    ASSERT_EQ(client_devices[u].trx_read_func(&client_devices[u], &rx_ts, client_rx_ptrs.data(), nsamps, client_rx), nsamps);
+    EXPECT_EQ(rx_ts, 0);
+
+    for (int rx_ch = 0; rx_ch < client_rx; rx_ch++) {
+      for (int i = 7; i < nsamps; i++) {
+        int32_t expected_r = 0;
+        int32_t expected_i = 0;
+        for (int tx_ch = 0; tx_ch < param.server_tx; tx_ch++) {
+          expected_r += server_tx_samples[tx_ch][i - 7].r;
+          expected_i += server_tx_samples[tx_ch][i - 7].i;
+        }
+        int16_t sat_r = (int16_t)((expected_r > 32767) ? 32767 : (expected_r < -32768) ? -32768 : expected_r);
+        int16_t sat_i = (int16_t)((expected_i > 32767) ? 32767 : (expected_i < -32768) ? -32768 : expected_i);
+        EXPECT_EQ(client_rx_samples[rx_ch][i].r, sat_r) << "DL Mismatch UE " << u << " rx_ant " << rx_ch << " sample " << i;
+        EXPECT_EQ(client_rx_samples[rx_ch][i].i, sat_i) << "DL Mismatch UE " << u << " rx_ant " << rx_ch << " sample " << i;
+      }
+    }
+  }
+}
+
+TEST_P(VRTSIMCIRDBMultiUETest, CIRDBDelayUL)
+{
+  const auto &param = GetParam();
+
+  // Setup Server
+  {
+    std::vector<std::string> server_args_store = {"test_vrtsim_cirdb",
+                                                  "--vrtsim.role",
+                                                  "server",
+                                                  "--vrtsim.shm_channel_name",
+                                                  shm_name.c_str(),
+                                                  "--vrtsim.disable-timing-thread",
+                                                  "1",
+                                                  "--vrtsim.cirdb",
+                                                  "0",
+                                                  "--vrtsim.num_ues",
+                                                  std::to_string(param.num_ues)};
+    for (int i = 0; i < param.num_ues; i++) {
+      server_args_store.push_back("--vrtsim.ue_config.[" + std::to_string(i) + "].antennas");
+      server_args_store.push_back(param.ue_antennas[i]);
+    }
+
+    std::vector<const char *> server_argv;
+    for (const auto &arg : server_args_store) {
+      server_argv.push_back(arg.c_str());
+    }
+
+    cfg_server = load_configmodule(server_argv.size(), (char **)server_argv.data(), CONFIG_ENABLECMDLINEONLY);
+    uniqCfg = cfg_server;
+    server_config.tx_num_channels = param.server_tx;
+    server_config.rx_num_channels = param.server_rx;
+    server_config.sample_rate = 30.72e6;
+    ASSERT_EQ(device_init(&server_device, &server_config), 0);
+    ASSERT_EQ(server_device.trx_start_func(&server_device), 0);
+  }
+
+  // Setup Clients
+  client_devices.resize(param.num_ues);
+  client_configs.resize(param.num_ues);
+  cfg_clients.resize(param.num_ues);
+
+  for (int i = 0; i < param.num_ues; i++) {
+    std::vector<std::string> client_args_store = {"test_vrtsim_cirdb",
+                                                  "--vrtsim.role",
+                                                  "client",
+                                                  "--vrtsim.shm_channel_name",
+                                                  shm_name.c_str(),
+                                                  "--vrtsim.cirdb",
+                                                  "1",
+                                                  "--vrtsim.cirdb-path",
+                                                  tmp_dir.c_str(),
+                                                  "--vrtsim.cirdb_model_id",
+                                                  "1",
+                                                  "--vrtsim.ue_id",
+                                                  std::to_string(i),
+                                                  "--vrtsim.ue_config.[" + std::to_string(i) + "].antennas",
+                                                  param.ue_antennas[i]};
+    std::vector<const char *> client_argv;
+    for (const auto &arg : client_args_store) {
+      client_argv.push_back(arg.c_str());
+    }
+    cfg_clients[i] = load_configmodule(client_argv.size(), (char **)client_argv.data(), CONFIG_ENABLECMDLINEONLY);
+    uniqCfg = cfg_clients[i];
+
+    int client_tx = 0, client_rx = 0;
+    sscanf(param.ue_antennas[i].c_str(), "%dx%d", &client_tx, &client_rx);
+
+    client_configs[i].tx_num_channels = client_tx;
+    client_configs[i].rx_num_channels = client_rx;
+    client_configs[i].sample_rate = 30.72e6;
+    ASSERT_EQ(device_init(&client_devices[i], &client_configs[i]), 0);
+    ASSERT_EQ(client_devices[i].trx_start_func(&client_devices[i]), 0);
+  }
+
+  const int nsamps = 1024;
+  // Prepare TX samples for each client (UL)
+  std::vector<std::vector<std::vector<c16_t>>> client_tx_samples(param.num_ues);
+  std::vector<std::vector<void *>> client_tx_ptrs(param.num_ues);
+  for (int u = 0; u < param.num_ues; u++) {
+    int client_tx = 0, client_rx = 0;
+    sscanf(param.ue_antennas[u].c_str(), "%dx%d", &client_tx, &client_rx);
+
+    client_tx_samples[u].resize(client_tx, std::vector<c16_t>(nsamps));
+    client_tx_ptrs[u].resize(client_tx);
+    for (int a = 0; a < client_tx; a++) {
+      for (int i = 0; i < nsamps; i++) {
+        client_tx_samples[u][a][i] = {(int16_t)(i + u * 1000 + a * 100), (int16_t) - (i + u * 1000 + a * 100)};
+      }
+      client_tx_ptrs[u][a] = client_tx_samples[u][a].data();
+    }
+  }
+
+  // All clients write at timestamp 0
+  for (int u = 0; u < param.num_ues; u++) {
+    int client_tx = 0, client_rx = 0;
+    sscanf(param.ue_antennas[u].c_str(), "%dx%d", &client_tx, &client_rx);
+    ASSERT_EQ(client_devices[u].trx_write_func(&client_devices[u], 0, client_tx_ptrs[u].data(), nsamps, client_tx, 0), nsamps);
+  }
+
+  // Server produces samples
+  vrtsim_produce_samples(&server_device, nsamps);
+
+  // Server reads from clients (UL combined) at timestamp 0
+  std::vector<std::vector<c16_t>> server_rx_samples(param.server_rx, std::vector<c16_t>(nsamps));
+  std::vector<void *> server_rx_ptrs(param.server_rx);
+  for (int a = 0; a < param.server_rx; a++) {
+    server_rx_ptrs[a] = server_rx_samples[a].data();
+  }
+
+  openair0_timestamp_t rx_ts;
+  ASSERT_EQ(server_device.trx_read_func(&server_device, &rx_ts, server_rx_ptrs.data(), nsamps, param.server_rx), nsamps);
+  EXPECT_EQ(rx_ts, 0);
+
+  // Verify UL combining (with CIRDB delay of 7)
+  for (int aarx = 0; aarx < param.server_rx; aarx++) {
+    for (int i = 7; i < nsamps; i++) {
+      int32_t expected_r = 0;
+      int32_t expected_i = 0;
+      for (int u = 0; u < param.num_ues; u++) {
+        int client_tx = 0, client_rx = 0;
+        sscanf(param.ue_antennas[u].c_str(), "%dx%d", &client_tx, &client_rx);
+        for (int tx_ch = 0; tx_ch < client_tx; tx_ch++) {
+          expected_r += client_tx_samples[u][tx_ch][i - 7].r;
+          expected_i += client_tx_samples[u][tx_ch][i - 7].i;
+        }
+      }
+      int16_t sat_r = (int16_t)((expected_r > 32767) ? 32767 : (expected_r < -32768) ? -32768 : expected_r);
+      int16_t sat_i = (int16_t)((expected_i > 32767) ? 32767 : (expected_i < -32768) ? -32768 : expected_i);
+      EXPECT_EQ(server_rx_samples[aarx][i].r, sat_r) << "UL Mismatch at sample " << i << " rx_ant " << aarx;
+      EXPECT_EQ(server_rx_samples[aarx][i].i, sat_i) << "UL Mismatch at sample " << i << " rx_ant " << aarx;
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(MultiUEVariations,
+                         VRTSIMCIRDBMultiUETest,
+                         ::testing::Values(CIRDBMultiUEParams(2, 2, 2, {"2x2", "1x2"}),
+                                           CIRDBMultiUEParams(2, 2, 2, {"1x2", "1x2"})));
 
 int main(int argc, char **argv)
 {

--- a/radio/vrtsim/vrtsim.c
+++ b/radio/vrtsim/vrtsim.c
@@ -252,7 +252,7 @@ static void *vrtsim_timing_job(void *arg)
       exit(1);
     }
     int64_t diff = (current_time.tv_sec - vrtsim_state->start_ts.tv_sec) * 1000000000
-                    + (current_time.tv_nsec - vrtsim_state->start_ts.tv_nsec);
+                   + (current_time.tv_nsec - vrtsim_state->start_ts.tv_nsec);
     double sample_index = vrtsim_state->sample_rate * vrtsim_state->timescale * diff / 1e9;
     int64_t samples_to_produce = sample_index - last_sample_index;
     if (samples_to_produce > 0) {

--- a/radio/vrtsim/vrtsim.c
+++ b/radio/vrtsim/vrtsim.c
@@ -114,6 +114,13 @@ typedef struct {
   cirdb_conf_t cir_conf;
 } ue_conf_t;
 
+typedef struct client_info_s {
+  int num_ues;
+  int gnb_num_tx_ant;
+  int gnb_num_rx_ant;
+  ue_conf_t ues[MAX_NUM_UES];
+} client_info_t;
+
 typedef struct {
   int role;
   char *connection_descriptor;
@@ -160,6 +167,11 @@ typedef struct {
   char *thread_pool_cores;
   char *shm_channel_name;
   int disable_timing_thread;
+
+  client_info_t client_info;
+  pthread_t ipc_thread;
+  bool run_ipc_thread;
+  int ipc_listen_fd;
 } vrtsim_state_t;
 
 static void histogram_add(histogram_t *histogram, double diff)
@@ -264,47 +276,126 @@ static void *vrtsim_timing_job(void *arg)
   return 0;
 }
 
-typedef struct client_info_s {
-  int num_ues;
-  int gnb_num_tx_ant;
-  int gnb_num_rx_ant;
-  ue_conf_t ues[MAX_NUM_UES];
-} client_info_t;
-/**
- * @brief Publishes the client information information to a file for the client to read.
- *
- * The server writes its client_info (number of RX antennas) to a file, which the client reads.
- * The server does not wait for the client to write back; the client can connect at any point.
- *
- * @param client_info The client information to publish.
- * @return The peer information (same as input, server is authoritative).
- */
-static void server_publish_client_info(client_info_t client_info, char *descriptor_file)
+static void *vrtsim_ipc_thread(void *arg)
 {
-  FILE *fp = fopen(descriptor_file, "wb");
-  AssertFatal(fp != NULL, "Failed to open client info file for writing: %s\n", strerror(errno));
-  size_t written = fwrite(&client_info, sizeof(client_info), 1, fp);
-  AssertFatal(written == 1, "Failed to write client info to file\n");
-  fclose(fp);
+  vrtsim_state_t *vrtsim_state = arg;
+  while (vrtsim_state->run_ipc_thread) {
+    fd_set read_fds;
+    FD_ZERO(&read_fds);
+    FD_SET(vrtsim_state->ipc_listen_fd, &read_fds);
+
+    struct timeval tv = {.tv_sec = 0, .tv_usec = 200000}; // 200ms timeout
+    int ret = select(vrtsim_state->ipc_listen_fd + 1, &read_fds, NULL, NULL, &tv);
+    if (ret < 0) {
+      if (errno == EINTR) continue;
+      break;
+    }
+    if (ret == 0) {
+      // Timeout, check run_ipc_thread again
+      continue;
+    }
+
+    int client_fd = accept(vrtsim_state->ipc_listen_fd, NULL, NULL);
+    if (client_fd < 0) {
+      if (errno == EINTR || !vrtsim_state->run_ipc_thread) {
+        break;
+      }
+      usleep(10000);
+      continue;
+    }
+
+    // Send client info structure
+    size_t total_sent = 0;
+    char *ptr = (char *)&vrtsim_state->client_info;
+    while (total_sent < sizeof(client_info_t)) {
+      ssize_t sent = write(client_fd, ptr + total_sent, sizeof(client_info_t) - total_sent);
+      if (sent < 0) {
+        if (errno == EINTR) {
+          continue;
+        }
+        LOG_E(HW, "Failed to send client info to client: %s\n", strerror(errno));
+        break;
+      }
+      total_sent += sent;
+    }
+    close(client_fd);
+  }
+  return NULL;
 }
 
-static client_info_t client_read_info(char *descriptor_file)
+/**
+ * @brief Publishes the client information to a Unix domain socket.
+ */
+static void server_publish_client_info(vrtsim_state_t *vrtsim_state)
+{
+  char *socket_path = vrtsim_state->connection_descriptor;
+  unlink(socket_path);
+
+  vrtsim_state->ipc_listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  AssertFatal(vrtsim_state->ipc_listen_fd >= 0, "Failed to create IPC socket: %s\n", strerror(errno));
+
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
+
+  int ret = bind(vrtsim_state->ipc_listen_fd, (struct sockaddr *)&addr, sizeof(addr));
+  AssertFatal(ret == 0, "Failed to bind IPC socket to %s: %s\n", socket_path, strerror(errno));
+
+  ret = listen(vrtsim_state->ipc_listen_fd, 10);
+  AssertFatal(ret == 0, "Failed to listen on IPC socket: %s\n", strerror(errno));
+
+  vrtsim_state->run_ipc_thread = true;
+  threadCreate(&vrtsim_state->ipc_thread, vrtsim_ipc_thread, vrtsim_state, "vrtsim_ipc", -1, OAI_PRIORITY_RT_MAX);
+  LOG_A(HW, "VRTSIM: Started IPC server on socket %s\n", socket_path);
+}
+
+static size_t try_read_client_info(int fd, client_info_t *client_info) {
+  size_t total_read = 0;
+  char *ptr = (char *)client_info;
+  while (total_read < sizeof(*client_info)) {
+    ssize_t r = read(fd, ptr + total_read, sizeof(*client_info) - total_read);
+    if (r < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      break;
+    }
+    if (r == 0) {
+      break; // Connection closed by peer
+    }
+    total_read += r;
+  }
+  return total_read;
+}
+
+static client_info_t client_read_info(char *socket_path)
 {
   client_info_t client_info;
   int tries = 0;
+  struct sockaddr_un addr;
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
+
   while (tries < 10) {
-    FILE *fp = fopen(descriptor_file, "rb");
-    if (fp) {
-      size_t read = fread(&client_info, sizeof(client_info), 1, fp);
-      fclose(fp);
-      if (read == 1) {
-        return client_info;
+    int sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sock_fd >= 0) {
+      if (connect(sock_fd, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
+        size_t total_read = try_read_client_info(sock_fd, &client_info);
+        close(sock_fd);
+        if (total_read == sizeof(client_info)) {
+          return client_info;
+        }
+      } else {
+        close(sock_fd);
       }
     }
     sleep(1);
     tries++;
   }
-  AssertFatal(0, "Timeout waiting for client info\n");
+  AssertFatal(0, "Timeout waiting for client info on socket %s\n", socket_path);
   return client_info;
 }
 
@@ -421,16 +512,16 @@ static int vrtsim_connect(openair0_device_t *device)
           num_rx_streams);
     // Exchange peer info
 
-    client_info_t client_info = {
+    vrtsim_state->client_info = (client_info_t){
         .num_ues = vrtsim_state->num_ues,
         .gnb_num_tx_ant = device->openair0_cfg[0].tx_num_channels,
         .gnb_num_rx_ant = device->openair0_cfg[0].rx_num_channels,
     };
 
     for (int i = 0; i < vrtsim_state->num_ues; i++)
-      client_info.ues[i] = vrtsim_state->ue_conf[i];
+      vrtsim_state->client_info.ues[i] = vrtsim_state->ue_conf[i];
 
-    server_publish_client_info(client_info, vrtsim_state->connection_descriptor);
+    server_publish_client_info(vrtsim_state);
     if (vrtsim_state->num_ues > 0) {
       vrtsim_state->peer_tx_ant = vrtsim_state->ue_conf[0].tx_ant;
       vrtsim_state->peer_rx_ant = vrtsim_state->ue_conf[0].rx_ant;
@@ -946,12 +1037,16 @@ static void vrtsim_end(openair0_device_t *device)
     histogram_print(&vrtsim_state->chanmod_histogram, "VRTSIM: Channel modelling delay histogram");
   }
   if (vrtsim_state->role == ROLE_SERVER) {
-    int ret = remove(vrtsim_state->connection_descriptor);
-    if (ret != 0) {
-      LOG_E(HW, "Failed to remove connection descriptor file %s: %s\n", vrtsim_state->connection_descriptor, strerror(errno));
-    } else {
-      LOG_A(HW, "Removed connection descriptor file %s\n", vrtsim_state->connection_descriptor);
+    if (vrtsim_state->run_ipc_thread) {
+      vrtsim_state->run_ipc_thread = false;
+      if (vrtsim_state->ipc_listen_fd >= 0) {
+        close(vrtsim_state->ipc_listen_fd);
+        vrtsim_state->ipc_listen_fd = -1;
+      }
+      int ret = pthread_join(vrtsim_state->ipc_thread, NULL);
+      AssertFatal(ret == 0, "pthread_join() failed: errno: %d, %s\n", errno, strerror(errno));
     }
+    unlink(vrtsim_state->connection_descriptor);
   }
   free(device->priv);
   device->priv = NULL;
@@ -1015,6 +1110,7 @@ __attribute__((__visibility__("default"))) int device_init(openair0_device_t *de
   device->priv = vrtsim_state;
   device->trx_write_init = vrtsim_stub;
   vrtsim_state->last_received_sample = 0;
+  vrtsim_state->ipc_listen_fd = -1;
   vrtsim_state->sample_rate = openair0_cfg->sample_rate;
   vrtsim_state->rx_freq = openair0_cfg->rx_freq[0];
   vrtsim_state->tx_bw = openair0_cfg->tx_bw;

--- a/radio/vrtsim/vrtsim.c
+++ b/radio/vrtsim/vrtsim.c
@@ -141,6 +141,7 @@ typedef struct {
   int tx_num_channels;
   int rx_num_channels;
   channel_desc_t *channel_desc[MAX_NUM_UES];
+  cirdb_provider_t *cirdb_providers[MAX_NUM_UES];
   char *taps_socket;
   void *taps_client;
   int peer_tx_ant;
@@ -287,7 +288,8 @@ static void *vrtsim_ipc_thread(void *arg)
     struct timeval tv = {.tv_sec = 0, .tv_usec = 200000}; // 200ms timeout
     int ret = select(vrtsim_state->ipc_listen_fd + 1, &read_fds, NULL, NULL, &tv);
     if (ret < 0) {
-      if (errno == EINTR) continue;
+      if (errno == EINTR)
+        continue;
       break;
     }
     if (ret == 0) {
@@ -646,7 +648,7 @@ static int vrtsim_connect(openair0_device_t *device)
                       ue_sel.want_model_id,
                       u);
 
-          cirdb_connect(u,
+          vrtsim_state->cirdb_providers[u] = cirdb_connect(
                         device->openair0_cfg[0].tx_num_channels,
                         vrtsim_state->ue_conf[u].rx_ant,
                         &ue_sel,
@@ -681,7 +683,7 @@ static int vrtsim_connect(openair0_device_t *device)
         }
         LOG_A(HW, "VRTSIM: Multi-UE channel taps via CIR DB\n");
       } else {
-        cirdb_connect(0, device->openair0_cfg[0].tx_num_channels, vrtsim_state->peer_rx_ant, &sel, &vrtsim_state->channel_desc[0]);
+        vrtsim_state->cirdb_providers[0] = cirdb_connect(device->openair0_cfg[0].tx_num_channels, vrtsim_state->peer_rx_ant, &sel, &vrtsim_state->channel_desc[0]);
         LOG_A(HW, "VRTSIM: channel taps via CIR DB\n");
       }
     } else {
@@ -729,7 +731,12 @@ static int vrtsim_write_with_chanmod(vrtsim_state_t *vrtsim_state,
   if (vrtsim_state->use_cirdb) {
     double seconds = (double)timestamp / vrtsim_state->sample_rate;
     uint64_t elapsed_ns = (uint64_t)(seconds * 1e9 + 0.5);
-    cirdb_update(elapsed_ns);
+    int num_providers = (vrtsim_state->role == ROLE_SERVER && vrtsim_state->num_ues > 1) ? vrtsim_state->num_ues : 1;
+    for (int p = 0; p < num_providers; p++) {
+      if (vrtsim_state->cirdb_providers[p]) {
+        cirdb_update(vrtsim_state->cirdb_providers[p], elapsed_ns);
+      }
+    }
   }
 
   int noise_power_dBFS = get_noise_power_dBFS();
@@ -740,6 +747,9 @@ static int vrtsim_write_with_chanmod(vrtsim_state_t *vrtsim_state,
     num_chan_desc = vrtsim_state->num_ues;
   }
   int rx_antenna_offset = 0;
+  if (vrtsim_state->role == ROLE_CLIENT) {
+    rx_antenna_offset = vrtsim_state->ue_id * vrtsim_state->peer_rx_ant;
+  }
   int nb_tx = nbAnt;
   for (int i = 0; i < num_chan_desc; i++) {
     channel_desc_t *chan_desc = NULL;
@@ -885,7 +895,7 @@ static int vrtsim_write(openair0_device_t *device,
   // We map the antennas in order: first TX stream is mapped to first RX stream and so on.
   if (vrtsim_state->role == ROLE_CLIENT) {
     for (int aatx = 0; aatx < nbAnt && aatx < vrtsim_state->peer_rx_ant; aatx++) {
-      int global_ul_ant = vrtsim_state->ue.tx_offset + aatx;
+      int global_ul_ant = vrtsim_state->ue_id * vrtsim_state->peer_rx_ant + aatx;
       vrtsim_write_internal(vrtsim_state, timestamp, (c16_t *)samplesVoid[aatx], nsamps, global_ul_ant);
     }
     return nsamps;
@@ -1011,7 +1021,12 @@ static void vrtsim_end(openair0_device_t *device)
     abortTpool(&vrtsim_state->tpool);
 #endif
     if (vrtsim_state->use_cirdb) {
-      cirdb_stop();
+      for (int p = 0; p < MAX_NUM_UES; p++) {
+        if (vrtsim_state->cirdb_providers[p]) {
+          cirdb_stop(vrtsim_state->cirdb_providers[p]);
+          vrtsim_state->cirdb_providers[p] = NULL;
+        }
+      }
 #ifdef OAI_VRTSIM_TAPS_CLIENT
     } else if (vrtsim_state->taps_client) {
       taps_client_stop(vrtsim_state->taps_client);


### PR DESCRIPTION
This PR fixes three issues: #130 #125, and an unreported issue related to flaky vrtsim tests. With the new unix domain socket initialization the unit test framework should be much more robust and not fail randomly.

Closes: #130 
Closes: #125