### PR TITLE
doc(kpi): kpi for openairinterface code base

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -21,6 +21,7 @@ Beware if you previously pulled the `develop` branch that your repository may be
 - [environment-variables.md](./environment-variables.md): the environment variables used by OAI
 - [tuning_and_security.md](./tuning_and_security.md): performance and security considerations
 - [Supported_Hardware_Operating_System.md](./Supported_Hardware_Operating_System.md): List of supported hardware and operating system for OAI
+- [kpi.md](./kpi.md): Key Performance Indicators for the OpenAirInterface Code Base
 
 There is some general information in the [OpenAirInterface Gitlab Wiki](https://gitlab.eurecom.fr/oai/openairinterface5g/-/wikis/home)
 

--- a/doc/kpi.md
+++ b/doc/kpi.md
@@ -4,18 +4,20 @@ This document summarizes the main throughput KPIs
 
 ## 1. `nr-softmodem` Performance in `oai-gNB` and `oai-gNB-du` Modes for FR1 bands
 
-### Test Profile
+### KPI with USRP
+
+#### Test Profile
 
 The following results apply to the TDD configuration below:
-
 |Parameter          |Value                   |
 |-------------------|------------------------|
-|Band               |n78/n77                 |
+|Band               |n41                     |
 |SCS                |30 kHz                  |
-|DL test TDD Pattern|`DDDSU`, 2.5ms, 10D2G2U |
-|UL test TDD Pattern|`DDSUU`, 2.5ms, 6D4G4U  |
+|DL test TDD Pattern|`DDDSU`, 2.5ms          |
+|UL test TDD Pattern|`DDSUU`, 2.5ms          |
 
-#### KPI with USRP
+- test machine: AMD Ryzen 9 7950X 16-Core Processor
+- radio: USRP N310, UE: Quectel RM500Q
 
 |Bandwidth MHz/PRB|Layers|DL Throughput (Mbps)|UL Throughput (Mbps)|
 |-----------------|-----:|-------------------:|-------------------:|
@@ -30,11 +32,29 @@ The following results apply to the TDD configuration below:
 |                 |4     |730                 |X                   |
 |80(217)          |1     |310                 |80                  |
 |                 |2     |622                 |140                 |
-|                 |4     |x                   |X                   |
+|                 |4     |X                   |X                   |
+|100(273)         |1     |400                 |101                 |
+|                 |2     |800                 |120                 |
 
-#### KPI with ORAN 7.2
+### KPI with ORAN 7.2
+- test branch: [2026.w22](https://github.com/duranta-project/openairinterface5g/releases/tag/2026.w22)
 
-9b BFP, 4T4R, Benetel550 RU, Quectel RM520N, OTA, distance: 2m
+#### Test Profile
+
+The following results apply to the TDD configuration below:
+|Parameter          |Value                   |
+|-------------------|------------------------|
+|Band               |n78/n77                 |
+|SCS                |30 kHz                  |
+|DL test TDD Pattern|`DDDSU`, 2.5ms, 10D2G2U |
+|UL test TDD Pattern|`DDSUU`, 2.5ms, 6D4G4U  |
+
+- test machine: AMD EPYC 9575F 64-Core Processor
+- radio: Benetel550 O-RU, UE: Quectel RM520N
+- OTA, distance: 2m
+- avx512 disabled (`--noavx512`)
+
+9b BFP static compression, 4T4R
 
 |Bandwidth MHz/PRB|Layers|DL Throughput (Mbps)|UL Throughput (Mbps)|
 |-----------------|-----:|-------------------:|-------------------:|
@@ -44,7 +64,7 @@ The following results apply to the TDD configuration below:
 |                 |2     |820                 |250                 |
 |                 |4     |1400                |X                   |
 
-16b no compression, 2T2R, Benetel550 RU, Quectel RM520N, OTA, distance: 2m
+16b no compression, 2T2R
 
 |Bandwidth MHz/PRB|Layers|DL Throughput (Mbps)|UL Throughput (Mbps)|
 |-----------------|-----:|-------------------:|-------------------:|

--- a/doc/kpi.md
+++ b/doc/kpi.md
@@ -1,14 +1,17 @@
 # Key Performance Indicators for the OpenAirInterface Code Base
 
-This document summarizes the main throughput KPIs
+The goal of this document is to provide some Key Performance Indicators (KPI) for openairinterface5g RAN and UE stack. 
+
+For every test we have mentioned the test/host system, but the same results can be achieved on [other systems](./Supported_Hardware_Operating_System.md)
 
 ## 1. `nr-softmodem` Performance in `oai-gNB` and `oai-gNB-du` Modes for FR1 bands
 
-### KPI with USRP
+### Application level throughput for USRP
 
 #### Test Profile
 
 The following results apply to the TDD configuration below:
+
 |Parameter          |Value                   |
 |-------------------|------------------------|
 |Band               |n41                     |
@@ -16,8 +19,11 @@ The following results apply to the TDD configuration below:
 |DL test TDD Pattern|`DDDSU`, 2.5ms          |
 |UL test TDD Pattern|`DDSUU`, 2.5ms          |
 
-- test machine: AMD Ryzen 9 7950X 16-Core Processor
-- radio: USRP N310, UE: Quectel RM500Q
+- Test System: AMD Ryzen 9 7950X 16-Core Processor
+- Radio: USRP N310 
+- UE: Quectel RM500Q
+- Environment: OTA, distance: 2m
+- Application level throughput tested using iperf3 UDP
 
 |Bandwidth MHz/PRB|Layers|DL Throughput (Mbps)|UL Throughput (Mbps)|
 |-----------------|-----:|-------------------:|-------------------:|
@@ -36,12 +42,12 @@ The following results apply to the TDD configuration below:
 |100(273)         |1     |400                 |101                 |
 |                 |2     |800                 |120                 |
 
-### KPI with ORAN 7.2
-- test branch: [2026.w22](https://github.com/duranta-project/openairinterface5g/releases/tag/2026.w22)
+### Application level throughput for O-RAN 7.2 Fronthaul
 
 #### Test Profile
 
 The following results apply to the TDD configuration below:
+
 |Parameter          |Value                   |
 |-------------------|------------------------|
 |Band               |n78/n77                 |
@@ -49,10 +55,12 @@ The following results apply to the TDD configuration below:
 |DL test TDD Pattern|`DDDSU`, 2.5ms, 10D2G2U |
 |UL test TDD Pattern|`DDSUU`, 2.5ms, 6D4G4U  |
 
-- test machine: AMD EPYC 9575F 64-Core Processor
-- radio: Benetel550 O-RU, UE: Quectel RM520N
-- OTA, distance: 2m
-- avx512 disabled (`--noavx512`)
+- Test System: AMD EPYC 9575F 64-Core Processor
+- Radio: Benetel 550 O-RU
+- UE: Quectel RM520N
+- Environment: OTA, distance: 2m
+- Uncompressed mode with avx512 disabled at compile time
+- Application level throughput tested using iperf3 UDP
 
 9b BFP static compression, 4T4R
 
@@ -86,16 +94,22 @@ The following results apply to the TDD configuration below:
 |DL test TDD Pattern|`DDDSU`, 0.625ms, 10D2U |
 |UL test TDD Pattern|`DDDSU`, 0.625ms, 64D4U |
 
-#### KPI
+- Test System: AMD EPYC 9575F 64-Core Processor
+- Radio: MicroAmp, LiteON FR2
+- UE: Quectel RG530F
+- Environment: OTA, distance: 2m
+- Application level throughput tested using iperf3 UDP
 
-Radio Unit: MicroAmp
+#### KPI
 
 |Bandwidth MHz/PRB|Layers|DL Throughput (Mbps)|UL Throughput (Mbps)|
 |-----------------|-----:|-------------------:|-------------------:|
+|100(66)          |1     |X                   |X                   |
+|                 |2     |550                 |x                   |
 |200(132)         |1     |500                 |86                  |
 |                 |2     |890                 |x                   |
 
-Round trip time (measured using ping): 4.526 ms
+Round trip time (measured using icmp ping): 4.526 ms
 
 With `ulsch_max_frame_inactivity= 0;`
 
@@ -107,11 +121,9 @@ For execution details, see [physical-simulators.md](./physical-simulators.md).
 
 #### Test Profile
 
-|Parameter |Value                           |
-|----------|--------------------------------|
-|Server    |AMD EPYC 9575F 64-Core Processor|
-|SNR       |40 dB                           |
-|MCS       |25                              |
+- Test System: AMD EPYC 9575F 64-Core Processor
+- SNR: 40 DB
+- MCS: 25
 
 #### nr_dlsim
 

--- a/doc/kpi.md
+++ b/doc/kpi.md
@@ -119,59 +119,123 @@ With `ulsch_max_frame_inactivity= 0;`
 
 For execution details, see [physical-simulators.md](./physical-simulators.md).
 
-#### Test Profile
+#### Test Profile 1
 
-- Test System: AMD EPYC 9575F 64-Core Processor
-- SNR: 40 DB
-- MCS: 25
+|Parameter   |Value                           |
+|------------|--------------------------------|
+|Machine     |AMD Ryzen 9 7945HX              |
+|Architecture|x86_64                          |
 
-#### nr_dlsim
-
-256 QAM modulation, 6 thread pool cores
-
-|Bandwidth MHz/PRB|Layers         |DL Processing (us) |Test Command                                                                             |
-|-----------------|---------------|-------------------|-----------------------------------------------------------------------------------------|
-|40(106)          |1              |35                 |nr_dlsim -n1000 -s30 -S30.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1             |
-|                 |2 (2 antennas) |52                 |nr_dlsim -n1000 -s40 -S40.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2 |
-|                 |  (4 antennas) |62                 |nr_dlsim -n1000 -s40 -S40.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4 |
-|100(273)         |1              |60                 |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1             |
-|                 |2 (2 antennas) |122                |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2 |
-|                 |  (4 antennas) |161                |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4 |
-
-#### nr_ulsim
-
-64 QAM modulation, 8 thread pool cores
-
-|Bandwidth MHz/PRB|Layers|UL Processing (us) |Test Command                                                    |
-|-----------------|------|-------------------|----------------------------------------------------------------|
-|40(106)          |1     |90                 |nr_ulsim -n1000 -s40 -S40.2 -m25 -r106 -R106 -C8 -P             |
-|                 |2     |247                |nr_ulsim -n1000 -s40 -S40.2 -m25 -r106 -R106 -C8 -P -W2 -z2 -y2 |
-|100(273)         |1     |170                |nr_ulsim -n1000 -s40 -S40.2 -m25 -r273 -R273 -C8 -P             |
-|                 |2     |591                |nr_ulsim -n1000 -s40 -S40.2 -m25 -r273 -R273 -C8 -P -W2 -z2 -y2 |
-
-#### nr_dlsim
+##### nr_dlsim
 
 256 QAM modulation, 6 thread pool cores
 
-|Bandwidth MHz/PRB|Layers         |gNB TX processing (us) |Test Command                                                                             |
-|-----------------|---------------|----------------------:|-----------------------------------------------------------------------------------------|
-|40(106)          |1              |35                     |nr_dlsim -n1000 -s30 -S30.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1             |
-|                 |2 (2 antennas) |52                     |nr_dlsim -n1000 -s40 -S40.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2 |
-|                 |  (4 antennas) |62                     |nr_dlsim -n1000 -s40 -S40.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4 |
-|100(273)         |1              |60                     |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1             |
-|                 |2 (2 antennas) |122                    |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2 |
-|                 |  (4 antennas) |161                    |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4 |
+DL Processing time is the `PHY proc tx` value reported by `nr_dlsim -P`, for gNB.
 
-#### nr_ulsim
+###### SNR 20 / MCS 20
+
+|Bandwidth MHz/PRB|Layers|DL Processing (us)|Test Command|
+|-----------------|------|------------------|------------|
+|40(106)|1|66.70|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1`|
+||2 (2 antennas)|87.96|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2`|
+||(4 antennas)|97.09|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4`|
+|100(273)|1|104.17|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1`|
+||2 (2 antennas)|170.40|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2`|
+||(4 antennas)|192.94|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4`|
+
+###### SNR 30 / MCS 25
+
+|Bandwidth MHz/PRB|Layers|DL Processing (us)|Test Command|
+|-----------------|------|------------------|------------|
+|40(106)|1|67.01|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1`|
+||2 (2 antennas)|95.87|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2`|
+||(4 antennas)|104.97|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4`|
+|100(273)|1|109.78|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1`|
+||2 (2 antennas)|193.51|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2`|
+||(4 antennas)|212.92|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4`|
+
+##### nr_ulsim
 
 64 QAM modulation, 8 thread pool cores
 
-|Bandwidth MHz/PRB|Layers|gNB RX processing (us) |Test Command                                                    |
-|-----------------|-----:|----------------------:|----------------------------------------------------------------|
-|40(106)          |1     |90                     |nr_ulsim -n1000 -s40 -S40.2 -m25 -r106 -R106 -C8 -P             |
-|                 |2     |247                    |nr_ulsim -n1000 -s40 -S40.2 -m25 -r106 -R106 -C8 -P -W2 -z2 -y2 |
-|100(273)         |1     |170                    |nr_ulsim -n1000 -s40 -S40.2 -m25 -r273 -R273 -C8 -P             |
-|                 |2     |591                    |nr_ulsim -n1000 -s40 -S40.2 -m25 -r273 -R273 -C8 -P -W2 -z2 -y2 |
+UL Processing time is the `Total PHY proc rx` value reported by `nr_ulsim -P`, for gNB.
+
+###### SNR 20 / MCS 20
+
+|Bandwidth MHz/PRB|Layers|UL Processing (us)|Test Command|
+|-----------------|------|------------------|------------|
+|40(106)|1|140.17|`./nr_ulsim -n1000 -s20 -S20 -m20 -r106 -R106 -C8 -P`|
+||2|321.56|`./nr_ulsim -n1000 -s20 -S20 -m20 -r106 -R106 -C8 -P -W2 -z2 -y2`|
+|100(273)|1|249.84|`./nr_ulsim -n1000 -s20 -S20 -m20 -r273 -R273 -C8 -P`|
+||2|892.62|`./nr_ulsim -n1000 -s20 -S20 -m20 -r273 -R273 -C8 -P -W2 -z2 -y2`|
+
+###### SNR 30 / MCS 25
+
+|Bandwidth MHz/PRB|Layers|UL Processing (us)|Test Command|
+|-----------------|------|------------------|------------|
+|40(106)|1|107.65|`./nr_ulsim -n1000 -s30 -S30 -m25 -r106 -R106 -C8 -P`|
+||2|305.61|`./nr_ulsim -n1000 -s30 -S30 -m25 -r106 -R106 -C8 -P -W2 -z2 -y2`|
+|100(273)|1|228.84|`./nr_ulsim -n1000 -s30 -S30 -m25 -r273 -R273 -C8 -P`|
+||2|889.85|`./nr_ulsim -n1000 -s30 -S30 -m25 -r273 -R273 -C8 -P -W2 -z2 -y2`|
+
+#### Test Profile 2
+
+|Parameter   |Value                           |
+|------------|--------------------------------|
+|Machine     |DGX Spark, Cortex-X925, 20 cores|
+|Architecture|aarch64                         |
+
+##### nr_dlsim
+
+256 QAM modulation, 6 thread pool cores
+
+DL Processing time is the `PHY proc tx` value reported by `nr_dlsim -P`, for gNB.
+
+###### SNR 20 / MCS 20
+
+|Bandwidth MHz/PRB|Layers|DL Processing (us)|Test Command|
+|-----------------|------|------------------|------------|
+|40(106)|1|104.04|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1`|
+||2 (2 antennas)|161.55|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2`|
+||(4 antennas)|191.94|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4`|
+|100(273)|1|189.12|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1`|
+||2 (2 antennas)|345.56|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2`|
+||(4 antennas)|418.26|`./nr_dlsim -n1000 -s20 -S20.2 -e20 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4`|
+
+###### SNR 30 / MCS 25
+
+|Bandwidth MHz/PRB|Layers|DL Processing (us)|Test Command|
+|-----------------|------|------------------|------------|
+|40(106)|1|103.05|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1`|
+||2 (2 antennas)|169.22|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2`|
+||(4 antennas)|197.41|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4`|
+|100(273)|1|194.23|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1`|
+||2 (2 antennas)|354.08|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2`|
+||(4 antennas)|428.30|`./nr_dlsim -n1000 -s30 -S30.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4`|
+
+##### nr_ulsim
+
+64 QAM modulation, 8 thread pool cores
+
+UL Processing time is the `Total PHY proc rx` value reported by `nr_ulsim -P`, for gNB.
+
+###### SNR 20 / MCS 20
+
+|Bandwidth MHz/PRB|Layers|UL Processing (us)|Test Command|
+|-----------------|------|------------------|------------|
+|40(106)|1|824.76|`./nr_ulsim -n1000 -s20 -S20 -m20 -r106 -R106 -C8 -P`|
+||2|3349.06|`./nr_ulsim -n1000 -s20 -S20 -m20 -r106 -R106 -C8 -P -W2 -z2 -y2`|
+|100(273)|1|1612.73|`./nr_ulsim -n1000 -s20 -S20 -m20 -r273 -R273 -C8 -P`|
+||2|7899.00|`./nr_ulsim -n1000 -s20 -S20 -m20 -r273 -R273 -C8 -P -W2 -z2 -y2`|
+
+###### SNR 30 / MCS 25
+
+|Bandwidth MHz/PRB|Layers|UL Processing (us)|Test Command|
+|-----------------|------|------------------|------------|
+|40(106)|1|656.31|`./nr_ulsim -n1000 -s30 -S30 -m25 -r106 -R106 -C8 -P`|
+||2|3187.49|`./nr_ulsim -n1000 -s30 -S30 -m25 -r106 -R106 -C8 -P -W2 -z2 -y2`|
+|100(273)|1|1509.84|`./nr_ulsim -n1000 -s30 -S30 -m25 -r273 -R273 -C8 -P`|
+||2|7389.53|`./nr_ulsim -n1000 -s30 -S30 -m25 -r273 -R273 -C8 -P -W2 -z2 -y2`|
 
 ## 4. `nr-uesoftmodem`
 

--- a/doc/kpi.md
+++ b/doc/kpi.md
@@ -8,19 +8,17 @@ This document summarizes the main throughput KPIs
 
 The following results apply to the TDD configuration below:
 
-|Parameter          |Value                |
-|-------------------|---------------------|
-|Band               |n78/n77              |
-|SCS                |30 kHz               |
-|DL test TDD Pattern|`DDDSU`, 2.5ms 10D2U |
-|UL test TDD Pattern|`DDSUU`, 2.5ms, 64D4U|
+|Parameter          |Value                   |
+|-------------------|------------------------|
+|Band               |n78/n77                 |
+|SCS                |30 kHz                  |
+|DL test TDD Pattern|`DDDSU`, 2.5ms, 10D2G2U |
+|UL test TDD Pattern|`DDSUU`, 2.5ms, 6D4G4U  |
 
-#### KPI
-
-Configuration: `DDDSU`, mixed slot `6D4U`
+#### KPI with USRP
 
 |Bandwidth MHz/PRB|Layers|DL Throughput (Mbps)|UL Throughput (Mbps)|
-|-----------------|------|--------------------|--------------------|
+|-----------------|-----:|-------------------:|-------------------:|
 |20(51)           |1     |72                  |39                  |
 |                 |2     |143                 |65                  |
 |                 |4     |258                 |X                   |
@@ -33,10 +31,27 @@ Configuration: `DDDSU`, mixed slot `6D4U`
 |80(217)          |1     |310                 |80                  |
 |                 |2     |622                 |140                 |
 |                 |4     |x                   |X                   |
-|100(273)         |1     |X                   |X                   |
-|                 |2     |X                   |X                   |
+
+#### KPI with ORAN 7.2
+
+9b BFP, 4T4R, Benetel550 RU, Quectel RM520N, OTA, distance: 2m
+
+|Bandwidth MHz/PRB|Layers|DL Throughput (Mbps)|UL Throughput (Mbps)|
+|-----------------|-----:|-------------------:|-------------------:|
+|40(106)          |1     |158                 |79                  |
+|                 |2     |315                 |118                 |
+|100(273)         |1     |412                 |180                 |
+|                 |2     |820                 |250                 |
 |                 |4     |1400                |X                   |
 
+16b no compression, 2T2R, Benetel550 RU, Quectel RM520N, OTA, distance: 2m
+
+|Bandwidth MHz/PRB|Layers|DL Throughput (Mbps)|UL Throughput (Mbps)|
+|-----------------|-----:|-------------------:|-------------------:|
+|40(106)          |1     |158                 |67                  |
+|                 |2     |315                 |83                  |
+|100(273)         |1     |412                 |160                 |
+|                 |2     |820                 |200                 |
 
 ## 2. `nr-softmodem` Performance in `oai-gNB` and `oai-gNB-du` Modes for FR2 bands
 
@@ -56,7 +71,7 @@ The following results apply to the TDD configuration below:
 Radio Unit: MicroAmp
 
 |Bandwidth MHz/PRB|Layers|DL Throughput (Mbps)|UL Throughput (Mbps)|
-|-----------------|------|--------------------|--------------------|
+|-----------------|-----:|-------------------:|-------------------:|
 |200(132)         |1     |500                 |86                  |
 |                 |2     |890                 |x                   |
 
@@ -70,12 +85,61 @@ With `ulsch_max_frame_inactivity= 0;`
 
 For execution details, see [physical-simulators.md](./physical-simulators.md).
 
-Results:
+#### Test Profile
 
+|Parameter |Value                           |
+|----------|--------------------------------|
+|Server    |AMD EPYC 9575F 64-Core Processor|
+|SNR       |40 dB                           |
+|MCS       |25                              |
 
-### 3.2 `phytest`
+#### nr_dlsim
 
-Needs to update
+256 QAM modulation, 6 thread pool cores
+
+|Bandwidth MHz/PRB|Layers         |DL Processing (us) |Test Command                                                                             |
+|-----------------|---------------|-------------------|-----------------------------------------------------------------------------------------|
+|40(106)          |1              |35                 |nr_dlsim -n1000 -s30 -S30.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1             |
+|                 |2 (2 antennas) |52                 |nr_dlsim -n1000 -s40 -S40.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2 |
+|                 |  (4 antennas) |62                 |nr_dlsim -n1000 -s40 -S40.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4 |
+|100(273)         |1              |60                 |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1             |
+|                 |2 (2 antennas) |122                |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2 |
+|                 |  (4 antennas) |161                |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4 |
+
+#### nr_ulsim
+
+64 QAM modulation, 8 thread pool cores
+
+|Bandwidth MHz/PRB|Layers|UL Processing (us) |Test Command                                                    |
+|-----------------|------|-------------------|----------------------------------------------------------------|
+|40(106)          |1     |90                 |nr_ulsim -n1000 -s40 -S40.2 -m25 -r106 -R106 -C8 -P             |
+|                 |2     |247                |nr_ulsim -n1000 -s40 -S40.2 -m25 -r106 -R106 -C8 -P -W2 -z2 -y2 |
+|100(273)         |1     |170                |nr_ulsim -n1000 -s40 -S40.2 -m25 -r273 -R273 -C8 -P             |
+|                 |2     |591                |nr_ulsim -n1000 -s40 -S40.2 -m25 -r273 -R273 -C8 -P -W2 -z2 -y2 |
+
+#### nr_dlsim
+
+256 QAM modulation, 6 thread pool cores
+
+|Bandwidth MHz/PRB|Layers         |gNB TX processing (us) |Test Command                                                                             |
+|-----------------|---------------|----------------------:|-----------------------------------------------------------------------------------------|
+|40(106)          |1              |35                     |nr_dlsim -n1000 -s30 -S30.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1             |
+|                 |2 (2 antennas) |52                     |nr_dlsim -n1000 -s40 -S40.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2 |
+|                 |  (4 antennas) |62                     |nr_dlsim -n1000 -s40 -S40.2 -e25 -b106 -R106 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4 |
+|100(273)         |1              |60                     |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1             |
+|                 |2 (2 antennas) |122                    |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z2 -y2 |
+|                 |  (4 antennas) |161                    |nr_dlsim -n1000 -s40 -S40.2 -e25 -b273 -R273 -X 8,9,10,11,12,13,14,15 -P -q1 -x2 -z4 -y4 |
+
+#### nr_ulsim
+
+64 QAM modulation, 8 thread pool cores
+
+|Bandwidth MHz/PRB|Layers|gNB RX processing (us) |Test Command                                                    |
+|-----------------|-----:|----------------------:|----------------------------------------------------------------|
+|40(106)          |1     |90                     |nr_ulsim -n1000 -s40 -S40.2 -m25 -r106 -R106 -C8 -P             |
+|                 |2     |247                    |nr_ulsim -n1000 -s40 -S40.2 -m25 -r106 -R106 -C8 -P -W2 -z2 -y2 |
+|100(273)         |1     |170                    |nr_ulsim -n1000 -s40 -S40.2 -m25 -r273 -R273 -C8 -P             |
+|                 |2     |591                    |nr_ulsim -n1000 -s40 -S40.2 -m25 -r273 -R273 -C8 -P -W2 -z2 -y2 |
 
 ## 4. `nr-uesoftmodem`
 
@@ -95,7 +159,7 @@ Testbed Architecture:
 UE <--> Over the Air 1.5m to 2m distance <--> USRP/RU <--> gNB/DU server
 
 | Platform    | UE-Radio  | Bandwidth | DL Throughput | UL Throughput |
-| ----------- | --------- | --------- | ------------- | ------------- |
+| ----------- | --------- | --------- | ------------: | ------------: |
 | Jetson Orin | B210      | 10 MHz    | 12 Mbps       | 7.5 Mbps      |
 | Jetson Orin | B210      | 20 MHz    | 20 Mbps       | 9.5 Mbps      |
 | Jetson Orin | B210      | 30 MHz    | 61 Mbps       | 33 Mbps       |

--- a/doc/kpi.md
+++ b/doc/kpi.md
@@ -1,0 +1,104 @@
+# Key Performance Indicators for the OpenAirInterface Code Base
+
+This document summarizes the main throughput KPIs
+
+## 1. `nr-softmodem` Performance in `oai-gNB` and `oai-gNB-du` Modes for FR1 bands
+
+### Test Profile
+
+The following results apply to the TDD configuration below:
+
+|Parameter          |Value                |
+|-------------------|---------------------|
+|Band               |n78/n77              |
+|SCS                |30 kHz               |
+|DL test TDD Pattern|`DDDSU`, 2.5ms 10D2U |
+|UL test TDD Pattern|`DDSUU`, 2.5ms, 64D4U|
+
+#### KPI
+
+Configuration: `DDDSU`, mixed slot `6D4U`
+
+|Bandwidth MHz/PRB|Layers|DL Throughput (Mbps)|UL Throughput (Mbps)|
+|-----------------|------|--------------------|--------------------|
+|20(51)           |1     |72                  |39                  |
+|                 |2     |143                 |65                  |
+|                 |4     |258                 |X                   |
+|40(106)          |1     |152                 |81                  |
+|                 |2     |304                 |154                 |
+|                 |4     |550                 |X                   |
+|60(162)          |1     |233                 |123                 |
+|                 |2     |466                 |175                 |
+|                 |4     |730                 |X                   |
+|80(217)          |1     |310                 |80                  |
+|                 |2     |622                 |140                 |
+|                 |4     |x                   |X                   |
+|100(273)         |1     |X                   |X                   |
+|                 |2     |X                   |X                   |
+|                 |4     |1400                |X                   |
+
+
+## 2. `nr-softmodem` Performance in `oai-gNB` and `oai-gNB-du` Modes for FR2 bands
+
+### Test Profile
+
+The following results apply to the TDD configuration below:
+
+|Parameter          |Value                   |
+|-------------------|------------------------|
+|Band               |257                     |
+|SCS                |120 kHz                 |
+|DL test TDD Pattern|`DDDSU`, 0.625ms, 10D2U |
+|UL test TDD Pattern|`DDDSU`, 0.625ms, 64D4U |
+
+#### KPI
+
+Radio Unit: MicroAmp
+
+|Bandwidth MHz/PRB|Layers|DL Throughput (Mbps)|UL Throughput (Mbps)|
+|-----------------|------|--------------------|--------------------|
+|200(132)         |1     |500                 |86                  |
+|                 |2     |890                 |x                   |
+
+Round trip time (measured using ping): 4.526 ms
+
+With `ulsch_max_frame_inactivity= 0;`
+
+## 3. Performance Metrics for OAI Block Tests
+
+### 3.1 Physical Simulators (`physims`)
+
+For execution details, see [physical-simulators.md](./physical-simulators.md).
+
+Results:
+
+
+### 3.2 `phytest`
+
+Needs to update
+
+## 4. `nr-uesoftmodem`
+
+### Test Profile
+
+The following results apply to the TDD configuration below:
+
+|Parameter|Value  |
+|---------|-------|
+|Band     |n78/n77|
+|SCS      |30 kHz |
+|QAM      |64     |
+|Mode     |SISO   |
+
+Testbed Architecture:
+
+UE <--> Over the Air 1.5m to 2m distance <--> USRP/RU <--> gNB/DU server
+
+| Platform    | UE-Radio  | Bandwidth | DL Throughput | UL Throughput |
+| ----------- | --------- | --------- | ------------- | ------------- |
+| Jetson Orin | B210      | 10 MHz    | 12 Mbps       | 7.5 Mbps      |
+| Jetson Orin | B210      | 20 MHz    | 20 Mbps       | 9.5 Mbps      |
+| Jetson Orin | B210      | 30 MHz    | 61 Mbps       | 33 Mbps       |
+| Jetson Orin | B210      | 40 MHz    | 69 Mbps       | 46 Mbps       |
+| DGX Spark   | B210      | 40 MHz    | 86 Mbps       | 46 Mbps       |
+| DGX Spark   | N310/x410 | 100 MHz   | 231 Mbps      | 118 Mbps      |


### PR DESCRIPTION
> [!NOTE]
> MR [!4057](https://gitlab.eurecom.fr/oai/openairinterface5g/-/merge_requests/4057) imported from GitLab 

The idea of this doc is to share with the users the KPI's of the OpenAirInterface code base (RAN+UE). 

It will be nice to add details about different TDD patterns, but I think to start with something, we can add information for the ones we test in CI, or ones that someone in the community has tested. 

I used some KPIs shared by @luispereira106 in the past. 

TBD: 
- [x] Add 100 MHz with USRP
- [x] Add HW description -> done for FHI72 and USRP tests
- [x] Physim with ARM (GH200 or DGX), reduce SNR: tested on groot and DGX Spark, for 2 different SNR/MCS combinations (20/20 and 30/25)
[groot_physim.log](https://github.com/user-attachments/files/32239309/groot_physim.log)
[dgx2_physim.log](https://github.com/user-attachments/files/32239310/dgx2_physim.log)
- [ ] Add configs
- [ ] test with phone, different distance from gNB


>For follow-up PR:
>- [ ] Phytest results
>- [ ] Add KPIs with and without offload (GPU/LPDC)
>- [ ] Add ATB KPIs
>- [ ] Add multi-ue kpi
>- [ ] Add information about RSRP and RI/CQI
>- [ ] FR2 with 2 UL layers
>- [ ] NR-DC measurements
>- [ ] Add 8T8R for outdoor setup