### PR TITLE
ci: remove first-time contributor job in workflow and update Jenkins job badges

### DIFF
--- a/.github/workflows/jenkins-dispatch.yml
+++ b/.github/workflows/jenkins-dispatch.yml
@@ -105,20 +105,3 @@ jobs:
         run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "${{ vars.RETRIGGER_CI_LABEL }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  welcome-first-time-contributor:
-    runs-on: ubuntu-24.04
-    if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
-
-    steps:
-      - name: Post welcome message
-        uses: actions/first-interaction@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: |
-            Welcome @${{ github.event.pull_request.user.login }}! Thanks for opening your first PR in this project!
-
-            Here are a few things to help you get started:
-            - Read the [Contributing Guide](https://github.com/${{ github.repository }}/blob/develop/CONTRIBUTING.md) to understand our development process.
-            - Check the [issues page](https://github.com/duranta-project/openairinterface5g/issues) to see if your PR is related to an existing issue.
-            - Add a [label](https://github.com/duranta-project/openairinterface5g/labels/) to categorize your PR so reviewers can triage it faster.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 </p>
 
 <p align="center">
-    <a href="https://jenkins-oai.eurecom.fr/job/RAN-Ubuntu18-Image-Builder/"><img src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins-oai.eurecom.fr%2Fjob%2FRAN-Ubuntu18-Image-Builder%2F&label=build-Ubuntu-x86%20Images"></a>
-    <a href="https://jenkins-oai.eurecom.fr/job/RAN-RHEL8-Cluster-Image-Builder/"><img src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins-oai.eurecom.fr%2Fjob%2FRAN-RHEL8-Cluster-Image-Builder%2F&label=build-UBI-x86%20Images"></a>
+    <a href="https://jenkins-oai.eurecom.fr/job/RAN-Ubuntu-Image-Builder/"><img src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins-oai.eurecom.fr%2Fjob%2FRAN-Ubuntu-Image-Builder%2F&label=build-Ubuntu-x86%20Images"></a>
+    <a href="https://jenkins-oai.eurecom.fr/job/RAN-RHEL-Cluster-Image-Builder/"><img src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins-oai.eurecom.fr%2Fjob%2FRAN-RHEL-Cluster-Image-Builder%2F&label=build-RHEL-Cluster%20Images"></a>
     <a href="https://jenkins-oai.eurecom.fr/job/RAN-Ubuntu-ARM-Image-Builder/"><img src="https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins-oai.eurecom.fr%2Fjob%2FRAN-Ubuntu-ARM-Image-Builder%2F&label=build-Ubuntu-ARM%20Images"></a>
 </p>
 


### PR DESCRIPTION
- Remove the first-time contributor GitHub Actions workflow
- Update Jenkins image builder badge URLs to match the current job names.

The first-time contributor workflow posts an automated welcome message through `github-actions[bot]`, creating additional bot activity on pull requests. Contributor onboarding information is better maintained through project announcements and documentation, where it is easier to update and more visible to new contributors.