### PR TITLE
fix(sdap): skip unmapped-QFI drop check on UE DL path

### DIFF
--- a/openair2/SDAP/nr_sdap/nr_sdap_entity.c
+++ b/openair2/SDAP/nr_sdap/nr_sdap_entity.c
@@ -209,7 +209,7 @@ static void nr_sdap_rx_entity(nr_sdap_entity_t *entity,
     const qfi2drb_t *mapping = &entity->qfi2drb_table[qfi];
     /* If the QFI has no active mapping, drop the packet: it can happen
      * after QoS-flow removal/reconfiguration due to packets that were already enqueued in PDCP */
-    if (mapping->drb_id == SDAP_NO_MAPPING_RULE) {
+    if (is_gnb && mapping->drb_id == SDAP_NO_MAPPING_RULE) {
       LOG_W(SDAP,
             "Dropping UL SDAP PDU with unmapped QFI=%d (ue=%ld pdu_session=%d drb=%d)\n",
             qfi,


### PR DESCRIPTION
Ping UE failed with 3rd-party gNB, UE will report error as below:
`[SDAP]   Dropping UL SDAP PDU with unmapped QFI=5 (ue=0 pdu_session=1 drb=2)`

gNB has configuration for SDAP as below:
```                                
                                drb-ToAddModList: 1 item
                                    Item 0
                                        DRB-ToAddMod
                                            cnAssociation: sdap-Config (1)
                                                sdap-Config
                                                    pdu-Session: 1
                                                    sdap-HeaderDL: absent (1)
                                                    sdap-HeaderUL: present (0)
                                                    ..1. .... defaultDRB: True
                                                    mappedQoS-FlowsToAdd: 1 item
                                                        Item 0
                                                            QFI: 2
                                            drb-Identity: 2
```
Complete gNB RRC log in pcap format:
[nr_rrc.zip](https://github.com/user-attachments/files/28781245/nr_rrc.zip)
UE log:
[nr_ue_ping_fail.log](https://github.com/user-attachments/files/28781274/nr_ue_ping_fail.log)

This PR fixed the issue, details are in commit message.
