### PR TITLE
Add new config files for n101 (tested), n100 (tested), n1 (untested), n28 (untested), n48 (untested)

### DIFF
--- a/ci-scripts/conf_files/gnb.sa.band100.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/gnb.sa.band100.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -1,0 +1,209 @@
+###############################################################################
+# OAI gNB SA — Band n100 (FRMCS/RMR 900), FDD, 5 MHz, 25 PRB, SCS 15 kHz
+# Verkabelung: gNB TX/RX --30dB--> Modul ANT4 (DL 922)   [DIP: RX getrennt]
+#              Modul ANT0 --30dB--> gNB RX2   (UL 877)
+# WICHTIG: set_rx_antenna("TX/RX")-Patch in usrp_lib.cpp DEAKTIVIEREN
+#          (FDD-RX muss auf RX2-Default laufen) + Rebuild!
+#
+# Frequenzplan (verifiziert):
+#   DL-Carrier 919.750–924.250 MHz (Center 922.000), PointA-ARFCN 183950
+#   UL-Carrier 874.750–879.250 MHz (Center 877.000), PointA-ARFCN 174950, Duplex 45 MHz
+#   SSB: GSCN 2305 = 921.850 MHz = ARFCN 184370 (M=5 — einzige Klasse mit
+#        ganzzahligem k_SSB bei diesem PointA!) -> offsetToPointA 1, k_SSB 8
+#   CORESET#0: Tab. 13-1 Index 0 (24 RB, 2 Symb, Offset 0) -> CRB 1..24, passt exakt
+#   Erwartete gNB-Logzeile nach Start:
+#   "ssbOffsetPointA 1 SSB SsbSubcarrierOffset 8 prb_offset 1 sc_offset 8 scs 0 ssb_start_subcarrier 20"
+#
+# GSCN 2305 bitte einmal gegen TS 38.101-1 Tab. 5.4.3.3-1 (n100-Range) pruefen.
+###############################################################################
+
+Active_gNBs = ( "gNB-FRMCS-n100" );
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    = 0xe00;
+    gNB_name  = "gNB-FRMCS-n100";
+
+    tracking_area_code = 1;
+    plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345679L;          # bewusst != n101-Zelle (12345678)
+
+    ////////// Physical parameters:
+    min_rxtxtime = 6;
+    sib1_tda = 15;
+
+    servingCellConfigCommon = (
+    {
+      physCellId                                              = 0;
+
+      ########## downlinkConfigCommon / frequencyInfoDL
+      # SSB: GSCN 2305, 921.850 MHz (M=5 -> k_SSB = 8, ganzzahlig)
+      absoluteFrequencySSB                                    = 184370;
+      dl_frequencyBand                                        = 100;
+      # PointA = Carrier-Unterkante 919.750 MHz
+      dl_absoluteFrequencyPointA                              = 183950;
+      # scs-SpecificCarrierList
+      dl_offstToCarrier                                       = 0;
+      # subcarrierSpacing: 0 = 15 kHz
+      dl_subcarrierSpacing                                    = 0;
+      dl_carrierBandwidth                                     = 25;
+
+      # initialDownlinkBWP — RIV: Start 0, Laenge 25 -> 275*24+0
+      initialDLBWPlocationAndBandwidth                        = 6600;
+      initialDLBWPsubcarrierSpacing                           = 0;
+      # pdcch-ConfigCommon: Tab. 13-1 Index 0 -> 24 RB / 2 Symbole / Offset 0
+      initialDLBWPcontrolResourceSetZero                      = 0;
+      initialDLBWPsearchSpaceZero                             = 0;
+
+      ########## uplinkConfigCommon / frequencyInfoUL
+      ul_frequencyBand                                        = 100;
+      # UL-PointA 874.750 MHz, Duplexabstand 45 MHz
+      ul_absoluteFrequencyPointA                              = 174950;
+      ul_offstToCarrier                                       = 0;
+      ul_subcarrierSpacing                                    = 0;
+      ul_carrierBandwidth                                     = 25;
+      pMax                                                    = 20;
+      initialULBWPlocationAndBandwidth                        = 6600;
+      initialULBWPsubcarrierSpacing                           = 0;
+
+      ########## rach-ConfigCommon
+      # FDD/paired spectrum: Tab. 6.3.3.2-2 Index 16 = Preamble-Format 0
+      # (lang, L=839, 1.25 kHz — Klassiker fuer FDD; ~6 RB im UL)
+      prach_ConfigurationIndex                                = 17;
+      # 0 = one
+      prach_msg1_FDM                                          = 0;
+      prach_msg1_FrequencyStart                               = 0;
+      zeroCorrelationZoneConfig                               = 12;
+      preambleReceivedTargetPower                             = -96;
+      # (0..10) = (3,4,5,6,7,8,10,20,50,100,200)
+      preambleTransMax                                        = 6;
+      # 0=dB0, 1=dB2, 2=dB4, 3=dB6
+      powerRampingStep                                        = 1;
+      # 1,2,4,8,10,20,40,80
+      ra_ResponseWindow                                       = 4;
+      # 1=1/8, 2=1/4, 3=1/2, 4=one, 5=two, 6=four, 7=eight, 8=sixteen
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR            = 4;
+      # bei "one": (0..15) -> 4,8,...,60,64 ; 14 = n60
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB               = 14;
+      # (0..7) -> sf 8,16,24,32,40,48,56,64
+      ra_ContentionResolutionTimer                            = 7;
+      rsrp_ThresholdSSB                                       = 19;
+      # 1 = l839 (Format 0), 2 = l139
+      prach_RootSequenceIndex_PR                              = 1;
+      prach_RootSequenceIndex                                 = 1;
+      # msg1_SubcarrierSpacing entfaellt bei Format 0 (lange Praeambel, 1.25 kHz fest)
+
+      ########## pusch-ConfigCommon
+      msg3_DeltaPreamble                                      = 1;
+      p0_NominalWithGrant                                     = -90;
+
+      ########## pucch-ConfigCommon
+      # 0 = neither
+      pucchGroupHopping                                       = 0;
+      hoppingId                                               = 40;
+      p0_nominal                                              = -90;
+
+      ########## SSB
+      ssb_PositionsInBurst_Bitmap                             = 1;
+      # 0=ms5, 1=ms10, 2=ms20, ...
+      ssb_periodicityServingCell                              = 2;
+
+      # 0 = pos2
+      dmrs_TypeA_Position                                     = 0;
+
+      # subcarrierSpacing (common): 0 = 15 kHz
+      subcarrierSpacing                                       = 0;
+
+      ### KEIN tdd-UL-DL-ConfigurationCommon — FDD! ###
+
+      ssPBCH_BlockPower                                       = -25;
+    }
+    );
+
+    # ------- SCTP definitions
+    SCTP : { SCTP_INSTREAMS = 2; SCTP_OUTSTREAMS = 2; };
+
+    ####### AMF / Netz — 1:1 aus eurer funktionierenden band101-Conf uebernehmen
+    amf_ip_address = ({ ipv4 = "192.168.70.132"; });
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF = "192.168.70.129";
+        GNB_IPV4_ADDRESS_FOR_NGU    = "192.168.70.129";
+        GNB_PORT_FOR_S1U            = 2152;
+    };
+  }
+);
+
+MACRLCs = (
+{
+  num_cc           = 1;
+  tr_s_preference  = "local_L1";
+  tr_n_preference  = "local_RRC";
+  pusch_TargetSNRx10 = 200;
+  pucch_TargetSNRx10 = 200;
+}
+);
+
+L1s = (
+{
+  num_cc = 1;
+  tr_n_preference       = "local_mac";
+  prach_dtx_threshold   = 120;
+  pucch0_dtx_threshold  = 100;
+  ofdm_offset_divisor   = 8;
+}
+);
+
+RUs = (
+{
+  local_rf       = "yes";
+  nb_tx          = 1;
+  nb_rx          = 1;
+  att_tx         = 12;
+  att_rx         = 12;
+  bands          = [100];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain     = 114;
+  eNB_instances  = [0];
+  # FDD: TX auf TX/RX-Port (922 MHz), RX auf RX2 (877 MHz) — RX2 ist UHD-Default,
+  # daher KEIN set_rx_antenna-Patch aktiv lassen!
+  #clock_src = "internal";
+}
+);
+
+THREAD_STRUCT = (
+{ parallel_config = "PARALLEL_SINGLE_THREAD"; worker_config = "WORKER_ENABLE"; }
+);
+
+rfsimulator : {
+  serveraddr = "server";
+  serverport = 4043;
+  options    = ();
+  modelname  = "AWGN";
+  IQfile     = "/tmp/rfsimulator.iqs";
+};
+
+security = {
+  ciphering_algorithms = ( "nea0" );
+  integrity_algorithms = ( "nia2", "nia0" );
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config : {
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};
+

--- a/ci-scripts/conf_files/gnb.sa.band100.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/gnb.sa.band100.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -1,16 +1,16 @@
 ###############################################################################
 # OAI gNB SA — Band n100 (FRMCS/RMR 900), FDD, 5 MHz, 25 PRB, SCS 15 kHz
-# Verkabelung: gNB TX/RX --30dB--> Modul ANT4 (DL 922)   [DIP: RX getrennt]
-#              Modul ANT0 --30dB--> gNB RX2   (UL 877)
-# WICHTIG: set_rx_antenna("TX/RX")-Patch in usrp_lib.cpp DEAKTIVIEREN
-#          (FDD-RX muss auf RX2-Default laufen) + Rebuild!
+# Cabling: gNB TX/RX --30dB--> module ANT4 (DL 922)   [DIP: RX separated]
+#           module ANT0 --30dB--> gNB RX2   (UL 877)
+# IMPORTANT: DISABLE the set_rx_antenna("TX/RX") patch in usrp_lib.cpp
+#            (FDD RX must use the RX2 default) + rebuild!
 #
 # Frequenzplan (verifiziert):
 #   DL-Carrier 919.750–924.250 MHz (Center 922.000), PointA-ARFCN 183950
 #   UL-Carrier 874.750–879.250 MHz (Center 877.000), PointA-ARFCN 174950, Duplex 45 MHz
-#   SSB: GSCN 2305 = 921.850 MHz = ARFCN 184370 (M=5 — einzige Klasse mit
+#   SSB: GSCN 2305 = 921.850 MHz = ARFCN 184370 (M=5 - the only class with
 #        ganzzahligem k_SSB bei diesem PointA!) -> offsetToPointA 1, k_SSB 8
-#   CORESET#0: Tab. 13-1 Index 0 (24 RB, 2 Symb, Offset 0) -> CRB 1..24, passt exakt
+#   CORESET#0: Tab. 13-1 index 0 (24 RB, 2 symbols, offset 0) -> CRB 1..24, fits exactly
 #   Erwartete gNB-Logzeile nach Start:
 #   "ssbOffsetPointA 1 SSB SsbSubcarrierOffset 8 prb_offset 1 sc_offset 8 scs 0 ssb_start_subcarrier 20"
 #
@@ -44,7 +44,7 @@ gNBs =
       # SSB: GSCN 2305, 921.850 MHz (M=5 -> k_SSB = 8, ganzzahlig)
       absoluteFrequencySSB                                    = 184370;
       dl_frequencyBand                                        = 100;
-      # PointA = Carrier-Unterkante 919.750 MHz
+      # PointA = carrier lower edge 919.750 MHz
       dl_absoluteFrequencyPointA                              = 183950;
       # scs-SpecificCarrierList
       dl_offstToCarrier                                       = 0;
@@ -72,7 +72,7 @@ gNBs =
 
       ########## rach-ConfigCommon
       # FDD/paired spectrum: Tab. 6.3.3.2-2 Index 16 = Preamble-Format 0
-      # (lang, L=839, 1.25 kHz — Klassiker fuer FDD; ~6 RB im UL)
+      # (long, L=839, 1.25 kHz - classic for FDD; ~6 RB in UL)
       prach_ConfigurationIndex                                = 17;
       # 0 = one
       prach_msg1_FDM                                          = 0;
@@ -118,7 +118,7 @@ gNBs =
       # subcarrierSpacing (common): 0 = 15 kHz
       subcarrierSpacing                                       = 0;
 
-      ### KEIN tdd-UL-DL-ConfigurationCommon — FDD! ###
+      ### NO tdd-UL-DL-ConfigurationCommon - FDD! ###
 
       ssPBCH_BlockPower                                       = -25;
     }
@@ -127,7 +127,7 @@ gNBs =
     # ------- SCTP definitions
     SCTP : { SCTP_INSTREAMS = 2; SCTP_OUTSTREAMS = 2; };
 
-    ####### AMF / Netz — 1:1 aus eurer funktionierenden band101-Conf uebernehmen
+    ####### AMF / network - copy 1:1 from your working band101 conf
     amf_ip_address = ({ ipv4 = "192.168.70.132"; });
 
     NETWORK_INTERFACES :
@@ -171,7 +171,7 @@ RUs = (
   max_rxgain     = 114;
   eNB_instances  = [0];
   # FDD: TX auf TX/RX-Port (922 MHz), RX auf RX2 (877 MHz) — RX2 ist UHD-Default,
-  # daher KEIN set_rx_antenna-Patch aktiv lassen!
+  # therefore do NOT keep the set_rx_antenna patch active!
   #clock_src = "internal";
 }
 );

--- a/ci-scripts/conf_files/gnb.sa.band100.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/gnb.sa.band100.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -11,10 +11,6 @@
 #   SSB: GSCN 2305 = 921.850 MHz = ARFCN 184370 (M=5 - the only class with
 #        integer k_SSB for this PointA!) -> offsetToPointA 1, k_SSB 8
 #   CORESET#0: Tab. 13-1 index 0 (24 RB, 2 symbols, offset 0) -> CRB 1..24, fits exactly
-#   Erwartete gNB-Logzeile nach Start:
-#   "ssbOffsetPointA 1 SSB SsbSubcarrierOffset 8 prb_offset 1 sc_offset 8 scs 0 ssb_start_subcarrier 20"
-#
-# GSCN 2305 bitte einmal gegen TS 38.101-1 Tab. 5.4.3.3-1 (n100-Range) pruefen.
 ###############################################################################
 
 Active_gNBs = ( "gNB-FRMCS-n100" );
@@ -30,7 +26,7 @@ gNBs =
     tracking_area_code = 1;
     plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
 
-    nr_cellid = 12345679L;          # bewusst != n101-Zelle (12345678)
+    nr_cellid = 12345679L;
 
     ////////// Physical parameters:
     min_rxtxtime = 6;
@@ -61,7 +57,7 @@ gNBs =
 
       ########## uplinkConfigCommon / frequencyInfoUL
       ul_frequencyBand                                        = 100;
-      # UL-PointA 874.750 MHz, Duplexabstand 45 MHz
+      # UL PointA 874.750 MHz, duplex spacing 45 MHz
       ul_absoluteFrequencyPointA                              = 174950;
       ul_offstToCarrier                                       = 0;
       ul_subcarrierSpacing                                    = 0;
@@ -71,7 +67,7 @@ gNBs =
       initialULBWPsubcarrierSpacing                           = 0;
 
       ########## rach-ConfigCommon
-      # FDD/paired spectrum: Tab. 6.3.3.2-2 Index 16 = Preamble-Format 0
+      # FDD/paired spectrum: Tab. 6.3.3.2-2 index 16 = preamble format 0
       # (long, L=839, 1.25 kHz - classic for FDD; ~6 RB in UL)
       prach_ConfigurationIndex                                = 17;
       # 0 = one
@@ -195,15 +191,16 @@ security = {
   drb_integrity = "no";
 };
 
-log_config : {
-  global_log_level = "info";
-  hw_log_level     = "info";
-  phy_log_level    = "info";
-  mac_log_level    = "info";
-  rlc_log_level    = "info";
-  pdcp_log_level   = "info";
-  rrc_log_level    = "info";
-  ngap_log_level   = "info";
-  f1ap_log_level   = "info";
+log_config :
+{
+  global_log_level                      ="info";
+  hw_log_level                          ="info";
+  phy_log_level                         ="info";
+  mac_log_level                         ="info";
+  rlc_log_level                         ="info";
+  pdcp_log_level                        ="info";
+  rrc_log_level                         ="info";
+  ngap_log_level                        ="info";
+  f1ap_log_level                        ="info";
 };
 

--- a/ci-scripts/conf_files/gnb.sa.band100.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/gnb.sa.band100.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -1,15 +1,15 @@
 ###############################################################################
-# OAI gNB SA — Band n100 (FRMCS/RMR 900), FDD, 5 MHz, 25 PRB, SCS 15 kHz
+# OAI gNB SA - Band n100 (FRMCS/RMR 900), FDD, 5 MHz, 25 PRB, SCS 15 kHz
 # Cabling: gNB TX/RX --30dB--> module ANT4 (DL 922)   [DIP: RX separated]
 #           module ANT0 --30dB--> gNB RX2   (UL 877)
 # IMPORTANT: DISABLE the set_rx_antenna("TX/RX") patch in usrp_lib.cpp
 #            (FDD RX must use the RX2 default) + rebuild!
 #
-# Frequenzplan (verifiziert):
-#   DL-Carrier 919.750–924.250 MHz (Center 922.000), PointA-ARFCN 183950
-#   UL-Carrier 874.750–879.250 MHz (Center 877.000), PointA-ARFCN 174950, Duplex 45 MHz
+# Frequency plan (verified):
+#   DL carrier 919.750-924.250 MHz (center 922.000), PointA ARFCN 183950
+#   UL carrier 874.750-879.250 MHz (center 877.000), PointA ARFCN 174950, duplex 45 MHz
 #   SSB: GSCN 2305 = 921.850 MHz = ARFCN 184370 (M=5 - the only class with
-#        ganzzahligem k_SSB bei diesem PointA!) -> offsetToPointA 1, k_SSB 8
+#        integer k_SSB for this PointA!) -> offsetToPointA 1, k_SSB 8
 #   CORESET#0: Tab. 13-1 index 0 (24 RB, 2 symbols, offset 0) -> CRB 1..24, fits exactly
 #   Erwartete gNB-Logzeile nach Start:
 #   "ssbOffsetPointA 1 SSB SsbSubcarrierOffset 8 prb_offset 1 sc_offset 8 scs 0 ssb_start_subcarrier 20"
@@ -41,7 +41,7 @@ gNBs =
       physCellId                                              = 0;
 
       ########## downlinkConfigCommon / frequencyInfoDL
-      # SSB: GSCN 2305, 921.850 MHz (M=5 -> k_SSB = 8, ganzzahlig)
+      # SSB: GSCN 2305, 921.850 MHz (M=5 -> k_SSB = 8, integer)
       absoluteFrequencySSB                                    = 184370;
       dl_frequencyBand                                        = 100;
       # PointA = carrier lower edge 919.750 MHz
@@ -52,7 +52,7 @@ gNBs =
       dl_subcarrierSpacing                                    = 0;
       dl_carrierBandwidth                                     = 25;
 
-      # initialDownlinkBWP — RIV: Start 0, Laenge 25 -> 275*24+0
+      # initialDownlinkBWP - RIV: start 0, length 25 -> 275*24+0
       initialDLBWPlocationAndBandwidth                        = 6600;
       initialDLBWPsubcarrierSpacing                           = 0;
       # pdcch-ConfigCommon: Tab. 13-1 Index 0 -> 24 RB / 2 Symbole / Offset 0
@@ -87,7 +87,7 @@ gNBs =
       ra_ResponseWindow                                       = 4;
       # 1=1/8, 2=1/4, 3=1/2, 4=one, 5=two, 6=four, 7=eight, 8=sixteen
       ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR            = 4;
-      # bei "one": (0..15) -> 4,8,...,60,64 ; 14 = n60
+      # for "one": (0..15) -> 4,8,...,60,64 ; 14 = n60
       ssb_perRACH_OccasionAndCB_PreamblesPerSSB               = 14;
       # (0..7) -> sf 8,16,24,32,40,48,56,64
       ra_ContentionResolutionTimer                            = 7;
@@ -95,7 +95,7 @@ gNBs =
       # 1 = l839 (Format 0), 2 = l139
       prach_RootSequenceIndex_PR                              = 1;
       prach_RootSequenceIndex                                 = 1;
-      # msg1_SubcarrierSpacing entfaellt bei Format 0 (lange Praeambel, 1.25 kHz fest)
+      # msg1_SubcarrierSpacing is omitted for format 0 (long preamble, fixed 1.25 kHz)
 
       ########## pusch-ConfigCommon
       msg3_DeltaPreamble                                      = 1;
@@ -170,7 +170,7 @@ RUs = (
   max_pdschReferenceSignalPower = -27;
   max_rxgain     = 114;
   eNB_instances  = [0];
-  # FDD: TX auf TX/RX-Port (922 MHz), RX auf RX2 (877 MHz) — RX2 ist UHD-Default,
+  # FDD: TX on TX/RX port (922 MHz), RX on RX2 (877 MHz) - RX2 is the UHD default,
   # therefore do NOT keep the set_rx_antenna patch active!
   #clock_src = "internal";
 }

--- a/ci-scripts/conf_files/gnb.sa.band101.fr1.24PRB.SCS30.usrpb205mini.conf
+++ b/ci-scripts/conf_files/gnb.sa.band101.fr1.24PRB.SCS30.usrpb205mini.conf
@@ -1,0 +1,255 @@
+Active_gNBs = ( "gNB-FRMCS");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    =  0xe00;
+    gNB_name  =  "gNB-FRMCS";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  1;
+    plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345678L;
+
+    ////////// Physical parameters:
+
+    do_CSIRS                                                  = 1;
+    do_SRS                                                    = 1;
+    sib1_tda                                                  = 15; 
+    min_rxtxtime = 3;
+
+    #uess_agg_levels = [0,1,2,2,1]
+    servingCellConfigCommon = (
+    {
+ #spCellConfigCommon
+
+      physCellId                                                    = 0;
+
+#  downlinkConfigCommon
+    #frequencyInfoDL
+      # this is 1900 MHz + 24 PRBs@30kHz SCS (same as initial BWP)
+      absoluteFrequencySSB                                             = 380930;
+      dl_frequencyBand                                                 = 101;
+      # this is 1900 MHz
+      dl_absoluteFrequencyPointA                                       = 380000;
+      #scs-SpecificCarrierList
+        dl_offstToCarrier                                              = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing                                           = 1;
+        dl_carrierBandwidth                                            = 24;
+     #initialDownlinkBWP
+      #genericParameters
+        # this is RBstart=27,L=48 (275*(L-1))+RBstart
+        initialDLBWPlocationAndBandwidth                               = 6325; # 12925; # 6366 12925 12956 28875 12952
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing                                   = 1;
+      #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero                              = 2;
+        initialDLBWPsearchSpaceZero                                     = 0;
+
+  #uplinkConfigCommon
+     #frequencyInfoUL
+      ul_frequencyBand                                              = 101;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 24;
+      pMax                                                          = 20;
+     #initialUplinkBWP
+      #genericParameters
+        initialULBWPlocationAndBandwidth                            = 6325; # 12925;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+        #rach-ConfigGeneric
+          prach_ConfigurationIndex                                  = 98;
+#prach_msg1_FDM
+#0 = one, 1=two, 2=four, 3=eight
+          prach_msg1_FDM                                            = 0;
+          prach_msg1_FrequencyStart                                 = 0;
+          zeroCorrelationZoneConfig                                 = 13;
+          preambleReceivedTargetPower                               = -96;
+#preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+          preambleTransMax                                          = 6;
+#powerRampingStep
+# 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep                                            = 1;
+#ra_ReponseWindow
+#1,2,4,8,10,20,40,80
+        ra_ResponseWindow                                           = 5;
+#ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+#1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+#one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
+#ra_ContentionResolutionTimer
+#(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer                                = 7;
+        rsrp_ThresholdSSB                                           = 19;
+#prach-RootSequenceIndex_PR
+#1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR                                  = 2;
+        prach_RootSequenceIndex                                     = 1;
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        #
+        msg1_SubcarrierSpacing                                      = 1,
+# restrictedSetConfig
+# 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig                                         = 0,
+
+        msg3_DeltaPreamble                                          = 1;
+        p0_NominalWithGrant                                         =-90;
+
+# pucch-ConfigCommon setup :
+# pucchGroupHopping
+# 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping                                           = 0;
+        hoppingId                                                   = 40;
+        p0_nominal                                                  = -90;
+
+      ssb_PositionsInBurst_Bitmap                                   = 1;
+
+# ssb_periodicityServingCell
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+# dmrs_TypeA_position
+# 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+  #tdd-UL-DL-ConfigurationCommon
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 6;
+      nrofDownlinkSlots                                             = 7;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 2;
+      nrofUplinkSymbols                                             = 4;
+
+      ssPBCH_BlockPower                                             = -25;
+  }
+
+  );
+
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+
+    ////////// AMF parameters:
+    amf_ip_address = ({ ipv4 = "192.168.70.132"; });
+
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.70.129/24";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "192.168.70.129/24";
+        GNB_PORT_FOR_S1U                         = 2152; # Spec 2152
+    };
+
+  }
+);
+
+MACRLCs = (
+{
+  num_cc                      = 1;
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 150;
+  pucch_TargetSNRx10          = 200;
+}
+);
+
+L1s = (
+{
+  num_cc = 1;
+  tr_n_preference       = "local_mac";
+  prach_dtx_threshold = 120;
+  pucch0_dtx_threshold  = 100;
+  ofdm_offset_divisor   = 8; #set this to UINT_MAX for offset 0
+}
+);
+
+RUs = (
+{
+  local_rf       = "yes"
+  nb_tx          = 1
+  nb_rx          = 1
+  att_tx         = 12;
+  att_rx = 12;
+  bands          = [101];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 114;
+  eNB_instances  = [0];
+  clock_src = "internal";
+}
+);
+
+
+rfsimulator :
+{
+  serveraddr = "server";
+  serverport = 4043;
+  options = (); #("saviq"); or/and "chanmod"
+  modelname = "AWGN";
+  IQfile = "/tmp/rfsimulator.iqs";
+};
+
+security = {
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms = ( "nea0" );
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms = ( "nia2", "nia0" );
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level                      ="info";
+  hw_log_level                          ="info";
+  phy_log_level                         ="debug";
+  mac_log_level                         ="debug";
+  rlc_log_level                         ="info";
+  pdcp_log_level                        ="info";
+  rrc_log_level                         ="info";
+  ngap_log_level                        ="debug";
+  f1ap_log_level                        ="debug";
+};
+
+e2_agent = {
+  near_ric_ip_addr = "127.0.0.1";
+  #sm_dir = "/path/where/the/SMs/are/located/"
+  sm_dir = "/usr/local/lib/flexric/"
+};

--- a/ci-scripts/conf_files/gnb.sa.band101.fr1.24PRB.SCS30.usrpb205mini.conf
+++ b/ci-scripts/conf_files/gnb.sa.band101.fr1.24PRB.SCS30.usrpb205mini.conf
@@ -239,13 +239,13 @@ log_config :
 {
   global_log_level                      ="info";
   hw_log_level                          ="info";
-  phy_log_level                         ="debug";
-  mac_log_level                         ="debug";
+  phy_log_level                         ="info";
+  mac_log_level                         ="info";
   rlc_log_level                         ="info";
   pdcp_log_level                        ="info";
   rrc_log_level                         ="info";
-  ngap_log_level                        ="debug";
-  f1ap_log_level                        ="debug";
+  ngap_log_level                        ="info";
+  f1ap_log_level                        ="info";
 };
 
 e2_agent = {

--- a/ci-scripts/conf_files/untested/gnb.sa.band1.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band1.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -1,15 +1,15 @@
 ###############################################################################
 # OAI gNB SA — Band n1 (2100 MHz IMT), FDD, 5 MHz, 25 PRB, SCS 15 kHz
 #
-# ACHTUNG: Das vorhandene Qualcomm-Modul kann KEIN n1 (Caps: 28/100/101)!
-# Diese Conf ist fuer rfsim/nrUE-Tests oder ein anderes UE (z. B. COTS-Phone,
-# Quectel RM5xx). gNB-Verkabelung wie n100: TX/RX -> UE-RX, UE-TX -> RX2,
-# je 30 dB. set_rx_antenna-Patch DEAKTIVIERT (FDD-RX = RX2).
+# NOTE: the Qualcomm module used here does NOT support n1 (caps: 28/100/101)!
+# This conf is for rfsim/nrUE tests or a different UE (e.g. a COTS phone,
+# Quectel RM5xx). gNB cabling as for n100: TX/RX -> UE RX, UE TX -> RX2,
+# 30 dB each. set_rx_antenna patch DISABLED (FDD RX = RX2).
 #
 # Frequenzplan (verifiziert):
 #   DL 2137.750–2142.250 MHz (Center 2140.000), PointA-ARFCN 427550
 #   UL 1947.750–1952.250 MHz (Center 1950.000), PointA-ARFCN 389550, Duplex 190 MHz
-#   SSB: GSCN 5350 = 2139.850 MHz = ARFCN 427970 (M=5; einzige k_SSB-taugliche
+#   SSB: GSCN 5350 = 2139.850 MHz = ARFCN 427970 (M=5; only k_SSB-valid
 #        Klasse bei diesem PointA) -> offsetToPointA 1, k_SSB 8
 #   CORESET#0: Tab. 13-1 Index 0 (24 RB, 2 Symb, Offset 0) -> CRB 1..24
 #   Erwartete gNB-Logzeile:
@@ -32,7 +32,7 @@ gNBs =
     nr_cellid = 12345681L;
 
     min_rxtxtime = 6;
-    sib1_tda     = 15;            # SIB1-PDSCH zeitlich hinter die SSB (Pflicht bei 5 MHz!)
+    sib1_tda     = 15;            # SIB1 PDSCH placed in time after the SSB (mandatory at 5 MHz!)
 
     servingCellConfigCommon = (
     {
@@ -42,7 +42,7 @@ gNBs =
       # SSB: GSCN 5350, 2139.850 MHz (M=5 -> k_SSB = 8)
       absoluteFrequencySSB                                    = 427970;
       dl_frequencyBand                                        = 1;
-      # PointA = Carrier-Unterkante 2137.750 MHz
+      # PointA = carrier lower edge 2137.750 MHz
       dl_absoluteFrequencyPointA                              = 427550;
       dl_offstToCarrier                                       = 0;
       dl_subcarrierSpacing                                    = 0;
@@ -94,7 +94,7 @@ gNBs =
       dmrs_TypeA_Position                                     = 0;
       subcarrierSpacing                                       = 0;
 
-      ### FDD — kein tdd-UL-DL-ConfigurationCommon ###
+      ### FDD - no tdd-UL-DL-ConfigurationCommon ###
 
       ssPBCH_BlockPower                                       = -25;
     }
@@ -102,7 +102,7 @@ gNBs =
 
     SCTP : { SCTP_INSTREAMS = 2; SCTP_OUTSTREAMS = 2; };
 
-    ####### AMF / Netz — aus der funktionierenden Conf uebernehmen
+    ####### AMF / network - copy from the working conf
     amf_ip_address = ({ ipv4 = "192.168.70.132"; });
     NETWORK_INTERFACES :
     {
@@ -129,7 +129,7 @@ RUs = (
   bands = [1];
   max_pdschReferenceSignalPower = -27; max_rxgain = 114;
   eNB_instances = [0];
-  # FDD: TX auf TX/RX (2140), RX auf RX2 (1950) — RX2-Default, KEIN Antennen-Patch
+  # FDD: TX on TX/RX (2140), RX on RX2 (1950) - RX2 default, NO antenna patch
 }
 );
 

--- a/ci-scripts/conf_files/untested/gnb.sa.band1.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band1.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -1,0 +1,150 @@
+###############################################################################
+# OAI gNB SA — Band n1 (2100 MHz IMT), FDD, 5 MHz, 25 PRB, SCS 15 kHz
+#
+# ACHTUNG: Das vorhandene Qualcomm-Modul kann KEIN n1 (Caps: 28/100/101)!
+# Diese Conf ist fuer rfsim/nrUE-Tests oder ein anderes UE (z. B. COTS-Phone,
+# Quectel RM5xx). gNB-Verkabelung wie n100: TX/RX -> UE-RX, UE-TX -> RX2,
+# je 30 dB. set_rx_antenna-Patch DEAKTIVIERT (FDD-RX = RX2).
+#
+# Frequenzplan (verifiziert):
+#   DL 2137.750–2142.250 MHz (Center 2140.000), PointA-ARFCN 427550
+#   UL 1947.750–1952.250 MHz (Center 1950.000), PointA-ARFCN 389550, Duplex 190 MHz
+#   SSB: GSCN 5350 = 2139.850 MHz = ARFCN 427970 (M=5; einzige k_SSB-taugliche
+#        Klasse bei diesem PointA) -> offsetToPointA 1, k_SSB 8
+#   CORESET#0: Tab. 13-1 Index 0 (24 RB, 2 Symb, Offset 0) -> CRB 1..24
+#   Erwartete gNB-Logzeile:
+#   "ssbOffsetPointA 1 SSB SsbSubcarrierOffset 8 prb_offset 1 sc_offset 8 scs 0 ssb_start_subcarrier 20"
+#   GSCN 5350 gegen TS 38.101-1 Tab. 5.4.3.3-1 (n1) pruefen.
+###############################################################################
+
+Active_gNBs = ( "gNB-FRMCS-n1" );
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    gNB_ID    = 0xe00;
+    gNB_name  = "gNB-FRMCS-n1";
+
+    tracking_area_code = 1;
+    plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345681L;
+
+    min_rxtxtime = 6;
+    sib1_tda     = 15;            # SIB1-PDSCH zeitlich hinter die SSB (Pflicht bei 5 MHz!)
+
+    servingCellConfigCommon = (
+    {
+      physCellId                                              = 0;
+
+      ########## downlinkConfigCommon / frequencyInfoDL
+      # SSB: GSCN 5350, 2139.850 MHz (M=5 -> k_SSB = 8)
+      absoluteFrequencySSB                                    = 427970;
+      dl_frequencyBand                                        = 1;
+      # PointA = Carrier-Unterkante 2137.750 MHz
+      dl_absoluteFrequencyPointA                              = 427550;
+      dl_offstToCarrier                                       = 0;
+      dl_subcarrierSpacing                                    = 0;
+      dl_carrierBandwidth                                     = 25;
+
+      initialDLBWPlocationAndBandwidth                        = 6600;
+      initialDLBWPsubcarrierSpacing                           = 0;
+      # Tab. 13-1 Index 0: 24 RB / 2 Symbole / Offset 0 -> CORESET#0 = CRB 1..24
+      initialDLBWPcontrolResourceSetZero                      = 0;
+      initialDLBWPsearchSpaceZero                             = 0;
+
+      ########## uplinkConfigCommon / frequencyInfoUL
+      ul_frequencyBand                                        = 1;
+      # UL-PointA 1947.750 MHz, Duplexabstand 190 MHz
+      ul_absoluteFrequencyPointA                              = 389550;
+      ul_offstToCarrier                                       = 0;
+      ul_subcarrierSpacing                                    = 0;
+      ul_carrierBandwidth                                     = 25;
+      pMax                                                    = 20;
+      initialULBWPlocationAndBandwidth                        = 6600;
+      initialULBWPsubcarrierSpacing                           = 0;
+
+      ########## rach-ConfigCommon — FDD: Format 0, Index 17 (Subframe 4)
+      prach_ConfigurationIndex                                = 17;
+      prach_msg1_FDM                                          = 0;
+      prach_msg1_FrequencyStart                               = 0;
+      zeroCorrelationZoneConfig                               = 12;
+      preambleReceivedTargetPower                             = -96;
+      preambleTransMax                                        = 6;
+      powerRampingStep                                        = 1;
+      ra_ResponseWindow                                       = 4;
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR            = 4;
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB               = 14;
+      ra_ContentionResolutionTimer                            = 7;
+      rsrp_ThresholdSSB                                       = 19;
+      prach_RootSequenceIndex_PR                              = 1;
+      prach_RootSequenceIndex                                 = 1;
+
+      ########## pusch/pucch-ConfigCommon
+      msg3_DeltaPreamble                                      = 1;
+      p0_NominalWithGrant                                     = -90;
+      pucchGroupHopping                                       = 0;
+      hoppingId                                               = 40;
+      p0_nominal                                              = -90;
+
+      ########## SSB
+      ssb_PositionsInBurst_Bitmap                             = 1;
+      ssb_periodicityServingCell                              = 2;
+      dmrs_TypeA_Position                                     = 0;
+      subcarrierSpacing                                       = 0;
+
+      ### FDD — kein tdd-UL-DL-ConfigurationCommon ###
+
+      ssPBCH_BlockPower                                       = -25;
+    }
+    );
+
+    SCTP : { SCTP_INSTREAMS = 2; SCTP_OUTSTREAMS = 2; };
+
+    ####### AMF / Netz — aus der funktionierenden Conf uebernehmen
+    amf_ip_address = ({ ipv4 = "192.168.70.132"; });
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF = "192.168.70.129";
+        GNB_IPV4_ADDRESS_FOR_NGU    = "192.168.70.129";
+        GNB_PORT_FOR_S1U            = 2152;
+    };
+  }
+);
+
+MACRLCs = (
+{ num_cc = 1; tr_s_preference = "local_L1"; tr_n_preference = "local_RRC";
+  pusch_TargetSNRx10 = 200; pucch_TargetSNRx10 = 200; }
+);
+
+L1s = (
+{ num_cc = 1; tr_n_preference = "local_mac";
+  prach_dtx_threshold = 120; pucch0_dtx_threshold = 100; ofdm_offset_divisor = 8; }
+);
+
+RUs = (
+{ local_rf = "yes"; nb_tx = 1; nb_rx = 1;
+  att_tx = 12; att_rx = 12;
+  bands = [1];
+  max_pdschReferenceSignalPower = -27; max_rxgain = 114;
+  eNB_instances = [0];
+  # FDD: TX auf TX/RX (2140), RX auf RX2 (1950) — RX2-Default, KEIN Antennen-Patch
+}
+);
+
+THREAD_STRUCT = ( { parallel_config = "PARALLEL_SINGLE_THREAD"; worker_config = "WORKER_ENABLE"; } );
+
+rfsimulator : { serveraddr = "server"; serverport = 4043; options = (); modelname = "AWGN"; IQfile = "/tmp/rfsimulator.iqs"; };
+
+security = {
+  ciphering_algorithms = ( "nea0" );
+  integrity_algorithms = ( "nia2", "nia0" );
+  drb_ciphering = "yes"; drb_integrity = "no";
+};
+
+log_config : {
+  global_log_level = "info"; hw_log_level = "info"; phy_log_level = "info";
+  mac_log_level = "info"; rlc_log_level = "info"; pdcp_log_level = "info";
+  rrc_log_level = "info"; ngap_log_level = "info"; f1ap_log_level = "info";
+};

--- a/ci-scripts/conf_files/untested/gnb.sa.band1.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band1.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -1,7 +1,6 @@
 ###############################################################################
 # OAI gNB SA - Band n1 (2100 MHz IMT), FDD, 5 MHz, 25 PRB, SCS 15 kHz
 #
-# NOTE: the Qualcomm module used here does NOT support n1 (caps: 28/100/101)!
 # This conf is for rfsim/nrUE tests or a different UE (e.g. a COTS phone,
 # Quectel RM5xx). gNB cabling as for n100: TX/RX -> UE RX, UE TX -> RX2,
 # 30 dB each. set_rx_antenna patch DISABLED (FDD RX = RX2).
@@ -12,19 +11,16 @@
 #   SSB: GSCN 5350 = 2139.850 MHz = ARFCN 427970 (M=5; only k_SSB-valid
 #        class for this PointA) -> offsetToPointA 1, k_SSB 8
 #   CORESET#0: Tab. 13-1 Index 0 (24 RB, 2 Symb, Offset 0) -> CRB 1..24
-#   Erwartete gNB-Logzeile:
-#   "ssbOffsetPointA 1 SSB SsbSubcarrierOffset 8 prb_offset 1 sc_offset 8 scs 0 ssb_start_subcarrier 20"
-#   GSCN 5350 gegen TS 38.101-1 Tab. 5.4.3.3-1 (n1) pruefen.
 ###############################################################################
 
-Active_gNBs = ( "gNB-FRMCS-n1" );
+Active_gNBs = ( "gNB-n1" );
 Asn1_verbosity = "none";
 
 gNBs =
 (
  {
     gNB_ID    = 0xe00;
-    gNB_name  = "gNB-FRMCS-n1";
+    gNB_name  = "gNB-n1";
 
     tracking_area_code = 1;
     plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
@@ -56,7 +52,7 @@ gNBs =
 
       ########## uplinkConfigCommon / frequencyInfoUL
       ul_frequencyBand                                        = 1;
-      # UL-PointA 1947.750 MHz, Duplexabstand 190 MHz
+      # UL PointA 1947.750 MHz, duplex spacing 190 MHz
       ul_absoluteFrequencyPointA                              = 389550;
       ul_offstToCarrier                                       = 0;
       ul_subcarrierSpacing                                    = 0;
@@ -143,8 +139,15 @@ security = {
   drb_ciphering = "yes"; drb_integrity = "no";
 };
 
-log_config : {
-  global_log_level = "info"; hw_log_level = "info"; phy_log_level = "info";
-  mac_log_level = "info"; rlc_log_level = "info"; pdcp_log_level = "info";
-  rrc_log_level = "info"; ngap_log_level = "info"; f1ap_log_level = "info";
+log_config :
+{
+  global_log_level                      ="info";
+  hw_log_level                          ="info";
+  phy_log_level                         ="info";
+  mac_log_level                         ="info";
+  rlc_log_level                         ="info";
+  pdcp_log_level                        ="info";
+  rrc_log_level                         ="info";
+  ngap_log_level                        ="info";
+  f1ap_log_level                        ="info";
 };

--- a/ci-scripts/conf_files/untested/gnb.sa.band1.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band1.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -1,16 +1,16 @@
 ###############################################################################
-# OAI gNB SA — Band n1 (2100 MHz IMT), FDD, 5 MHz, 25 PRB, SCS 15 kHz
+# OAI gNB SA - Band n1 (2100 MHz IMT), FDD, 5 MHz, 25 PRB, SCS 15 kHz
 #
 # NOTE: the Qualcomm module used here does NOT support n1 (caps: 28/100/101)!
 # This conf is for rfsim/nrUE tests or a different UE (e.g. a COTS phone,
 # Quectel RM5xx). gNB cabling as for n100: TX/RX -> UE RX, UE TX -> RX2,
 # 30 dB each. set_rx_antenna patch DISABLED (FDD RX = RX2).
 #
-# Frequenzplan (verifiziert):
-#   DL 2137.750–2142.250 MHz (Center 2140.000), PointA-ARFCN 427550
-#   UL 1947.750–1952.250 MHz (Center 1950.000), PointA-ARFCN 389550, Duplex 190 MHz
+# Frequency plan (verified):
+#   DL 2137.750-2142.250 MHz (center 2140.000), PointA ARFCN 427550
+#   UL 1947.750-1952.250 MHz (center 1950.000), PointA ARFCN 389550, duplex 190 MHz
 #   SSB: GSCN 5350 = 2139.850 MHz = ARFCN 427970 (M=5; only k_SSB-valid
-#        Klasse bei diesem PointA) -> offsetToPointA 1, k_SSB 8
+#        class for this PointA) -> offsetToPointA 1, k_SSB 8
 #   CORESET#0: Tab. 13-1 Index 0 (24 RB, 2 Symb, Offset 0) -> CRB 1..24
 #   Erwartete gNB-Logzeile:
 #   "ssbOffsetPointA 1 SSB SsbSubcarrierOffset 8 prb_offset 1 sc_offset 8 scs 0 ssb_start_subcarrier 20"
@@ -65,7 +65,7 @@ gNBs =
       initialULBWPlocationAndBandwidth                        = 6600;
       initialULBWPsubcarrierSpacing                           = 0;
 
-      ########## rach-ConfigCommon — FDD: Format 0, Index 17 (Subframe 4)
+      ########## rach-ConfigCommon - FDD: format 0, index 17 (subframe 4)
       prach_ConfigurationIndex                                = 17;
       prach_msg1_FDM                                          = 0;
       prach_msg1_FrequencyStart                               = 0;

--- a/ci-scripts/conf_files/untested/gnb.sa.band101.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band101.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -31,8 +31,8 @@ gNBs =
 
 #  downlinkConfigCommon
     #frequencyInfoDL
-      # 5 MHz @ 15 kHz SCS = 25 PRB; SSB (20 RB @ 15 kHz) auf GSCN-Raster
-      # SSB = 1902.25 MHz (GSCN N=1585, M=5), mittig im 4.5-MHz-Carrier
+      # 5 MHz @ 15 kHz SCS = 25 PRB; SSB (20 RB @ 15 kHz) on GSCN raster
+      # SSB = 1902.25 MHz (GSCN N=1585, M=5), centered in the 4.5 MHz carrier
       absoluteFrequencySSB                                             = 380450;
       dl_frequencyBand                                                 = 101;
       # this is 1900 MHz
@@ -102,7 +102,7 @@ gNBs =
 #1 = 839, 2 = 139
         prach_RootSequenceIndex_PR                                  = 2;
         prach_RootSequenceIndex                                     = 1;
-        # SCS for msg1: jetzt 15 kHz (mu=0) passend zum Carrier
+        # SCS for msg1: now 15 kHz (mu=0) matching the carrier
         #
         msg1_SubcarrierSpacing                                      = 0,
 # restrictedSetConfig

--- a/ci-scripts/conf_files/untested/gnb.sa.band101.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band101.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -1,0 +1,259 @@
+Active_gNBs = ( "gNB-FRMCS");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    =  0xe00;
+    gNB_name  =  "gNB-FRMCS";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  1;
+    plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345678L;
+
+    ////////// Physical parameters:
+
+    do_CSIRS                                                  = 1;
+    do_SRS                                                    = 1;
+    sib1_tda                                                  = 15; 
+    min_rxtxtime = 3;
+
+    #uess_agg_levels = [0,1,2,2,1]
+    servingCellConfigCommon = (
+    {
+ #spCellConfigCommon
+
+      physCellId                                                    = 0;
+
+#  downlinkConfigCommon
+    #frequencyInfoDL
+      # 5 MHz @ 15 kHz SCS = 25 PRB; SSB (20 RB @ 15 kHz) auf GSCN-Raster
+      # SSB = 1902.25 MHz (GSCN N=1585, M=5), mittig im 4.5-MHz-Carrier
+      absoluteFrequencySSB                                             = 380450;
+      dl_frequencyBand                                                 = 101;
+      # this is 1900 MHz
+      dl_absoluteFrequencyPointA                                       = 380000;
+      #scs-SpecificCarrierList
+        dl_offstToCarrier                                              = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing                                           = 0;
+        dl_carrierBandwidth                                            = 25;
+     #initialDownlinkBWP
+      #genericParameters
+        # RBstart=0, L=25 -> RIV = 275*(25-1)+0 = 6600
+        initialDLBWPlocationAndBandwidth                               = 6600;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing                                   = 0;
+      #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero                              = 2;
+        initialDLBWPsearchSpaceZero                                     = 0;
+
+  #uplinkConfigCommon
+     #frequencyInfoUL
+      ul_frequencyBand                                              = 101;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 0;
+      ul_carrierBandwidth                                           = 25;
+      pMax                                                          = 20;
+     #initialUplinkBWP
+      #genericParameters
+        initialULBWPlocationAndBandwidth                            = 6600;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing                               = 0;
+      #rach-ConfigCommon
+        #rach-ConfigGeneric
+          # ACHTUNG: prach_ConfigurationIndex fuer mu=0 / unpaired (TS 38.211
+          # Tab. 6.3.3.2-3) pruefen. 98 stammt aus dem 30-kHz-Setup.
+          prach_ConfigurationIndex                                  = 98;
+#prach_msg1_FDM
+#0 = one, 1=two, 2=four, 3=eight
+          prach_msg1_FDM                                            = 0;
+          prach_msg1_FrequencyStart                                 = 0;
+          zeroCorrelationZoneConfig                                 = 13;
+          preambleReceivedTargetPower                               = -96;
+#preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+          preambleTransMax                                          = 6;
+#powerRampingStep
+# 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep                                            = 1;
+#ra_ReponseWindow
+#1,2,4,8,10,20,40,80
+        ra_ResponseWindow                                           = 5;
+#ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+#1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+#one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
+#ra_ContentionResolutionTimer
+#(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer                                = 7;
+        rsrp_ThresholdSSB                                           = 19;
+#prach-RootSequenceIndex_PR
+#1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR                                  = 2;
+        prach_RootSequenceIndex                                     = 1;
+        # SCS for msg1: jetzt 15 kHz (mu=0) passend zum Carrier
+        #
+        msg1_SubcarrierSpacing                                      = 0,
+# restrictedSetConfig
+# 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig                                         = 0,
+
+        msg3_DeltaPreamble                                          = 1;
+        p0_NominalWithGrant                                         =-90;
+
+# pucch-ConfigCommon setup :
+# pucchGroupHopping
+# 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping                                           = 0;
+        hoppingId                                                   = 40;
+        p0_nominal                                                  = -90;
+
+      ssb_PositionsInBurst_Bitmap                                   = 1;
+
+# ssb_periodicityServingCell
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+# dmrs_TypeA_position
+# 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 0;
+
+
+  #tdd-UL-DL-ConfigurationCommon
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 0;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      # mu=0: 5 ms = 5 Slots -> 3 DL + 1 Special + 1 UL
+      dl_UL_TransmissionPeriodicity                                 = 6;
+      nrofDownlinkSlots                                             = 3;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 1;
+      nrofUplinkSymbols                                             = 4;
+
+      ssPBCH_BlockPower                                             = -25;
+  }
+
+  );
+
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+
+    ////////// AMF parameters:
+    amf_ip_address = ({ ipv4 = "192.168.70.132"; });
+
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.70.129/24";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "192.168.70.129/24";
+        GNB_PORT_FOR_S1U                         = 2152; # Spec 2152
+    };
+
+  }
+);
+
+MACRLCs = (
+{
+  num_cc                      = 1;
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 150;
+  pucch_TargetSNRx10          = 200;
+}
+);
+
+L1s = (
+{
+  num_cc = 1;
+  tr_n_preference       = "local_mac";
+  prach_dtx_threshold = 120;
+  pucch0_dtx_threshold  = 100;
+  ofdm_offset_divisor   = 8; #set this to UINT_MAX for offset 0
+}
+);
+
+RUs = (
+{
+  local_rf       = "yes"
+  nb_tx          = 1
+  nb_rx          = 1
+  att_tx         = 12;
+  att_rx = 12;
+  bands          = [101];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 114;
+  eNB_instances  = [0];
+  clock_src = "internal";
+}
+);
+
+
+rfsimulator :
+{
+  serveraddr = "server";
+  serverport = 4043;
+  options = (); #("saviq"); or/and "chanmod"
+  modelname = "AWGN";
+  IQfile = "/tmp/rfsimulator.iqs";
+};
+
+security = {
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms = ( "nea0" );
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms = ( "nia2", "nia0" );
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level                      ="info";
+  hw_log_level                          ="info";
+  phy_log_level                         ="debug";
+  mac_log_level                         ="debug";
+  rlc_log_level                         ="info";
+  pdcp_log_level                        ="info";
+  rrc_log_level                         ="info";
+  ngap_log_level                        ="debug";
+  f1ap_log_level                        ="debug";
+};
+
+e2_agent = {
+  near_ric_ip_addr = "127.0.0.1";
+  #sm_dir = "/path/where/the/SMs/are/located/"
+  sm_dir = "/usr/local/lib/flexric/"
+};

--- a/ci-scripts/conf_files/untested/gnb.sa.band101.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band101.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -243,13 +243,13 @@ log_config :
 {
   global_log_level                      ="info";
   hw_log_level                          ="info";
-  phy_log_level                         ="debug";
-  mac_log_level                         ="debug";
+  phy_log_level                         ="info";
+  mac_log_level                         ="info";
   rlc_log_level                         ="info";
   pdcp_log_level                        ="info";
   rrc_log_level                         ="info";
-  ngap_log_level                        ="debug";
-  f1ap_log_level                        ="debug";
+  ngap_log_level                        ="info";
+  f1ap_log_level                        ="info";
 };
 
 e2_agent = {

--- a/ci-scripts/conf_files/untested/gnb.sa.band101.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band101.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -72,8 +72,8 @@ gNBs =
         initialULBWPsubcarrierSpacing                               = 0;
       #rach-ConfigCommon
         #rach-ConfigGeneric
-          # ACHTUNG: prach_ConfigurationIndex fuer mu=0 / unpaired (TS 38.211
-          # Tab. 6.3.3.2-3) pruefen. 98 stammt aus dem 30-kHz-Setup.
+          # NOTE: verify prach_ConfigurationIndex for mu=0 / unpaired (TS 38.211
+          # Tab. 6.3.3.2-3). 98 originates from the 30 kHz setup.
           prach_ConfigurationIndex                                  = 98;
 #prach_msg1_FDM
 #0 = one, 1=two, 2=four, 3=eight

--- a/ci-scripts/conf_files/untested/gnb.sa.band28.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band28.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -1,17 +1,17 @@
 ###############################################################################
 # OAI gNB SA — Band n28 (700 MHz APT), FDD, 5 MHz, 25 PRB, SCS 15 kHz
 #
-# ACHTUNG Verkabelung (Modul-Antennentabelle!):
-#   n28-PRX liegt auf ANT0 (ANT4 ist n100-only) -> die n100-Zweikabel-
-#   Verkabelung funktioniert NICHT. Fuer dieses Modul: Splitter an ANT0,
+# NOTE on cabling (module antenna table!):
+#   n28 PRX is on ANT0 (ANT4 is n100-only) -> the n100 two-cable
+#   cabling does NOT work. For this module: splitter on ANT0,
 #   ein Zweig -> gNB TX/RX (30 dB), ein Zweig -> gNB RX2 (30 dB).
-#   set_rx_antenna("TX/RX")-Patch DEAKTIVIERT lassen (FDD-RX = RX2).
+#   keep the set_rx_antenna("TX/RX") patch DISABLED (FDD RX = RX2).
 #
 # Frequenzplan (verifiziert):
 #   DL 777.750–782.250 MHz (Center 780.000), PointA-ARFCN 155550
 #   UL 722.750–727.250 MHz (Center 725.000), PointA-ARFCN 144550, Duplex 55 MHz
 #   SSB: GSCN 1950 = 780.150 MHz = ARFCN 156030 (M=3; bei diesem PointA die
-#        einzige k_SSB-taugliche Klasse) -> offsetToPointA 3, k_SSB 4
+#        only k_SSB-valid class) -> offsetToPointA 3, k_SSB 4
 #   CORESET#0: Tab. 13-1 Index 1 (24 RB, 2 Symb, Offset 2) -> CRB 1..24
 #   Erwartete gNB-Logzeile:
 #   "ssbOffsetPointA 3 SSB SsbSubcarrierOffset 4 prb_offset 3 sc_offset 4 scs 0 ssb_start_subcarrier 40"
@@ -33,7 +33,7 @@ gNBs =
     nr_cellid = 12345680L;
 
     min_rxtxtime = 6;
-    sib1_tda     = 15;            # SIB1-PDSCH zeitlich hinter die SSB (Pflicht bei 5 MHz!)
+    sib1_tda     = 15;            # SIB1 PDSCH placed in time after the SSB (mandatory at 5 MHz!)
 
     servingCellConfigCommon = (
     {
@@ -43,7 +43,7 @@ gNBs =
       # SSB: GSCN 1950, 780.150 MHz (M=3 -> k_SSB = 4)
       absoluteFrequencySSB                                    = 156030;
       dl_frequencyBand                                        = 28;
-      # PointA = Carrier-Unterkante 777.750 MHz
+      # PointA = carrier lower edge 777.750 MHz
       dl_absoluteFrequencyPointA                              = 155550;
       dl_offstToCarrier                                       = 0;
       dl_subcarrierSpacing                                    = 0;
@@ -67,7 +67,7 @@ gNBs =
       initialULBWPsubcarrierSpacing                           = 0;
 
       ########## rach-ConfigCommon — FDD: Format 0 (Tab. 6.3.3.2-2, Index 17 = Subframe 4,
-      # kollidiert nicht mit CSI-PUCCH in Subframe 1; Lektion aus n100)
+      # does not collide with CSI-PUCCH in subframe 1; lesson from n100)
       prach_ConfigurationIndex                                = 17;
       prach_msg1_FDM                                          = 0;
       prach_msg1_FrequencyStart                               = 0;
@@ -97,7 +97,7 @@ gNBs =
       dmrs_TypeA_Position                                     = 0;
       subcarrierSpacing                                       = 0;
 
-      ### FDD — kein tdd-UL-DL-ConfigurationCommon ###
+      ### FDD - no tdd-UL-DL-ConfigurationCommon ###
 
       ssPBCH_BlockPower                                       = -25;
     }
@@ -105,7 +105,7 @@ gNBs =
 
     SCTP : { SCTP_INSTREAMS = 2; SCTP_OUTSTREAMS = 2; };
 
-    ####### AMF / Netz — aus der funktionierenden band100/101-Conf uebernehmen
+    ####### AMF / network - copy from the working band100/101 conf
     amf_ip_address = ({ ipv4 = "192.168.70.132"; });
     NETWORK_INTERFACES :
     {
@@ -132,7 +132,7 @@ RUs = (
   bands = [28];
   max_pdschReferenceSignalPower = -27; max_rxgain = 114;
   eNB_instances = [0];
-  # FDD: TX auf TX/RX (780), RX auf RX2 (725) — RX2-Default, KEIN Antennen-Patch
+  # FDD: TX on TX/RX (780), RX on RX2 (725) - RX2 default, NO antenna patch
 }
 );
 

--- a/ci-scripts/conf_files/untested/gnb.sa.band28.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band28.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -1,5 +1,5 @@
 ###############################################################################
-# OAI gNB SA — Band n28 (700 MHz APT), FDD, 5 MHz, 25 PRB, SCS 15 kHz
+# OAI gNB SA - Band n28 (700 MHz APT), FDD, 5 MHz, 25 PRB, SCS 15 kHz
 #
 # NOTE on cabling (module antenna table!):
 #   n28 PRX is on ANT0 (ANT4 is n100-only) -> the n100 two-cable
@@ -7,12 +7,12 @@
 #   ein Zweig -> gNB TX/RX (30 dB), ein Zweig -> gNB RX2 (30 dB).
 #   keep the set_rx_antenna("TX/RX") patch DISABLED (FDD RX = RX2).
 #
-# Frequenzplan (verifiziert):
-#   DL 777.750–782.250 MHz (Center 780.000), PointA-ARFCN 155550
-#   UL 722.750–727.250 MHz (Center 725.000), PointA-ARFCN 144550, Duplex 55 MHz
-#   SSB: GSCN 1950 = 780.150 MHz = ARFCN 156030 (M=3; bei diesem PointA die
-#        only k_SSB-valid class) -> offsetToPointA 3, k_SSB 4
-#   CORESET#0: Tab. 13-1 Index 1 (24 RB, 2 Symb, Offset 2) -> CRB 1..24
+# Frequency plan (verified):
+#   DL 777.750-782.250 MHz (center 780.000), PointA ARFCN 155550
+#   UL 722.750-727.250 MHz (center 725.000), PointA ARFCN 144550, duplex 55 MHz
+#   SSB: GSCN 1950 = 780.150 MHz = ARFCN 156030 (M=3; the only k_SSB-valid
+#        class for this PointA) -> offsetToPointA 3, k_SSB 4
+#   CORESET#0: Tab. 13-1 index 1 (24 RB, 2 symbols, offset 2) -> CRB 1..24
 #   Erwartete gNB-Logzeile:
 #   "ssbOffsetPointA 3 SSB SsbSubcarrierOffset 4 prb_offset 3 sc_offset 4 scs 0 ssb_start_subcarrier 40"
 #   GSCN 1950 gegen TS 38.101-1 Tab. 5.4.3.3-1 (n28) pruefen.
@@ -66,7 +66,7 @@ gNBs =
       initialULBWPlocationAndBandwidth                        = 6600;
       initialULBWPsubcarrierSpacing                           = 0;
 
-      ########## rach-ConfigCommon — FDD: Format 0 (Tab. 6.3.3.2-2, Index 17 = Subframe 4,
+      ########## rach-ConfigCommon - FDD: format 0 (Tab. 6.3.3.2-2, index 17 = subframe 4,
       # does not collide with CSI-PUCCH in subframe 1; lesson from n100)
       prach_ConfigurationIndex                                = 17;
       prach_msg1_FDM                                          = 0;

--- a/ci-scripts/conf_files/untested/gnb.sa.band28.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band28.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -4,7 +4,7 @@
 # NOTE on cabling (module antenna table!):
 #   n28 PRX is on ANT0 (ANT4 is n100-only) -> the n100 two-cable
 #   cabling does NOT work. For this module: splitter on ANT0,
-#   ein Zweig -> gNB TX/RX (30 dB), ein Zweig -> gNB RX2 (30 dB).
+#   one branch -> gNB TX/RX (30 dB), one branch -> gNB RX2 (30 dB).
 #   keep the set_rx_antenna("TX/RX") patch DISABLED (FDD RX = RX2).
 #
 # Frequency plan (verified):
@@ -13,19 +13,16 @@
 #   SSB: GSCN 1950 = 780.150 MHz = ARFCN 156030 (M=3; the only k_SSB-valid
 #        class for this PointA) -> offsetToPointA 3, k_SSB 4
 #   CORESET#0: Tab. 13-1 index 1 (24 RB, 2 symbols, offset 2) -> CRB 1..24
-#   Erwartete gNB-Logzeile:
-#   "ssbOffsetPointA 3 SSB SsbSubcarrierOffset 4 prb_offset 3 sc_offset 4 scs 0 ssb_start_subcarrier 40"
-#   GSCN 1950 gegen TS 38.101-1 Tab. 5.4.3.3-1 (n28) pruefen.
 ###############################################################################
 
-Active_gNBs = ( "gNB-FRMCS-n28" );
+Active_gNBs = ( "gNB-n28" );
 Asn1_verbosity = "none";
 
 gNBs =
 (
  {
     gNB_ID    = 0xe00;
-    gNB_name  = "gNB-FRMCS-n28";
+    gNB_name  = "gNB-n28";
 
     tracking_area_code = 1;
     plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
@@ -57,7 +54,7 @@ gNBs =
 
       ########## uplinkConfigCommon / frequencyInfoUL
       ul_frequencyBand                                        = 28;
-      # UL-PointA 722.750 MHz, Duplexabstand 55 MHz
+      # UL PointA 722.750 MHz, duplex spacing 55 MHz
       ul_absoluteFrequencyPointA                              = 144550;
       ul_offstToCarrier                                       = 0;
       ul_subcarrierSpacing                                    = 0;
@@ -146,8 +143,15 @@ security = {
   drb_ciphering = "yes"; drb_integrity = "no";
 };
 
-log_config : {
-  global_log_level = "info"; hw_log_level = "info"; phy_log_level = "info";
-  mac_log_level = "info"; rlc_log_level = "info"; pdcp_log_level = "info";
-  rrc_log_level = "info"; ngap_log_level = "info"; f1ap_log_level = "info";
+log_config :
+{
+  global_log_level                      ="info";
+  hw_log_level                          ="info";
+  phy_log_level                         ="info";
+  mac_log_level                         ="info";
+  rlc_log_level                         ="info";
+  pdcp_log_level                        ="info";
+  rrc_log_level                         ="info";
+  ngap_log_level                        ="info";
+  f1ap_log_level                        ="info";
 };

--- a/ci-scripts/conf_files/untested/gnb.sa.band28.fr1.25PRB.SCS15.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band28.fr1.25PRB.SCS15.usrpb205mini.conf
@@ -1,0 +1,153 @@
+###############################################################################
+# OAI gNB SA — Band n28 (700 MHz APT), FDD, 5 MHz, 25 PRB, SCS 15 kHz
+#
+# ACHTUNG Verkabelung (Modul-Antennentabelle!):
+#   n28-PRX liegt auf ANT0 (ANT4 ist n100-only) -> die n100-Zweikabel-
+#   Verkabelung funktioniert NICHT. Fuer dieses Modul: Splitter an ANT0,
+#   ein Zweig -> gNB TX/RX (30 dB), ein Zweig -> gNB RX2 (30 dB).
+#   set_rx_antenna("TX/RX")-Patch DEAKTIVIERT lassen (FDD-RX = RX2).
+#
+# Frequenzplan (verifiziert):
+#   DL 777.750–782.250 MHz (Center 780.000), PointA-ARFCN 155550
+#   UL 722.750–727.250 MHz (Center 725.000), PointA-ARFCN 144550, Duplex 55 MHz
+#   SSB: GSCN 1950 = 780.150 MHz = ARFCN 156030 (M=3; bei diesem PointA die
+#        einzige k_SSB-taugliche Klasse) -> offsetToPointA 3, k_SSB 4
+#   CORESET#0: Tab. 13-1 Index 1 (24 RB, 2 Symb, Offset 2) -> CRB 1..24
+#   Erwartete gNB-Logzeile:
+#   "ssbOffsetPointA 3 SSB SsbSubcarrierOffset 4 prb_offset 3 sc_offset 4 scs 0 ssb_start_subcarrier 40"
+#   GSCN 1950 gegen TS 38.101-1 Tab. 5.4.3.3-1 (n28) pruefen.
+###############################################################################
+
+Active_gNBs = ( "gNB-FRMCS-n28" );
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    gNB_ID    = 0xe00;
+    gNB_name  = "gNB-FRMCS-n28";
+
+    tracking_area_code = 1;
+    plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345680L;
+
+    min_rxtxtime = 6;
+    sib1_tda     = 15;            # SIB1-PDSCH zeitlich hinter die SSB (Pflicht bei 5 MHz!)
+
+    servingCellConfigCommon = (
+    {
+      physCellId                                              = 0;
+
+      ########## downlinkConfigCommon / frequencyInfoDL
+      # SSB: GSCN 1950, 780.150 MHz (M=3 -> k_SSB = 4)
+      absoluteFrequencySSB                                    = 156030;
+      dl_frequencyBand                                        = 28;
+      # PointA = Carrier-Unterkante 777.750 MHz
+      dl_absoluteFrequencyPointA                              = 155550;
+      dl_offstToCarrier                                       = 0;
+      dl_subcarrierSpacing                                    = 0;
+      dl_carrierBandwidth                                     = 25;
+
+      initialDLBWPlocationAndBandwidth                        = 6600;
+      initialDLBWPsubcarrierSpacing                           = 0;
+      # Tab. 13-1 Index 1: 24 RB / 2 Symbole / Offset 2 -> CORESET#0 = CRB 1..24
+      initialDLBWPcontrolResourceSetZero                      = 1;
+      initialDLBWPsearchSpaceZero                             = 0;
+
+      ########## uplinkConfigCommon / frequencyInfoUL
+      ul_frequencyBand                                        = 28;
+      # UL-PointA 722.750 MHz, Duplexabstand 55 MHz
+      ul_absoluteFrequencyPointA                              = 144550;
+      ul_offstToCarrier                                       = 0;
+      ul_subcarrierSpacing                                    = 0;
+      ul_carrierBandwidth                                     = 25;
+      pMax                                                    = 20;
+      initialULBWPlocationAndBandwidth                        = 6600;
+      initialULBWPsubcarrierSpacing                           = 0;
+
+      ########## rach-ConfigCommon — FDD: Format 0 (Tab. 6.3.3.2-2, Index 17 = Subframe 4,
+      # kollidiert nicht mit CSI-PUCCH in Subframe 1; Lektion aus n100)
+      prach_ConfigurationIndex                                = 17;
+      prach_msg1_FDM                                          = 0;
+      prach_msg1_FrequencyStart                               = 0;
+      zeroCorrelationZoneConfig                               = 12;
+      preambleReceivedTargetPower                             = -96;
+      preambleTransMax                                        = 6;
+      powerRampingStep                                        = 1;
+      ra_ResponseWindow                                       = 4;
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR            = 4;
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB               = 14;
+      ra_ContentionResolutionTimer                            = 7;
+      rsrp_ThresholdSSB                                       = 19;
+      # 1 = l839 (Format 0)
+      prach_RootSequenceIndex_PR                              = 1;
+      prach_RootSequenceIndex                                 = 1;
+
+      ########## pusch/pucch-ConfigCommon
+      msg3_DeltaPreamble                                      = 1;
+      p0_NominalWithGrant                                     = -90;
+      pucchGroupHopping                                       = 0;
+      hoppingId                                               = 40;
+      p0_nominal                                              = -90;
+
+      ########## SSB
+      ssb_PositionsInBurst_Bitmap                             = 1;
+      ssb_periodicityServingCell                              = 2;
+      dmrs_TypeA_Position                                     = 0;
+      subcarrierSpacing                                       = 0;
+
+      ### FDD — kein tdd-UL-DL-ConfigurationCommon ###
+
+      ssPBCH_BlockPower                                       = -25;
+    }
+    );
+
+    SCTP : { SCTP_INSTREAMS = 2; SCTP_OUTSTREAMS = 2; };
+
+    ####### AMF / Netz — aus der funktionierenden band100/101-Conf uebernehmen
+    amf_ip_address = ({ ipv4 = "192.168.70.132"; });
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF = "192.168.70.129";
+        GNB_IPV4_ADDRESS_FOR_NGU    = "192.168.70.129";
+        GNB_PORT_FOR_S1U            = 2152;
+    };
+  }
+);
+
+MACRLCs = (
+{ num_cc = 1; tr_s_preference = "local_L1"; tr_n_preference = "local_RRC";
+  pusch_TargetSNRx10 = 200; pucch_TargetSNRx10 = 200; }
+);
+
+L1s = (
+{ num_cc = 1; tr_n_preference = "local_mac";
+  prach_dtx_threshold = 120; pucch0_dtx_threshold = 100; ofdm_offset_divisor = 8; }
+);
+
+RUs = (
+{ local_rf = "yes"; nb_tx = 1; nb_rx = 1;
+  att_tx = 12; att_rx = 12;
+  bands = [28];
+  max_pdschReferenceSignalPower = -27; max_rxgain = 114;
+  eNB_instances = [0];
+  # FDD: TX auf TX/RX (780), RX auf RX2 (725) — RX2-Default, KEIN Antennen-Patch
+}
+);
+
+THREAD_STRUCT = ( { parallel_config = "PARALLEL_SINGLE_THREAD"; worker_config = "WORKER_ENABLE"; } );
+
+rfsimulator : { serveraddr = "server"; serverport = 4043; options = (); modelname = "AWGN"; IQfile = "/tmp/rfsimulator.iqs"; };
+
+security = {
+  ciphering_algorithms = ( "nea0" );
+  integrity_algorithms = ( "nia2", "nia0" );
+  drb_ciphering = "yes"; drb_integrity = "no";
+};
+
+log_config : {
+  global_log_level = "info"; hw_log_level = "info"; phy_log_level = "info";
+  mac_log_level = "info"; rlc_log_level = "info"; pdcp_log_level = "info";
+  rrc_log_level = "info"; ngap_log_level = "info"; f1ap_log_level = "info";
+};

--- a/ci-scripts/conf_files/untested/gnb.sa.band48.fr1.24PRB.SCS30.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band48.fr1.24PRB.SCS30.usrpb205mini.conf
@@ -1,7 +1,6 @@
 ###############################################################################
 # OAI gNB SA - Band n48 (3.5 GHz CBRS), TDD, 24 PRB, SCS 30 kHz
 #
-# NOTE: the Qualcomm module used here does NOT support n48 (caps: 28/100/101)!
 # This conf is for rfsim/nrUE tests or a different UE.
 # Cabling as for n101 (TDD, ONE cable UE <-> 30 dB <-> gNB TX/RX):
 #   ENABLE the set_rx_antenna("TX/RX") patch in usrp_lib.cpp + rebuild!
@@ -12,19 +11,16 @@
 #   SSB: GSCN 7933 = 3624.960 MHz = ARFCN 641664
 #        -> offsetToPointA 4, k_SSB 22 (identical geometry to the n101 fix)
 #   CORESET#0: Tab. 13-4 Index 2 (24 RB, 2 Symb, Offset 2) -> CRB 0..23
-#   Erwartete gNB-Logzeile:
-#   "ssbOffsetPointA 4 SSB SsbSubcarrierOffset 22 prb_offset 2 sc_offset 11 scs 1 ssb_start_subcarrier 35"
-#   GSCN 7933 gegen TS 38.101-1 Tab. 5.4.3.3-1 (n48) pruefen.
 ###############################################################################
 
-Active_gNBs = ( "gNB-FRMCS-n48" );
+Active_gNBs = ( "gNB-n48" );
 Asn1_verbosity = "none";
 
 gNBs =
 (
  {
     gNB_ID    = 0xe00;
-    gNB_name  = "gNB-FRMCS-n48";
+    gNB_name  = "gNB-n48";
 
     tracking_area_code = 1;
     plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
@@ -56,7 +52,7 @@ gNBs =
       initialDLBWPcontrolResourceSetZero                      = 2;
       initialDLBWPsearchSpaceZero                             = 0;
 
-      ########## uplinkConfigCommon (TDD: gleiche Frequenzlage)
+      ########## uplinkConfigCommon (TDD: same frequency location)
       ul_frequencyBand                                        = 48;
       ul_offstToCarrier                                       = 0;
       ul_subcarrierSpacing                                    = 1;
@@ -83,10 +79,10 @@ gNBs =
       # sf64
       ra_ContentionResolutionTimer                            = 7;
       rsrp_ThresholdSSB                                       = 19;
-      # 2 = l139 (Kurzformat)
+      # 2 = l139 (short format)
       prach_RootSequenceIndex_PR                              = 2;
       prach_RootSequenceIndex                                 = 1;
-      # 1 = 30 kHz (Kurzformat-Preamble)
+      # 1 = 30 kHz (short-format preamble)
       msg1_SubcarrierSpacing                                  = 1,
 
       restrictedSetConfig                                     = 0,
@@ -162,8 +158,15 @@ security = {
   drb_ciphering = "yes"; drb_integrity = "no";
 };
 
-log_config : {
-  global_log_level = "info"; hw_log_level = "info"; phy_log_level = "info";
-  mac_log_level = "info"; rlc_log_level = "info"; pdcp_log_level = "info";
-  rrc_log_level = "info"; ngap_log_level = "info"; f1ap_log_level = "info";
+log_config :
+{
+  global_log_level                      ="info";
+  hw_log_level                          ="info";
+  phy_log_level                         ="info";
+  mac_log_level                         ="info";
+  rlc_log_level                         ="info";
+  pdcp_log_level                        ="info";
+  rrc_log_level                         ="info";
+  ngap_log_level                        ="info";
+  f1ap_log_level                        ="info";
 };

--- a/ci-scripts/conf_files/untested/gnb.sa.band48.fr1.24PRB.SCS30.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band48.fr1.24PRB.SCS30.usrpb205mini.conf
@@ -1,13 +1,13 @@
 ###############################################################################
 # OAI gNB SA — Band n48 (3.5 GHz CBRS), TDD, 24 PRB, SCS 30 kHz
 #
-# ACHTUNG: Das vorhandene Qualcomm-Modul kann KEIN n48 (Caps: 28/100/101)!
-# Diese Conf ist fuer rfsim/nrUE-Tests oder ein anderes UE.
-# Verkabelung wie n101 (TDD, EIN Kabel UE <-> 30 dB <-> gNB TX/RX):
-#   set_rx_antenna("TX/RX")-Patch in usrp_lib.cpp AKTIVIEREN + Rebuild!
+# NOTE: the Qualcomm module used here does NOT support n48 (caps: 28/100/101)!
+# This conf is for rfsim/nrUE tests or a different UE.
+# Cabling as for n101 (TDD, ONE cable UE <-> 30 dB <-> gNB TX/RX):
+#   ENABLE the set_rx_antenna("TX/RX") patch in usrp_lib.cpp + rebuild!
 #
 # Frequenzplan (verifiziert; >3 GHz ist das 15-kHz-Grid konstruktionsbedingt
-# immer erfuellt — die n101-k_SSB-Falle existiert hier nicht):
+# always satisfied here - the n101 k_SSB pitfall does not exist):
 #   Carrier 3620.310–3628.950 MHz (Center 3624.630), PointA-ARFCN 641354
 #   SSB: GSCN 7933 = 3624.960 MHz = ARFCN 641664
 #        -> offsetToPointA 4, k_SSB 22 (identische Geometrie wie n101-Fix)
@@ -42,7 +42,7 @@ gNBs =
       # SSB: GSCN 7933, 3624.960 MHz
       absoluteFrequencySSB                                    = 641664;
       dl_frequencyBand                                        = 48;
-      # PointA = Carrier-Unterkante 3620.310 MHz
+      # PointA = carrier lower edge 3620.310 MHz
       dl_absoluteFrequencyPointA                              = 641354;
       dl_offstToCarrier                                       = 0;
       # 1 = 30 kHz
@@ -121,7 +121,7 @@ gNBs =
 
     SCTP : { SCTP_INSTREAMS = 2; SCTP_OUTSTREAMS = 2; };
 
-    ####### AMF / Netz — aus der funktionierenden band101-Conf uebernehmen
+    ####### AMF / network - copy from the working band101 conf
     amf_ip_address = ({ ipv4 = "192.168.70.132"; });
     NETWORK_INTERFACES :
     {
@@ -148,7 +148,7 @@ RUs = (
   bands = [48];
   max_pdschReferenceSignalPower = -27; max_rxgain = 114;
   eNB_instances = [0];
-  # TDD-Einkabel: set_rx_antenna("TX/RX") AKTIV (wie n101)!
+  # TDD single cable: set_rx_antenna("TX/RX") ACTIVE (as for n101)!
 }
 );
 

--- a/ci-scripts/conf_files/untested/gnb.sa.band48.fr1.24PRB.SCS30.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band48.fr1.24PRB.SCS30.usrpb205mini.conf
@@ -1,16 +1,16 @@
 ###############################################################################
-# OAI gNB SA — Band n48 (3.5 GHz CBRS), TDD, 24 PRB, SCS 30 kHz
+# OAI gNB SA - Band n48 (3.5 GHz CBRS), TDD, 24 PRB, SCS 30 kHz
 #
 # NOTE: the Qualcomm module used here does NOT support n48 (caps: 28/100/101)!
 # This conf is for rfsim/nrUE tests or a different UE.
 # Cabling as for n101 (TDD, ONE cable UE <-> 30 dB <-> gNB TX/RX):
 #   ENABLE the set_rx_antenna("TX/RX") patch in usrp_lib.cpp + rebuild!
 #
-# Frequenzplan (verifiziert; >3 GHz ist das 15-kHz-Grid konstruktionsbedingt
+# Frequency plan (verified; above 3 GHz the 15 kHz grid is by construction
 # always satisfied here - the n101 k_SSB pitfall does not exist):
-#   Carrier 3620.310–3628.950 MHz (Center 3624.630), PointA-ARFCN 641354
+#   carrier 3620.310-3628.950 MHz (center 3624.630), PointA ARFCN 641354
 #   SSB: GSCN 7933 = 3624.960 MHz = ARFCN 641664
-#        -> offsetToPointA 4, k_SSB 22 (identische Geometrie wie n101-Fix)
+#        -> offsetToPointA 4, k_SSB 22 (identical geometry to the n101 fix)
 #   CORESET#0: Tab. 13-4 Index 2 (24 RB, 2 Symb, Offset 2) -> CRB 0..23
 #   Erwartete gNB-Logzeile:
 #   "ssbOffsetPointA 4 SSB SsbSubcarrierOffset 22 prb_offset 2 sc_offset 11 scs 1 ssb_start_subcarrier 35"
@@ -32,7 +32,7 @@ gNBs =
     nr_cellid = 12345682L;
 
     min_rxtxtime = 6;
-    sib1_tda     = 15;            # SIB1-PDSCH zeitlich hinter die SSB
+    sib1_tda     = 15;            # SIB1 PDSCH placed in time after the SSB
 
     servingCellConfigCommon = (
     {
@@ -49,7 +49,7 @@ gNBs =
       dl_subcarrierSpacing                                    = 1;
       dl_carrierBandwidth                                     = 24;
 
-      # RIV: Start 0, Laenge 24 -> 275*23+0 = 6325
+      # RIV: start 0, length 24 -> 275*23+0 = 6325
       initialDLBWPlocationAndBandwidth                        = 6325;
       initialDLBWPsubcarrierSpacing                           = 1;
       # Tab. 13-4 Index 2: 24 RB / 2 Symbole / Offset 2 -> CORESET#0 = CRB 0..23
@@ -65,7 +65,7 @@ gNBs =
       initialULBWPlocationAndBandwidth                        = 6325;
       initialULBWPsubcarrierSpacing                           = 1;
 
-      ########## rach-ConfigCommon — TDD: Index 98 (Kurzformat, wie n101)
+      ########## rach-ConfigCommon - TDD: index 98 (short format, as for n101)
       prach_ConfigurationIndex                                = 98;
       prach_msg1_FDM                                          = 0;
       prach_msg1_FrequencyStart                               = 0;
@@ -106,7 +106,7 @@ gNBs =
       # 30 kHz
       subcarrierSpacing                                       = 1;
 
-      ########## tdd-UL-DL-ConfigurationCommon — wie n101 (DDDDDDDSUU, 5 ms)
+      ########## tdd-UL-DL-ConfigurationCommon - as for n101 (DDDDDDDSUU, 5 ms)
       referenceSubcarrierSpacing                              = 1;
       # ms5
       dl_UL_TransmissionPeriodicity                           = 6;

--- a/ci-scripts/conf_files/untested/gnb.sa.band48.fr1.24PRB.SCS30.usrpb205mini.conf
+++ b/ci-scripts/conf_files/untested/gnb.sa.band48.fr1.24PRB.SCS30.usrpb205mini.conf
@@ -1,0 +1,169 @@
+###############################################################################
+# OAI gNB SA — Band n48 (3.5 GHz CBRS), TDD, 24 PRB, SCS 30 kHz
+#
+# ACHTUNG: Das vorhandene Qualcomm-Modul kann KEIN n48 (Caps: 28/100/101)!
+# Diese Conf ist fuer rfsim/nrUE-Tests oder ein anderes UE.
+# Verkabelung wie n101 (TDD, EIN Kabel UE <-> 30 dB <-> gNB TX/RX):
+#   set_rx_antenna("TX/RX")-Patch in usrp_lib.cpp AKTIVIEREN + Rebuild!
+#
+# Frequenzplan (verifiziert; >3 GHz ist das 15-kHz-Grid konstruktionsbedingt
+# immer erfuellt — die n101-k_SSB-Falle existiert hier nicht):
+#   Carrier 3620.310–3628.950 MHz (Center 3624.630), PointA-ARFCN 641354
+#   SSB: GSCN 7933 = 3624.960 MHz = ARFCN 641664
+#        -> offsetToPointA 4, k_SSB 22 (identische Geometrie wie n101-Fix)
+#   CORESET#0: Tab. 13-4 Index 2 (24 RB, 2 Symb, Offset 2) -> CRB 0..23
+#   Erwartete gNB-Logzeile:
+#   "ssbOffsetPointA 4 SSB SsbSubcarrierOffset 22 prb_offset 2 sc_offset 11 scs 1 ssb_start_subcarrier 35"
+#   GSCN 7933 gegen TS 38.101-1 Tab. 5.4.3.3-1 (n48) pruefen.
+###############################################################################
+
+Active_gNBs = ( "gNB-FRMCS-n48" );
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    gNB_ID    = 0xe00;
+    gNB_name  = "gNB-FRMCS-n48";
+
+    tracking_area_code = 1;
+    plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345682L;
+
+    min_rxtxtime = 6;
+    sib1_tda     = 15;            # SIB1-PDSCH zeitlich hinter die SSB
+
+    servingCellConfigCommon = (
+    {
+      physCellId                                              = 0;
+
+      ########## downlinkConfigCommon / frequencyInfoDL
+      # SSB: GSCN 7933, 3624.960 MHz
+      absoluteFrequencySSB                                    = 641664;
+      dl_frequencyBand                                        = 48;
+      # PointA = Carrier-Unterkante 3620.310 MHz
+      dl_absoluteFrequencyPointA                              = 641354;
+      dl_offstToCarrier                                       = 0;
+      # 1 = 30 kHz
+      dl_subcarrierSpacing                                    = 1;
+      dl_carrierBandwidth                                     = 24;
+
+      # RIV: Start 0, Laenge 24 -> 275*23+0 = 6325
+      initialDLBWPlocationAndBandwidth                        = 6325;
+      initialDLBWPsubcarrierSpacing                           = 1;
+      # Tab. 13-4 Index 2: 24 RB / 2 Symbole / Offset 2 -> CORESET#0 = CRB 0..23
+      initialDLBWPcontrolResourceSetZero                      = 2;
+      initialDLBWPsearchSpaceZero                             = 0;
+
+      ########## uplinkConfigCommon (TDD: gleiche Frequenzlage)
+      ul_frequencyBand                                        = 48;
+      ul_offstToCarrier                                       = 0;
+      ul_subcarrierSpacing                                    = 1;
+      ul_carrierBandwidth                                     = 24;
+      pMax                                                    = 20;
+      initialULBWPlocationAndBandwidth                        = 6325;
+      initialULBWPsubcarrierSpacing                           = 1;
+
+      ########## rach-ConfigCommon — TDD: Index 98 (Kurzformat, wie n101)
+      prach_ConfigurationIndex                                = 98;
+      prach_msg1_FDM                                          = 0;
+      prach_msg1_FrequencyStart                               = 0;
+      zeroCorrelationZoneConfig                               = 13;
+      preambleReceivedTargetPower                             = -96;
+      # n10
+      preambleTransMax                                        = 6;
+      # dB2
+      powerRampingStep                                        = 1;
+      # sl20
+      ra_ResponseWindow                                       = 5;
+      # one / n60
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR            = 4;
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB               = 14;
+      # sf64
+      ra_ContentionResolutionTimer                            = 7;
+      rsrp_ThresholdSSB                                       = 19;
+      # 2 = l139 (Kurzformat)
+      prach_RootSequenceIndex_PR                              = 2;
+      prach_RootSequenceIndex                                 = 1;
+      # 1 = 30 kHz (Kurzformat-Preamble)
+      msg1_SubcarrierSpacing                                  = 1,
+
+      restrictedSetConfig                                     = 0,
+
+      ########## pusch/pucch-ConfigCommon
+      msg3_DeltaPreamble                                      = 1;
+      p0_NominalWithGrant                                     = -90;
+      pucchGroupHopping                                       = 0;
+      hoppingId                                               = 40;
+      p0_nominal                                              = -90;
+
+      ########## SSB
+      ssb_PositionsInBurst_Bitmap                             = 1;
+      # ms20
+      ssb_periodicityServingCell                              = 2;
+      dmrs_TypeA_Position                                     = 0;
+      # 30 kHz
+      subcarrierSpacing                                       = 1;
+
+      ########## tdd-UL-DL-ConfigurationCommon — wie n101 (DDDDDDDSUU, 5 ms)
+      referenceSubcarrierSpacing                              = 1;
+      # ms5
+      dl_UL_TransmissionPeriodicity                           = 6;
+      nrofDownlinkSlots                                       = 7;
+      nrofDownlinkSymbols                                     = 6;
+      nrofUplinkSlots                                         = 2;
+      nrofUplinkSymbols                                       = 4;
+
+      ssPBCH_BlockPower                                       = -25;
+    }
+    );
+
+    SCTP : { SCTP_INSTREAMS = 2; SCTP_OUTSTREAMS = 2; };
+
+    ####### AMF / Netz — aus der funktionierenden band101-Conf uebernehmen
+    amf_ip_address = ({ ipv4 = "192.168.70.132"; });
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF = "192.168.70.129";
+        GNB_IPV4_ADDRESS_FOR_NGU    = "192.168.70.129";
+        GNB_PORT_FOR_S1U            = 2152;
+    };
+  }
+);
+
+MACRLCs = (
+{ num_cc = 1; tr_s_preference = "local_L1"; tr_n_preference = "local_RRC";
+  pusch_TargetSNRx10 = 200; pucch_TargetSNRx10 = 200; }
+);
+
+L1s = (
+{ num_cc = 1; tr_n_preference = "local_mac";
+  prach_dtx_threshold = 120; pucch0_dtx_threshold = 100; ofdm_offset_divisor = 8; }
+);
+
+RUs = (
+{ local_rf = "yes"; nb_tx = 1; nb_rx = 1;
+  att_tx = 12; att_rx = 12;
+  bands = [48];
+  max_pdschReferenceSignalPower = -27; max_rxgain = 114;
+  eNB_instances = [0];
+  # TDD-Einkabel: set_rx_antenna("TX/RX") AKTIV (wie n101)!
+}
+);
+
+THREAD_STRUCT = ( { parallel_config = "PARALLEL_SINGLE_THREAD"; worker_config = "WORKER_ENABLE"; } );
+
+rfsimulator : { serveraddr = "server"; serverport = 4043; options = (); modelname = "AWGN"; IQfile = "/tmp/rfsimulator.iqs"; };
+
+security = {
+  ciphering_algorithms = ( "nea0" );
+  integrity_algorithms = ( "nia2", "nia0" );
+  drb_ciphering = "yes"; drb_integrity = "no";
+};
+
+log_config : {
+  global_log_level = "info"; hw_log_level = "info"; phy_log_level = "info";
+  mac_log_level = "info"; rlc_log_level = "info"; pdcp_log_level = "info";
+  rrc_log_level = "info"; ngap_log_level = "info"; f1ap_log_level = "info";
+};


### PR DESCRIPTION
These config files add ready-to-use SA setups for several FR1 bands on a single USRP B205mini, all with a frequency plan (point A, GSCN/SSB ARFCN, k_SSB, CORESET#0) computed and verified up front rather than left to silent rounding.

## Tested on hardware

(B205mini, UHD 4.8.0, against a COTS 5G module over attenuated cable, with OAI CN5G)

- **n101** (TDD, 24 PRB, 30 kHz SCS): module camps, completes 4-step RA, reaches RRC_CONNECTED and registers with the 5GC. Single cable (module ANT0 → attenuator 10W/30 dB → gNB TX/RX); RX is forced to the TX/RX port (the gNB's default RX2 is unconnected here, so the uplink would otherwise only reach the receiver via internal port leakage — enough for PRACH, but Msg3 fails).
- **n100** (FDD, 25 PRB, 15 kHz SCS): same attach result, with clean uplink (UL SNR ~21–24 dB, 0 ULSCH errors). Two cables (gNB TX/RX → attenuator 10W/30 dB → module RX, module TX → attenuator 10W/30 dB → gNB RX2).

## Untested

(provided as rfsim / reference configs, computed but not run on HW — the module here lacks n1/n48, and n28 needs different cabling)

- **n1** (FDD, 25 PRB, 15 kHz)
- **n28** (FDD, 25 PRB, 15 kHz)
- **n48** (TDD, 24 PRB, 30 kHz)

Each file documents in its header the expected `ssbOffsetPointA / k_SSB / ssb_start_subcarrier` log line, so the placement can be checked at startup.

## Related

Related to [#168](https://github.com/duranta-project/openairinterface5g/issues/168): the n101 config uses the corrected, k_SSB-aligned SSB ARFCN (380930, GSCN 4762) that avoids the off-raster placement described there; the broken counterpart from that issue is intentionally **not** used here.

## Notes for reviewers

- FDD configs need `sib1_tda = 15` (SIB1 PDSCH cannot share symbols with the SSB at 5 MHz) and PRACH config index 17 (subframe 4) to avoid the CSI-PUCCH collision in subframe 1.
- For the TDD single-cable setups (n101, n48), the gNB RX antenna must be the TX/RX port, not the default RX2. This currently requires a one-line change in `radio/USRP/usrp_lib.cpp` (`set_rx_antenna("TX/RX", ...)`) — there is no config switch for it yet. The FDD two-cable setups (n100, n1, n28) use the RX2 default and need no patch.
- AMF/NETWORK_INTERFACES are the standard CN5G Docker defaults — please adjust to your deployment.
