### PR TITLE
ci: maintainer approval for additional file changes and update maintainer's contact

### DIFF
--- a/.github/workflows/jenkins-dispatch.yml
+++ b/.github/workflows/jenkins-dispatch.yml
@@ -40,6 +40,11 @@ jobs:
               - 'ci-scripts/**'
               - '.github/workflows/**'
               - '.github/actions/**'
+              - 'docker/**'
+              - 'charts/**'
+              - 'openshift/**'
+              - 'cmake_targets/build_oai'
+              - 'cmake_targets/tools/build_helper'
 
   require-maintainer-approval:
     needs: detect-changes

--- a/charts/physims-4g/Chart.yaml
+++ b/charts/physims-4g/Chart.yaml
@@ -35,4 +35,4 @@ sources:
 
 maintainers:
   - name:  OPENAIRINTERFACE
-    email: contact@openairinterface.org
+    email: oaicicdteam@openairinterface.org

--- a/charts/physims-4g/charts/physims.4g/Chart.yaml
+++ b/charts/physims-4g/charts/physims.4g/Chart.yaml
@@ -34,4 +34,4 @@ sources:
 
 maintainers:
   - name:  OPENAIRINTERFACE
-    email: contact@openairinterface.org
+    email: oaicicdteam@openairinterface.org

--- a/charts/physims-5g/Chart.yaml
+++ b/charts/physims-5g/Chart.yaml
@@ -35,4 +35,4 @@ sources:
 
 maintainers:
   - name:  OPENAIRINTERFACE
-    email: contact@openairinterface.org
+    email: oaicicdteam@openairinterface.org

--- a/charts/physims-5g/charts/physims.5g/Chart.yaml
+++ b/charts/physims-5g/charts/physims.5g/Chart.yaml
@@ -34,4 +34,4 @@ sources:
 
 maintainers:
   - name:  OPENAIRINTERFACE
-    email: contact@openairinterface.org
+    email: oaicicdteam@openairinterface.org

--- a/doc/GET_SOURCES.md
+++ b/doc/GET_SOURCES.md
@@ -13,7 +13,7 @@ sudo apt-get update
 sudo apt-get install git
 ```
 
-## Clone the Git repository (for OAI Users without login to gitlab server)
+## Clone the Git repository (for OAI Users without login to github server)
 
 The [openairinterface5g repository](https://github.com/duranta-project/openairinterface5g.git)
 holds the source code for the RAN (4G and 5G).

--- a/docker/Dockerfile.base.rhel9
+++ b/docker/Dockerfile.base.rhel9
@@ -9,7 +9,7 @@
 
 
 FROM registry.redhat.io/ubi9/ubi:latest AS ran-base
-LABEL MAINTAINER OpenAirInterface <contact@openairinterface.org>
+LABEL MAINTAINER OpenAirInterface <oaicicdteam@openairinterface.org>
 ARG NEEDED_GIT_PROXY
 ARG TARGETARCH
 ENV TZ=Europe/Paris


### PR DESCRIPTION
- Add ci-approval for changes to docker/, charts/, openshift/, build_oai, and build_helper files
- Update the OAI contact email to oaicicdteam@openairinterface.org
- Replace GitLab with GitHub in `GET_SOURCES.md`