### PR TITLE
CI OCUDU configuration changes

### DIFF
--- a/ci-scripts/yaml_files/5g_zmq_radio_1x1_ocudu/ocudu.yml
+++ b/ci-scripts/yaml_files/5g_zmq_radio_1x1_ocudu/ocudu.yml
@@ -20,6 +20,8 @@ ru_sdr:
   srate: 23.04
   tx_gain: 25
   rx_gain: 25
+  amplitude_control:
+    tx_gain_backoff: 22
 
 cell_cfg:
   dl_arfcn: 632628

--- a/ci-scripts/yaml_files/5g_zmq_radio_1x1_ocudu/ocudu.yml
+++ b/ci-scripts/yaml_files/5g_zmq_radio_1x1_ocudu/ocudu.yml
@@ -44,7 +44,7 @@ cell_cfg:
     nof_cell_csi_res: 0
 
 log:
-  filename: gnb.log
+  filename: stdout
   all_level: info
 
 pcap:

--- a/ci-scripts/yaml_files/5g_zmq_radio_1x1_ocudu/ocudu.yml
+++ b/ci-scripts/yaml_files/5g_zmq_radio_1x1_ocudu/ocudu.yml
@@ -43,7 +43,7 @@ cell_cfg:
 
 log:
   filename: gnb.log
-  all_level: debug
+  all_level: info
 
 pcap:
   mac_enable: false

--- a/ci-scripts/yaml_files/5g_zmq_radio_2x2_ocudu/ocudu.yml
+++ b/ci-scripts/yaml_files/5g_zmq_radio_2x2_ocudu/ocudu.yml
@@ -20,6 +20,8 @@ ru_sdr:
   srate: 61.44
   tx_gain: 25
   rx_gain: 25
+  amplitude_control:
+    tx_gain_backoff: 22
 
 cell_cfg:
   dl_arfcn: 632628

--- a/ci-scripts/yaml_files/5g_zmq_radio_2x2_ocudu/ocudu.yml
+++ b/ci-scripts/yaml_files/5g_zmq_radio_2x2_ocudu/ocudu.yml
@@ -45,7 +45,7 @@ cell_cfg:
 
 log:
   filename: gnb.log
-  all_level: debug
+  all_level: info
 
 pcap:
   mac_enable: false

--- a/ci-scripts/yaml_files/5g_zmq_radio_2x2_ocudu/ocudu.yml
+++ b/ci-scripts/yaml_files/5g_zmq_radio_2x2_ocudu/ocudu.yml
@@ -46,7 +46,7 @@ cell_cfg:
     nof_cell_csi_res: 0
 
 log:
-  filename: gnb.log
+  filename: stdout
   all_level: info
 
 pcap:


### PR DESCRIPTION
1. Enable more logs in ocudu gnb.
2. Reduce tx amplitude to prevent clipping in OAI DFT.