### PR TITLE
Local ssb detection

### DIFF
--- a/executables/main_nr_ru.c
+++ b/executables/main_nr_ru.c
@@ -111,7 +111,10 @@ void perform_symbol_rotation(const int nsymb, const int numerology_index, double
 {
   return;
 }
-void init_timeshift_rotation(NR_DL_FRAME_PARMS *fp)
+void init_timeshift_rotation(const int ofdm_symbol_size,
+                             const int nb_prefix_samples,
+                             const uint ofdm_offset_divisor,
+                             c16_t *timeshift_symbol_rotation)
 {
   return;
 };

--- a/executables/main_nr_ru.c
+++ b/executables/main_nr_ru.c
@@ -107,7 +107,7 @@ struct timespec timespec_sub(struct timespec, struct timespec)
   return t;
 };
 
-void perform_symbol_rotation(NR_DL_FRAME_PARMS *fp, double f0, c16_t *symbol_rotation)
+void perform_symbol_rotation(const int nsymb, const int numerology_index, double f0, c16_t *symbol_rotation)
 {
   return;
 }

--- a/executables/nr-gnb.c
+++ b/executables/nr-gnb.c
@@ -172,13 +172,17 @@ static void rx_func(processingData_L1_t *info)
     if (gNB->phase_comp) {
       //apply the rx signal rotation here
       int soffset = (slot_rx % RU_RX_SLOT_DEPTH) * gNB->frame_parms.symbols_per_slot * gNB->frame_parms.ofdm_symbol_size;
-      for (int aa = 0; aa < gNB->frame_parms.nb_antennas_tx; aa++) {
-        const uint max_symb = (gNB->frame_parms.Ncp == NR_EXTENDED) ? 12 : 14;
+      const NR_DL_FRAME_PARMS *fp = &gNB->frame_parms;
+      for (int aa = 0; aa < fp->nb_antennas_rx; aa++) {
+        const uint max_symb = fp->Ncp == NR_EXTENDED ? 12 : 14;
         for (int sym = 0; sym < max_symb; sym++)
-          apply_nr_rotation_symbol_RX(&gNB->frame_parms,
-                                      gNB->common_vars.rxdataF[aa] + soffset + sym * gNB->frame_parms.ofdm_symbol_size,
-                                      gNB->frame_parms.symbol_rotation[1],
-                                      gNB->frame_parms.N_RB_UL,
+          apply_nr_rotation_symbol_RX(fp->symbols_per_slot,
+                                      fp->slots_per_subframe,
+                                      fp->timeshift_symbol_rotation,
+                                      fp->first_carrier_offset,
+                                      gNB->common_vars.rxdataF[aa] + soffset + sym * fp->ofdm_symbol_size,
+                                      fp->symbol_rotation[1],
+                                      fp->N_RB_UL,
                                       slot_rx,
                                       sym);
       }

--- a/openair1/PHY/INIT/nr_init.c
+++ b/openair1/PHY/INIT/nr_init.c
@@ -307,7 +307,7 @@ void nr_phy_config_request_sim(PHY_VARS_gNB *gNB,
 
   fp->ofdm_offset_divisor = UINT_MAX;
   init_symbol_rotation(fp);
-  init_timeshift_rotation(fp);
+  init_timeshift_rotation(fp->ofdm_symbol_size, fp->nb_prefix_samples, fp->ofdm_offset_divisor, fp->timeshift_symbol_rotation);
 
   gNB->configured = 1;
 }
@@ -359,7 +359,7 @@ void nr_phy_config_request(NR_PHY_Config_t *phy_config)
 
   fp->ofdm_offset_divisor = RC.gNB[Mod_id]->ofdm_offset_divisor;
   init_symbol_rotation(fp);
-  init_timeshift_rotation(fp);
+  init_timeshift_rotation(fp->ofdm_symbol_size, fp->nb_prefix_samples, fp->ofdm_offset_divisor, fp->timeshift_symbol_rotation);
 }
 
 static void init_DLSCH_struct(PHY_VARS_gNB *gNB)

--- a/openair1/PHY/INIT/nr_init_ue.c
+++ b/openair1/PHY/INIT/nr_init_ue.c
@@ -460,7 +460,6 @@ void phy_init_nr_top(PHY_VARS_NR_UE *ue) {
   crcTableInit();
   init_byte2m128i();
   load_dftslib();
-  init_context_synchro_nr(frame_parms);
   generate_ul_reference_signal_sequences(SHRT_MAX);
 }
 

--- a/openair1/PHY/INIT/nr_init_ue.c
+++ b/openair1/PHY/INIT/nr_init_ue.c
@@ -255,7 +255,7 @@ int init_nr_ue_signal(PHY_VARS_NR_UE *ue, int nb_connected_gNB)
 
   ue->init_averaging = 1;
   init_symbol_rotation(fp);
-  init_timeshift_rotation(fp);
+  init_timeshift_rotation(fp->ofdm_symbol_size, fp->nb_prefix_samples, fp->ofdm_offset_divisor, fp->timeshift_symbol_rotation);
 
   // initialize to false only for SA since in do-ra and phy-test it is already set to true before getting here
   if (IS_SA_MODE(get_softmodem_params()))

--- a/openair1/PHY/INIT/nr_parms.c
+++ b/openair1/PHY/INIT/nr_parms.c
@@ -568,8 +568,10 @@ int nr_init_frame_parms_ue_sl(NR_DL_FRAME_PARMS *fp,
 
   // ssb_offset_pointa points to the first RE where Sidelink-PSBCH starts
   fp->ssb_start_subcarrier = config->sl_bwp_config.sl_ssb_offset_point_a;
-
-  perform_symbol_rotation(fp, fp->sl_CarrierFreq, fp->symbol_rotation[link_type_sl]);
+  perform_symbol_rotation(fp->symbols_per_slot * fp->slots_per_frame / 10,
+                          fp->numerology_index,
+                          fp->sl_CarrierFreq,
+                          fp->symbol_rotation[link_type_sl]);
   init_timeshift_rotation(fp);
 
   // Not used for Sidelink

--- a/openair1/PHY/INIT/nr_parms.c
+++ b/openair1/PHY/INIT/nr_parms.c
@@ -572,7 +572,7 @@ int nr_init_frame_parms_ue_sl(NR_DL_FRAME_PARMS *fp,
                           fp->numerology_index,
                           fp->sl_CarrierFreq,
                           fp->symbol_rotation[link_type_sl]);
-  init_timeshift_rotation(fp);
+  init_timeshift_rotation(fp->ofdm_symbol_size, fp->nb_prefix_samples, fp->ofdm_offset_divisor, fp->timeshift_symbol_rotation);
 
   // Not used for Sidelink
   fp->Lmax = 0;

--- a/openair1/PHY/LTE_ESTIMATION/lte_ul_channel_estimation.c
+++ b/openair1/PHY/LTE_ESTIMATION/lte_ul_channel_estimation.c
@@ -231,8 +231,8 @@ int32_t lte_ul_channel_estimation(LTE_DL_FRAME_PARMS *frame_parms,
             current_phase1 = cmin(abs(current_phase1),127);
             current_phase2 = cmin(abs(current_phase2), 127);
             // rotate channel estimates by estimated phase
-            rotate_cpx_vector(ul_ch1, &ru1[current_phase1], &ul_ch_estimates[aa][frame_parms->N_RB_UL * 12 * k], Msc_RS, 15);
-            rotate_cpx_vector(ul_ch2, &ru2[current_phase2], tmp_estimates, Msc_RS, 15);
+            rotate_cpx_vector(ul_ch1, ru1[current_phase1], &ul_ch_estimates[aa][frame_parms->N_RB_UL * 12 * k], Msc_RS, 15);
+            rotate_cpx_vector(ul_ch2, ru2[current_phase2], tmp_estimates, Msc_RS, 15);
             // Combine the two rotated estimates
             mult_complex_vector_real_scalar(&ul_ch_estimates[aa][frame_parms->N_RB_UL * 12 * k],
                                             SCALE,
@@ -436,8 +436,8 @@ int32_t lte_ul_channel_estimation_RRU(LTE_DL_FRAME_PARMS *frame_parms,
           current_phase1 = cmin(abs(current_phase1),127);
           current_phase2 = cmin(abs(current_phase2), 127);
           // rotate channel estimates by estimated phase
-          rotate_cpx_vector(ul_ch1, &ru1[current_phase1], &ul_ch_estimates[aa][frame_parms->N_RB_UL * 12 * k], Msc_RS, 15);
-          rotate_cpx_vector(ul_ch2, &ru2[current_phase2], tmp_estimates, Msc_RS, 15);
+          rotate_cpx_vector(ul_ch1, ru1[current_phase1], &ul_ch_estimates[aa][frame_parms->N_RB_UL * 12 * k], Msc_RS, 15);
+          rotate_cpx_vector(ul_ch2, ru2[current_phase2], tmp_estimates, Msc_RS, 15);
           // Combine the two rotated estimates
           mult_complex_vector_real_scalar(&ul_ch_estimates[aa][frame_parms->N_RB_UL * 12 * k],
                                           SCALE,

--- a/openair1/PHY/MODULATION/nr_modulation.c
+++ b/openair1/PHY/MODULATION/nr_modulation.c
@@ -573,13 +573,12 @@ void nr_dft(c16_t *z, c16_t *d, uint32_t Msc_PUSCH)
   }
 }
 
-void perform_symbol_rotation(NR_DL_FRAME_PARMS *fp, double f0, c16_t *symbol_rotation)
+void perform_symbol_rotation(const int nsymb, const int numerology_index, double f0, c16_t *symbol_rotation)
 {
-  const int nsymb = fp->symbols_per_slot * fp->slots_per_frame / 10;
   const double Tc = (1 / 480e3 / 4096);
-  const double Nu = 2048 * 64 * (1 / (float)(1 << fp->numerology_index));
-  const double Ncp0 = 16 * 64 + (144 * 64 * (1 / (float)(1 << fp->numerology_index)));
-  const double Ncp1 = (144 * 64 * (1 / (float)(1 << fp->numerology_index)));
+  const double Nu = 2048 * 64 * (1 / (float)(1 << numerology_index));
+  const double Ncp0 = 16 * 64 + (144 * 64 * (1 / (float)(1 << numerology_index)));
+  const double Ncp1 = (144 * 64 * (1 / (float)(1 << numerology_index)));
 
   LOG_D(PHY, "Doing symbol rotation calculation for TX/RX, f0 %f Hz, Nsymb %d\n", f0, nsymb);
 
@@ -590,7 +589,7 @@ void perform_symbol_rotation(NR_DL_FRAME_PARMS *fp, double f0, c16_t *symbol_rot
 
   for (int l = 0; l < nsymb; l++) {
     double Ncp;
-    if (l == 0 || l == (7 * (1 << fp->numerology_index))) {
+    if (l == 0 || l == (7 * (1 << numerology_index))) {
       Ncp = Ncp0;
     } else {
       Ncp = Ncp1;
@@ -624,8 +623,7 @@ void init_symbol_rotation(NR_DL_FRAME_PARMS *fp)
     if (f0 == 0)
       continue;
     c16_t *rot = fp->symbol_rotation[ll];
-
-    perform_symbol_rotation(fp, f0, rot);
+    perform_symbol_rotation(fp->symbols_per_slot * fp->slots_per_frame / 10, fp->numerology_index, f0, rot);
   }
 }
 

--- a/openair1/PHY/MODULATION/nr_modulation.c
+++ b/openair1/PHY/MODULATION/nr_modulation.c
@@ -627,22 +627,25 @@ void init_symbol_rotation(NR_DL_FRAME_PARMS *fp)
   }
 }
 
-void init_timeshift_rotation(NR_DL_FRAME_PARMS *fp)
+void init_timeshift_rotation(const int ofdm_symbol_size,
+                             const int nb_prefix_samples,
+                             const uint ofdm_offset_divisor,
+                             c16_t *timeshift_symbol_rotation)
 {
-  const int sample_offset = fp->nb_prefix_samples / fp->ofdm_offset_divisor;
-  for (int i = 0; i < fp->ofdm_symbol_size; i++) {
-    double poff = -i * 2.0 * M_PI * sample_offset / fp->ofdm_symbol_size;
+  const int sample_offset = nb_prefix_samples / ofdm_offset_divisor;
+  for (int i = 0; i < ofdm_symbol_size; i++) {
+    double poff = -i * 2.0 * M_PI * sample_offset / ofdm_symbol_size;
     double exp_re = cos(poff);
     double exp_im = sin(-poff);
-    fp->timeshift_symbol_rotation[i].r = (int16_t)round(exp_re * 32767);
-    fp->timeshift_symbol_rotation[i].i = (int16_t)round(exp_im * 32767);
+    timeshift_symbol_rotation[i].r = (int16_t)round(exp_re * 32767);
+    timeshift_symbol_rotation[i].i = (int16_t)round(exp_im * 32767);
 
     if (i < 10)
       LOG_D(PHY,
             "Timeshift symbol rotation %d => (%d,%d) %f\n",
             i,
-            fp->timeshift_symbol_rotation[i].r,
-            fp->timeshift_symbol_rotation[i].i,
+            timeshift_symbol_rotation[i].r,
+            timeshift_symbol_rotation[i].i,
             poff);
   }
 }

--- a/openair1/PHY/MODULATION/nr_modulation.h
+++ b/openair1/PHY/MODULATION/nr_modulation.h
@@ -101,8 +101,7 @@ void nr_ofdm_demod_and_rx_rotation(c16_t **rxdata,
                                    int slot_offsetF,
                                    enum nr_Link linktype,
                                    bool was_symbol_used[NR_SYMBOLS_PER_SLOT]);
-
-void perform_symbol_rotation(NR_DL_FRAME_PARMS *fp, double f0, c16_t *symbol_rotation);
+void perform_symbol_rotation(const int nsymb, const int numerology_index, double f0, c16_t *symbol_rotation);
 
 void init_symbol_rotation(NR_DL_FRAME_PARMS *fp);
 

--- a/openair1/PHY/MODULATION/nr_modulation.h
+++ b/openair1/PHY/MODULATION/nr_modulation.h
@@ -110,7 +110,10 @@ void init_timeshift_rotation(const int ofdm_symbol_size,
                              const uint ofdm_offset_divisor,
                              c16_t *timeshift_symbol_rotation);
 
-void apply_nr_rotation_symbol_RX(const NR_DL_FRAME_PARMS *frame_parms,
+void apply_nr_rotation_symbol_RX(const int symbols_per_slot,
+                                 const int slots_per_subframe,
+                                 const c16_t *timeshift_symbol_rotation,
+                                 const int first_carrier_offset,
                                  c16_t *rxdataF,
                                  const c16_t *rot,
                                  int nb_rb,

--- a/openair1/PHY/MODULATION/nr_modulation.h
+++ b/openair1/PHY/MODULATION/nr_modulation.h
@@ -105,7 +105,10 @@ void perform_symbol_rotation(const int nsymb, const int numerology_index, double
 
 void init_symbol_rotation(NR_DL_FRAME_PARMS *fp);
 
-void init_timeshift_rotation(NR_DL_FRAME_PARMS *fp);
+void init_timeshift_rotation(const int ofdm_symbol_size,
+                             const int nb_prefix_samples,
+                             const uint ofdm_offset_divisor,
+                             c16_t *timeshift_symbol_rotation);
 
 void apply_nr_rotation_symbol_RX(const NR_DL_FRAME_PARMS *frame_parms,
                                  c16_t *rxdataF,

--- a/openair1/PHY/MODULATION/ofdm_mod.c
+++ b/openair1/PHY/MODULATION/ofdm_mod.c
@@ -283,15 +283,15 @@ void apply_nr_rotation_TX(const NR_DL_FRAME_PARMS *fp,
   symbol_rotation += symb_offset;
 
   for (int sidx = first_symbol; sidx < first_symbol + nsymb; sidx++) {
-    const c16_t *this_rotation = symbol_rotation + sidx;
-    c16_t *this_symbol = (txdataF) + sidx * fp->ofdm_symbol_size;
+    const c16_t this_rotation = symbol_rotation[sidx];
+    c16_t *this_symbol = txdataF + sidx * fp->ofdm_symbol_size;
 
     LOG_D(PHY,"Rotating symbol %d, slot %d, symbol_subframe_index %d (%d,%d)\n",
       sidx,
       slot,
       sidx + symb_offset,
-      this_rotation->r,
-      this_rotation->i);
+      this_rotation.r,
+      this_rotation.i);
 
     if (is_flat_buff)
       rotate_cpx_vector(this_symbol, this_rotation, this_symbol, nb_rb * NR_NB_SC_PER_RB, 15);

--- a/openair1/PHY/MODULATION/slot_fep_nr.c
+++ b/openair1/PHY/MODULATION/slot_fep_nr.c
@@ -31,7 +31,10 @@ void nr_symbol_fep(const NR_DL_FRAME_PARMS *frame_parms,
     if (dft_stats) stop_meas(dft_stats);
 
     const bool is_sl = (link_type == link_type_sl);
-    apply_nr_rotation_symbol_RX(frame_parms,
+    apply_nr_rotation_symbol_RX(frame_parms->symbols_per_slot,
+                                frame_parms->slots_per_subframe,
+                                frame_parms->timeshift_symbol_rotation,
+                                frame_parms->first_carrier_offset,
                                 rxdataF[aa],
                                 frame_parms->symbol_rotation[link_type],
                                 is_sl ? frame_parms->N_RB_SL : frame_parms->N_RB_DL,
@@ -159,45 +162,39 @@ int nr_symbol_fep_ul(const NR_DL_FRAME_PARMS *fp,
   return 0;
 }
 
-void apply_nr_rotation_symbol_RX(const NR_DL_FRAME_PARMS *frame_parms,
+void apply_nr_rotation_symbol_RX(const int symbols_per_slot,
+                                 const int slots_per_subframe,
+                                 const c16_t *shift_rot,
+                                 const int first_carrier_offset,
                                  c16_t *rxdataF,
                                  const c16_t *rot,
                                  int nb_rb,
                                  int slot,
                                  int symbol)
 {
-  const int symb_offset = (slot % frame_parms->slots_per_subframe) * frame_parms->symbols_per_slot;
+  const int symb_offset = (slot % slots_per_subframe) * symbols_per_slot;
 
   c16_t rot2 = rot[symbol + symb_offset];
   rot2.i = -rot2.i;
-  LOG_D(PHY,"slot %d, symb_offset %d rotating by %d.%d\n", slot, symb_offset, rot2.r, rot2.i);
-  const c16_t *shift_rot = frame_parms->timeshift_symbol_rotation;
+  LOG_D(PHY, "slot %d, symb_offset %d rotating by %d.%d\n", slot, symb_offset, rot2.r, rot2.i);
   c16_t *this_symbol = rxdataF;
 
   if (nb_rb & 1) {
     rotate_cpx_vector(this_symbol, &rot2, this_symbol, (nb_rb + 1) * 6, 15);
-    rotate_cpx_vector(this_symbol + frame_parms->first_carrier_offset - 6,
-                      &rot2,
-                      this_symbol + frame_parms->first_carrier_offset - 6,
-                      (nb_rb + 1) * 6,
-                      15);
+    rotate_cpx_vector(this_symbol + first_carrier_offset - 6, &rot2, this_symbol + first_carrier_offset - 6, (nb_rb + 1) * 6, 15);
     mult_cpx_vector(this_symbol, shift_rot, this_symbol, (nb_rb + 1) * 6, 15);
-    mult_cpx_vector(this_symbol + frame_parms->first_carrier_offset - 6,
-                    shift_rot + frame_parms->first_carrier_offset - 6,
-                    this_symbol + frame_parms->first_carrier_offset - 6,
+    mult_cpx_vector(this_symbol + first_carrier_offset - 6,
+                    shift_rot + first_carrier_offset - 6,
+                    this_symbol + first_carrier_offset - 6,
                     (nb_rb + 1) * 6,
                     15);
   } else {
     rotate_cpx_vector(this_symbol, &rot2, this_symbol, nb_rb * 6, 15);
-    rotate_cpx_vector(this_symbol + frame_parms->first_carrier_offset,
-                      &rot2,
-                      this_symbol + frame_parms->first_carrier_offset,
-                      nb_rb * 6,
-                      15);
+    rotate_cpx_vector(this_symbol + first_carrier_offset, &rot2, this_symbol + first_carrier_offset, nb_rb * 6, 15);
     mult_cpx_vector(this_symbol, shift_rot, this_symbol, nb_rb * 6, 15);
-    mult_cpx_vector(this_symbol + frame_parms->first_carrier_offset,
-                    shift_rot + frame_parms->first_carrier_offset,
-                    this_symbol + frame_parms->first_carrier_offset,
+    mult_cpx_vector(this_symbol + first_carrier_offset,
+                    shift_rot + first_carrier_offset,
+                    this_symbol + first_carrier_offset,
                     nb_rb * 6,
                     15);
   }
@@ -216,7 +213,10 @@ void nr_ofdm_demod_and_rx_rotation(c16_t **rxdata,
     for (uint8_t symbol = 0; symbol < fp->symbols_per_slot; symbol++) {
       if (was_symbol_used[symbol] == true) {
         nr_symbol_fep_ul(fp, &rxdata[aa][0], &rxdataF[aa][slot_offsetF + symbol * fp->ofdm_symbol_size], symbol, slot, 0);
-        apply_nr_rotation_symbol_RX(fp,
+        apply_nr_rotation_symbol_RX(fp->symbols_per_slot,
+                                    fp->slots_per_subframe,
+                                    fp->timeshift_symbol_rotation,
+                                    fp->first_carrier_offset,
                                     &rxdataF[aa][slot_offsetF + symbol * fp->ofdm_symbol_size],
                                     fp->symbol_rotation[linktype],
                                     fp->N_RB_UL,

--- a/openair1/PHY/MODULATION/slot_fep_nr.c
+++ b/openair1/PHY/MODULATION/slot_fep_nr.c
@@ -180,8 +180,8 @@ void apply_nr_rotation_symbol_RX(const int symbols_per_slot,
   c16_t *this_symbol = rxdataF;
 
   if (nb_rb & 1) {
-    rotate_cpx_vector(this_symbol, &rot2, this_symbol, (nb_rb + 1) * 6, 15);
-    rotate_cpx_vector(this_symbol + first_carrier_offset - 6, &rot2, this_symbol + first_carrier_offset - 6, (nb_rb + 1) * 6, 15);
+    rotate_cpx_vector(this_symbol, rot2, this_symbol, (nb_rb + 1) * 6, 15);
+    rotate_cpx_vector(this_symbol + first_carrier_offset - 6, rot2, this_symbol + first_carrier_offset - 6, (nb_rb + 1) * 6, 15);
     mult_cpx_vector(this_symbol, shift_rot, this_symbol, (nb_rb + 1) * 6, 15);
     mult_cpx_vector(this_symbol + first_carrier_offset - 6,
                     shift_rot + first_carrier_offset - 6,
@@ -189,8 +189,8 @@ void apply_nr_rotation_symbol_RX(const int symbols_per_slot,
                     (nb_rb + 1) * 6,
                     15);
   } else {
-    rotate_cpx_vector(this_symbol, &rot2, this_symbol, nb_rb * 6, 15);
-    rotate_cpx_vector(this_symbol + first_carrier_offset, &rot2, this_symbol + first_carrier_offset, nb_rb * 6, 15);
+    rotate_cpx_vector(this_symbol, rot2, this_symbol, nb_rb * 6, 15);
+    rotate_cpx_vector(this_symbol + first_carrier_offset, rot2, this_symbol + first_carrier_offset, nb_rb * 6, 15);
     mult_cpx_vector(this_symbol, shift_rot, this_symbol, nb_rb * 6, 15);
     mult_cpx_vector(this_symbol + first_carrier_offset,
                     shift_rot + first_carrier_offset,

--- a/openair1/PHY/NR_ESTIMATION/nr_ul_channel_estimation.c
+++ b/openair1/PHY/NR_ESTIMATION/nr_ul_channel_estimation.c
@@ -734,7 +734,7 @@ void nr_pusch_ptrs_processing(PHY_VARS_gNB *gNB,
           printf("[PHY][UL][PTRS]: Rotate Symbol %2d with  %d + j* %d\n", i, phase_per_symbol[i].r, phase_per_symbol[i].i);
 #endif
           rotate_cpx_vector(&pusch_vars->rxdataF_comp[aarx][i * nb_re_pusch],
-                            &phase_per_symbol[i],
+                            phase_per_symbol[i],
                             &pusch_vars->rxdataF_comp[aarx][i * nb_re_pusch],
                             (nb_rb * NR_NB_SC_PER_RB),
                             15);

--- a/openair1/PHY/NR_REFSIG/pss_nr.h
+++ b/openair1/PHY/NR_REFSIG/pss_nr.h
@@ -53,15 +53,18 @@
   #define  SYNCHRO_RATE_CHANGE_FACTOR  (1)
 #endif
 
-pss_detection_result_t pss_search_time_nr(const c16_t **rxdata,
-                                          int ofdm_symbol_size,
-                                          int nb_antennas_rx,
-                                          int subcarrier_spacing,
-                                          const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
-                                          bool fo_flag,
-                                          int target_Nid_cell,
-                                          int search_start,
-                                          int search_length);
+typedef struct {
+  c16_t **rxdata;
+  int nb_antennas_rx;
+  int rxdata_length;
+  int ofdm_symbol_size;
+  int subcarrier_spacing;
+  bool fo_flag;
+  int target_Nid_cell;
+  c16_t *pssTime;
+} pss_search_t;
+
+pss_detection_result_t pss_search_time_nr(const pss_search_t *p);
 
 void generate_pss_nr_time(int ofdm_symbol_size,
                           int first_carrier_offset,

--- a/openair1/PHY/NR_REFSIG/pss_nr.h
+++ b/openair1/PHY/NR_REFSIG/pss_nr.h
@@ -17,7 +17,7 @@
 
 #include "PHY/defs_nr_common.h"
 #include "PHY/NR_REFSIG/ss_pbch_nr.h"
-
+#include "PHY/defs_nr_UE.h"
 /************** CODE GENERATION ***********************************/
 
 //#define PSS_DECIMATOR                          /* decimation of sample is done between time correlation */
@@ -53,32 +53,16 @@
   #define  SYNCHRO_RATE_CHANGE_FACTOR  (1)
 #endif
 
-int pss_synchro_nr(const c16_t **rxdata,
-                   int nb_ant,
-                   int ofdm_symbol_size,
-                   int rxdata_size,
-                   int subcarrier_spacing,
-                   const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
-                   bool fo_flag,
-                   int target_Nid_cell,
-                   int *nid2,
-                   int *f_off,
-                   int *pssPeak,
-                   int *pssAvg);
+pss_detection_result_t pss_search_time_nr(const c16_t **rxdata,
+                                          int ofdm_symbol_size,
+                                          int nb_antennas_rx,
+                                          int subcarrier_spacing,
+                                          const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
+                                          bool fo_flag,
+                                          int target_Nid_cell,
+                                          int search_start,
+                                          int search_length);
 
-int pss_search_time_nr(const c16_t **rxdata,
-                       int ofdm_symbol_size,
-                       int nb_antennas_rx,
-                       int subcarrier_spacing,
-                       const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
-                       bool fo_flag,
-                       int target_Nid_cell,
-                       int *nid2,
-                       int *f_off,
-                       int *pssPeak,
-                       int *pssAvg,
-                       int search_start,
-                       int search_length);
 void generate_pss_nr_time(int ofdm_symbol_size,
                           int first_carrier_offset,
                           const int N_ID_2,

--- a/openair1/PHY/NR_REFSIG/pss_nr.h
+++ b/openair1/PHY/NR_REFSIG/pss_nr.h
@@ -54,20 +54,24 @@
 #endif
 
 int pss_synchro_nr(const c16_t **rxdata,
-                   const NR_DL_FRAME_PARMS *frame_parms,
-                   const c16_t pssTime[NUMBER_PSS_SEQUENCE][frame_parms->ofdm_symbol_size],
-                   int is,
+                   int nb_ant,
+                   int ofdm_symbol_size,
+                   int rxdata_size,
+                   int subcarrier_spacing,
+                   const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
                    bool fo_flag,
                    int target_Nid_cell,
                    int *nid2,
                    int *f_off,
                    int *pssPeak,
                    int *pssAvg);
+
 int pss_search_time_nr(const c16_t **rxdata,
-                       const NR_DL_FRAME_PARMS *frame_parms,
-                       const c16_t pssTime[NUMBER_PSS_SEQUENCE][frame_parms->ofdm_symbol_size],
+                       int ofdm_symbol_size,
+                       int nb_antennas_rx,
+                       int subcarrier_spacing,
+                       const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
                        bool fo_flag,
-                       int is,
                        int target_Nid_cell,
                        int *nid2,
                        int *f_off,
@@ -75,7 +79,11 @@ int pss_search_time_nr(const c16_t **rxdata,
                        int *pssAvg,
                        int search_start,
                        int search_length);
-void generate_pss_nr_time(const NR_DL_FRAME_PARMS *fp, const int N_ID_2, int ssbFirstSCS, c16_t pssTime[fp->ofdm_symbol_size]);
+void generate_pss_nr_time(int ofdm_symbol_size,
+                          int first_carrier_offset,
+                          const int N_ID_2,
+                          int ssbFirstSCS,
+                          c16_t pssTime[ofdm_symbol_size]);
 void generate_pss_nr(const int N_ID_2, int16_t *pss);
 #endif /* PSS_NR_H */
 

--- a/openair1/PHY/NR_REFSIG/pss_nr.h
+++ b/openair1/PHY/NR_REFSIG/pss_nr.h
@@ -53,7 +53,6 @@
   #define  SYNCHRO_RATE_CHANGE_FACTOR  (1)
 #endif
 
-void init_context_synchro_nr(NR_DL_FRAME_PARMS *frame_parms_ue);
 int pss_synchro_nr(const c16_t **rxdata,
                    const NR_DL_FRAME_PARMS *frame_parms,
                    const c16_t pssTime[NUMBER_PSS_SEQUENCE][frame_parms->ofdm_symbol_size],
@@ -77,8 +76,7 @@ int pss_search_time_nr(const c16_t **rxdata,
                        int search_start,
                        int search_length);
 void generate_pss_nr_time(const NR_DL_FRAME_PARMS *fp, const int N_ID_2, int ssbFirstSCS, c16_t pssTime[fp->ofdm_symbol_size]);
-int16_t *get_primary_synchro_nr2(const int nid2);
-
+void generate_pss_nr(const int N_ID_2, int16_t *pss);
 #endif /* PSS_NR_H */
 
 

--- a/openair1/PHY/NR_REFSIG/sss_nr.h
+++ b/openair1/PHY/NR_REFSIG/sss_nr.h
@@ -43,15 +43,22 @@
 
 #define SSS_METRIC_FLOOR_NR   (30000)
 
-bool rx_sss_nr(const NR_DL_FRAME_PARMS *frame_parms,
+typedef struct {
+  int nb_antennas_rx;
+  int samples_per_slot_wCP;
+  int ofdm_symbol_size;
+  int first_carrier_offset;
+  int ssb_start_subcarrier;
+  int subcarrier_spacing;
+} nr_sss_params_t;
+bool rx_sss_nr(nr_sss_params_t *params,
                int nid2,
                int target_Nid_cell,
                int freq_offset_pss,
-               int ssb_start_subcarrier,
                int *Nid_cell,
                int32_t *tot_metric,
                uint8_t *phase_max,
                int *freq_offset_sss,
-               c16_t rxdataF[NR_N_SYMBOLS_SSB][frame_parms->nb_antennas_rx][frame_parms->ofdm_symbol_size]);
-#endif /* SSS_NR_H */
+               c16_t rxdataF[NR_N_SYMBOLS_SSB][params->nb_antennas_rx][params->ofdm_symbol_size]); /* SSS_NR_H */
 
+#endif

--- a/openair1/PHY/NR_REFSIG/sss_nr.h
+++ b/openair1/PHY/NR_REFSIG/sss_nr.h
@@ -51,14 +51,9 @@ typedef struct {
   int ssb_start_subcarrier;
   int subcarrier_spacing;
 } nr_sss_params_t;
-bool rx_sss_nr(nr_sss_params_t *params,
-               int nid2,
-               int target_Nid_cell,
-               int freq_offset_pss,
-               int *Nid_cell,
-               int32_t *tot_metric,
-               uint8_t *phase_max,
-               int *freq_offset_sss,
-               c16_t rxdataF[NR_N_SYMBOLS_SSB][params->nb_antennas_rx][params->ofdm_symbol_size]); /* SSS_NR_H */
+sss_detection_result_t rx_sss_nr(nr_sss_params_t *params,
+                                 pss_detection_result_t *pss,
+                                 int target_Nid_cell,
+                                 c16_t rxdataF[NR_N_SYMBOLS_SSB][params->nb_antennas_rx][params->ofdm_symbol_size]);
 
-#endif
+#endif /* SSS_NR_H */

--- a/openair1/PHY/NR_REFSIG/sss_nr.h
+++ b/openair1/PHY/NR_REFSIG/sss_nr.h
@@ -43,9 +43,6 @@
 
 #define SSS_METRIC_FLOOR_NR   (30000)
 
-void init_context_sss_nr(int amp);
-void free_context_sss_nr(void);
-
 bool rx_sss_nr(const NR_DL_FRAME_PARMS *frame_parms,
                int nid2,
                int target_Nid_cell,

--- a/openair1/PHY/NR_UE_ESTIMATION/nr_dl_channel_estimation.c
+++ b/openair1/PHY/NR_UE_ESTIMATION/nr_dl_channel_estimation.c
@@ -1436,7 +1436,7 @@ void nr_pdsch_ptrs_processing(int nbRx,
 #ifdef DEBUG_DL_PTRS
           printf("[PHY][DL][PTRS]: Rotate Symbol %2d with  %d + j* %d\n", i, phase_per_symbol[i].r, phase_per_symbol[i].i);
 #endif
-          rotate_cpx_vector(rxdataF_comp[i][0][aarx], &phase_per_symbol[i], rxdataF_comp[i][0][aarx], nb_rb * NR_NB_SC_PER_RB, 15);
+          rotate_cpx_vector(rxdataF_comp[i][0][aarx], phase_per_symbol[i], rxdataF_comp[i][0][aarx], nb_rb * NR_NB_SC_PER_RB, 15);
         }// if not DMRS Symbol
       }// symbol loop
     }// last symbol check

--- a/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
+++ b/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
@@ -340,16 +340,14 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
   int32_t sss_metric = 0;
   uint8_t sss_phase = 0;
   int freq_offset_sss = 0;
-  bool sss_detected = rx_sss_nr(frame_parms,
-                                pss_index,
-                                known_pci,
-                                0,
-                                frame_parms->ssb_start_subcarrier,
-                                &detected_nid_cell,
-                                &sss_metric,
-                                &sss_phase,
-                                &freq_offset_sss,
-                                rxdataF);
+  nr_sss_params_t p = (nr_sss_params_t){.nb_antennas_rx = frame_parms->nb_antennas_rx,
+                                        .samples_per_slot_wCP = frame_parms->samples_per_slot_wCP,
+                                        .ofdm_symbol_size = frame_parms->ofdm_symbol_size,
+                                        .first_carrier_offset = frame_parms->first_carrier_offset,
+                                        .ssb_start_subcarrier = frame_parms->ssb_start_subcarrier,
+                                        .subcarrier_spacing = frame_parms->subcarrier_spacing};
+  bool sss_detected =
+      rx_sss_nr(&p, pss_index, known_pci, 0, &detected_nid_cell, &sss_metric, &sss_phase, &freq_offset_sss, rxdataF);
 
   if (!sss_detected) {
     if (neighboring_cell_info->valid_meas)

--- a/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
+++ b/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
@@ -227,11 +227,6 @@ static bool search_neighboring_cell(NR_DL_FRAME_PARMS *frame_parms,
                                     c16_t rxdataF[][frame_parms->nb_antennas_rx][frame_parms->ofdm_symbol_size],
                                     c16_t pssTime[][frame_parms->ofdm_symbol_size])
 {
-  int detected_nid_cell = -1;
-  int32_t sss_metric = 0;
-  uint8_t sss_phase = 0;
-  int freq_offset_sss = 0;
-
   nr_ssb_search_params_t search_params = {
       .dl_CarrierFreq = frame_parms->dl_CarrierFreq,
       .sampling_rate = frame_parms->samples_per_subframe * 1000,
@@ -257,20 +252,16 @@ static bool search_neighboring_cell(NR_DL_FRAME_PARMS *frame_parms,
       .fo_flag = false,
       .rxdataF = rxdataF,
       .pssTime = pssTime,
-      .detected_nid_cell = &detected_nid_cell,
-      .sss_metric = &sss_metric,
-      .freq_offset_sss = &freq_offset_sss,
-      .sss_phase = &sss_phase,
   };
 
   bool found = nr_search_ssb_common(&search_params);
 
   if (found) {
-    nr_neighboring_cell->Nid_cell = detected_nid_cell;
+    nr_neighboring_cell->Nid_cell = search_params.sss_res.nid_cell;
     LOG_I(NR_PHY,
           "Found neighbor cell PCI=%d (sss_metric=%d, pss peak pos =%d, pss_peak=%d dB, pss_avg=%d dB)\n",
-          detected_nid_cell,
-          sss_metric,
+          search_params.sss_res.nid_cell,
+          search_params.sss_res.metric,
           search_params.pss_res.pos,
           search_params.pss_res.peak,
           search_params.pss_res.avg);
@@ -291,7 +282,6 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
                                c16_t pssTime[][frame_parms->ofdm_symbol_size])
 {
   int known_pci = nr_neighboring_cell->Nid_cell;
-  int pss_index = GET_NID2(known_pci);
 
   int start = neighboring_cell_info->pss_search_start;
   int length = neighboring_cell_info->pss_search_length;
@@ -337,31 +327,26 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
            sizeof(c16_t) * frame_parms->ofdm_symbol_size);
   }
 
-  int detected_nid_cell = -1;
-  int32_t sss_metric = 0;
-  uint8_t sss_phase = 0;
-  int freq_offset_sss = 0;
   nr_sss_params_t p = (nr_sss_params_t){.nb_antennas_rx = frame_parms->nb_antennas_rx,
                                         .samples_per_slot_wCP = frame_parms->samples_per_slot_wCP,
                                         .ofdm_symbol_size = frame_parms->ofdm_symbol_size,
                                         .first_carrier_offset = frame_parms->first_carrier_offset,
                                         .ssb_start_subcarrier = frame_parms->ssb_start_subcarrier,
                                         .subcarrier_spacing = frame_parms->subcarrier_spacing};
-  bool sss_detected =
-      rx_sss_nr(&p, pss_index, known_pci, 0, &detected_nid_cell, &sss_metric, &sss_phase, &freq_offset_sss, rxdataF);
+  sss_detection_result_t res = rx_sss_nr(&p, &pss_res, known_pci, rxdataF);
 
-  if (!sss_detected) {
+  if (!res.success) {
     if (neighboring_cell_info->valid_meas)
       neighboring_cell_info->consec_fail++;
     LOG_D(NR_PHY,
           "Known PCI validation failed for PCI=%d (metric=%d), consec_fail=%d\n",
           known_pci,
-          sss_metric,
+          res.metric,
           neighboring_cell_info->consec_fail);
     return false;
   }
 
-  LOG_D(NR_PHY, "Known PCI validation completed for PCI=%d, metric=%d\n", known_pci, sss_metric);
+  LOG_D(NR_PHY, "Known PCI validation completed for PCI=%d, metric=%d\n", known_pci, res.metric);
   neighboring_cell_info->consec_fail = 0;
   neighboring_cell_info->valid_meas = true;
   neighboring_cell_info->pss_search_start = pss_res.pos - 16;

--- a/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
+++ b/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
@@ -228,10 +228,6 @@ static bool search_neighboring_cell(NR_DL_FRAME_PARMS *frame_parms,
                                     c16_t pssTime[][frame_parms->ofdm_symbol_size])
 {
   int detected_nid_cell = -1;
-  int ssb_offset = 0;
-  int freq_offset_pss = 0;
-  int pss_peak = 0;
-  int pss_avg = 0;
   int32_t sss_metric = 0;
   uint8_t sss_phase = 0;
   int freq_offset_sss = 0;
@@ -262,13 +258,9 @@ static bool search_neighboring_cell(NR_DL_FRAME_PARMS *frame_parms,
       .rxdataF = rxdataF,
       .pssTime = pssTime,
       .detected_nid_cell = &detected_nid_cell,
-      .ssb_offset = &ssb_offset,
       .sss_metric = &sss_metric,
-      .freq_offset_pss = &freq_offset_pss,
       .freq_offset_sss = &freq_offset_sss,
       .sss_phase = &sss_phase,
-      .pss_peak = &pss_peak,
-      .pss_avg = &pss_avg,
   };
 
   bool found = nr_search_ssb_common(&search_params);
@@ -276,15 +268,15 @@ static bool search_neighboring_cell(NR_DL_FRAME_PARMS *frame_parms,
   if (found) {
     nr_neighboring_cell->Nid_cell = detected_nid_cell;
     LOG_I(NR_PHY,
-          "Found neighbor cell PCI=%d (sss_metric=%d, ssb_offset=%d, pss_peak=%d dB, pss_avg=%d dB)\n",
+          "Found neighbor cell PCI=%d (sss_metric=%d, pss peak pos =%d, pss_peak=%d dB, pss_avg=%d dB)\n",
           detected_nid_cell,
           sss_metric,
-          ssb_offset,
-          pss_peak,
-          pss_avg);
+          search_params.pss_res.pos,
+          search_params.pss_res.peak,
+          search_params.pss_res.avg);
 
     // Update search window
-    neighboring_cell_info->pss_search_start = ssb_offset + frame_parms->nb_prefix_samples - 16;
+    neighboring_cell_info->pss_search_start = search_params.pss_res.pos - 16;
     neighboring_cell_info->pss_search_length = 32;
   }
 
@@ -300,28 +292,21 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
 {
   int known_pci = nr_neighboring_cell->Nid_cell;
   int pss_index = GET_NID2(known_pci);
-  int f_off = 0;
-  int pss_peak = 0;
-  int pss_avg = 0;
 
   int start = neighboring_cell_info->pss_search_start;
   int length = neighboring_cell_info->pss_search_length;
 
-  int peak_position = pss_search_time_nr((const c16_t **)rxdata,
-                                         frame_parms->ofdm_symbol_size,
-                                         frame_parms->nb_antennas_rx,
-                                         frame_parms->subcarrier_spacing,
-                                         pssTime,
-                                         false, // no frequency offset estimation for tracking
-                                         known_pci,
-                                         &pss_index,
-                                         &f_off,
-                                         &pss_peak,
-                                         &pss_avg,
-                                         start,
-                                         length);
+  pss_detection_result_t pss_res = pss_search_time_nr((const c16_t **)rxdata,
+                                                      frame_parms->ofdm_symbol_size,
+                                                      frame_parms->nb_antennas_rx,
+                                                      frame_parms->subcarrier_spacing,
+                                                      pssTime,
+                                                      false, // no frequency offset estimation for tracking
+                                                      known_pci,
+                                                      start,
+                                                      length);
 
-  if (peak_position < frame_parms->nb_prefix_samples) {
+  if (!pss_res.success) {
     if (neighboring_cell_info->valid_meas)
       neighboring_cell_info->consec_fail++;
     LOG_D(NR_PHY,
@@ -329,18 +314,20 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
           known_pci,
           start,
           length,
-          pss_peak,
-          pss_avg,
+          pss_res.peak,
+          pss_res.avg,
           neighboring_cell_info->consec_fail);
     return false;
   }
 
-  int ssb_offset = peak_position - frame_parms->nb_prefix_samples;
+  int ssb_time_offset = pss_res.pos - frame_parms->nb_prefix_samples;
+  if (ssb_time_offset < 0)
+    return false; // pss position is too close to buffer begining
 
   __attribute__((aligned(32))) c16_t rxdataF_tmp[frame_parms->nb_antennas_rx][frame_parms->samples_per_slot_wCP];
   uint8_t sss_symbol = SSS_SYMBOL_NB - PSS_SYMBOL_NB;
-  nr_slot_fep(NULL, frame_parms, 0, 0, rxdataF_tmp, link_type_dl, ssb_offset, (c16_t **)rxdata);
-  nr_slot_fep(NULL, frame_parms, 0, sss_symbol, rxdataF_tmp, link_type_dl, ssb_offset, (c16_t **)rxdata);
+  nr_slot_fep(NULL, frame_parms, 0, 0, rxdataF_tmp, link_type_dl, ssb_time_offset, (c16_t **)rxdata);
+  nr_slot_fep(NULL, frame_parms, 0, sss_symbol, rxdataF_tmp, link_type_dl, ssb_time_offset, (c16_t **)rxdata);
   /* TODO: Once symbol based PDSCH proc is imeplemented, nr_slot_fep() will use
   the new rxdataF buffer format so the following memcpy can be removed. */
   for (int aarx = 0; aarx < frame_parms->nb_antennas_rx; aarx++) {
@@ -377,7 +364,7 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
   LOG_D(NR_PHY, "Known PCI validation completed for PCI=%d, metric=%d\n", known_pci, sss_metric);
   neighboring_cell_info->consec_fail = 0;
   neighboring_cell_info->valid_meas = true;
-  neighboring_cell_info->pss_search_start = peak_position - 16;
+  neighboring_cell_info->pss_search_start = pss_res.pos - 16;
   neighboring_cell_info->pss_search_length = 32;
 
   return true;

--- a/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
+++ b/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
@@ -283,18 +283,20 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
 {
   int known_pci = nr_neighboring_cell->Nid_cell;
 
-  int start = neighboring_cell_info->pss_search_start;
   int length = neighboring_cell_info->pss_search_length;
+  c16_t *rx[frame_parms->nb_antennas_rx];
+  for (int i=0; i<frame_parms->nb_antennas_rx; i++)
+    rx[i]=rxdata[i]+neighboring_cell_info->pss_search_start;
 
-  pss_detection_result_t pss_res = pss_search_time_nr((const c16_t **)rxdata,
-                                                      frame_parms->ofdm_symbol_size,
-                                                      frame_parms->nb_antennas_rx,
-                                                      frame_parms->subcarrier_spacing,
-                                                      pssTime,
-                                                      false, // no frequency offset estimation for tracking
-                                                      known_pci,
-                                                      start,
-                                                      length);
+  pss_search_t p_pss = (pss_search_t){.rxdata = rx,
+                                      .nb_antennas_rx = frame_parms->nb_antennas_rx,
+                                      .rxdata_length = length,
+                                      .ofdm_symbol_size = frame_parms->ofdm_symbol_size,
+                                      .subcarrier_spacing = frame_parms->subcarrier_spacing,
+                                      .fo_flag = false,
+                                      .target_Nid_cell = known_pci,
+                                      .pssTime = (c16_t *)pssTime};
+  pss_detection_result_t pss_res = pss_search_time_nr(&p_pss);
 
   if (!pss_res.success) {
     if (neighboring_cell_info->valid_meas)
@@ -302,7 +304,7 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
     LOG_D(NR_PHY,
           "PSS validation failed for PCI=%d (search window: start=%d, length=%d, peak=%d dB, avg=%d dB), consec_fail=%d\n",
           known_pci,
-          start,
+          neighboring_cell_info->pss_search_start,
           length,
           pss_res.peak,
           pss_res.avg,
@@ -310,7 +312,7 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
     return false;
   }
 
-  int ssb_time_offset = pss_res.pos - frame_parms->nb_prefix_samples;
+  int ssb_time_offset = neighboring_cell_info->pss_search_start + pss_res.pos - frame_parms->nb_prefix_samples;
   if (ssb_time_offset < 0)
     return false; // pss position is too close to buffer begining
 
@@ -327,13 +329,13 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
            sizeof(c16_t) * frame_parms->ofdm_symbol_size);
   }
 
-  nr_sss_params_t p = (nr_sss_params_t){.nb_antennas_rx = frame_parms->nb_antennas_rx,
-                                        .samples_per_slot_wCP = frame_parms->samples_per_slot_wCP,
-                                        .ofdm_symbol_size = frame_parms->ofdm_symbol_size,
-                                        .first_carrier_offset = frame_parms->first_carrier_offset,
-                                        .ssb_start_subcarrier = frame_parms->ssb_start_subcarrier,
-                                        .subcarrier_spacing = frame_parms->subcarrier_spacing};
-  sss_detection_result_t res = rx_sss_nr(&p, &pss_res, known_pci, rxdataF);
+  nr_sss_params_t p_sss = (nr_sss_params_t){.nb_antennas_rx = frame_parms->nb_antennas_rx,
+                                            .samples_per_slot_wCP = frame_parms->samples_per_slot_wCP,
+                                            .ofdm_symbol_size = frame_parms->ofdm_symbol_size,
+                                            .first_carrier_offset = frame_parms->first_carrier_offset,
+                                            .ssb_start_subcarrier = frame_parms->ssb_start_subcarrier,
+                                            .subcarrier_spacing = frame_parms->subcarrier_spacing};
+  sss_detection_result_t res = rx_sss_nr(&p_sss, &pss_res, known_pci, rxdataF);
 
   if (!res.success) {
     if (neighboring_cell_info->valid_meas)

--- a/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
+++ b/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
@@ -237,14 +237,27 @@ static bool search_neighboring_cell(NR_DL_FRAME_PARMS *frame_parms,
   int freq_offset_sss = 0;
 
   nr_ssb_search_params_t search_params = {
-      .frame_parms = frame_parms,
-      .rxdata = rxdata,
+      .dl_CarrierFreq = frame_parms->dl_CarrierFreq,
+      .sampling_rate = frame_parms->samples_per_subframe * 1000,
+      .slots_per_frame = frame_parms->slots_per_frame,
+      .slots_per_subframe = frame_parms->slots_per_subframe,
+      .numerology_index = frame_parms->numerology_index,
+      .ofdm_symbol_size = frame_parms->ofdm_symbol_size,
+      .ofdm_offset_divisor = frame_parms->ofdm_offset_divisor,
+      .nb_antennas_rx = frame_parms->nb_antennas_rx,
+      .symbols_per_slot = frame_parms->symbols_per_slot,
+      .first_carrier_offset = frame_parms->first_carrier_offset,
+      .N_RB_DL = frame_parms->N_RB_DL,
       .rxdata_size = rxdata_size,
+      .rxdata = rxdata,
+      .nb_prefix_samples = frame_parms->nb_prefix_samples,
+      .nb_prefix_samples0 = frame_parms->nb_prefix_samples0,
       .ssb_start_subcarrier = frame_parms->ssb_start_subcarrier,
+      .subcarrier_spacing = frame_parms->subcarrier_spacing,
+      .samples_per_slot_wCP = frame_parms->samples_per_slot_wCP,
       .target_nid_cell = -1, // Blind search
       .exclude_nid_cell = frame_parms->Nid_cell, // Exclude serving cell
       .apply_freq_offset = false,
-      .search_frame_id = 0, // Search in first frame of buffer
       .fo_flag = false,
       .rxdataF = rxdataF,
       .pssTime = pssTime,
@@ -295,10 +308,11 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
   int length = neighboring_cell_info->pss_search_length;
 
   int peak_position = pss_search_time_nr((const c16_t **)rxdata,
-                                         frame_parms,
+                                         frame_parms->ofdm_symbol_size,
+                                         frame_parms->nb_antennas_rx,
+                                         frame_parms->subcarrier_spacing,
                                          pssTime,
                                          false, // no frequency offset estimation for tracking
-                                         0, // first frame
                                          known_pci,
                                          &pss_index,
                                          &f_off,
@@ -378,7 +392,11 @@ void do_neighboring_cell_measurements(UE_nr_rxtx_proc_t *proc, PHY_VARS_NR_UE *u
   // Generate PSS time-domain sequences once for all neighbor cells
   __attribute__((aligned(32))) c16_t pssTime[NUMBER_PSS_SEQUENCE][frame_parms->ofdm_symbol_size];
   for (int nid2_idx = 0; nid2_idx < NUMBER_PSS_SEQUENCE; nid2_idx++) {
-    generate_pss_nr_time(frame_parms, nid2_idx, frame_parms->ssb_start_subcarrier, pssTime[nid2_idx]);
+    generate_pss_nr_time(frame_parms->ofdm_symbol_size,
+                         frame_parms->first_carrier_offset,
+                         nid2_idx,
+                         frame_parms->ssb_start_subcarrier,
+                         pssTime[nid2_idx]);
   }
 
   __attribute__((aligned(32))) c16_t rxdataF[NR_N_SYMBOLS_SSB][frame_parms->nb_antennas_rx][rxdataF_sz];

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -207,8 +207,7 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
 
   // Extract SSB symbols to frequency domain
   // Symbol ordering: 0=PSS, 1=PBCH, 2=SSS, 3=PBCH
-  c16_t(*rxdataF)[NR_N_SYMBOLS_SSB][fp->nb_antennas_rx][fp->ofdm_symbol_size] =
-      (c16_t(*)[NR_N_SYMBOLS_SSB][fp->nb_antennas_rx][fp->ofdm_symbol_size])params->rxdataF;
+  c16_t(*rxdataF)[fp->nb_antennas_rx][fp->ofdm_symbol_size] = (c16_t(*)[fp->nb_antennas_rx][fp->ofdm_symbol_size])params->rxdataF;
 
   __attribute__((aligned(32))) c16_t rxdataF_tmp[fp->nb_antennas_rx][fp->samples_per_slot_wCP];
 
@@ -217,7 +216,7 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
     nr_slot_fep(NULL, fp, 0, i, rxdataF_tmp, link_type_dl, sample_offset, (c16_t **)params->rxdata);
     // TODO: In later commit, call the modified symbol demod function and remove the following memcpy.
     for (int aarx = 0; aarx < fp->nb_antennas_rx; aarx++)
-      memcpy((*rxdataF)[i][aarx], &rxdataF_tmp[aarx][i * fp->ofdm_symbol_size], sizeof(c16_t) * fp->ofdm_symbol_size);
+      memcpy(rxdataF[i][aarx], &rxdataF_tmp[aarx][i * fp->ofdm_symbol_size], sizeof(c16_t) * fp->ofdm_symbol_size);
   }
 
   // Perform SSS detection
@@ -225,17 +224,15 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
   int32_t sss_metric = 0;
   uint8_t sss_phase = 0;
   int freq_offset_sss = 0;
+  nr_sss_params_t p = (nr_sss_params_t){.nb_antennas_rx = fp->nb_antennas_rx,
+                                        .samples_per_slot_wCP = fp->samples_per_slot_wCP,
+                                        .ofdm_symbol_size = fp->ofdm_symbol_size,
+                                        .first_carrier_offset = fp->first_carrier_offset,
+                                        .ssb_start_subcarrier = fp->ssb_start_subcarrier,
+                                        .subcarrier_spacing = fp->subcarrier_spacing};
 
-  bool sss_detected = rx_sss_nr(fp,
-                                nid2,
-                                params->target_nid_cell,
-                                freq_offset_pss,
-                                params->ssb_start_subcarrier,
-                                &detected_nid_cell,
-                                &sss_metric,
-                                &sss_phase,
-                                &freq_offset_sss,
-                                *rxdataF);
+  bool sss_detected =
+      rx_sss_nr(&p, nid2, -1, freq_offset_pss, &detected_nid_cell, &sss_metric, &sss_phase, &freq_offset_sss, rxdataF);
 
   if (params->sss_metric)
     *params->sss_metric = sss_metric;

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -130,17 +130,64 @@ static bool nr_pbch_detection(const UE_nr_rxtx_proc_t *proc,
   return false;
 }
 
-static void compensate_freq_offset(c16_t **x, const NR_DL_FRAME_PARMS *fp, const int offset, const int sn)
+static void compensate_freq_offset(c16_t **x, const int nb_antennas_rx, const int x_len, const int offset, const int sampling_rate)
 {
-  double s_time = 1 / (1.0e3 * fp->samples_per_subframe); // sampling time
+  double s_time = 1.0 / sampling_rate; // sampling time
   double off_angle = -2 * M_PI * s_time * (offset); // offset rotation angle compensation per sample
 
-  for (int n = sn * fp->samples_per_frame; n < (sn + 1) * fp->samples_per_frame; n++) {
-    for (int ar = 0; ar < fp->nb_antennas_rx; ar++) {
+  for (int n = 0; n < x_len; n++) {
+    for (int ar = 0; ar < nb_antennas_rx; ar++) {
       const double re = x[ar][n].r;
       const double im = x[ar][n].i;
       x[ar][n].r = (short)(round(re * cos(n * off_angle) - im * sin(n * off_angle)));
       x[ar][n].i = (short)(round(re * sin(n * off_angle) + im * cos(n * off_angle)));
+    }
+  }
+}
+
+/* rxdataF should be 16 bytes aligned */
+static void generate_table(nr_ssb_search_params_t *params,
+                           c16_t timeshift_symbol_rotation[params->ofdm_symbol_size],
+                           c16_t symbol_rotation[224])
+{
+  init_timeshift_rotation(params->ofdm_symbol_size,
+                          params->nb_prefix_samples,
+                          params->ofdm_offset_divisor,
+                          timeshift_symbol_rotation);
+  perform_symbol_rotation(params->symbols_per_slot * params->slots_per_frame / 10,
+                          params->numerology_index,
+                          params->dl_CarrierFreq,
+                          symbol_rotation);
+}
+
+static void do_time_to_freq(nr_ssb_search_params_t *params, uint32_t sample_offset)
+{
+  c16_t timeshift_symbol_rotation[params->ofdm_symbol_size];
+  c16_t symbol_rotation[224];
+  generate_table(params, timeshift_symbol_rotation, symbol_rotation);
+
+  c16_t(*rxdataF)[params->nb_antennas_rx][params->ofdm_symbol_size] =
+      (c16_t(*)[params->nb_antennas_rx][params->ofdm_symbol_size])params->rxdataF;
+  dft_size_idx_t dftsize = get_dft(params->ofdm_symbol_size);
+
+  for (int symb = 0; symb < NR_N_SYMBOLS_SSB; symb++) {
+    // For Sidelink 16 frames worth of samples is processed to find SSB, for 5G-NR 2.
+    unsigned int rx_offset = sample_offset + params->nb_prefix_samples;
+    rx_offset += symb * (params->nb_prefix_samples + params->ofdm_symbol_size);
+    // use OFDM symbol from within 1/8th of the CP to avoid ISI
+    rx_offset -= params->nb_prefix_samples / params->ofdm_offset_divisor;
+    for (unsigned char aa = 0; aa < params->nb_antennas_rx; aa++) {
+      c16_t *rxF = rxdataF[symb][aa];
+      dft(dftsize, (int16_t *)&params->rxdata[aa][rx_offset], (int16_t *)rxF, 1);
+      apply_nr_rotation_symbol_RX(params->symbols_per_slot,
+                                  params->slots_per_subframe,
+                                  timeshift_symbol_rotation,
+                                  params->first_carrier_offset,
+                                  rxF,
+                                  symbol_rotation,
+                                  params->N_RB_DL,
+                                  0,
+                                  symb);
     }
   }
 }
@@ -150,9 +197,7 @@ static void compensate_freq_offset(c16_t **x, const NR_DL_FRAME_PARMS *fp, const
  */
 bool nr_search_ssb_common(nr_ssb_search_params_t *params)
 {
-  const NR_DL_FRAME_PARMS *fp = params->frame_parms;
-
-  const uint32_t pssTime_sz = fp->ofdm_symbol_size;
+  const uint32_t pssTime_sz = params->ofdm_symbol_size;
   c16_t(*pssTime)[pssTime_sz] = (c16_t(*)[pssTime_sz])params->pssTime;
 
   // Perform PSS search
@@ -161,9 +206,11 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
   int pss_peak = 0;
   int pss_avg = 0;
   const int sync_pos = pss_synchro_nr((const c16_t **)params->rxdata,
-                                      fp,
+                                      params->nb_antennas_rx,
+                                      params->ofdm_symbol_size,
+                                      params->rxdata_size,
+                                      params->subcarrier_spacing,
                                       pssTime,
-                                      params->search_frame_id,
                                       params->fo_flag,
                                       params->target_nid_cell,
                                       &nid2,
@@ -178,11 +225,11 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
   if (params->freq_offset_pss)
     *params->freq_offset_pss = freq_offset_pss;
 
-  if (sync_pos < fp->nb_prefix_samples || nid2 < 0) {
+  if (sync_pos < params->nb_prefix_samples || nid2 < 0) {
     return false;
   }
 
-  const int ssb_offset = sync_pos - fp->nb_prefix_samples;
+  const int ssb_offset = sync_pos - params->nb_prefix_samples;
   if (params->ssb_offset)
     *params->ssb_offset = ssb_offset;
 
@@ -191,7 +238,7 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
 #endif
 
   // Check that SSB fits within buffer
-  if (ssb_offset + NR_N_SYMBOLS_SSB * (fp->ofdm_symbol_size + fp->nb_prefix_samples) >= params->rxdata_size) {
+  if (ssb_offset + NR_N_SYMBOLS_SSB * (params->ofdm_symbol_size + params->nb_prefix_samples) >= params->rxdata_size) {
     LOG_D(PHY,
           "SSB extends beyond buffer boundary (sync_pos %d, ssb_offset %d, buffer_size %d)\n",
           sync_pos,
@@ -202,35 +249,27 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
 
   // Apply frequency offset compensation if requested
   if (params->apply_freq_offset && freq_offset_pss != 0) {
-    compensate_freq_offset(params->rxdata, fp, freq_offset_pss, params->search_frame_id);
+    compensate_freq_offset(params->rxdata, params->nb_antennas_rx, params->rxdata_size, freq_offset_pss, params->sampling_rate);
   }
 
   // Extract SSB symbols to frequency domain
   // Symbol ordering: 0=PSS, 1=PBCH, 2=SSS, 3=PBCH
-  c16_t(*rxdataF)[fp->nb_antennas_rx][fp->ofdm_symbol_size] = (c16_t(*)[fp->nb_antennas_rx][fp->ofdm_symbol_size])params->rxdataF;
-
-  __attribute__((aligned(32))) c16_t rxdataF_tmp[fp->nb_antennas_rx][fp->samples_per_slot_wCP];
-
-  for (int i = 0; i < NR_N_SYMBOLS_SSB; i++) {
-    const int sample_offset = params->search_frame_id * fp->samples_per_frame + ssb_offset;
-    nr_slot_fep(NULL, fp, 0, i, rxdataF_tmp, link_type_dl, sample_offset, (c16_t **)params->rxdata);
-    // TODO: In later commit, call the modified symbol demod function and remove the following memcpy.
-    for (int aarx = 0; aarx < fp->nb_antennas_rx; aarx++)
-      memcpy(rxdataF[i][aarx], &rxdataF_tmp[aarx][i * fp->ofdm_symbol_size], sizeof(c16_t) * fp->ofdm_symbol_size);
-  }
+  do_time_to_freq(params, ssb_offset);
 
   // Perform SSS detection
   int detected_nid_cell = -1;
   int32_t sss_metric = 0;
   uint8_t sss_phase = 0;
   int freq_offset_sss = 0;
-  nr_sss_params_t p = (nr_sss_params_t){.nb_antennas_rx = fp->nb_antennas_rx,
-                                        .samples_per_slot_wCP = fp->samples_per_slot_wCP,
-                                        .ofdm_symbol_size = fp->ofdm_symbol_size,
-                                        .first_carrier_offset = fp->first_carrier_offset,
-                                        .ssb_start_subcarrier = fp->ssb_start_subcarrier,
-                                        .subcarrier_spacing = fp->subcarrier_spacing};
+  nr_sss_params_t p = (nr_sss_params_t){.nb_antennas_rx = params->nb_antennas_rx,
+                                        .samples_per_slot_wCP = params->samples_per_slot_wCP,
+                                        .ofdm_symbol_size = params->ofdm_symbol_size,
+                                        .first_carrier_offset = params->first_carrier_offset,
+                                        .ssb_start_subcarrier = params->ssb_start_subcarrier,
+                                        .subcarrier_spacing = params->subcarrier_spacing};
 
+  c16_t(*rxdataF)[params->nb_antennas_rx][params->ofdm_symbol_size] =
+      (c16_t(*)[params->nb_antennas_rx][params->ofdm_symbol_size])params->rxdataF;
   bool sss_detected =
       rx_sss_nr(&p, nid2, -1, freq_offset_pss, &detected_nid_cell, &sss_metric, &sss_phase, &freq_offset_sss, rxdataF);
 
@@ -279,16 +318,16 @@ void nr_scan_ssb(void *arg)
   __attribute__((aligned(32))) c16_t pssTime[NUMBER_PSS_SEQUENCE][fp->ofdm_symbol_size];
   const int pss_sequence = get_softmodem_params()->sl_mode == 0 ? NUMBER_PSS_SEQUENCE : NUMBER_PSS_SEQUENCE_SL;
   for (int nid2 = 0; nid2 < pss_sequence; nid2++)
-    generate_pss_nr_time(fp, nid2, ssbInfo->gscnInfo.ssbFirstSC, pssTime[nid2]);
+    generate_pss_nr_time(fp->ofdm_symbol_size, fp->first_carrier_offset, nid2, ssbInfo->gscnInfo.ssbFirstSC, pssTime[nid2]);
 
   __attribute__((aligned(32))) c16_t rxdataF[NR_N_SYMBOLS_SSB][fp->nb_antennas_rx][fp->ofdm_symbol_size];
 
   // initial sync performed on two successive frames, if pbch passes on first frame, no need to process second frame
   // only one frame is used for simulation tools
-  for (int frame_id = 0; frame_id < ssbInfo->nFrames && !ssbInfo->syncRes.cell_detected; frame_id++) {
-    if (ssbInfo->freqOffset)
-      compensate_freq_offset(rxdata, fp, ssbInfo->freqOffset, frame_id);
+  if (ssbInfo->freqOffset)
+    compensate_freq_offset(rxdata, fp->nb_antennas_rx, ssbInfo->rxdata_sz, ssbInfo->freqOffset, fp->samples_per_subframe * 1000);
 
+  for (int frame_id = 0; frame_id < ssbInfo->nFrames && !ssbInfo->syncRes.cell_detected; frame_id++) {
     int detected_nid_cell = -1;
     int ssb_offset = 0;
     int freq_offset_pss = 0;
@@ -296,15 +335,32 @@ void nr_scan_ssb(void *arg)
     int32_t sss_metric = 0;
     uint8_t sss_phase = 0;
 
+    c16_t *rxdataShift[fp->nb_antennas_rx];
+    for (int i = 0; i < fp->nb_antennas_rx; i++)
+      rxdataShift[i] = rxdata[i] + fp->samples_per_frame * frame_id;
+
     nr_ssb_search_params_t search_params = {
-        .frame_parms = fp,
-        .rxdata = rxdata,
+        .dl_CarrierFreq = fp->dl_CarrierFreq,
+        .sampling_rate = fp->samples_per_subframe * 1000,
+        .slots_per_frame = fp->slots_per_frame,
+        .slots_per_subframe = fp->slots_per_subframe,
+        .numerology_index = fp->numerology_index,
+        .ofdm_symbol_size = fp->ofdm_symbol_size,
+        .ofdm_offset_divisor = fp->ofdm_offset_divisor,
+        .nb_antennas_rx = fp->nb_antennas_rx,
+        .symbols_per_slot = fp->symbols_per_slot,
+        .first_carrier_offset = fp->first_carrier_offset,
+        .N_RB_DL = fp->N_RB_DL,
         .rxdata_size = fp->samples_per_frame,
+        .rxdata = rxdataShift,
+        .nb_prefix_samples = fp->nb_prefix_samples,
+        .nb_prefix_samples0 = fp->nb_prefix_samples0,
         .ssb_start_subcarrier = ssbInfo->gscnInfo.ssbFirstSC,
+        .subcarrier_spacing = fp->subcarrier_spacing,
+        .samples_per_slot_wCP = fp->samples_per_slot_wCP,
         .target_nid_cell = ssbInfo->targetNidCell,
         .exclude_nid_cell = -1, // No exclusion for initial sync
         .apply_freq_offset = ssbInfo->foFlag,
-        .search_frame_id = frame_id,
         .fo_flag = ssbInfo->foFlag,
         .rxdataF = rxdataF,
         .pssTime = pssTime,
@@ -392,9 +448,10 @@ nr_initial_sync_t nr_initial_sync(UE_nr_rxtx_proc_t *proc,
                                   .targetNidCell = ue->target_Nid_cell};
     ssbInfo->rxdata = malloc16_clear(fp->nb_antennas_rx * sizeof(c16_t *));
     for (int ant = 0; ant < fp->nb_antennas_rx; ant++) {
-      ssbInfo->rxdata[ant] = malloc16(sizeof(c16_t) * (fp->samples_per_frame * 2 + fp->ofdm_symbol_size));
-      memcpy(ssbInfo->rxdata[ant], ue->common_vars.rxdata[ant], sizeof(c16_t) * fp->samples_per_frame * 2);
-      memset(ssbInfo->rxdata[ant] + fp->samples_per_frame * 2, 0, fp->ofdm_symbol_size * sizeof(c16_t));
+      ssbInfo->rxdata[ant] = malloc16(sizeof(c16_t) * (fp->samples_per_frame * n_frames + fp->ofdm_symbol_size));
+      memcpy(ssbInfo->rxdata[ant], ue->common_vars.rxdata[ant], sizeof(c16_t) * fp->samples_per_frame * n_frames);
+      memset(ssbInfo->rxdata[ant] + fp->samples_per_frame * n_frames, 0, fp->ofdm_symbol_size * sizeof(c16_t));
+      ssbInfo->rxdata_sz = fp->samples_per_frame * n_frames + fp->ofdm_symbol_size;
     }
     LOG_I(NR_PHY,
           "Scanning GSCN: %d, with SSB offset: %d, SSB Freq: %lf\n",
@@ -467,7 +524,11 @@ nr_initial_sync_t nr_initial_sync(UE_nr_rxtx_proc_t *proc,
     if (res->freqOffset && ue->UE_fo_compensation) {
       // In SA we need to perform frequency offset correction until the end of buffer because we need to decode SIB1
       // and we do not know yet in which slot it goes.
-      compensate_freq_offset(ue->common_vars.rxdata, fp, res->freqOffset, res->syncRes.frame_id);
+      compensate_freq_offset(ue->common_vars.rxdata,
+                             fp->nb_antennas_rx,
+                             fp->samples_per_frame,
+                             res->freqOffset,
+                             fp->samples_per_subframe * 1000);
     }
     // sync at symbol ue->symbol_offset
     // computing the offset wrt the beginning of the frame

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -262,7 +262,7 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
   return true;
 }
 
-void nr_scan_ssb(void *arg)
+static void nr_scan_ssb(void *arg)
 {
   /*   Initial synchronisation
    *

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -240,10 +240,6 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
   do_time_to_freq(params, ssb_time_offset);
 
   // Perform SSS detection
-  int detected_nid_cell = -1;
-  int32_t sss_metric = 0;
-  uint8_t sss_phase = 0;
-  int freq_offset_sss = 0;
   nr_sss_params_t p = (nr_sss_params_t){.nb_antennas_rx = params->nb_antennas_rx,
                                         .samples_per_slot_wCP = params->samples_per_slot_wCP,
                                         .ofdm_symbol_size = params->ofdm_symbol_size,
@@ -253,34 +249,15 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
 
   c16_t(*rxdataF)[params->nb_antennas_rx][params->ofdm_symbol_size] =
       (c16_t(*)[params->nb_antennas_rx][params->ofdm_symbol_size])params->rxdataF;
-  bool sss_detected = rx_sss_nr(&p,
-                                params->pss_res.nid2,
-                                -1,
-                                params->pss_res.freq_offset,
-                                &detected_nid_cell,
-                                &sss_metric,
-                                &sss_phase,
-                                &freq_offset_sss,
-                                rxdataF);
+  params->sss_res = rx_sss_nr(&p, &params->pss_res, -1, rxdataF);
 
-  if (params->sss_metric)
-    *params->sss_metric = sss_metric;
-  if (params->sss_phase)
-    *params->sss_phase = sss_phase;
-  if (params->freq_offset_sss)
-    *params->freq_offset_sss = freq_offset_sss;
-
-  if (!sss_detected || detected_nid_cell < 0) {
+  if (!params->sss_res.success || params->sss_res.nid_cell < 0) {
     return false;
   }
 
   // Check if we should exclude the serving cell
-  if (params->exclude_nid_cell >= 0 && detected_nid_cell == params->exclude_nid_cell) {
+  if (params->exclude_nid_cell >= 0 && params->sss_res.nid_cell == params->exclude_nid_cell)
     return false;
-  }
-
-  if (params->detected_nid_cell)
-    *params->detected_nid_cell = detected_nid_cell;
 
   return true;
 }
@@ -318,12 +295,6 @@ void nr_scan_ssb(void *arg)
     compensate_freq_offset(rxdata, fp->nb_antennas_rx, ssbInfo->rxdata_sz, ssbInfo->freqOffset, fp->samples_per_subframe * 1000);
 
   for (int frame_id = 0; frame_id < ssbInfo->nFrames && !ssbInfo->syncRes.cell_detected; frame_id++) {
-    int detected_nid_cell = -1;
-    int freq_offset_pss = 0;
-    int freq_offset_sss = 0;
-    int32_t sss_metric = 0;
-    uint8_t sss_phase = 0;
-
     c16_t *rxdataShift[fp->nb_antennas_rx];
     for (int i = 0; i < fp->nb_antennas_rx; i++)
       rxdataShift[i] = rxdata[i] + fp->samples_per_frame * frame_id;
@@ -353,10 +324,6 @@ void nr_scan_ssb(void *arg)
         .fo_flag = ssbInfo->foFlag,
         .rxdataF = rxdataF,
         .pssTime = pssTime,
-        .detected_nid_cell = &detected_nid_cell,
-        .sss_metric = &sss_metric,
-        .freq_offset_sss = &freq_offset_sss,
-        .sss_phase = &sss_phase,
     };
 
     ssbInfo->syncRes.frame_id = frame_id;
@@ -367,8 +334,7 @@ void nr_scan_ssb(void *arg)
     }
 
     ssbInfo->ssbOffset = search_params.pss_res.pos - search_params.nb_prefix_samples;
-    ;
-    ssbInfo->nidCell = detected_nid_cell;
+    ssbInfo->nidCell = search_params.sss_res.nid_cell;
 
 #ifdef DEBUG_INITIAL_SYNCH
     LOG_I(PHY,
@@ -379,7 +345,7 @@ void nr_scan_ssb(void *arg)
           sss_phase,
           ssbInfo->syncRes.rx_offset);
 #endif
-    ssbInfo->freqOffset += freq_offset_pss + freq_offset_sss;
+    ssbInfo->freqOffset += search_params.pss_res.freq_offset + search_params.sss_res.freq_offset;
 
     if (ssbInfo->syncRes.cell_detected) { // we got sss channel
       ssbInfo->syncRes.cell_detected = nr_pbch_detection(ssbInfo->proc,

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -472,16 +472,6 @@ nr_initial_sync_t nr_initial_sync(UE_nr_rxtx_proc_t *proc,
   LOG_D(PHY, "nr_initial sync ue RB_DL %d\n", fp->N_RB_DL);
 
   if (res) {
-    // digital compensation of FFO for SSB symbols
-    if (res->freqOffset && ue->UE_fo_compensation) {
-      // In SA we need to perform frequency offset correction until the end of buffer because we need to decode SIB1
-      // and we do not know yet in which slot it goes.
-      compensate_freq_offset(ue->common_vars.rxdata,
-                             fp->nb_antennas_rx,
-                             fp->samples_per_frame,
-                             res->freqOffset,
-                             fp->samples_per_subframe * 1000);
-    }
     // sync at symbol ue->symbol_offset
     // computing the offset wrt the beginning of the frame
     int mu = fp->numerology_index;
@@ -498,24 +488,24 @@ nr_initial_sync_t nr_initial_sync(UE_nr_rxtx_proc_t *proc,
     if (res->ssbOffset < sync_pos_frame) {
       res->syncRes.rx_offset = fp->samples_per_frame - sync_pos_frame + res->ssbOffset;
       ue->init_sync_frame += 1;
-    } else
+    } else {
       res->syncRes.rx_offset = res->ssbOffset - sync_pos_frame;
-  }
+    }
 
-  if (res) {
     LOG_I(PHY, "[UE%d] In synch, rx_offset %d samples\n", ue->Mod_id, res->syncRes.rx_offset);
     LOG_I(PHY, "[UE %d] Measured Carrier Frequency offset %d Hz\n", ue->Mod_id, res->freqOffset);
+    LOG_A(PHY, "Initial sync successful, PCI: %d\n", fp->Nid_cell);
+    return res->syncRes;
   } else {
 #ifdef DEBUG_INITIAL_SYNC
     LOG_I(PHY,"[UE%d] Initial sync : PBCH not ok\n",ue->Mod_id);
     LOG_I(PHY, "[UE%d] Initial sync : Estimated PSS position %d, Nid2 %d\n", ue->Mod_id, sync_pos, ue->common_vars.nid2);
     LOG_I(PHY,"[UE%d] Initial sync : Estimated Nid_cell %d, Frame_type %d\n",ue->Mod_id,
           fp->Nid_cell,fp->frame_type);
+    LOG_I(PHY, "[UE%d] Initial sync failed : Estimated power: %d dB\n", ue->Mod_id, ue->measurements.rx_power_avg_dB[0]);
 #endif
-  }
-
-  // gain control
-  if (!res) { // we are not synched, so we cannot use rssi measurement (which is based on channel estimates)
+    // gain control
+    // we are not synched, so we cannot use rssi measurement (which is based on channel estimates)
     int rx_power = 0;
 
     // do a measurement on the best guess of the PSS
@@ -532,18 +522,7 @@ nr_initial_sync_t nr_initial_sync(UE_nr_rxtx_proc_t *proc,
 
     // we might add a low-pass filter here later
     ue->measurements.rx_power_avg[0] = rx_power / fp->nb_antennas_rx;
-
     ue->measurements.rx_power_avg_dB[0] = dB_fixed(ue->measurements.rx_power_avg[0]);
-
-#ifdef DEBUG_INITIAL_SYNCH
-    LOG_I(PHY, "[UE%d] Initial sync failed : Estimated power: %d dB\n", ue->Mod_id, ue->measurements.rx_power_avg_dB[0]);
-#endif
-  } else {
-    LOG_A(PHY, "Initial sync successful, PCI: %d\n", fp->Nid_cell);
-  }
-  //  exit_fun("debug exit");
-  if (res)
-    return res->syncRes;
-  else
     return (nr_initial_sync_t){.cell_detected = false};
+  }
 }

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -201,60 +201,43 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
   c16_t(*pssTime)[pssTime_sz] = (c16_t(*)[pssTime_sz])params->pssTime;
 
   // Perform PSS search
-  int nid2 = -1;
-  int freq_offset_pss = 0;
-  int pss_peak = 0;
-  int pss_avg = 0;
-  const int sync_pos = pss_synchro_nr((const c16_t **)params->rxdata,
-                                      params->nb_antennas_rx,
-                                      params->ofdm_symbol_size,
-                                      params->rxdata_size,
-                                      params->subcarrier_spacing,
-                                      pssTime,
-                                      params->fo_flag,
-                                      params->target_nid_cell,
-                                      &nid2,
-                                      &freq_offset_pss,
-                                      &pss_peak,
-                                      &pss_avg);
+  params->pss_res = pss_search_time_nr((const c16_t **)params->rxdata,
+                                       params->ofdm_symbol_size,
+                                       params->nb_antennas_rx,
+                                       params->subcarrier_spacing,
+                                       pssTime,
+                                       params->fo_flag,
+                                       params->target_nid_cell,
+                                       0,
+                                       params->rxdata_size);
 
-  if (params->pss_peak)
-    *params->pss_peak = pss_peak;
-  if (params->pss_avg)
-    *params->pss_avg = pss_avg;
-  if (params->freq_offset_pss)
-    *params->freq_offset_pss = freq_offset_pss;
-
-  if (sync_pos < params->nb_prefix_samples || nid2 < 0) {
+  if (!params->pss_res.success)
     return false;
-  }
 
-  const int ssb_offset = sync_pos - params->nb_prefix_samples;
-  if (params->ssb_offset)
-    *params->ssb_offset = ssb_offset;
+  const int ssb_time_offset = params->pss_res.pos - params->nb_prefix_samples;
 
 #ifdef DEBUG_INITIAL_SYNCH
   LOG_I(PHY, "Initial sync : Estimated PSS position %d, Nid2 %d, ssb offset %d\n", sync_pos, nid2, ssb_offset);
 #endif
 
   // Check that SSB fits within buffer
-  if (ssb_offset + NR_N_SYMBOLS_SSB * (params->ofdm_symbol_size + params->nb_prefix_samples) >= params->rxdata_size) {
+  if (ssb_time_offset + NR_N_SYMBOLS_SSB * (params->ofdm_symbol_size + params->nb_prefix_samples) >= params->rxdata_size) {
     LOG_D(PHY,
           "SSB extends beyond buffer boundary (sync_pos %d, ssb_offset %d, buffer_size %d)\n",
-          sync_pos,
-          ssb_offset,
+          params->pss_res.pos,
+          ssb_time_offset,
           params->rxdata_size);
     return false;
   }
 
   // Apply frequency offset compensation if requested
-  if (params->apply_freq_offset && freq_offset_pss != 0) {
-    compensate_freq_offset(params->rxdata, params->nb_antennas_rx, params->rxdata_size, freq_offset_pss, params->sampling_rate);
+  if (params->apply_freq_offset && params->pss_res.freq_offset != 0) {
+    compensate_freq_offset(params->rxdata, params->nb_antennas_rx, params->rxdata_size, params->pss_res.freq_offset, params->sampling_rate);
   }
 
   // Extract SSB symbols to frequency domain
   // Symbol ordering: 0=PSS, 1=PBCH, 2=SSS, 3=PBCH
-  do_time_to_freq(params, ssb_offset);
+  do_time_to_freq(params, ssb_time_offset);
 
   // Perform SSS detection
   int detected_nid_cell = -1;
@@ -270,8 +253,15 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
 
   c16_t(*rxdataF)[params->nb_antennas_rx][params->ofdm_symbol_size] =
       (c16_t(*)[params->nb_antennas_rx][params->ofdm_symbol_size])params->rxdataF;
-  bool sss_detected =
-      rx_sss_nr(&p, nid2, -1, freq_offset_pss, &detected_nid_cell, &sss_metric, &sss_phase, &freq_offset_sss, rxdataF);
+  bool sss_detected = rx_sss_nr(&p,
+                                params->pss_res.nid2,
+                                -1,
+                                params->pss_res.freq_offset,
+                                &detected_nid_cell,
+                                &sss_metric,
+                                &sss_phase,
+                                &freq_offset_sss,
+                                rxdataF);
 
   if (params->sss_metric)
     *params->sss_metric = sss_metric;
@@ -329,7 +319,6 @@ void nr_scan_ssb(void *arg)
 
   for (int frame_id = 0; frame_id < ssbInfo->nFrames && !ssbInfo->syncRes.cell_detected; frame_id++) {
     int detected_nid_cell = -1;
-    int ssb_offset = 0;
     int freq_offset_pss = 0;
     int freq_offset_sss = 0;
     int32_t sss_metric = 0;
@@ -365,13 +354,9 @@ void nr_scan_ssb(void *arg)
         .rxdataF = rxdataF,
         .pssTime = pssTime,
         .detected_nid_cell = &detected_nid_cell,
-        .ssb_offset = &ssb_offset,
         .sss_metric = &sss_metric,
-        .freq_offset_pss = &freq_offset_pss,
         .freq_offset_sss = &freq_offset_sss,
         .sss_phase = &sss_phase,
-        .pss_peak = &ssbInfo->pssCorrPeakPower,
-        .pss_avg = &ssbInfo->pssCorrAvgPower,
     };
 
     ssbInfo->syncRes.frame_id = frame_id;
@@ -381,7 +366,8 @@ void nr_scan_ssb(void *arg)
       continue;
     }
 
-    ssbInfo->ssbOffset = ssb_offset;
+    ssbInfo->ssbOffset = search_params.pss_res.pos - search_params.nb_prefix_samples;
+    ;
     ssbInfo->nidCell = detected_nid_cell;
 
 #ifdef DEBUG_INITIAL_SYNCH

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -201,15 +201,15 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
   c16_t(*pssTime)[pssTime_sz] = (c16_t(*)[pssTime_sz])params->pssTime;
 
   // Perform PSS search
-  params->pss_res = pss_search_time_nr((const c16_t **)params->rxdata,
-                                       params->ofdm_symbol_size,
-                                       params->nb_antennas_rx,
-                                       params->subcarrier_spacing,
-                                       pssTime,
-                                       params->fo_flag,
-                                       params->target_nid_cell,
-                                       0,
-                                       params->rxdata_size);
+  pss_search_t p_pss = (pss_search_t){.rxdata = params->rxdata,
+                                      .nb_antennas_rx = params->nb_antennas_rx,
+                                      .rxdata_length = params->rxdata_size,
+                                      .ofdm_symbol_size = params->ofdm_symbol_size,
+                                      .subcarrier_spacing = params->subcarrier_spacing,
+                                      .fo_flag = params->fo_flag,
+                                      .target_Nid_cell = params->target_nid_cell,
+                                      .pssTime = (c16_t *)pssTime};
+  params->pss_res = pss_search_time_nr(&p_pss);
 
   if (!params->pss_res.success)
     return false;
@@ -240,16 +240,16 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
   do_time_to_freq(params, ssb_time_offset);
 
   // Perform SSS detection
-  nr_sss_params_t p = (nr_sss_params_t){.nb_antennas_rx = params->nb_antennas_rx,
-                                        .samples_per_slot_wCP = params->samples_per_slot_wCP,
-                                        .ofdm_symbol_size = params->ofdm_symbol_size,
-                                        .first_carrier_offset = params->first_carrier_offset,
-                                        .ssb_start_subcarrier = params->ssb_start_subcarrier,
-                                        .subcarrier_spacing = params->subcarrier_spacing};
+  nr_sss_params_t p_sss = (nr_sss_params_t){.nb_antennas_rx = params->nb_antennas_rx,
+                                            .samples_per_slot_wCP = params->samples_per_slot_wCP,
+                                            .ofdm_symbol_size = params->ofdm_symbol_size,
+                                            .first_carrier_offset = params->first_carrier_offset,
+                                            .ssb_start_subcarrier = params->ssb_start_subcarrier,
+                                            .subcarrier_spacing = params->subcarrier_spacing};
 
   c16_t(*rxdataF)[params->nb_antennas_rx][params->ofdm_symbol_size] =
       (c16_t(*)[params->nb_antennas_rx][params->ofdm_symbol_size])params->rxdataF;
-  params->sss_res = rx_sss_nr(&p, &params->pss_res, -1, rxdataF);
+  params->sss_res = rx_sss_nr(&p_sss, &params->pss_res, -1, rxdataF);
 
   if (!params->sss_res.success || params->sss_res.nid_cell < 0) {
     return false;

--- a/openair1/PHY/NR_UE_TRANSPORT/pss_nr.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/pss_nr.c
@@ -33,13 +33,6 @@
 //#define DBG_PSS_NR
 static time_stats_t generic_time[TIME_LAST];
 
-static int16_t d_pss[NUMBER_PSS_SEQUENCE][LENGTH_PSS_NR] = {0};
-static c16_t primary_synchro[NUMBER_PSS_SEQUENCE][LENGTH_PSS_NR] = {0};
-int16_t *get_primary_synchro_nr2(const int nid2)
-{
-  return d_pss[nid2];
-}
-
 /*******************************************************************
 *
 * NAME :         generate_pss_nr
@@ -54,43 +47,20 @@ int16_t *get_primary_synchro_nr2(const int nid2)
 *
 *********************************************************************/
 
-void generate_pss_nr(NR_DL_FRAME_PARMS *fp, int N_ID_2)
+void generate_pss_nr(const int N_ID_2, int16_t *pss)
 {
-  AssertFatal(fp->ofdm_symbol_size > 127,"Illegal ofdm_symbol_size %d\n",fp->ofdm_symbol_size);
-  AssertFatal(N_ID_2 >= 0 && N_ID_2 <= 2, "Illegal N_ID_2 %d\n", N_ID_2);
+  AssertFatal(N_ID_2 >= 0 && N_ID_2 < NUMBER_PSS_SEQUENCE, "Illegal N_ID_2 %d\n", N_ID_2);
   int16_t x[LENGTH_PSS_NR];
-
 #define INITIAL_PSS_NR (7)
   const int16_t x_initial[INITIAL_PSS_NR] = {0, 1, 1, 0, 1, 1, 1};
-  assert(N_ID_2 < NUMBER_PSS_SEQUENCE);
   memcpy(x, x_initial, sizeof(x_initial));
 
   for (int i = 0; i < (LENGTH_PSS_NR - INITIAL_PSS_NR); i++)
-    x[i + INITIAL_PSS_NR] = (x[i + 4] + x[i]) % (2);
-  int16_t *pss = d_pss[N_ID_2];
+    x[i + INITIAL_PSS_NR] = (x[i + 4] + x[i]) % 2;
   for (int n=0; n < LENGTH_PSS_NR; n++) {
     const int m = (n + 43 * N_ID_2) % (LENGTH_PSS_NR);
     pss[n] = 1 - 2 * x[m];
   }
-
-  /* PSS is directly mapped to subcarrier without modulation 38.211 */
-  for (int i=0; i < LENGTH_PSS_NR; i++) {
-    primary_synchro[N_ID_2][i].r = (pss[i] * SHRT_MAX) >> SCALING_PSS_NR; /* Maximum value for type short int ie int16_t */
-  }
-
-#ifdef DBG_PSS_NR
-
-  if (N_ID_2 == 0) {
-    char output_file[255];
-    char sequence_name[255];
-    sprintf(output_file, "pss_seq_%d_%u.m", N_ID_2, fp->ofdm_symbol_size);
-    sprintf(sequence_name, "pss_seq_%d_%u", N_ID_2, fp->ofdm_symbol_size);
-    printf("file %s sequence %s\n", output_file, sequence_name);
-
-    LOG_M(output_file, sequence_name, primary_synchro, LENGTH_PSS_NR, 1, 1);
-  }
-
-#endif
 }
 
   /* call of IDFT should be done with ordered input as below
@@ -120,10 +90,12 @@ void generate_pss_nr_time(const NR_DL_FRAME_PARMS *fp, const int N_ID_2, int ssb
   c16_t synchroF_tmp[fp->ofdm_symbol_size] __attribute__((aligned(32)));
   memset(synchroF_tmp, 0, sizeof(synchroF_tmp));
   unsigned int k = fp->first_carrier_offset + ssbFirstSCS + subcarrier_start;
+  int16_t pss[LENGTH_PSS_NR];
+  generate_pss_nr(N_ID_2, pss);
   for (int i=0; i < LENGTH_PSS_NR; i++) {
     if (k >= fp->ofdm_symbol_size)
       k -= fp->ofdm_symbol_size;
-    synchroF_tmp[k] = primary_synchro[N_ID_2][i];
+    synchroF_tmp[k] = (c16_t){.r = (pss[i] * SHRT_MAX) >> SCALING_PSS_NR}; /* Maximum value for type short int ie int16_t */
     k++;
   }
 
@@ -132,159 +104,6 @@ void generate_pss_nr_time(const NR_DL_FRAME_PARMS *fp, const int N_ID_2, int ssb
        (int16_t *)synchroF_tmp, /* complex input but legacy type is wrong*/
        (int16_t *)pssTime, /* complex output */
        1); /* scaling factor */
-
-#ifdef DBG_PSS_NR
-
-  if (N_ID_2 == 0) {
-    char output_file[255];
-    char sequence_name[255];
-    sprintf(output_file, "%s%d_%u%s","pss_seq_t_", N_ID_2, length, ".m");
-    sprintf(sequence_name, "%s%d_%u","pss_seq_t_", N_ID_2, length);
-
-    printf("file %s sequence %s\n", output_file, sequence_name);
-
-    LOG_M(output_file, sequence_name, primary_synchro_time, length, 1, 1);
-    sprintf(output_file, "%s%d_%u%s","pss_seq_f_", N_ID_2, length, ".m");
-    sprintf(sequence_name, "%s%d_%u","pss_seq_f_", N_ID_2, length);
-    LOG_M(output_file, sequence_name, synchroF_tmp, length, 1, 1);
-  }
-
-#endif
-}
-
-/*******************************************************************
-*
-* NAME :         init_context_pss_nr
-*
-* PARAMETERS :   structure NR_DL_FRAME_PARMS give frame parameters
-*
-* RETURN :       generate binary pss sequences (this is a m-sequence)
-*
-* DESCRIPTION :  3GPP TS 38.211 7.4.2.2 Primary synchronisation signal
-*                Sequence generation
-*
-*********************************************************************/
-
-static void init_context_pss_nr(NR_DL_FRAME_PARMS *frame_parms_ue)
-{
-  AssertFatal(frame_parms_ue->ofdm_symbol_size > 127, "illegal ofdm_symbol_size %d\n", frame_parms_ue->ofdm_symbol_size);
-  int pss_sequence = get_softmodem_params()->sl_mode == 0 ? NUMBER_PSS_SEQUENCE : NUMBER_PSS_SEQUENCE_SL;
-  for (int i = 0; i < pss_sequence; i++) {
-    generate_pss_nr(frame_parms_ue,i);
-  }
-}
-
-/*******************************************************************
-*
-* NAME :         init_context_synchro_nr
-*
-* PARAMETERS :   none
-*
-* RETURN :       generate context for pss and sss
-*
-* DESCRIPTION :  initialise contexts and buffers for synchronisation
-*
-*********************************************************************/
-
-void init_context_synchro_nr(NR_DL_FRAME_PARMS *frame_parms_ue)
-{
-  /* initialise global buffers for synchronisation */
-  init_context_pss_nr(frame_parms_ue);
-  init_context_sss_nr(AMP);
-}
-
-/*******************************************************************
-*
-* NAME :         set_frame_context_pss_nr
-*
-* PARAMETERS :   configuration for UE with new FFT size
-*
-* RETURN :       0 if OK else error
-*
-* DESCRIPTION :  initialisation of UE contexts
-*
-*********************************************************************/
-
-void set_frame_context_pss_nr(NR_DL_FRAME_PARMS *frame_parms_ue, int rate_change)
-{
-  /* set new value according to rate_change */
-  frame_parms_ue->ofdm_symbol_size = (frame_parms_ue->ofdm_symbol_size / rate_change);
-  frame_parms_ue->samples_per_subframe = (frame_parms_ue->samples_per_subframe / rate_change);
-
-  /* pss reference have to be rebuild with new parameters ie ofdm symbol size */
-  init_context_synchro_nr(frame_parms_ue);
-
-#ifdef SYNCHRO_DECIMAT
-  set_pss_nr(frame_parms_ue->ofdm_symbol_size);
-#endif
-}
-
-/*******************************************************************
-*
-* NAME :         restore_frame_context_pss_nr
-*
-* PARAMETERS :   configuration for UE and eNB with new FFT size
-*
-* RETURN :       0 if OK else error
-*
-* DESCRIPTION :  initialisation of UE and eNode contexts
-*
-*********************************************************************/
-
-void restore_frame_context_pss_nr(NR_DL_FRAME_PARMS *frame_parms_ue, int rate_change)
-{
-  frame_parms_ue->ofdm_symbol_size = frame_parms_ue->ofdm_symbol_size * rate_change;
-  frame_parms_ue->samples_per_subframe = frame_parms_ue->samples_per_subframe * rate_change;
-
-  /* pss reference have to be rebuild with new parameters ie ofdm symbol size */
-  init_context_synchro_nr(frame_parms_ue);
-#ifdef SYNCHRO_DECIMAT
-  set_pss_nr(frame_parms_ue->ofdm_symbol_size);
-#endif
-}
-
-/********************************************************************
-*
-* NAME :         decimation_synchro_nr
-*
-* INPUT :        UE context
-*                for first and second pss sequence
-*                - position of pss in the received UE buffer
-*                - number of pss sequence
-*
-* RETURN :      0 if OK else error
-*
-* DESCRIPTION :  detect pss sequences in the received UE buffer
-*
-********************************************************************/
-
-void decimation_synchro_nr(PHY_VARS_NR_UE *PHY_vars_UE, int rate_change, int **rxdata)
-{
-  NR_DL_FRAME_PARMS *frame_parms = &(PHY_vars_UE->frame_parms);
-  int samples_for_frame = 2*frame_parms->samples_per_frame;
-
-  start_meas(&generic_time[TIME_RATE_CHANGE]);
-/* build with cic filter does not work properly. Performances are significantly deteriorated */
-#ifdef CIC_DECIMATOR
-
-  cic_decimator((int16_t *)&(PHY_vars_UE->common_vars.rxdata[0][0]), (int16_t *)&(rxdata[0][0]),
-                            samples_for_frame, rate_change, CIC_FILTER_STAGE_NUMBER, 0, FIR_RATE_CHANGE);
-#else
-
-  fir_decimator((int16_t *)&(PHY_vars_UE->common_vars.rxdata[0][0]), (int16_t *)&(rxdata[0][0]),
-                            samples_for_frame, rate_change, 0);
-
-#endif
-
-  set_frame_context_pss_nr(frame_parms, rate_change);
-
-#if TEST_SYNCHRO_TIMING_PSS
-
-  stop_meas(&generic_time[TIME_RATE_CHANGE]);
-
-  printf("Rate change execution duration %5.2f \n", generic_time[TIME_RATE_CHANGE].p_time/(cpuf*1000.0));
-
-#endif
 }
 
 /*******************************************************************
@@ -310,11 +129,6 @@ int pss_synchro_nr(const c16_t **rxdata,
                    int *pssPeak,
                    int *pssAvg)
 {
-#ifdef DBG_PSS_NR
-  LOG_M("rxdata0_rand.m", "rxd0_rand", &PHY_vars_UE->common_vars.rxdata[0][0], frame_parms->samples_per_frame, 1, 1);
-  LOG_M("rxdata0_des.m", "rxd0_des", &rxdata[0][0], frame_parms->samples_per_frame, 1, 1);
-#endif
-
   start_meas(&generic_time[TIME_PSS]);
   int synchro_position =
       pss_search_time_nr(rxdata, frame_parms, pssTime, fo_flag, is, target_Nid_cell, nid2, f_off, pssPeak, pssAvg, -1, -1);
@@ -326,18 +140,6 @@ int pss_synchro_nr(const c16_t **rxdata,
 #ifndef NR_UNIT_TEST
   LOG_D(PHY, "PSS execution duration %4d microseconds \n", duration_ms);
 #endif
-#endif
-
-#ifdef SYNCHRO_DECIMAT
-  if (rate_change != 1) {
-    if (rxdata[0] != NULL) {
-      for (int aa=0;aa<frame_parms->nb_antennas_rx;aa++) {
-        free(rxdata[aa]);
-      }
-      free(rxdata);
-    }
-    restore_frame_context_pss_nr(frame_parms, rate_change);
-  }
 #endif
 
   return synchro_position;

--- a/openair1/PHY/NR_UE_TRANSPORT/pss_nr.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/pss_nr.c
@@ -30,8 +30,7 @@
 #include "PHY/NR_REFSIG/sss_nr.h"
 #include "PHY/NR_UE_TRANSPORT/cic_filter_nr.h"
 
-//#define DBG_PSS_NR
-static time_stats_t generic_time[TIME_LAST];
+// #define DBG_PSS_NR
 
 /*******************************************************************
 *
@@ -112,58 +111,6 @@ void generate_pss_nr_time(int ofdm_symbol_size,
 
 /*******************************************************************
 *
-* NAME :         pss_synchro_nr
-*
-* PARAMETERS :   int rate_change
-*
-* RETURN :       position of detected pss
-*
-* DESCRIPTION :  pss search can be done with sampling decimation.*
-*
-*********************************************************************/
-
-int pss_synchro_nr(const c16_t **rxdata,
-                   int nb_ant,
-                   int ofdm_symbol_size,
-                   int rxdata_size,
-                   int subcarrier_spacing,
-                   const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
-                   bool fo_flag,
-                   int target_Nid_cell,
-                   int *nid2,
-                   int *f_off,
-                   int *pssPeak,
-                   int *pssAvg)
-{
-  start_meas(&generic_time[TIME_PSS]);
-  int synchro_position = pss_search_time_nr(rxdata,
-                                            ofdm_symbol_size,
-                                            nb_ant,
-                                            subcarrier_spacing,
-                                            pssTime,
-                                            fo_flag,
-                                            target_Nid_cell,
-                                            nid2,
-                                            f_off,
-                                            pssPeak,
-                                            pssAvg,
-                                            0,
-                                            rxdata_size - ofdm_symbol_size);
-  stop_meas(&generic_time[TIME_PSS]);
-
-#if TEST_SYNCHRO_TIMING_PSS
-
-  int duration_ms = generic_time[TIME_PSS].p_time / (cpuf * 1000.0);
-#ifndef NR_UNIT_TEST
-  LOG_D(PHY, "PSS execution duration %4d microseconds \n", duration_ms);
-#endif
-#endif
-
-  return synchro_position;
-}
-
-/*******************************************************************
-*
 * NAME :         pss_search_time_nr
 *
 * PARAMETERS :   received buffer in time domain
@@ -212,25 +159,21 @@ int pss_synchro_nr(const c16_t **rxdata,
 *
 *********************************************************************/
 
-int pss_search_time_nr(const c16_t **rxdata,
-                       int ofdm_symbol_size,
-                       int nb_antennas_rx,
-                       int subcarrier_spacing,
-                       const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
-                       bool fo_flag,
-                       int target_Nid_cell,
-                       int *nid2,
-                       int *f_off,
-                       int *pssPeak,
-                       int *pssAvg,
-                       int search_start,
-                       int search_length)
+pss_detection_result_t pss_search_time_nr(const c16_t **rxdata,
+                                          int ofdm_symbol_size,
+                                          int nb_antennas_rx,
+                                          int subcarrier_spacing,
+                                          const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
+                                          bool fo_flag,
+                                          int target_Nid_cell,
+                                          int start,
+                                          int length)
 {
-  // Determine search window
-  unsigned int start, length;
-  // Use provided search window for known neighboring cells
-  start = search_start;
-  length = search_length;
+  if (start < 0 || length == 0) {
+    LOG_E(PHY, "inconsistent call to pss_search_time_nr %d, %d\n", start, length);
+    return (pss_detection_result_t){.success = false};
+  }
+
   int maxval=0;
   int max_size = get_softmodem_params()->sl_mode == 0 ?  NUMBER_PSS_SEQUENCE : NUMBER_PSS_SEQUENCE_SL;
   for (int j = 0; j < max_size; j++)
@@ -307,12 +250,6 @@ int pss_search_time_nr(const c16_t **rxdata,
     printf("ffo %lf\n", ffo_est);
 #endif
   }
-  // computing absolute value of frequency offset
-  *f_off = ffo_est * subcarrier_spacing;
-
-  *nid2 = pss_source;
-  *pssPeak = dB_fixed64(peak_value);
-  *pssAvg = dB_fixed64(avg[pss_source]);
 
   LOG_D(PHY,
         "[UE] nr_synchro_time: Sync source (nid2) = %d, Peak found at pos %d, val = %ld (%d dB power over signal avg %d dB), ffo "
@@ -324,8 +261,8 @@ int pss_search_time_nr(const c16_t **rxdata,
         dB_fixed64(avg[pss_source]),
         ffo_est);
 
-  if ((search_start < 0 || search_length == 0) && peak_value < 5 * avg[pss_source])
-    return (-1);
+  if (peak_value == 0 || peak_value < 5 * avg[pss_source])
+    return (pss_detection_result_t){.success = false};
 
 #ifdef DBG_PSS_NR
   static int debug_cnt = 0;
@@ -336,7 +273,12 @@ int pss_search_time_nr(const c16_t **rxdata,
   }
 #endif
 
-  return peak_position;
+  return (pss_detection_result_t){.success = true,
+                                  .nid2 = pss_source,
+                                  .pos = peak_position,
+                                  .freq_offset = ffo_est * subcarrier_spacing,
+                                  .peak = dB_fixed64(peak_value),
+                                  .avg = dB_fixed64(avg[pss_source])};
 }
 
 void sl_generate_pss(SL_NR_UE_INIT_PARAMS_t *sl_init_params, uint8_t n_sl_id2, uint16_t scaling)

--- a/openair1/PHY/NR_UE_TRANSPORT/pss_nr.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/pss_nr.c
@@ -159,25 +159,18 @@ void generate_pss_nr_time(int ofdm_symbol_size,
 *
 *********************************************************************/
 
-pss_detection_result_t pss_search_time_nr(const c16_t **rxdata,
-                                          int ofdm_symbol_size,
-                                          int nb_antennas_rx,
-                                          int subcarrier_spacing,
-                                          const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
-                                          bool fo_flag,
-                                          int target_Nid_cell,
-                                          int start,
-                                          int length)
+pss_detection_result_t pss_search_time_nr(const pss_search_t *p)
 {
-  if (start < 0 || length == 0) {
-    LOG_E(PHY, "inconsistent call to pss_search_time_nr %d, %d\n", start, length);
+  if (p->rxdata_length == 0) {
+    LOG_E(PHY, "inconsistent call to pss_search_time_nr %d\n", p->rxdata_length);
     return (pss_detection_result_t){.success = false};
   }
 
+  c16_t(*pssTime)[p->ofdm_symbol_size] = (c16_t(*)[p->ofdm_symbol_size])p->pssTime;
   int maxval=0;
   int max_size = get_softmodem_params()->sl_mode == 0 ?  NUMBER_PSS_SEQUENCE : NUMBER_PSS_SEQUENCE_SL;
   for (int j = 0; j < max_size; j++)
-    for (int i = 0; i < ofdm_symbol_size; i++) {
+    for (int i = 0; i < p->ofdm_symbol_size; i++) {
       maxval = max(maxval, abs(pssTime[j][i].r));
       maxval = max(maxval, abs(pssTime[j][i].i));
     }
@@ -187,60 +180,57 @@ pss_detection_result_t pss_search_time_nr(const c16_t **rxdata,
   /* This is required by SIMD (single instruction Multiple Data) Extensions of Intel processors. */
   /* Correlation computation is based on a a dot product which is realized thank to SIMS extensions */
 
-  int pss_index_start;
-  int pss_index_end;
-  if (target_Nid_cell != -1) {
-    pss_index_start = GET_NID2(target_Nid_cell);
-    pss_index_end = pss_index_start + 1;
-  } else {
-    pss_index_start = 0;
-    pss_index_end = max_size;
+  int pss_space[NUMBER_PSS_SEQUENCE+1]={0,1,2,-1};
+  if (p->target_Nid_cell != -1) {
+    pss_space[0] = GET_NID2(p->target_Nid_cell);
+    pss_space[1] = -1;
   }
 
   int64_t avg[NUMBER_PSS_SEQUENCE] = {0};
   int64_t peak_value = 0;
   unsigned int peak_position = 0;
   unsigned int pss_source = 0;
-  for (int pss_index = pss_index_start; pss_index < pss_index_end; pss_index++) {
-    for (int n = start; n < start + length; n += 4) { //
+  for (int i=0; pss_space[i] != -1; i++) {
+    const int pss=pss_space[i];
+    for (int n = 0; n < p->rxdata_length; n += 4) { //
       int64_t pss_corr_ue = 0;
       /* calculate dot product of primary_synchro_time_nr and rxdata[ar][n]
        * (ar=0..nb_ant_rx) and store the sum in temp[n]; */
-      for (int ar = 0; ar < nb_antennas_rx; ar++) {
+      for (int ar = 0; ar < p->nb_antennas_rx; ar++) {
         /* perform correlation of rx data and pss sequence ie it is a dot product */
-        const c32_t result = dot_product(pssTime[pss_index], &rxdata[ar][n], ofdm_symbol_size, shift);
+        const c32_t result = dot_product(pssTime[pss], &p->rxdata[ar][n], p->ofdm_symbol_size, shift);
         const c64_t r64 = {.r = result.r, .i = result.i};
         pss_corr_ue += squaredMod(r64);
       }
 
       /* calculate the absolute value of sync_corr[n] */
-      avg[pss_index] += pss_corr_ue;
+      avg[pss] += pss_corr_ue;
       if (pss_corr_ue > peak_value) {
         peak_value = pss_corr_ue;
         peak_position = n;
-        pss_source = pss_index;
+        pss_source = pss;
 
 #ifdef DEBUG_PSS_NR
-        printf("pss_index %d: n %6u peak_value %lu\n", pss_index, n, pss_corr_ue);
+        printf("pss_index %d: n %6u peak_value %lu\n", pss, n, pss_corr_ue);
 #endif
       }
     }
-    avg[pss_index] /= (length / 4);
+    avg[pss] /= (p->rxdata_length / 4);
   }
 
   double ffo_est = 0;
-  if (fo_flag) {
+  if (p->fo_flag) {
     // fractional frequency offset computation according to Cross-correlation Synchronization Algorithm Using PSS
     // Shoujun Huang, Yongtao Su, Ying He and Shan Tang, "Joint time and frequency offset estimation in LTE downlink," 7th
     // International Conference on Communications and Networking in China, 2012.
 
     // Computing cross-correlation at peak on half the symbol size for first half of data
-    c32_t r1 = dot_product(pssTime[pss_source], &(rxdata[0][peak_position]), ofdm_symbol_size >> 1, shift);
+    c32_t r1 = dot_product(pssTime[pss_source], &p->rxdata[0][peak_position], p->ofdm_symbol_size >> 1, shift);
     // Computing cross-correlation at peak on half the symbol size for data shifted by half symbol size
     // as it is real and complex it is necessary to shift by a value equal to symbol size to obtain such shift
-    c32_t r2 = dot_product(pssTime[pss_source] + (ofdm_symbol_size >> 1),
-                           &(rxdata[0][peak_position]) + (ofdm_symbol_size >> 1),
-                           ofdm_symbol_size >> 1,
+    c32_t r2 = dot_product(pssTime[pss_source] + (p->ofdm_symbol_size >> 1),
+                           &p->rxdata[0][peak_position] + (p->ofdm_symbol_size >> 1),
+                           p->ofdm_symbol_size >> 1,
                            shift);
     cd_t r1d = {r1.r, r1.i}, r2d = {r2.r, r2.i};
     // estimation of fractional frequency offset: angle[(result1)'*(result2)]/pi
@@ -276,7 +266,7 @@ pss_detection_result_t pss_search_time_nr(const c16_t **rxdata,
   return (pss_detection_result_t){.success = true,
                                   .nid2 = pss_source,
                                   .pos = peak_position,
-                                  .freq_offset = ffo_est * subcarrier_spacing,
+                                  .freq_offset = ffo_est * p->subcarrier_spacing,
                                   .peak = dB_fixed64(peak_value),
                                   .avg = dB_fixed64(avg[pss_source])};
 }

--- a/openair1/PHY/NR_UE_TRANSPORT/pss_nr.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/pss_nr.c
@@ -84,23 +84,27 @@ void generate_pss_nr(const int N_ID_2, int16_t *pss)
   *
   * sample 0 is for continuous frequency which is used here
   */
-void generate_pss_nr_time(const NR_DL_FRAME_PARMS *fp, const int N_ID_2, int ssbFirstSCS, c16_t pssTime[fp->ofdm_symbol_size])
+void generate_pss_nr_time(int ofdm_symbol_size,
+                          int first_carrier_offset,
+                          const int N_ID_2,
+                          int ssbFirstSCS,
+                          c16_t pssTime[ofdm_symbol_size])
 {
   unsigned int subcarrier_start = get_softmodem_params()->sl_mode == 0 ? PSS_SSS_SUB_CARRIER_START : PSS_SSS_SUB_CARRIER_START_SL;
-  c16_t synchroF_tmp[fp->ofdm_symbol_size] __attribute__((aligned(32)));
+  c16_t synchroF_tmp[ofdm_symbol_size] __attribute__((aligned(32)));
   memset(synchroF_tmp, 0, sizeof(synchroF_tmp));
-  unsigned int k = fp->first_carrier_offset + ssbFirstSCS + subcarrier_start;
+  unsigned int k = first_carrier_offset + ssbFirstSCS + subcarrier_start;
   int16_t pss[LENGTH_PSS_NR];
   generate_pss_nr(N_ID_2, pss);
   for (int i=0; i < LENGTH_PSS_NR; i++) {
-    if (k >= fp->ofdm_symbol_size)
-      k -= fp->ofdm_symbol_size;
+    if (k >= ofdm_symbol_size)
+      k -= ofdm_symbol_size;
     synchroF_tmp[k] = (c16_t){.r = (pss[i] * SHRT_MAX) >> SCALING_PSS_NR}; /* Maximum value for type short int ie int16_t */
     k++;
   }
 
   /* IFFT will give temporal signal of Pss */
-  idft((int16_t)get_idft(fp->ofdm_symbol_size),
+  idft((int16_t)get_idft(ofdm_symbol_size),
        (int16_t *)synchroF_tmp, /* complex input but legacy type is wrong*/
        (int16_t *)pssTime, /* complex output */
        1); /* scaling factor */
@@ -119,9 +123,11 @@ void generate_pss_nr_time(const NR_DL_FRAME_PARMS *fp, const int N_ID_2, int ssb
 *********************************************************************/
 
 int pss_synchro_nr(const c16_t **rxdata,
-                   const NR_DL_FRAME_PARMS *frame_parms,
-                   const c16_t pssTime[NUMBER_PSS_SEQUENCE][frame_parms->ofdm_symbol_size],
-                   int is,
+                   int nb_ant,
+                   int ofdm_symbol_size,
+                   int rxdata_size,
+                   int subcarrier_spacing,
+                   const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
                    bool fo_flag,
                    int target_Nid_cell,
                    int *nid2,
@@ -130,8 +136,19 @@ int pss_synchro_nr(const c16_t **rxdata,
                    int *pssAvg)
 {
   start_meas(&generic_time[TIME_PSS]);
-  int synchro_position =
-      pss_search_time_nr(rxdata, frame_parms, pssTime, fo_flag, is, target_Nid_cell, nid2, f_off, pssPeak, pssAvg, -1, -1);
+  int synchro_position = pss_search_time_nr(rxdata,
+                                            ofdm_symbol_size,
+                                            nb_ant,
+                                            subcarrier_spacing,
+                                            pssTime,
+                                            fo_flag,
+                                            target_Nid_cell,
+                                            nid2,
+                                            f_off,
+                                            pssPeak,
+                                            pssAvg,
+                                            0,
+                                            rxdata_size - ofdm_symbol_size);
   stop_meas(&generic_time[TIME_PSS]);
 
 #if TEST_SYNCHRO_TIMING_PSS
@@ -196,10 +213,11 @@ int pss_synchro_nr(const c16_t **rxdata,
 *********************************************************************/
 
 int pss_search_time_nr(const c16_t **rxdata,
-                       const NR_DL_FRAME_PARMS *frame_parms,
-                       const c16_t pssTime[NUMBER_PSS_SEQUENCE][frame_parms->ofdm_symbol_size],
+                       int ofdm_symbol_size,
+                       int nb_antennas_rx,
+                       int subcarrier_spacing,
+                       const c16_t pssTime[NUMBER_PSS_SEQUENCE][ofdm_symbol_size],
                        bool fo_flag,
-                       int is,
                        int target_Nid_cell,
                        int *nid2,
                        int *f_off,
@@ -210,24 +228,13 @@ int pss_search_time_nr(const c16_t **rxdata,
 {
   // Determine search window
   unsigned int start, length;
-  if (search_start >= 0 && search_length > 0) {
-    // Use provided search window for known neighboring cells
-    start = search_start;
-    length = search_length;
-  } else {
-    // For initial cell search
-    start = 0;
-    if (is == 0)
-      length = frame_parms->samples_per_frame + (2 * frame_parms->ofdm_symbol_size);
-    else
-      length = frame_parms->samples_per_frame;
-  }
-
-  AssertFatal(length > 0, "illegal length %d\n", length);
+  // Use provided search window for known neighboring cells
+  start = search_start;
+  length = search_length;
   int maxval=0;
   int max_size = get_softmodem_params()->sl_mode == 0 ?  NUMBER_PSS_SEQUENCE : NUMBER_PSS_SEQUENCE_SL;
   for (int j = 0; j < max_size; j++)
-    for (int i = 0; i < frame_parms->ofdm_symbol_size; i++) {
+    for (int i = 0; i < ofdm_symbol_size; i++) {
       maxval = max(maxval, abs(pssTime[j][i].r));
       maxval = max(maxval, abs(pssTime[j][i].i));
     }
@@ -256,12 +263,9 @@ int pss_search_time_nr(const c16_t **rxdata,
       int64_t pss_corr_ue = 0;
       /* calculate dot product of primary_synchro_time_nr and rxdata[ar][n]
        * (ar=0..nb_ant_rx) and store the sum in temp[n]; */
-      for (int ar = 0; ar < frame_parms->nb_antennas_rx; ar++) {
+      for (int ar = 0; ar < nb_antennas_rx; ar++) {
         /* perform correlation of rx data and pss sequence ie it is a dot product */
-        const c32_t result = dot_product(pssTime[pss_index],
-                                         &rxdata[ar][n + is * frame_parms->samples_per_frame],
-                                         frame_parms->ofdm_symbol_size,
-                                         shift);
+        const c32_t result = dot_product(pssTime[pss_index], &rxdata[ar][n], ofdm_symbol_size, shift);
         const c64_t r64 = {.r = result.r, .i = result.i};
         pss_corr_ue += squaredMod(r64);
       }
@@ -274,7 +278,7 @@ int pss_search_time_nr(const c16_t **rxdata,
         pss_source = pss_index;
 
 #ifdef DEBUG_PSS_NR
-        printf("pss_index %d: n %6u peak_value %15llu\n", pss_index, n, (unsigned long long)pss_corr_ue[n]);
+        printf("pss_index %d: n %6u peak_value %lu\n", pss_index, n, pss_corr_ue);
 #endif
       }
     }
@@ -288,15 +292,12 @@ int pss_search_time_nr(const c16_t **rxdata,
     // International Conference on Communications and Networking in China, 2012.
 
     // Computing cross-correlation at peak on half the symbol size for first half of data
-    c32_t r1 = dot_product(pssTime[pss_source],
-                           &(rxdata[0][peak_position + is * frame_parms->samples_per_frame]),
-                           frame_parms->ofdm_symbol_size >> 1,
-                           shift);
+    c32_t r1 = dot_product(pssTime[pss_source], &(rxdata[0][peak_position]), ofdm_symbol_size >> 1, shift);
     // Computing cross-correlation at peak on half the symbol size for data shifted by half symbol size
     // as it is real and complex it is necessary to shift by a value equal to symbol size to obtain such shift
-    c32_t r2 = dot_product(pssTime[pss_source] + (frame_parms->ofdm_symbol_size >> 1),
-                           &(rxdata[0][peak_position + is * frame_parms->samples_per_frame]) + (frame_parms->ofdm_symbol_size >> 1),
-                           frame_parms->ofdm_symbol_size >> 1,
+    c32_t r2 = dot_product(pssTime[pss_source] + (ofdm_symbol_size >> 1),
+                           &(rxdata[0][peak_position]) + (ofdm_symbol_size >> 1),
+                           ofdm_symbol_size >> 1,
                            shift);
     cd_t r1d = {r1.r, r1.i}, r2d = {r2.r, r2.i};
     // estimation of fractional frequency offset: angle[(result1)'*(result2)]/pi
@@ -307,7 +308,7 @@ int pss_search_time_nr(const c16_t **rxdata,
 #endif
   }
   // computing absolute value of frequency offset
-  *f_off = ffo_est * frame_parms->subcarrier_spacing;
+  *f_off = ffo_est * subcarrier_spacing;
 
   *nid2 = pss_source;
   *pssPeak = dB_fixed64(peak_value);
@@ -329,10 +330,7 @@ int pss_search_time_nr(const c16_t **rxdata,
 #ifdef DBG_PSS_NR
   static int debug_cnt = 0;
   if (debug_cnt == 0) {
-    if (is)
-      LOG_M("rxdata1.m", "rxd0", rxdata[frame_parms->samples_per_frame], length, 1, 1);
-    else
-      LOG_M("rxdata0.m", "rxd0", rxdata[0], length, 1, 1);
+    LOG_M("rxdata0.m", "rxd0", rxdata[0], length, 1, 1);
   } else {
     debug_cnt++;
   }

--- a/openair1/PHY/NR_UE_TRANSPORT/sss_nr.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/sss_nr.c
@@ -46,9 +46,7 @@
 
 #define INITIAL_SSS_NR    (7)
 
-static int16_t d_sss[N_ID_2_NUMBER][N_ID_1_NUMBER][LENGTH_SSS_NR];
-
-void init_context_sss_nr(int amp)
+static void init_context_sss_nr(int amp, int16_t d_sss[N_ID_2_NUMBER][N_ID_1_NUMBER][LENGTH_SSS_NR])
 {
   int16_t x0[LENGTH_SSS_NR];
   int16_t x1[LENGTH_SSS_NR];
@@ -107,14 +105,14 @@ void init_context_sss_nr(int amp)
 *
 *********************************************************************/
 
-static void pss_ch_est_nr(const NR_DL_FRAME_PARMS *frame_parms,
-                         int nid2,
-                         c16_t pss_ext[frame_parms->nb_antennas_rx][LENGTH_PSS_NR],
-                         c16_t sss_ext[frame_parms->nb_antennas_rx][LENGTH_SSS_NR])
+static void pss_ch_est_nr(int nb_antennas_rx,
+                          int nid2,
+                          c16_t pss_ext[nb_antennas_rx][LENGTH_PSS_NR],
+                          c16_t sss_ext[nb_antennas_rx][LENGTH_SSS_NR])
 {
-  int16_t *pss = get_primary_synchro_nr2(nid2);
-
-  for (int aarx = 0; aarx < frame_parms->nb_antennas_rx; aarx++) {
+  int16_t pss[LENGTH_PSS_NR];
+  generate_pss_nr(nid2, pss);
+  for (int aarx = 0; aarx < nb_antennas_rx; aarx++) {
     c16_t *sss_ext2 = sss_ext[aarx];
     c16_t *pss_ext2 = pss_ext[aarx];
     for (int i = 0; i < LENGTH_PSS_NR; i++) {
@@ -201,6 +199,8 @@ bool rx_sss_nr(const NR_DL_FRAME_PARMS *frame_parms,
   c16_t pss_ext[frame_parms->nb_antennas_rx][LENGTH_PSS_NR];
   c16_t sss_ext[frame_parms->nb_antennas_rx][LENGTH_SSS_NR];
   const int Nid2 = GET_NID2(nid2);
+  int16_t d_sss[N_ID_2_NUMBER][N_ID_1_NUMBER][LENGTH_SSS_NR];
+  init_context_sss_nr(AMP, d_sss);
 
   // pss sss extraction
   pss_sss_extract_nr(frame_parms, pss_ext, sss_ext, ssb_start_subcarrier, rxdataF); /* subframe */
@@ -254,8 +254,8 @@ bool rx_sss_nr(const NR_DL_FRAME_PARMS *frame_parms,
 
 #ifdef DEBUG_SSS_NR
         LOG_D(PHY,
-              "(phase,Nid1) (%d,%d), metric_phase %d tot_metric %d, phase_max %d \n",
-              phase,
+              "(phase,Nid1) (%d,%d), metric_phase %ld tot_metric %d, phase_max %d \n",
+              *phase_max,
               n1,
               metric,
               *tot_metric,

--- a/openair1/PHY/NR_UE_TRANSPORT/sss_nr.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/sss_nr.c
@@ -141,31 +141,32 @@ static void pss_ch_est_nr(int nb_antennas_rx,
  *
  * DESCRIPTION : it allows extracting sss from samples buffer
  *
- *********************************************************************/
+ *********************************************************************
+ */
+
 static void pss_sss_extract_nr(
-    const NR_DL_FRAME_PARMS *frame_parms,
-    c16_t pss_ext[frame_parms->nb_antennas_rx][LENGTH_PSS_NR],
-    c16_t sss_ext[frame_parms->nb_antennas_rx][LENGTH_SSS_NR],
-    int ssb_start_subcarrier,
-    const c16_t rxdataF[NR_N_SYMBOLS_SSB][frame_parms->nb_antennas_rx]
-                       [frame_parms->ofdm_symbol_size]) // add flag to indicate extracting only PSS, only SSS, or both
+    nr_sss_params_t *params,
+    c16_t pss_ext[params->nb_antennas_rx][LENGTH_PSS_NR],
+    c16_t sss_ext[params->nb_antennas_rx][LENGTH_SSS_NR],
+    const c16_t rxdataF[NR_N_SYMBOLS_SSB][params->nb_antennas_rx]
+                       [params->ofdm_symbol_size]) // add flag to indicate extracting only PSS, only SSS, or both
 {
-  AssertFatal(frame_parms->nb_antennas_rx > 0, "nb antennas as sss_ext is not set to any value\n");
+  AssertFatal(params->nb_antennas_rx > 0, "nb antennas as sss_ext is not set to any value\n");
   const int pss_symbol = 0;
   const int sss_symbol =
       get_softmodem_params()->sl_mode == 0 ? (SSS_SYMBOL_NB - PSS_SYMBOL_NB) : (SSS0_SL_SYMBOL_NB - PSS0_SL_SYMBOL_NB);
 
-  for (int aarx = 0; aarx < frame_parms->nb_antennas_rx; aarx++) {
+  for (int aarx = 0; aarx < params->nb_antennas_rx; aarx++) {
     const c16_t *pss_rxF = rxdataF[pss_symbol][aarx];
     const c16_t *sss_rxF = rxdataF[sss_symbol][aarx];
     c16_t *pss_rxF_ext = pss_ext[aarx];
     c16_t *sss_rxF_ext = sss_ext[aarx];
-    unsigned int k = frame_parms->first_carrier_offset + ssb_start_subcarrier
+    unsigned int k = params->first_carrier_offset + params->ssb_start_subcarrier
                      + ((get_softmodem_params()->sl_mode == 0) ? PSS_SSS_SUB_CARRIER_START : PSS_SSS_SUB_CARRIER_START_SL);
 
     for (int i=0; i < LENGTH_PSS_NR; i++) {
-      if (k >= frame_parms->ofdm_symbol_size)
-        k -= frame_parms->ofdm_symbol_size;
+      if (k >= params->ofdm_symbol_size)
+        k -= params->ofdm_symbol_size;
       pss_rxF_ext[i] = pss_rxF[k];
       sss_rxF_ext[i] = sss_rxF[k];
       k++;
@@ -185,25 +186,23 @@ static void pss_sss_extract_nr(
  *                so Nid_cell in ue context is set according to Nid1 & Nid2
  *
  *********************************************************************/
-bool rx_sss_nr(const NR_DL_FRAME_PARMS *frame_parms,
+bool rx_sss_nr(nr_sss_params_t *params,
                int nid2,
                int target_Nid_cell,
                int freq_offset_pss,
-               int ssb_start_subcarrier,
                int *Nid_cell,
                int32_t *tot_metric,
                uint8_t *phase_max,
                int *freq_offset_sss,
-               c16_t rxdataF[NR_N_SYMBOLS_SSB][frame_parms->nb_antennas_rx][frame_parms->ofdm_symbol_size])
+               c16_t rxdataF[NR_N_SYMBOLS_SSB][params->nb_antennas_rx][params->ofdm_symbol_size])
 {
-  c16_t pss_ext[frame_parms->nb_antennas_rx][LENGTH_PSS_NR];
-  c16_t sss_ext[frame_parms->nb_antennas_rx][LENGTH_SSS_NR];
+  c16_t pss_ext[params->nb_antennas_rx][LENGTH_PSS_NR];
+  c16_t sss_ext[params->nb_antennas_rx][LENGTH_SSS_NR];
   const int Nid2 = GET_NID2(nid2);
   int16_t d_sss[N_ID_2_NUMBER][N_ID_1_NUMBER][LENGTH_SSS_NR];
   init_context_sss_nr(AMP, d_sss);
 
-  // pss sss extraction
-  pss_sss_extract_nr(frame_parms, pss_ext, sss_ext, ssb_start_subcarrier, rxdataF); /* subframe */
+  pss_sss_extract_nr(params, pss_ext, sss_ext, rxdataF); /* subframe */
 
 #ifdef DEBUG_PLOT_SSS
   write_output("rxsig0.m","rxs0",&ue->common_vars.rxdata[0][0],ue->frame_parms.samples_per_subframe,1,1);
@@ -214,7 +213,7 @@ bool rx_sss_nr(const NR_DL_FRAME_PARMS *frame_parms,
 
   // get conjugated channel estimate from PSS, H* = R* \cdot PSS
   // and do channel estimation and compensation based on PSS
-  pss_ch_est_nr(frame_parms, nid2, pss_ext, sss_ext);
+  pss_ch_est_nr(params->nb_antennas_rx, nid2, pss_ext, sss_ext);
 
   // now do the SSS detection based on the precomputed sequences in PHY/LTE_TRANSPORT/sss.h
   *tot_metric = INT_MIN;
@@ -288,18 +287,18 @@ bool rx_sss_nr(const NR_DL_FRAME_PARMS *frame_parms,
     sig_sum.i += d[i] * sss[i].i;
   }
   double ffo_sss = atan2(sig_sum.i, sig_sum.r) / M_PI / 4.3;
-  *freq_offset_sss = (int)(ffo_sss*frame_parms->subcarrier_spacing);
+  *freq_offset_sss = (int)(ffo_sss * params->subcarrier_spacing);
 
-  double ffo_pss = (double)freq_offset_pss / frame_parms->subcarrier_spacing;
+  double ffo_pss = (double)freq_offset_pss / params->subcarrier_spacing;
   LOG_D(NR_PHY,
         "SSS detected, PCI: %d, ffo_pss %f (%i Hz), ffo_sss %f (%i Hz),  ffo_pss+ffo_sss %f (%i Hz), nid1: %d, nid2: %d\n",
         *Nid_cell,
         ffo_pss,
-        (int)(ffo_pss * frame_parms->subcarrier_spacing),
+        (int)(ffo_pss * params->subcarrier_spacing),
         ffo_sss,
         *freq_offset_sss,
         ffo_pss + ffo_sss,
-        (int)((ffo_pss + ffo_sss) * frame_parms->subcarrier_spacing),
+        (int)((ffo_pss + ffo_sss) * params->subcarrier_spacing),
         Nid1,
         Nid2);
 

--- a/openair1/PHY/NR_UE_TRANSPORT/sss_nr.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/sss_nr.c
@@ -108,7 +108,8 @@ static void init_context_sss_nr(int amp, int16_t d_sss[N_ID_2_NUMBER][N_ID_1_NUM
 static void pss_ch_est_nr(int nb_antennas_rx,
                           int nid2,
                           c16_t pss_ext[nb_antennas_rx][LENGTH_PSS_NR],
-                          c16_t sss_ext[nb_antennas_rx][LENGTH_SSS_NR])
+                          c16_t sss_ext[nb_antennas_rx][LENGTH_SSS_NR],
+                          c16_t sss_comp[LENGTH_SSS_NR])
 {
   int16_t pss[LENGTH_PSS_NR];
   generate_pss_nr(nid2, pss);
@@ -122,13 +123,9 @@ static void pss_ch_est_nr(int nb_antennas_rx,
       const int shift = log2_approx(amp) / 2;
       // This is R(SSS) \cdot H*(PSS)
       const c16_t new_sss = c16mulShift(tmp, sss_ext2[i], shift);
-      if (aarx == 0)
-        sss_ext2[i] = new_sss;
-      else
-        sss_ext2[i] = c16add(sss_ext2[i], new_sss);
+      sss_comp[i] = c16add(sss_comp[i], new_sss);
     }
   }
-  // sss_ext[0] now contains the compensated SSS
 }
 
 /*******************************************************************
@@ -186,19 +183,14 @@ static void pss_sss_extract_nr(
  *                so Nid_cell in ue context is set according to Nid1 & Nid2
  *
  *********************************************************************/
-bool rx_sss_nr(nr_sss_params_t *params,
-               int nid2,
-               int target_Nid_cell,
-               int freq_offset_pss,
-               int *Nid_cell,
-               int32_t *tot_metric,
-               uint8_t *phase_max,
-               int *freq_offset_sss,
-               c16_t rxdataF[NR_N_SYMBOLS_SSB][params->nb_antennas_rx][params->ofdm_symbol_size])
+sss_detection_result_t rx_sss_nr(nr_sss_params_t *params,
+                                 pss_detection_result_t *pss,
+                                 int target_Nid_cell,
+                                 c16_t rxdataF[NR_N_SYMBOLS_SSB][params->nb_antennas_rx][params->ofdm_symbol_size])
 {
   c16_t pss_ext[params->nb_antennas_rx][LENGTH_PSS_NR];
   c16_t sss_ext[params->nb_antennas_rx][LENGTH_SSS_NR];
-  const int Nid2 = GET_NID2(nid2);
+  const int Nid2 = GET_NID2(pss->nid2);
   int16_t d_sss[N_ID_2_NUMBER][N_ID_1_NUMBER][LENGTH_SSS_NR];
   init_context_sss_nr(AMP, d_sss);
 
@@ -213,12 +205,11 @@ bool rx_sss_nr(nr_sss_params_t *params,
 
   // get conjugated channel estimate from PSS, H* = R* \cdot PSS
   // and do channel estimation and compensation based on PSS
-  pss_ch_est_nr(params->nb_antennas_rx, nid2, pss_ext, sss_ext);
+  c16_t sss_comp[LENGTH_SSS_NR] = {};
+  pss_ch_est_nr(params->nb_antennas_rx, pss->nid2, pss_ext, sss_ext, sss_comp);
 
   // now do the SSS detection based on the precomputed sequences in PHY/LTE_TRANSPORT/sss.h
-  *tot_metric = INT_MIN;
-
-  c16_t *sss = sss_ext[0];
+  sss_detection_result_t res = {.metric = -INT_MAX};
 
   /* for phase evaluation, one uses an array of possible phase shifts */
   /* then a correlation is done between received signal with a shift pĥase and the reference signal */
@@ -229,8 +220,12 @@ bool rx_sss_nr(nr_sss_params_t *params,
   int Nid1_start = 0;
   int Nid1_end = N_ID_1_NUMBER;
   if (target_Nid_cell != -1) {
-    Nid1_start = GET_NID1(target_Nid_cell);
-    Nid1_end = Nid1_start + 1;
+    if (GET_NID1(target_Nid_cell) != pss->nid2) {
+      LOG_E(PHY, "calling sss detection with incoherent context %d, %d\n", pss->nid2, target_Nid_cell);
+    } else {
+      Nid1_start = GET_NID1(target_Nid_cell);
+      Nid1_end = Nid1_start + 1;
+    }
   }
 
   const int phase_to_try[] = {0, 2, -2, 4, -4, 6, -6, 8, -8, 10, -10, 12, -12, 14, -14};
@@ -242,67 +237,68 @@ bool rx_sss_nr(nr_sss_params_t *params,
       int16_t *d = d_sss[Nid2][n1];
       for (int i = 0; i < LENGTH_SSS_NR; i++) {
         // metric is only real part because sss is a pure real signal (imaginary is 0)
-        metric += d[i] * (rot.r * sss[i].r - rot.i * sss[i].i);
+        metric += d[i] * (rot.r * sss_comp[i].r - rot.i * sss_comp[i].i);
       }
       metric >>= SCALING_METRIC_SSS_NR;
       // if the current metric is better than the last save it
-      if (metric > *tot_metric) {
-        *tot_metric = metric;
-        *Nid_cell = Nid2 + (3 * n1);
-        *phase_max = idx;
+      if (metric > res.metric) {
+        res.metric = metric;
+        res.nid_cell = Nid2 + 3 * n1;
+        res.phase = idx;
 
 #ifdef DEBUG_SSS_NR
         LOG_D(PHY,
-              "(phase,Nid1) (%d,%d), metric_phase %ld tot_metric %d, phase_max %d \n",
-              *phase_max,
+              "(phase,Nid1) (%d,%d), metric_phase %ld metric %d, phase_max %d \n",
+              res.phase,
               n1,
               metric,
-              *tot_metric,
-              *phase_max);
+              res.metric,
+              res.phase);
 #endif
       }
     }
     // we try progressively rotation between pss and sss
     // but pss and sss are in phase at emission
     // rotation means doppler variation, or very noisy pss detection
-    if (*tot_metric >= SSS_METRIC_FLOOR_NR)
+    if (res.metric >= SSS_METRIC_FLOOR_NR)
       break;
   }
 
-  if (*tot_metric < SSS_METRIC_FLOOR_NR) {
+  if (res.metric < SSS_METRIC_FLOOR_NR) {
     LOG_D(PHY,
           "Failed to detect SSS after PSS, metric of SSS %d, threshold to consider SSS valid %d, detected PCI: %d\n",
-          *tot_metric,
+          res.metric,
           SSS_METRIC_FLOOR_NR,
-          *Nid_cell);
-    return false;
-  }
+          res.nid_cell);
+    res.success = false;
+    return res;
+  } else
+    res.success = true;
 
-  int Nid1 = GET_NID1(*Nid_cell);
-  LOG_D(PHY, "Nid2 %d Nid1 %d tot_metric %d, phase_max %d \n", Nid2, Nid1, *tot_metric, *phase_max);
+  int Nid1 = GET_NID1(res.nid_cell);
+  LOG_D(PHY, "Nid2 %d Nid1 %d metric %d, phase_max %d \n", Nid2, Nid1, res.metric, res.phase);
   int16_t *d = d_sss[Nid2][Nid1];
   c32_t sig_sum = {};
   for (int i = 0; i < LENGTH_SSS_NR; i++) {
-    sig_sum.r += d[i] * sss[i].r;
-    sig_sum.i += d[i] * sss[i].i;
+    sig_sum.r += d[i] * sss_comp[i].r;
+    sig_sum.i += d[i] * sss_comp[i].i;
   }
   double ffo_sss = atan2(sig_sum.i, sig_sum.r) / M_PI / 4.3;
-  *freq_offset_sss = (int)(ffo_sss * params->subcarrier_spacing);
+  res.freq_offset = (int)(ffo_sss * params->subcarrier_spacing);
 
-  double ffo_pss = (double)freq_offset_pss / params->subcarrier_spacing;
+  double ffo_pss = (double)pss->freq_offset / params->subcarrier_spacing;
   LOG_D(NR_PHY,
         "SSS detected, PCI: %d, ffo_pss %f (%i Hz), ffo_sss %f (%i Hz),  ffo_pss+ffo_sss %f (%i Hz), nid1: %d, nid2: %d\n",
-        *Nid_cell,
+        res.nid_cell,
         ffo_pss,
         (int)(ffo_pss * params->subcarrier_spacing),
         ffo_sss,
-        *freq_offset_sss,
+        res.freq_offset,
         ffo_pss + ffo_sss,
         (int)((ffo_pss + ffo_sss) * params->subcarrier_spacing),
         Nid1,
         Nid2);
-
-  return true;
+  return res;
 }
 
 void sl_generate_sss(SL_NR_UE_INIT_PARAMS_t *sl_init_params, uint16_t slss_id, uint16_t scaling)

--- a/openair1/PHY/TOOLS/tests/benchmark_rotate_vector.cpp
+++ b/openair1/PHY/TOOLS/tests/benchmark_rotate_vector.cpp
@@ -33,7 +33,7 @@ static void BM_rotate_cpx_vector(benchmark::State &state)
   output.resize(vector_size);
   int shift = 2;
   for (auto _ : state) {
-    rotate_cpx_vector(input_complex_16.data(), input_alpha.data(), output.data(), vector_size, shift);
+    rotate_cpx_vector(input_complex_16.data(), input_alpha.data()[0], output.data(), vector_size, shift);
   }
 }
 

--- a/openair1/PHY/TOOLS/tools_defs.h
+++ b/openair1/PHY/TOOLS/tools_defs.h
@@ -702,18 +702,18 @@ static inline idft_size_idx_t get_idft(int size)
   return IDFT_SIZE_IDXTABLESIZE; // never reached and will trigger assertion in idft function
 }
 
-
-/*!\fn int32_t rotate_cpx_vector(c16_t *x,c16_t *alpha,c16_t *y,uint32_t N,uint16_t output_shift)
+/*!\fn int32_t rotate_cpx_vector(c16_t *x,c16_t alpha,c16_t *y,uint32_t N,uint16_t output_shift)
 This function performs componentwise multiplication of a vector with a complex scalar.
 @param x Vector input (Q1.15)  in the format  |Re0  Im0|,......,|Re(N-1) Im(N-1)|
 @param alpha Scalar input (Q1.15) in the format  |Re0 Im0|
 @param y Output (Q1.15) in the format  |Re0  Im0|,......,|Re(N-1) Im(N-1)|
 @param N Length of x WARNING: N>=4
-@param output_shift Number of bits to shift output down to Q1.15 (should be 15 for Q1.15 inputs) WARNING: log2_amp>0 can cause overflow!!
+@param output_shift Number of bits to shift output down to Q1.15 (should be 15 for Q1.15 inputs) WARNING: log2_amp>0 can cause
+overflow!!
 
 The function implemented is : \f$\mathbf{y} = \alpha\mathbf{x}\f$
 */
-static inline void rotate_cpx_vector(const c16_t *const x, const c16_t *const alpha, c16_t *y, uint32_t N, uint16_t output_shift)
+static inline void rotate_cpx_vector(const c16_t *const x, const c16_t alpha, c16_t *y, uint32_t N, uint16_t output_shift)
 {
   // multiply a complex vector with a complex value (alpha)
   // stores result in y
@@ -723,9 +723,9 @@ static inline void rotate_cpx_vector(const c16_t *const x, const c16_t *const al
   if (__builtin_cpu_supports("avx2")) {
     // output is 32 bytes aligned, but not the input
 
-    const c16_t for_re = {alpha->r, (int16_t)-alpha->i};
+    const c16_t for_re = {alpha.r, (int16_t)-alpha.i};
     const simde__m256i alpha_for_real = simde_mm256_set1_epi32(*(uint32_t *)&for_re);
-    const c16_t for_im = {alpha->i, alpha->r};
+    const c16_t for_im = {alpha.i, alpha.r};
     const simde__m256i alpha_for_im = simde_mm256_set1_epi32(*(uint32_t *)&for_im);
     const simde__m256i perm_mask = simde_mm256_set_epi8(31,
                                                         30,
@@ -769,10 +769,10 @@ static inline void rotate_cpx_vector(const c16_t *const x, const c16_t *const al
       const simde__m256i tmp = simde_mm256_packs_epi32(xre, xim);
       simde_mm256_storeu_si256(yd, simde_mm256_shuffle_epi8(tmp, perm_mask));
     }
-    c16_t *alpha16 = (c16_t *)alpha, *yLast;
+    c16_t *yLast;
     yLast = ((c16_t *)y) + (N / 8) * 8;
     for (c16_t *xTail = (c16_t *)end; xTail < ((c16_t *)x) + N; xTail++, yLast++) {
-      *yLast = c16mulShift(*xTail, *alpha16, output_shift);
+      *yLast = c16mulShift(*xTail, alpha, output_shift);
     }
   } else {
 #endif
@@ -794,8 +794,8 @@ static inline void rotate_cpx_vector(const c16_t *const x, const c16_t *const al
 #ifdef __aarch64__
     if (output_shift == 15) { // allows specific NEON instruction
 
-      int16x8_t ar = (int16x8_t)vdupq_n_s16(alpha->r);
-      int16x8_t ai = (int16x8_t)vdupq_n_s16(alpha->i);
+      int16x8_t ar = (int16x8_t)vdupq_n_s16(alpha.r);
+      int16x8_t ai = (int16x8_t)vdupq_n_s16(alpha.i);
       int16x8_t *y_128 = (int16x8_t *)y;
       int16x8_t *x_128 = (int16x8_t *)x;
       for (uint32_t i = 0; i < (N >> 2); i++) {
@@ -853,14 +853,14 @@ static inline void rotate_cpx_vector(const c16_t *const x, const c16_t *const al
 
     simde__m128i shift = simde_mm_cvtsi32_si128(output_shift);
 
-    ((int16_t *)&alpha_128)[0] = alpha->r;
-    ((int16_t *)&alpha_128)[1] = -alpha->i;
-    ((int16_t *)&alpha_128)[2] = alpha->i;
-    ((int16_t *)&alpha_128)[3] = alpha->r;
-    ((int16_t *)&alpha_128)[4] = alpha->r;
-    ((int16_t *)&alpha_128)[5] = -alpha->i;
-    ((int16_t *)&alpha_128)[6] = alpha->i;
-    ((int16_t *)&alpha_128)[7] = alpha->r;
+    ((int16_t *)&alpha_128)[0] = alpha.r;
+    ((int16_t *)&alpha_128)[1] = (int16_t)-alpha.i;
+    ((int16_t *)&alpha_128)[2] = alpha.i;
+    ((int16_t *)&alpha_128)[3] = alpha.r;
+    ((int16_t *)&alpha_128)[4] = alpha.r;
+    ((int16_t *)&alpha_128)[5] =  (int16_t)-alpha.i;
+    ((int16_t *)&alpha_128)[6] = alpha.i;
+    ((int16_t *)&alpha_128)[7] = alpha.r;
     y_128 = (simd_q15_t *)y;
 
     for (i = 0; i < N >> 2; i++) {

--- a/openair1/PHY/defs_nr_UE.h
+++ b/openair1/PHY/defs_nr_UE.h
@@ -486,6 +486,15 @@ typedef struct {
   task_ans_t *ans;
 } nr_ue_ssb_scan_t;
 
+typedef struct {
+  bool success;
+  int pos;
+  int nid2;
+  int freq_offset; // PSS frequency offset estimate
+  int peak; // PSS correlation peak power
+  int avg; // PSS correlation average power
+} pss_detection_result_t;
+
 // Common SSB search parameters - used by both initial sync and neighbor cell search
 typedef struct {
   uint64_t dl_CarrierFreq;
@@ -513,14 +522,11 @@ typedef struct {
   void *rxdataF; // Pre-allocated rxdataF buffer
   void *pssTime; // Pre-generated PSS time sequences
   // Output parameters
+  pss_detection_result_t pss_res;
   int *detected_nid_cell; // detected PCI
-  int *ssb_offset; // SSB offset in samples
   int32_t *sss_metric; // SSS detection metric
-  int *freq_offset_pss; // PSS frequency offset estimate
   int *freq_offset_sss; // SSS frequency offset estimate
   uint8_t *sss_phase; // SSS phase
-  int *pss_peak; // PSS correlation peak power
-  int *pss_avg; // PSS correlation average power
 } nr_ssb_search_params_t;
 
 typedef struct nr_phy_data_tx_s {

--- a/openair1/PHY/defs_nr_UE.h
+++ b/openair1/PHY/defs_nr_UE.h
@@ -495,6 +495,14 @@ typedef struct {
   int avg; // PSS correlation average power
 } pss_detection_result_t;
 
+typedef struct {
+  bool success;
+  int nid_cell; // detected PCI
+  int32_t metric; // SSS detection metric
+  int freq_offset; // SSS frequency offset estimate
+  int phase; // SSS phase
+} sss_detection_result_t;
+
 // Common SSB search parameters - used by both initial sync and neighbor cell search
 typedef struct {
   uint64_t dl_CarrierFreq;
@@ -523,10 +531,7 @@ typedef struct {
   void *pssTime; // Pre-generated PSS time sequences
   // Output parameters
   pss_detection_result_t pss_res;
-  int *detected_nid_cell; // detected PCI
-  int32_t *sss_metric; // SSS detection metric
-  int *freq_offset_sss; // SSS frequency offset estimate
-  uint8_t *sss_phase; // SSS phase
+  sss_detection_result_t sss_res;
 } nr_ssb_search_params_t;
 
 typedef struct nr_phy_data_tx_s {

--- a/openair1/PHY/defs_nr_UE.h
+++ b/openair1/PHY/defs_nr_UE.h
@@ -468,6 +468,7 @@ typedef struct {
   int foFlag;
   int targetNidCell;
   c16_t **rxdata;
+  int rxdata_sz;
   NR_DL_FRAME_PARMS *fp;
   UE_nr_rxtx_proc_t *proc;
   int nFrames;
@@ -487,14 +488,27 @@ typedef struct {
 
 // Common SSB search parameters - used by both initial sync and neighbor cell search
 typedef struct {
-  const NR_DL_FRAME_PARMS *frame_parms;
-  c16_t **rxdata;
+  uint64_t dl_CarrierFreq;
+  uint sampling_rate;
+  int slots_per_frame;
+  int slots_per_subframe;
+  int numerology_index;
+  int ofdm_symbol_size;
+  uint ofdm_offset_divisor;
+  int nb_antennas_rx;
+  int symbols_per_slot;
+  int first_carrier_offset;
+  int N_RB_DL;
   uint32_t rxdata_size;
+  c16_t **rxdata;
+  int nb_prefix_samples;
+  int nb_prefix_samples0;
   int ssb_start_subcarrier;
+  int subcarrier_spacing;
+  int samples_per_slot_wCP;
   int target_nid_cell; // -1 for blind search, specific PCI for targeted search
   int exclude_nid_cell; // -1 for no exclusion, or serving cell PCI to exclude
   bool apply_freq_offset; // whether to compensate frequency offset
-  int search_frame_id; // Frame index to search (0, 1, 2...) within rxdata buffer
   bool fo_flag; // frequency offset estimation flag for pss_synchro_nr()
   void *rxdataF; // Pre-allocated rxdataF buffer
   void *pssTime; // Pre-generated PSS time sequences

--- a/openair1/PHY/nr_phy_common/src/nr_phy_common.c
+++ b/openair1/PHY/nr_phy_common/src/nr_phy_common.c
@@ -448,7 +448,7 @@ void nr_fo_compensation(double fo_Hz, int samples_per_ms, int sample_offset, con
   const c16_t rot_vec = get_sin_cos(CHUNK * phase_inc);
   while (size > CHUNK) {
     mult_complex_vectors(rxdata_in, rot, rxdata_out, CHUNK, 14);
-    rotate_cpx_vector(rot, &rot_vec, rot, CHUNK, 14);
+    rotate_cpx_vector(rot, rot_vec, rot, CHUNK, 14);
     rxdata_in += CHUNK;
     rxdata_out += CHUNK;
     size -= CHUNK;

--- a/openair1/SIMULATION/NR_PHY/psbchsim.c
+++ b/openair1/SIMULATION/NR_PHY/psbchsim.c
@@ -213,7 +213,7 @@ static void configure_SL_UE(PHY_VARS_NR_UE *UE, int mu, int N_RB, int ssb_offset
                           fp->numerology_index,
                           fp->sl_CarrierFreq,
                           fp->symbol_rotation[link_type_sl]);
-  init_timeshift_rotation(fp);
+  init_timeshift_rotation(fp->ofdm_symbol_size, fp->nb_prefix_samples, fp->ofdm_offset_divisor, fp->timeshift_symbol_rotation);
   LOG_I(PHY, "Dumping Sidelink Frame Parameters\n");
   nr_dump_frame_parms(fp);
 }

--- a/openair1/SIMULATION/NR_PHY/psbchsim.c
+++ b/openair1/SIMULATION/NR_PHY/psbchsim.c
@@ -209,7 +209,10 @@ static void configure_SL_UE(PHY_VARS_NR_UE *UE, int mu, int N_RB, int ssb_offset
 
   sl_init_frame_parameters(UE);
   sl_ue_phy_init(UE);
-  perform_symbol_rotation(fp, fp->sl_CarrierFreq, fp->symbol_rotation[link_type_sl]);
+  perform_symbol_rotation(fp->symbols_per_slot * fp->slots_per_frame / 10,
+                          fp->numerology_index,
+                          fp->sl_CarrierFreq,
+                          fp->symbol_rotation[link_type_sl]);
   init_timeshift_rotation(fp);
   LOG_I(PHY, "Dumping Sidelink Frame Parameters\n");
   nr_dump_frame_parms(fp);

--- a/openair2/RRC/NR/tests/CMakeLists.txt
+++ b/openair2/RRC/NR/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(rrc_bearers_test rrc_bearers_test.c ../rrc_gNB_radio_bearers.c ${
 add_dependencies(tests rrc_bearers_test)
 add_test(NAME rrc_bearers_test COMMAND rrc_bearers_test)
 target_include_directories(rrc_bearers_test PRIVATE ./common/utils/ds common/utils/LOG)
-target_link_libraries(rrc_bearers_test PRIVATE ds alg asn1_e1ap asn1_lte_rrc_hdrs asn1_nr_rrc_hdrs LOG T)
+target_link_libraries(rrc_bearers_test PRIVATE ds alg asn1_e1ap asn1_lte_rrc_hdrs asn1_nr_rrc_hdrs LOG ${T_LIB})
 target_compile_definitions(rrc_bearers_test PRIVATE ENABLE_TESTS)
 
 add_executable(rrc_cell_management_test rrc_cell_management_test.c)


### PR DESCRIPTION
PSS/SSS detection in the UE code uses a global structure that describe the cell parameters  
it is not logical because we will populate this information from what we read in the MIB and the SIB1 later  
it also blocks us to make a cell scanner in a logical manner, just calling pss detection function with a set of detection parameters and a buffer of digital radio

this MR fixes this and simplifies the code.

This work has already been reviewed in and migrated from https://gitlab.eurecom.fr/oai/openairinterface5g/-/merge_requests/4104/.