### PR TITLE
Change ambigous language in Aerial_FAPI_Split_Tutorial.md

### DIFF
--- a/doc/Aerial_FAPI_Split_Tutorial.md
+++ b/doc/Aerial_FAPI_Split_Tutorial.md
@@ -254,7 +254,7 @@ Both `GNB_IPV4_ADDRESS_FOR_NG_AMF` and `GNB_IPV4_ADDRESS_FOR_NGU` need to be
 set to the IP address of the NIC referenced previously.
 
 **Note**: If the Core Network is running on the same server, 3 cores should be
-allocated to it. 2 for the UPF and 1 for the all the remaining services as shown
+allocated to it. 2 for the UPF and 1 core shared between the remaining services as shown
 below.
 
 ```patch


### PR DESCRIPTION
This PR addresses Issue [1103](https://gitlab.eurecom.fr/oai/openairinterface5g/-/work_items/1103), changing one note in  Aerial_FAPI_Split_Tutorial.md regarding CN core allocation when running on the same server.
The original wording could be interpreted as allocating a separate core to each of the core network functions, when that's not the intended interpretation.