### PR TITLE
Extension of the DL-RI / PMI calculation based on CSI-RS to other scenarios

### DIFF
--- a/nfapi/open-nFAPI/nfapi/public_inc/fapi_nr_ue_interface.h
+++ b/nfapi/open-nFAPI/nfapi/public_inc/fapi_nr_ue_interface.h
@@ -54,8 +54,10 @@ typedef struct {
   int rsrp_dBm;
   float sinr_dB;  
   uint8_t rank_indicator;
-  uint16_t i1;
-  uint8_t i2;
+  uint8_t i_1_1;
+  uint8_t i_1_2;
+  uint8_t i_1_3;
+  uint8_t i_2;
   uint8_t cqi;
   rlm_t radiolink_monitoring;
 } fapi_nr_l1_measurements_t;

--- a/openair1/PHY/NR_UE_TRANSPORT/csi_rx.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/csi_rx.c
@@ -598,120 +598,399 @@ static int nr_csi_rs_ri_estimation(const PHY_VARS_NR_UE *ue,
   }
 }
 
-static int nr_csi_rs_pmi_estimation(const PHY_VARS_NR_UE *ue,
-                                    const fapi_nr_dl_config_csirs_pdu_rel15_t *csirs_config_pdu,
-                                    const uint8_t N_ports,
-                                    const c16_t csi_rs_estimated_channel_freq[][N_ports][ue->frame_parms.ofdm_symbol_size],
-                                    const uint32_t interference_plus_noise_power,
-                                    const uint8_t rank_indicator,
-                                    const int16_t log2_re,
-                                    uint8_t *i2,
-                                    int32_t *precoded_sinr_dB)
+// Type1 Single Panel PMI indices (TS 38.214 Section 5.2.2.2.1).
+typedef struct {
+  uint8_t i_1_1; // first DFT beam index (4/8 ports; range depends on N1*O1)
+  uint8_t i_1_2; // second DFT beam index (8 ports only; range depends on N2*O2)
+  uint8_t i_1_3; // beam-pair / k1 selection (rank>=2 with 4/8 ports)
+  uint8_t i_2; // co-phasing index (rank 1: 0..3; rank>=2: 0..1)
+} csi_rs_pmi_t;
+
+// DFT codebook: v_l = [1, exp(j*pi*l/4)]^T, l in {0..7}. Q8 fixed-point.
+#define PMI_Q 256
+static const int16_t vl_r[8] = {256, 181, 0, -181, -256, -181, 0, 181};
+static const int16_t vl_i[8] = {0, 181, 256, 181, 0, -181, -256, -181};
+// Co-phasing phi_n = exp(j*pi*n/2): pure integer entries.
+static const int8_t phi_r[4] = {1, 0, -1, 0};
+static const int8_t phi_i[4] = {0, 1, 0, -1};
+
+// SISO case
+static void nr_csi_rs_pmi_1port(int nb_antennas_rx,
+                                int N_ports,
+                                int osz,
+                                const c16_t ch_freq[][N_ports][osz],
+                                const fapi_nr_dl_config_csirs_pdu_rel15_t *cfg,
+                                uint32_t noise,
+                                int32_t *precoded_sinr_dB)
 {
-  const NR_DL_FRAME_PARMS *frame_parms = &ue->frame_parms;
-  const uint32_t ipn = interference_plus_noise_power == 0 ? 1 : interference_plus_noise_power;
-  // i1 is a three-element vector in the form of [i11 i12 i13], when CodebookType is specified as 'Type1SinglePanel'.
-  // Note that i13 is not applicable when the number of transmission layers is one of {1, 5, 6, 7, 8}.
-  // i2, for 'Type1SinglePanel' codebook type, it is a scalar when PMIMode is specified as 'wideband', and when PMIMode
-  // is specified as 'subband' or when PRGSize, the length of the i2 vector equals to the number of subbands or PRGs.
-  // Note that when the number of CSI-RS ports is 2, the applicable codebook type is 'Type1SinglePanel'. In this case,
-  // the precoding matrix is obtained by a single index (i2 field here) based on TS 38.214 Table 5.2.2.2.1-1.
-  // The first column is applicable if the UE is reporting a Rank = 1, whereas the second column is applicable if the
-  // UE is reporting a Rank = 2.
-
-  if (N_ports == 1) {
-    // SISO case: SINR = E[|h|^2] / noise_power. No PMI to estimate.
-    int64_t signal_power = 0;
-    int count = 0;
-
-    for (int rb = csirs_config_pdu->start_rb; rb < (csirs_config_pdu->start_rb + csirs_config_pdu->nr_of_rbs); rb++) {
-      if (csirs_config_pdu->freq_density <= 1 && csirs_config_pdu->freq_density != (rb % 2)) {
-        continue;
-      }
-      uint16_t k = rb * NR_NB_SC_PER_RB;
-
-      const c16_t h = csi_rs_estimated_channel_freq[0][0][k];
+  int64_t signal_power = 0;
+  int num_h_vectors = 0;
+  for (int rb = cfg->start_rb; rb < cfg->start_rb + cfg->nr_of_rbs; rb++) {
+    if (cfg->freq_density <= 1 && cfg->freq_density != (rb % 2))
+      continue;
+    int k = rb * NR_NB_SC_PER_RB;
+    for (int ant_rx = 0; ant_rx < nb_antennas_rx; ant_rx++) {
+      c16_t h = ch_freq[ant_rx][0][k];
       signal_power += (int64_t)h.r * h.r + (int64_t)h.i * h.i;
-      count++;
     }
+    num_h_vectors++;
+  }
+  if (num_h_vectors == 0)
+    return;
 
-    if (count > 0) {
-      const int64_t avg_signal_power = signal_power / count;
-      // Non RF devices like ZMQ has virtually zero noise. So here we make noise as 1 to return maximum sinr.
-      const uint32_t sinr = avg_signal_power / ipn;
-      *precoded_sinr_dB = dB_fixed(sinr);
+  signal_power /= num_h_vectors;
+  *precoded_sinr_dB = dB_fixed(signal_power) - dB_fixed(noise);
+
+  LOG_D(NR_PHY,
+        "[nr_csi_rs_pmi_1port] signal_power = %li (%i dB), noise = %u (%i dB)\n  --> precoded_sinr_dB = %i dB\n",
+        signal_power,
+        (int)(10 * log10(signal_power)),
+        noise,
+        (int)(10 * log10(noise)),
+        *precoded_sinr_dB);
+}
+
+// Rank 1 or 2;  2 ports (TS 38.214 - Table 5.2.2.2.1-1)
+static void nr_csi_rs_pmi_2ports(int nb_antennas_rx,
+                                 int N_ports,
+                                 int osz,
+                                 const c16_t ch_freq[][N_ports][osz],
+                                 const fapi_nr_dl_config_csirs_pdu_rel15_t *cfg,
+                                 uint32_t noise,
+                                 uint8_t rank_indicator,
+                                 csi_rs_pmi_t *pmi,
+                                 int32_t *precoded_sinr_dB)
+{
+  if (rank_indicator > 1) {
+    LOG_W(NR_PHY, "PMI not implemented for 2 ports and rank %d\n", rank_indicator + 1);
+    return;
+  }
+  // R = sum H^H H, 2x2 Hermitian (only R[0][0], R[0][1], R[1][1] needed)
+  c64_t R[2][2] = {{{0}}};
+  int num_h_vectors = 0;
+  for (int rb = cfg->start_rb; rb < cfg->start_rb + cfg->nr_of_rbs; rb++) {
+    if (cfg->freq_density <= 1 && cfg->freq_density != (rb % 2))
+      continue;
+    int k = rb * NR_NB_SC_PER_RB;
+    for (int ant_rx = 0; ant_rx < nb_antennas_rx; ant_rx++) {
+      c16_t h0 = ch_freq[ant_rx][0][k], h1 = ch_freq[ant_rx][1][k];
+      R[0][0].r += (int64_t)h0.r * h0.r + (int64_t)h0.i * h0.i; // |h0|^2 (real)
+      R[1][1].r += (int64_t)h1.r * h1.r + (int64_t)h1.i * h1.i; // |h1|^2 (real)
+      R[0][1].r += (int64_t)h0.r * h1.r + (int64_t)h0.i * h1.i; // Re(conj(h0)*h1)
+      R[0][1].i += (int64_t)h0.r * h1.i - (int64_t)h0.i * h1.r; // Im(conj(h0)*h1)
     }
+    num_h_vectors++;
+  }
+  if (num_h_vectors == 0)
+    return;
 
-    return 0;
+  // total power, constant for all n
+  const int64_t trace = R[0][0].r + R[1][1].r;
+  int64_t signal_power = 0;
+
+  if (rank_indicator == 0) {
+    // Rank 1 (Table 5.2.2.2.1-1): 4 hypotheses, W_n = (1/sqrt(2))*[1; phi_n]
+    // W^H R W = (1/2) * (trace + 2*Re(phi_n * R[0][1]))
+    int64_t best = INT64_MIN, best_signal = 0;
+    for (int n = 0; n < 4; n++) {
+      int64_t cross = (int64_t)phi_r[n] * R[0][1].r - (int64_t)phi_i[n] * R[0][1].i;
+      int64_t m = trace + 2 * cross;
+      if (m > best) {
+        best = m;
+        pmi->i_2 = n;
+        best_signal = m;
+      }
+    }
+    // Average signal power per RE = best / (2 * num_REs)  (1/2 of W^H R W)
+    signal_power = best_signal / (2LL * num_h_vectors);
+    *precoded_sinr_dB = dB_fixed(signal_power) - dB_fixed(noise);
+  } else {
+    // Rank 2 (Table 5.2.2.2.1-1): 2 hypotheses.
+    // The two PMI hypotheses span the same 2D subspace, giving identical trace, determinant and eigenvalues of W^H R W.
+    // They differ only in how the basis is rotated:
+    //   - i_2=0  uses W = (1/2)[[1, 1],[1, -1]]   -> off-diag picks up Im(R_01)
+    //   - i_2=1  uses W = (1/2)[[1, 1],[j, -j]]   -> off-diag picks up Re(R_01)
+    // We will choose the rotation that minimises the off-diagonal magnitude (smaller cross-layer interference for sub-MMSE
+    // receivers).
+    pmi->i_2 = (llabs(R[0][1].i) < llabs(R[0][1].r)) ? 0 : 1;
+    signal_power = trace / (2LL * num_h_vectors);
+    *precoded_sinr_dB = dB_fixed(signal_power) - dB_fixed(noise);
   }
 
-  if(rank_indicator == 0 || rank_indicator == 1) {
-    c64_t sum[4] = {0};
-    c64_t sum2[4] = {0};
-    int64_t tested_precoded_sinr[4] = {0};
+  LOG_D(NR_PHY,
+        "[nr_csi_rs_pmi_2ports] signal_power = %li (%i dB), noise = %u (%i dB)\n  --> precoded_sinr_dB = %i dB\n",
+        signal_power,
+        (int)(10 * log10(signal_power)),
+        noise,
+        (int)(10 * log10(noise)),
+        *precoded_sinr_dB);
+}
 
-    for (int rb = csirs_config_pdu->start_rb; rb < (csirs_config_pdu->start_rb+csirs_config_pdu->nr_of_rbs); rb++) {
-
-      if (csirs_config_pdu->freq_density <= 1 && csirs_config_pdu->freq_density != (rb % 2)) {
-        continue;
-      }
-      uint16_t k = rb * NR_NB_SC_PER_RB;
-      for (int ant_rx = 0; ant_rx < frame_parms->nb_antennas_rx; ant_rx++) {
-        const c16_t p0 = csi_rs_estimated_channel_freq[ant_rx][0][k];
-        const c16_t p1 = csi_rs_estimated_channel_freq[ant_rx][1][k];
-
-        // H_p0 + 1*H_p1 = (H_p0_re + H_p1_re) + 1j*(H_p0_im + H_p1_im)
-        sum[0].r += (p0.r + p1.r);
-        sum[0].i += (p0.i + p1.i);
-        sum2[0].r += (sum[0].r * sum[0].r) >> log2_re;
-        sum2[0].i += (sum[0].i * sum[0].i) >> log2_re;
-
-        // H_p0 + 1j*H_p1 = (H_p0_re - H_p1_im) + 1j*(H_p0_im + H_p1_re)
-        sum[1].r += (p0.r - p1.i);
-        sum[1].i += (p0.i + p1.r);
-        sum2[1].r += (sum[1].r * sum[1].r) >> log2_re;
-        sum2[1].i += (sum[1].i * sum[1].i) >> log2_re;
-
-        // H_p0 - 1*H_p1 = (H_p0_re - H_p1_re) + 1j*(H_p0_im - H_p1_im)
-        sum[2].r += (p0.r - p1.r);
-        sum[2].i += (p0.i - p1.i);
-        sum2[2].r += (sum[2].r * sum[2].r) >> log2_re;
-        sum2[2].i += (sum[2].i * sum[2].i) >> log2_re;
-
-        // H_p0 - 1j*H_p1 = (H_p0_re + H_p1_im) + 1j*(H_p0_im - H_p1_re)
-        sum[3].r += (p0.r + p1.i);
-        sum[3].i += (p0.i - p1.r);
-        sum2[3].r += (sum[3].r * sum[3].r) >> log2_re;
-        sum2[3].i += (sum[3].i * sum[3].i) >> log2_re;
-      }
+// Rank 1 or 2; 4 ports (TS 38.214 - Tables 5.2.2.2.1-5 and -6)
+static void nr_csi_rs_pmi_4ports(int nb_antennas_rx,
+                                 int N_ports,
+                                 int osz,
+                                 const c16_t ch_freq[][N_ports][osz],
+                                 const fapi_nr_dl_config_csirs_pdu_rel15_t *cfg,
+                                 uint32_t noise,
+                                 uint8_t rank_indicator,
+                                 csi_rs_pmi_t *pmi,
+                                 int32_t *precoded_sinr_dB)
+{
+  if (rank_indicator > 1) {
+    LOG_W(NR_PHY, "PMI not implemented for 4 ports and rank %d\n", rank_indicator + 1);
+    return;
+  }
+  // R = sum H^H H, 4x4 Hermitian, upper triangle only.
+  c64_t R[4][4] = {{{0}}};
+  int num_h_vectors = 0;
+  for (int rb = cfg->start_rb; rb < cfg->start_rb + cfg->nr_of_rbs; rb++) {
+    if (cfg->freq_density <= 1 && cfg->freq_density != (rb % 2))
+      continue;
+    int k = rb * NR_NB_SC_PER_RB;
+    for (int ant_rx = 0; ant_rx < nb_antennas_rx; ant_rx++) {
+      c16_t h[4];
+      for (int p = 0; p < 4; p++)
+        h[p] = ch_freq[ant_rx][p][k];
+      for (int i = 0; i < 4; i++)
+        for (int j = i; j < 4; j++) {
+          R[i][j] = c64x16maddConjShift(h[i], h[j], R[i][j], 0);
+        }
     }
+    num_h_vectors++;
+  }
+  if (num_h_vectors == 0)
+    return;
 
-    // We should perform >>nr_csi_info->log2_re here for all terms, but since sum2_re and sum2_im can be high values,
-    // we performed this above.
-    for(int p = 0; p<4; p++) {
-      int64_t power_re = sum2[p].r - (sum[p].r >> log2_re) * (sum[p].r >> log2_re);
-      int64_t power_im = sum2[p].i - (sum[p].i >> log2_re) * (sum[p].i >> log2_re);
-      tested_precoded_sinr[p] = (power_re + power_im) / ipn;
-    }
+  // For W = c*[v_l; phi_n*v_l], W^H R W = (1/4)[A_l + B_l + 2*Re(phi_n*D_l)]
+  // A_l = v_l^H R[0:2,0:2] v_l   (Hermitian -> real)
+  // B_l = v_l^H R[2:4,2:4] v_l   (Hermitian -> real)
+  // D_l = v_l^H R[0:2,2:4] v_l   (general -> complex)
+  int64_t A[8];
+  int64_t B[8];
+  c64_t D[8];
+  for (int l = 0; l < 8; l++) {
+    const c64_t v = {vl_r[l], vl_i[l]};
+    A[l] = PMI_Q * PMI_Q * (R[0][0].r + R[1][1].r) + 2LL * PMI_Q * (R[0][1].r * v.r - R[0][1].i * v.i);
+    B[l] = PMI_Q * PMI_Q * (R[2][2].r + R[3][3].r) + 2LL * PMI_Q * (R[2][3].r * v.r - R[2][3].i * v.i);
+    D[l].r = PMI_Q * PMI_Q * (R[0][2].r + R[1][3].r) + PMI_Q * ((R[0][3].r + R[1][2].r) * v.r + (R[1][2].i - R[0][3].i) * v.i);
+    D[l].i = PMI_Q * PMI_Q * (R[0][2].i + R[1][3].i) + PMI_Q * ((R[0][3].i + R[1][2].i) * v.r + (R[0][3].r - R[1][2].r) * v.i);
+  }
 
-    if(rank_indicator == 0) {
-      for(int tested_i2 = 0; tested_i2 < 4; tested_i2++) {
-        if(tested_precoded_sinr[tested_i2] > tested_precoded_sinr[i2[0]]) {
-          i2[0] = tested_i2;
+  int64_t best = INT64_MIN, best_signal = 0;
+  if (rank_indicator == 0) {
+    // Rank 1, Table 5.2.2.2.1-5: 32 entries indexed by (l, n).
+    for (int l = 0; l < 8; l++) {
+      const int64_t AB = A[l] + B[l];
+      for (int n = 0; n < 4; n++) {
+        int64_t cross = (int64_t)phi_r[n] * D[l].r - (int64_t)phi_i[n] * D[l].i;
+        int64_t m = AB + 2 * cross;
+        if (m > best) {
+          best = m;
+          pmi->i_1_1 = l;
+          pmi->i_2 = n;
+          best_signal = m;
         }
       }
-      *precoded_sinr_dB = dB_fixed(tested_precoded_sinr[i2[0]]);
-    } else {
-      i2[0] = tested_precoded_sinr[0]+tested_precoded_sinr[2] > tested_precoded_sinr[1]+tested_precoded_sinr[3] ? 0 : 1;
-      *precoded_sinr_dB = dB_fixed((tested_precoded_sinr[i2[0]] + tested_precoded_sinr[i2[0]+2])>>1);
     }
-
   } else {
-    LOG_W(NR_PHY, "PMI computation is not implemented for rank indicator %i\n", rank_indicator+1);
-    return -1;
+    // Rank 2, Table 5.2.2.2.1-6: 32 entries indexed by (l, i13, n). l' = (l + 4*i13) mod 8.
+    // trace(W^H R W) = (1/8)[A_l + A_l' + B_l + B_l' + 2*Re(phi_n*(D_l - D_l'))]
+    for (int l = 0; l < 8; l++)
+      for (int i13 = 0; i13 < 2; i13++) {
+        const int lp = (l + 4 * i13) & 7;
+        const int64_t AB = (A[l] + A[lp]) + (B[l] + B[lp]);
+        const int64_t dDr = D[l].r - D[lp].r, dDi = D[l].i - D[lp].i;
+        for (int n = 0; n < 2; n++) {
+          int64_t cross = (int64_t)phi_r[n] * dDr - (int64_t)phi_i[n] * dDi;
+          int64_t m = AB + 2 * cross;
+          if (m > best) {
+            best = m;
+            pmi->i_1_1 = l;
+            pmi->i_1_3 = i13;
+            pmi->i_2 = n;
+            best_signal = m;
+          }
+        }
+      }
+  }
+  // Average signal power per RE = best / (4 * Q^2 * num_REs)  [rank 1]
+  // For rank 2 the (1/8) cancels in best, but we keep the (1/4) here for SINR consistency.
+  int64_t signal_power = best_signal / (4LL * PMI_Q * PMI_Q * num_h_vectors);
+  *precoded_sinr_dB = dB_fixed(signal_power) - dB_fixed(noise);
+
+  LOG_D(NR_PHY,
+        "[nr_csi_rs_pmi_4ports] signal_power = %li (%i dB), noise = %u (%i dB)\n  --> precoded_sinr_dB = %i dB\n",
+        signal_power,
+        (int)(10 * log10(signal_power)),
+        noise,
+        (int)(10 * log10(noise)),
+        *precoded_sinr_dB);
+}
+
+static c64_t block_elem_sum(const c64_t R[8][8], int row0, int col0, int size)
+{
+  c64_t sum = {0};
+  const int64_t scale = (int64_t)PMI_Q * PMI_Q;
+  for (int i = 0; i < size; i++) {
+    sum.r += R[row0 + i][col0 + i].r;
+    sum.i += R[row0 + i][col0 + i].i;
+  }
+  sum.r *= scale;
+  sum.i *= scale;
+  return sum;
+}
+
+// Rank 1; 8 ports (TS 38.214 - Table 5.2.2.2.1-9)
+static void nr_csi_rs_pmi_8ports(int nb_antennas_rx,
+                                 int N_ports,
+                                 int osz,
+                                 const c16_t ch_freq[][N_ports][osz],
+                                 const fapi_nr_dl_config_csirs_pdu_rel15_t *cfg,
+                                 uint32_t noise,
+                                 uint8_t rank_indicator,
+                                 csi_rs_pmi_t *pmi,
+                                 int32_t *precoded_sinr_dB)
+{
+  if (rank_indicator != 0) {
+    LOG_W(NR_PHY, "PMI not implemented for 8 ports and rank %d\n", rank_indicator + 1);
+    return;
+  }
+  // R = sum H^H H, 8x8 Hermitian, upper triangle only.
+  c64_t R[8][8] = {{{0}}};
+  int num_h_vectors = 0;
+  for (int rb = cfg->start_rb; rb < cfg->start_rb + cfg->nr_of_rbs; rb++) {
+    if (cfg->freq_density <= 1 && cfg->freq_density != (rb % 2))
+      continue;
+    int k = rb * NR_NB_SC_PER_RB;
+    for (int ant_rx = 0; ant_rx < nb_antennas_rx; ant_rx++) {
+      c16_t h[8];
+      for (int p = 0; p < 8; p++)
+        h[p] = ch_freq[ant_rx][p][k];
+      for (int i = 0; i < 8; i++)
+        for (int j = i; j < 8; j++) {
+          R[i][j] = c64x16maddConjShift(h[i], h[j], R[i][j], 0);
+        }
+      num_h_vectors++;
+    }
+  }
+  if (num_h_vectors == 0)
+    return;
+
+  // For W = c*[v_lm; phi_n*v_lm] with v_lm = v_l1 (x) u_m2 (4x1, |v_lm[i]|=Q), decompose R into 4x4 blocks
+  // R_TL = R[0:4,0:4], R_TR = R[0:4,4:8], R_BR = R[4:8,4:8],
+  // and precompute A_lm, B_lm, D_lm for each (l1, m2).
+  // The Kronecker structure means v_lm = [1, exp(j*pi*m2/4), exp(j*pi*l1/4), exp(j*pi*(l1+m2)/4)],
+  // so the fourth entry is just a lookup at index (l1+m2)%8.
+  int64_t A[8][8];
+  int64_t B[8][8];
+  c64_t D[8][8];
+  const c64_t Adiag = block_elem_sum(R, 0, 0, 4);
+  const c64_t Bdiag = block_elem_sum(R, 4, 4, 4);
+  const c64_t Ddiag = block_elem_sum(R, 0, 4, 4);
+  for (int l1 = 0; l1 < 8; l1++) {
+    for (int m2 = 0; m2 < 8; m2++) {
+      const c16_t v[4] = {{PMI_Q, 0},
+                          {vl_r[m2], vl_i[m2]},
+                          {vl_r[l1], vl_i[l1]},
+                          {vl_r[(l1 + m2) & 7], vl_i[(l1 + m2) & 7]}};
+      int64_t Aval = Adiag.r;
+      int64_t Bval = Bdiag.r;
+      c64_t Dval = Ddiag;
+      for (int i = 0; i < 4; i++)
+        for (int j = i + 1; j < 4; j++) {
+          // c = conj(v[i]) * v[j]
+          c64_t c = c64x16maddConjShift(v[i], v[j], (c64_t){0, 0}, 0);
+          // Hermitian blocks: 2 * Re(c * M[i][j])
+          Aval += 2 * (c.r * R[i][j].r - c.i * R[i][j].i);
+          Bval += 2 * (c.r * R[i + 4][j + 4].r - c.i * R[i + 4][j + 4].i);
+          // General block R_TR: c * R[i][j+4] + conj(c) * R[j][i+4]
+          Dval.r += c.r * (R[i][j + 4].r + R[j][i + 4].r) + c.i * (R[j][i + 4].i - R[i][j + 4].i);
+          Dval.i += c.r * (R[i][j + 4].i + R[j][i + 4].i) + c.i * (R[i][j + 4].r - R[j][i + 4].r);
+        }
+      A[l1][m2] = Aval;
+      B[l1][m2] = Bval;
+      D[l1][m2] = Dval;
+    }
   }
 
-  return 0;
+  // Enumerate (l1, m2, n) - 256 hypotheses, each evaluation is O(1).
+  int64_t best = INT64_MIN, best_signal = 0;
+  for (int l1 = 0; l1 < 8; l1++)
+    for (int m2 = 0; m2 < 8; m2++) {
+      const int64_t AB = A[l1][m2] + B[l1][m2];
+      for (int n = 0; n < 4; n++) {
+        int64_t cross = (int64_t)phi_r[n] * D[l1][m2].r - (int64_t)phi_i[n] * D[l1][m2].i;
+        int64_t m = AB + 2 * cross;
+        if (m > best) {
+          best = m;
+          pmi->i_1_1 = l1;
+          pmi->i_1_2 = m2;
+          pmi->i_2 = n;
+          best_signal = m;
+        }
+      }
+    }
+  // Average signal power per RE = best / (8 * Q^2 * N_RE_total)
+  int64_t sp = best_signal / (8LL * PMI_Q * PMI_Q * (int64_t)num_h_vectors);
+  *precoded_sinr_dB = dB_fixed(sp) - dB_fixed(noise);
+}
+
+static void nr_csi_rs_pmi_estimation(const PHY_VARS_NR_UE *ue,
+                                     const fapi_nr_dl_config_csirs_pdu_rel15_t *csirs_config_pdu,
+                                     const uint8_t N_ports,
+                                     const c16_t csi_rs_estimated_channel_freq[][N_ports][ue->frame_parms.ofdm_symbol_size],
+                                     const uint32_t interference_plus_noise_power,
+                                     const uint8_t rank_indicator,
+                                     csi_rs_pmi_t *pmi,
+                                     int32_t *precoded_sinr_dB)
+{
+  memset(pmi, 0, sizeof(*pmi));
+  const NR_DL_FRAME_PARMS *fp = &ue->frame_parms;
+  const int nrx = fp->nb_antennas_rx;
+  const int osz = fp->ofdm_symbol_size;
+  const uint32_t noise = (interference_plus_noise_power == 0) ? 1 : interference_plus_noise_power;
+
+  switch (N_ports) {
+    case 1:
+      nr_csi_rs_pmi_1port(nrx, N_ports, osz, csi_rs_estimated_channel_freq, csirs_config_pdu, noise, precoded_sinr_dB);
+      break;
+    case 2:
+      nr_csi_rs_pmi_2ports(nrx,
+                           N_ports,
+                           osz,
+                           csi_rs_estimated_channel_freq,
+                           csirs_config_pdu,
+                           noise,
+                           rank_indicator,
+                           pmi,
+                           precoded_sinr_dB);
+      break;
+    case 4:
+      nr_csi_rs_pmi_4ports(nrx,
+                           N_ports,
+                           osz,
+                           csi_rs_estimated_channel_freq,
+                           csirs_config_pdu,
+                           noise,
+                           rank_indicator,
+                           pmi,
+                           precoded_sinr_dB);
+      break;
+    case 8:
+      nr_csi_rs_pmi_8ports(nrx,
+                           N_ports,
+                           osz,
+                           csi_rs_estimated_channel_freq,
+                           csirs_config_pdu,
+                           noise,
+                           rank_indicator,
+                           pmi,
+                           precoded_sinr_dB);
+      break;
+    default:
+      LOG_W(NR_PHY, "PMI not implemented for %d antenna ports\n", N_ports);
+  }
 }
 
 int nr_csi_rs_cqi_estimation(const uint32_t precoded_sinr,
@@ -1000,8 +1279,7 @@ void nr_ue_csi_rs_procedures(PHY_VARS_NR_UE *ue,
     rank_indicator = nr_csi_rs_ri_estimation(ue, csirs_config_pdu, mapping_parms.ports, csi_rs_estimated_channel_freq, log2_maxh);
   }
 
-  uint8_t i1[3] = {0};
-  uint8_t i2[1] = {0};
+  csi_rs_pmi_t pmi = {0};
   uint8_t cqi = 0;
   int32_t precoded_sinr_dB = 0;
   // bit 3 in bitmap to indicate RI measurment
@@ -1012,8 +1290,7 @@ void nr_ue_csi_rs_procedures(PHY_VARS_NR_UE *ue,
                              csi_rs_estimated_channel_freq,
                              csi_info->csi_im_meas_computed ? csi_info->interference_plus_noise_power : noise_power,
                              rank_indicator,
-                             log2_re,
-                             i2,
+                             &pmi,
                              &precoded_sinr_dB);
 
     // bit 4 in bitmap to indicate RI measurment
@@ -1048,11 +1325,11 @@ void nr_ue_csi_rs_procedures(PHY_VARS_NR_UE *ue,
       break;
     case 26 :
       LOG_D(NR_PHY, "RI = %i i1 = %i.%i.%i, i2 = %i, SINR = %i dB, CQI = %i\n",
-            rank_indicator + 1, i1[0], i1[1], i1[2], i2[0], precoded_sinr_dB, cqi);
+            rank_indicator + 1, pmi.i_1_1, pmi.i_1_2, pmi.i_1_3, pmi.i_2, precoded_sinr_dB, cqi);
       break;
     case 27 :
       LOG_D(NR_PHY, "RSRP = %i dBm, RI = %i i1 = %i.%i.%i, i2 = %i, SINR = %i dB, CQI = %i\n",
-            rsrp_dBm, rank_indicator + 1, i1[0], i1[1], i1[2], i2[0], precoded_sinr_dB, cqi);
+            rsrp_dBm, rank_indicator + 1, pmi.i_1_1, pmi.i_1_2, pmi.i_1_3, pmi.i_2, precoded_sinr_dB, cqi);
       break;
     default :
       AssertFatal(false, "Not supported measurement configuration\n");
@@ -1073,8 +1350,10 @@ void nr_ue_csi_rs_procedures(PHY_VARS_NR_UE *ue,
       .is_neighboring_cell = false,
       .rsrp_dBm = rsrp_dBm,
       .rank_indicator = rank_indicator,
-      .i1 = *i1,
-      .i2 = *i2,
+      .i_1_1 = pmi.i_1_1,
+      .i_1_2 = pmi.i_1_2,
+      .i_1_3 = pmi.i_1_3,
+      .i_2 = pmi.i_2,
       .cqi = cqi,
       .radiolink_monitoring = RLM_no_monitoring, // TODO do be activated in case of RLM based on CSI-RS
   };

--- a/openair1/PHY/NR_UE_TRANSPORT/csi_rx.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/csi_rx.c
@@ -25,76 +25,79 @@
 //#define NR_CSIRS_DEBUG
 //#define NR_CSIIM_DEBUG
 
-void nr_det_A_MF_2x2(int32_t *a_mf_00,
-                     int32_t *a_mf_01,
-                     int32_t *a_mf_10,
-                     int32_t *a_mf_11,
-                     int32_t *det_fin,
-                     const unsigned short nb_rb) {
-
-  simde__m128i ad_re_128, bc_re_128, det_re_128;
-
+static void nr_det_A_2x2(c16_t *a_mf_00,
+                         c16_t *a_mf_01,
+                         c16_t *a_mf_10,
+                         c16_t *a_mf_11,
+                         int32_t *det_fin,
+                         const unsigned short nb_rb)
+{
   simde__m128i *a_mf_00_128 = (simde__m128i *)a_mf_00;
   simde__m128i *a_mf_01_128 = (simde__m128i *)a_mf_01;
   simde__m128i *a_mf_10_128 = (simde__m128i *)a_mf_10;
   simde__m128i *a_mf_11_128 = (simde__m128i *)a_mf_11;
   simde__m128i *det_fin_128 = (simde__m128i *)det_fin;
 
-  for (int rb = 0; rb<3*nb_rb; rb++) {
+  for (int rb = 0; rb < 3 * nb_rb; rb++) {
+    // complex multiplication (I_a+jQ_a)(I_d+jQ_d) = (I_aI_d - Q_aQ_d) + j(Q_aI_d + I_aQ_d)
+    // The imag part is often zero, we compute only the real part
+    simde__m128i ad_re_128 = simde_mm_madd_epi16(oai_mm_conj(a_mf_00_128[0]), a_mf_11_128[0]); // Re: I_a0*I_d0 - Q_a1*Q_d1
 
-    //complex multiplication (I_a+jQ_a)(I_d+jQ_d) = (I_aI_d - Q_aQ_d) + j(Q_aI_d + I_aQ_d)
-    //The imag part is often zero, we compute only the real part
-    ad_re_128 = simde_mm_madd_epi16(oai_mm_conj(a_mf_00_128[0]), a_mf_11_128[0]); //Re: I_a0*I_d0 - Q_a1*Q_d1
+    // complex multiplication (I_b+jQ_b)(I_c+jQ_c) = (I_bI_c - Q_bQ_c) + j(Q_bI_c + I_bQ_c)
+    // The imag part is often zero, we compute only the real part
+    simde__m128i bc_re_128 = simde_mm_madd_epi16(oai_mm_conj(a_mf_01_128[0]), a_mf_10_128[0]); // Re: I_b0*I_c0 - Q_b1*Q_c1
 
-    //complex multiplication (I_b+jQ_b)(I_c+jQ_c) = (I_bI_c - Q_bQ_c) + j(Q_bI_c + I_bQ_c)
-    //The imag part is often zero, we compute only the real part
-    bc_re_128 = simde_mm_madd_epi16(oai_mm_conj(a_mf_01_128[0]), a_mf_10_128[0]); //Re: I_b0*I_c0 - Q_b1*Q_c1
+    simde__m128i det_re_128 = simde_mm_sub_epi32(ad_re_128, bc_re_128);
 
-    det_re_128 = simde_mm_sub_epi32(ad_re_128, bc_re_128);
-
-    //det in Q30 format
+    // det in Q30 format
     det_fin_128[0] = simde_mm_abs_epi32(det_re_128);
 
-    det_fin_128+=1;
-    a_mf_00_128+=1;
-    a_mf_01_128+=1;
-    a_mf_10_128+=1;
-    a_mf_11_128+=1;
+    det_fin_128 += 1;
+    a_mf_00_128 += 1;
+    a_mf_01_128 += 1;
+    a_mf_10_128 += 1;
+    a_mf_11_128 += 1;
   }
 }
 
-void nr_squared_matrix_element(int32_t *a,
-                               int32_t *a_sq,
-                               const unsigned short nb_rb) {
+/*
+ * nr_sq_matrix_elem(): Calculate the squares of the elements of a matrix
+ */
+static void nr_sq_matrix_elem(c16_t *a, int32_t *a_sq, const unsigned short nb_rb)
+{
   simde__m128i *a_128 = (simde__m128i *)a;
   simde__m128i *a_sq_128 = (simde__m128i *)a_sq;
-  for (int rb=0; rb<3*nb_rb; rb++) {
+  for (int rb = 0; rb < 3 * nb_rb; rb++) {
     a_sq_128[0] = simde_mm_madd_epi16(a_128[0], a_128[0]);
-    a_sq_128+=1;
-    a_128+=1;
+    a_sq_128 += 1;
+    a_128 += 1;
   }
 }
 
-void nr_numer_2x2(int32_t *a_00_sq,
-                  int32_t *a_01_sq,
-                  int32_t *a_10_sq,
-                  int32_t *a_11_sq,
-                  int32_t *num_fin,
-                  const unsigned short nb_rb) {
+/*
+ * Frobenius norm^2 of A
+ */
+static void nr_frob_norm_2x2(int32_t *a_00_sq,
+                             int32_t *a_01_sq,
+                             int32_t *a_10_sq,
+                             int32_t *a_11_sq,
+                             int32_t *num_fin,
+                             const unsigned short nb_rb)
+{
   simde__m128i *a_00_sq_128 = (simde__m128i *)a_00_sq;
   simde__m128i *a_01_sq_128 = (simde__m128i *)a_01_sq;
   simde__m128i *a_10_sq_128 = (simde__m128i *)a_10_sq;
   simde__m128i *a_11_sq_128 = (simde__m128i *)a_11_sq;
   simde__m128i *num_fin_128 = (simde__m128i *)num_fin;
-  for (int rb=0; rb<3*nb_rb; rb++) {
+  for (int rb = 0; rb < 3 * nb_rb; rb++) {
     simde__m128i sq_a_plus_sq_d_128 = simde_mm_add_epi32(a_00_sq_128[0], a_11_sq_128[0]);
     simde__m128i sq_b_plus_sq_c_128 = simde_mm_add_epi32(a_01_sq_128[0], a_10_sq_128[0]);
     num_fin_128[0] = simde_mm_add_epi32(sq_a_plus_sq_d_128, sq_b_plus_sq_c_128);
-    num_fin_128+=1;
-    a_00_sq_128+=1;
-    a_01_sq_128+=1;
-    a_10_sq_128+=1;
-    a_11_sq_128+=1;
+    num_fin_128 += 1;
+    a_00_sq_128 += 1;
+    a_01_sq_128 += 1;
+    a_10_sq_128 += 1;
+    a_11_sq_128 += 1;
   }
 }
 
@@ -428,135 +431,171 @@ static int nr_csi_rs_channel_estimation(
   return 0;
 }
 
-static int nr_csi_rs_ri_estimation(const PHY_VARS_NR_UE *ue,
-                                   const fapi_nr_dl_config_csirs_pdu_rel15_t *csirs_config_pdu,
-                                   const uint8_t N_ports,
-                                   c16_t csi_rs_estimated_channel_freq[][N_ports][ue->frame_parms.ofdm_symbol_size],
-                                   const int16_t log2_maxh,
-                                   uint8_t *rank_indicator)
+/*
+ * Rank Indicator (RI) estimation based on the condition number of the CSI-RS channel correlation matrix.
+ *
+ * For the estimated MIMO channel H (rows -> UE receive antenna, columns -> transmit layers), the algorithm computes either:
+ *      A = H^H x H
+ * or equivalently:
+ *      A = H x H^H
+ * depending on which dimension is smaller, such that A remains 2x2.
+ *
+ * In the 2x2 case:
+ *      A = | a b |
+ *          | c d |
+ *
+ * The condition metric is approximated as:
+ *                           ||A||²_F
+ *      cond_dB = 10log10( ------------ )
+ *                            det(A)
+ * where:
+ *      ||A||²_F = |a|² + |b|² + |c|² + |d|²
+ * and
+ *      det(A) = ad - bc
+ *
+ * This metric is related to the matrix condition number:
+ *      lambda_max / lambda_min
+ * where lambda_max and lambda_min are the largest and smallest eigenvalues of A.
+ *
+ * Similar eigenvalues indicate low spatial correlation and good layer separability (RI = 2), while highly unbalanced eigenvalues
+ * indicate an ill-conditioned channel and rank-1 preference.
+ *
+ * The condition metric is evaluated for each CSI-RS RE and compared against a fixed threshold (5 dB).
+ */
+static int nr_csi_rs_ri_estimation_2(int nb_antennas_rx,
+                                     int N_ports,
+                                     int ofdm_sz,
+                                     const c16_t ch_freq[][N_ports][ofdm_sz],
+                                     int start_rb,
+                                     int nr_of_rbs,
+                                     int freq_density,
+                                     int16_t log2_maxh)
 {
-  const NR_DL_FRAME_PARMS *frame_parms = &ue->frame_parms;
-  const int16_t cond_dB_threshold = 5;
+  // Choose between H^H*H (sum over RX antennas) and H*H^H (sum over TX ports)
+  // so that the resulting A matrix stays 2x2 regardless of the asymmetric dimension.
+  const bool is_HhxH = (N_ports <= nb_antennas_rx);
+  const int A_dim = 2; // min(nb_antennas_rx, N_ports), always 2 here
+  const int outer_dim = is_HhxH ? nb_antennas_rx : N_ports; // dimension being summed over
+
+  // A 12 dB threshold was chosen to allow rank-2 operation also in moderately correlated channels.
+  // A fairly conservative value for many real-world scenarios would be 5. While 18 would almost always give RI = 2.
+  // Add 3 dB since ||A||^2_F / det(A) has a theoretical 3 dB floor for an ideal 2x2 channel, i.e., 12 + 3 = 15.
+  const int cond_dB_threshold = 15;
   int count = 0;
-  *rank_indicator = 0;
 
-  if (ue->frame_parms.nb_antennas_rx == 1 || N_ports == 1) {
-    return 0;
-  } else if( !(ue->frame_parms.nb_antennas_rx == 2 && N_ports == 2) ) {
-    LOG_W(NR_PHY, "Rank indicator computation is not implemented for %i x %i system\n",
-          ue->frame_parms.nb_antennas_rx, N_ports);
-    return -1;
-  }
+  // 2x2 correlation matrix A and per-subcarrier intermediates.
+  c16_t A[A_dim][A_dim][ofdm_sz] __attribute__((aligned(32)));
+  memset(A, 0, sizeof(A));
+  int32_t A_sq[A_dim][A_dim][ofdm_sz] __attribute__((aligned(32)));
+  int32_t det_A[ofdm_sz] __attribute__((aligned(32)));
+  int32_t A_frob_norm_sq[ofdm_sz] __attribute__((aligned(32)));
 
-  /* Example 2x2: Hh x H =
-  *            | conjch00 conjch10 | x | ch00 ch01 | = | conjch00*ch00+conjch10*ch10 conjch00*ch01+conjch10*ch11 |
-  *            | conjch01 conjch11 |   | ch10 ch11 |   | conjch01*ch00+conjch11*ch10 conjch01*ch01+conjch11*ch11 |
-  */
+  // Scratch buffer for one conj-product, reused across the (i, j, outer) triple loop.
+  c16_t conjch_ch[ofdm_sz] __attribute__((aligned(32)));
 
-  c16_t csi_rs_estimated_conjch_ch[frame_parms->nb_antennas_rx][N_ports][frame_parms->nb_antennas_rx][N_ports]
-                                  [frame_parms->ofdm_symbol_size] __attribute__((aligned(32)));
-  int32_t csi_rs_estimated_A_MF[N_ports][N_ports][frame_parms->ofdm_symbol_size] __attribute__((aligned(32)));
-  int32_t csi_rs_estimated_A_MF_sq[N_ports][N_ports][frame_parms->ofdm_symbol_size] __attribute__((aligned(32)));
-  int32_t csi_rs_estimated_determ_fin[frame_parms->ofdm_symbol_size] __attribute__((aligned(32)));
-  int32_t csi_rs_estimated_numer_fin[frame_parms->ofdm_symbol_size] __attribute__((aligned(32)));
-  const uint8_t sum_shift = 1; // log2(2x2) = 2, which is a shift of 1 bit
-  
-  for (int rb = csirs_config_pdu->start_rb; rb < (csirs_config_pdu->start_rb+csirs_config_pdu->nr_of_rbs); rb++) {
-
-    if (csirs_config_pdu->freq_density <= 1 && csirs_config_pdu->freq_density != (rb % 2)) {
+  for (int rb = start_rb; rb < start_rb + nr_of_rbs; rb++) {
+    if (freq_density <= 1 && freq_density != (rb % 2))
       continue;
-    }
-    uint16_t k = rb * NR_NB_SC_PER_RB;
+    const int k = rb * NR_NB_SC_PER_RB;
 
-    for (int ant_rx_conjch = 0; ant_rx_conjch < frame_parms->nb_antennas_rx; ant_rx_conjch++) {
-      for(uint16_t port_tx_conjch = 0; port_tx_conjch < N_ports; port_tx_conjch++) {
-        for (int ant_rx_ch = 0; ant_rx_ch < frame_parms->nb_antennas_rx; ant_rx_ch++) {
-          for(uint16_t port_tx_ch = 0; port_tx_ch < N_ports; port_tx_ch++) {
-
-            // conjch x ch computation
-            nr_conjch0_mult_ch1(&csi_rs_estimated_channel_freq[ant_rx_conjch][port_tx_conjch][k],
-                                &csi_rs_estimated_channel_freq[ant_rx_ch][port_tx_ch][k],
-                                &csi_rs_estimated_conjch_ch[ant_rx_conjch][port_tx_conjch][ant_rx_ch][port_tx_ch][k],
-                                1,
-                                log2_maxh);
-
-            // construct Hh x H elements
-            if(ant_rx_conjch == ant_rx_ch) {
-              nr_a_sum_b((c16_t *)&csi_rs_estimated_A_MF[port_tx_conjch][port_tx_ch][k],
-                         (c16_t *)&csi_rs_estimated_conjch_ch[ant_rx_conjch][port_tx_conjch][ant_rx_ch][port_tx_ch][k],
-                         1);
-            }
-          }
+    // Accumulate A[i][j] over the outer dimension:
+    //   is_HhxH : A[i][j] = sum_{m} conj(ch[m][i]) * ch[m][j]      (m = RX antenna)
+    //   !is_HhxH: A[i][j] = sum_{m} conj(ch[i][m]) * ch[j][m]      (m = TX port; gives (H*H^H)^T)
+    for (int idx_outer = 0; idx_outer < outer_dim; idx_outer++) {
+      for (int i = 0; i < A_dim; i++) {
+        for (int j = 0; j < A_dim; j++) {
+          const c16_t *ch_for_conj = is_HhxH ? &ch_freq[idx_outer][i][k] : &ch_freq[i][idx_outer][k];
+          const c16_t *ch_plain = is_HhxH ? &ch_freq[idx_outer][j][k] : &ch_freq[j][idx_outer][k];
+          // conjch_ch = conj(ch_for_conj) * ch_plain over 1 RB (12 subcarriers)
+          mult_cpx_conj_vector((c16_t *)ch_for_conj, (c16_t *)ch_plain, &conjch_ch[k], NR_NB_SC_PER_RB, log2_maxh);
+          // A[i][j] += conjch_ch
+          nr_a_sum_b(&A[i][j][k], &conjch_ch[k], 1);
         }
       }
     }
 
-    // compute the determinant of A_MF (denominator)
-    nr_det_A_MF_2x2(&csi_rs_estimated_A_MF[0][0][k],
-                    &csi_rs_estimated_A_MF[0][1][k],
-                    &csi_rs_estimated_A_MF[1][0][k],
-                    &csi_rs_estimated_A_MF[1][1][k],
-                    &csi_rs_estimated_determ_fin[k],
-                    1);
+    // Determinant of A (denominator of the condition metric).
+    nr_det_A_2x2(&A[0][0][k], &A[0][1][k], &A[1][0][k], &A[1][1][k], &det_A[k], 1);
 
-    // compute the square of A_MF (numerator)
-    nr_squared_matrix_element(&csi_rs_estimated_A_MF[0][0][k], &csi_rs_estimated_A_MF_sq[0][0][k], 1);
-    nr_squared_matrix_element(&csi_rs_estimated_A_MF[0][1][k], &csi_rs_estimated_A_MF_sq[0][1][k], 1);
-    nr_squared_matrix_element(&csi_rs_estimated_A_MF[1][0][k], &csi_rs_estimated_A_MF_sq[1][0][k], 1);
-    nr_squared_matrix_element(&csi_rs_estimated_A_MF[1][1][k], &csi_rs_estimated_A_MF_sq[1][1][k], 1);
-    nr_numer_2x2(&csi_rs_estimated_A_MF_sq[0][0][k],
-                 &csi_rs_estimated_A_MF_sq[0][1][k],
-                 &csi_rs_estimated_A_MF_sq[1][0][k],
-                 &csi_rs_estimated_A_MF_sq[1][1][k],
-                 &csi_rs_estimated_numer_fin[k],
-                 1);
+    // Per-element |A_ij|^2 and their sum -> Frobenius norm^2 of A (numerator).
+    nr_sq_matrix_elem(&A[0][0][k], &A_sq[0][0][k], 1);
+    nr_sq_matrix_elem(&A[0][1][k], &A_sq[0][1][k], 1);
+    nr_sq_matrix_elem(&A[1][0][k], &A_sq[1][0][k], 1);
+    nr_sq_matrix_elem(&A[1][1][k], &A_sq[1][1][k], 1);
+    nr_frob_norm_2x2(&A_sq[0][0][k], &A_sq[0][1][k], &A_sq[1][0][k], &A_sq[1][1][k], &A_frob_norm_sq[k], 1);
 
 #ifdef NR_CSIRS_DEBUG
-    for(uint16_t port_tx_conjch = 0; port_tx_conjch < N_ports; port_tx_conjch++) {
-      for(uint16_t port_tx_ch = 0; port_tx_ch < N_ports; port_tx_ch++) {
-        c16_t *csi_rs_estimated_A_MF_k = (c16_t *)&csi_rs_estimated_A_MF[port_tx_conjch][port_tx_ch][k];
-        LOG_I(NR_PHY, "(%i) csi_rs_estimated_A_MF[%i][%i] = (%i, %i)\n",
-              k, port_tx_conjch, port_tx_ch, csi_rs_estimated_A_MF_k->r, csi_rs_estimated_A_MF_k->i);
-        c16_t *csi_rs_estimated_A_MF_sq_k = (c16_t *)&csi_rs_estimated_A_MF_sq[port_tx_conjch][port_tx_ch][k];
-        LOG_I(NR_PHY, "(%i) csi_rs_estimated_A_MF_sq[%i][%i] = (%i, %i)\n",
-              k, port_tx_conjch, port_tx_ch, csi_rs_estimated_A_MF_sq_k->r, csi_rs_estimated_A_MF_sq_k->i);
+    for (int i = 0; i < A_dim; i++) {
+      for (int j = 0; j < A_dim; j++) {
+        c16_t *a_k = &A[i][j][k];
+        int32_t *a_sq_k = &A_sq[i][j][k];
+        LOG_I(NR_PHY, "A[%i][%i][%i] = (%i, %i)\n", i, j, k, a_k->r, a_k->i);
+        LOG_I(NR_PHY, "A_sq[%i][%i][%i] = %i\n", i, j, k, *a_sq_k);
       }
     }
-    LOG_I(NR_PHY, "(%i) csi_rs_estimated_determ_fin = %i\n", k, csi_rs_estimated_determ_fin[k]);
-    LOG_I(NR_PHY, "(%i) csi_rs_estimated_numer_fin = %i\n", k, csi_rs_estimated_numer_fin[k] >> sum_shift);
+    LOG_I(NR_PHY, "(%i) det_A = %i\n", k, det_A[k]);
+    LOG_I(NR_PHY, "(%i) A_frob_norm_sq = %i\n", k, A_frob_norm_sq[k]);
 #endif
 
-    // compute the conditional number
-    for (int sc_idx=0; sc_idx < NR_NB_SC_PER_RB; sc_idx++) {
-      int8_t csi_rs_estimated_denum_db = dB_fixed(csi_rs_estimated_determ_fin[k + sc_idx]);
-      int8_t csi_rs_estimated_numer_db = dB_fixed(csi_rs_estimated_numer_fin[k + sc_idx] >> sum_shift);
-      int8_t cond_db = csi_rs_estimated_numer_db - csi_rs_estimated_denum_db;
+    // Evaluate the condition metric per RE and run a majority vote.
+    for (int sc_idx = 0; sc_idx < NR_NB_SC_PER_RB; sc_idx++) {
+      int8_t denum_db = dB_fixed(det_A[k + sc_idx]);
+      int8_t numer_db = dB_fixed(A_frob_norm_sq[k + sc_idx]);
+      int cond_db = numer_db - denum_db;
 
 #ifdef NR_CSIRS_DEBUG
-      LOG_I(NR_PHY, "csi_rs_estimated_denum_db = %i\n", csi_rs_estimated_denum_db);
-      LOG_I(NR_PHY, "csi_rs_estimated_numer_db = %i\n", csi_rs_estimated_numer_db);
-      LOG_I(NR_PHY, "cond_db = %i\n", cond_db);
+      LOG_I(NR_PHY, "denum_db = %i, numer_db = %i, cond_db = %i\n", denum_db, numer_db, cond_db);
 #endif
 
-      if (cond_db < cond_dB_threshold) {
+      if (cond_db < cond_dB_threshold)
         count++;
-      } else {
+      else
         count--;
-      }
     }
-  }
-
-  // conditional number is lower than cond_dB_threshold in half on more REs
-  if (count > 0) {
-    *rank_indicator = 1;
   }
 
 #ifdef NR_CSIRS_DEBUG
   LOG_I(NR_PHY, "count = %i\n", count);
-  LOG_I(NR_PHY, "rank = %i\n", (*rank_indicator)+1);
 #endif
 
-  return 0;
+  // Rank 2 if the channel is well-conditioned in the majority of REs, rank 1 otherwise.
+  if (count > 0) {
+#ifdef NR_CSIRS_DEBUG
+    LOG_I(NR_PHY, "rank = 2\n");
+#endif
+    return 1;
+  } else {
+#ifdef NR_CSIRS_DEBUG
+    LOG_I(NR_PHY, "rank = 1\n");
+#endif
+    return 0;
+  }
+}
+
+static int nr_csi_rs_ri_estimation(const PHY_VARS_NR_UE *ue,
+                                   const fapi_nr_dl_config_csirs_pdu_rel15_t *csirs_config_pdu,
+                                   const uint8_t N_ports,
+                                   const c16_t csi_rs_estimated_channel_freq[][N_ports][ue->frame_parms.ofdm_symbol_size],
+                                   const int16_t log2_maxh)
+{
+  const NR_DL_FRAME_PARMS *fp = &ue->frame_parms;
+  const int max_rank = min(fp->nb_antennas_rx, N_ports);
+  switch (max_rank) {
+    case 1:
+      return 0;
+    case 2:
+      return nr_csi_rs_ri_estimation_2(fp->nb_antennas_rx,
+                                       N_ports,
+                                       fp->ofdm_symbol_size,
+                                       csi_rs_estimated_channel_freq,
+                                       csirs_config_pdu->start_rb,
+                                       csirs_config_pdu->nr_of_rbs,
+                                       csirs_config_pdu->freq_density,
+                                       log2_maxh);
+    default:
+      LOG_W(NR_PHY, "Rank indicator computation is not implemented for %i x %i system\n", fp->nb_antennas_rx, N_ports);
+      return 0;
+  }
 }
 
 static int nr_csi_rs_pmi_estimation(const PHY_VARS_NR_UE *ue,
@@ -955,15 +994,10 @@ void nr_ue_csi_rs_procedures(PHY_VARS_NR_UE *ue,
                                 &noise_power);
   }
 
+  // bit 1 in bitmap to indicate RI measurement
   uint8_t rank_indicator = 0;
-  // bit 1 in bitmap to indicate RI measurment
   if (csirs_config_pdu->measurement_bitmap & 2) {
-    nr_csi_rs_ri_estimation(ue,
-                            csirs_config_pdu,
-                            mapping_parms.ports,
-                            csi_rs_estimated_channel_freq,
-                            log2_maxh,
-                            &rank_indicator);
+    rank_indicator = nr_csi_rs_ri_estimation(ue, csirs_config_pdu, mapping_parms.ports, csi_rs_estimated_channel_freq, log2_maxh);
   }
 
   uint8_t i1[3] = {0};

--- a/openair1/PHY/NR_UE_TRANSPORT/csi_rx.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/csi_rx.c
@@ -158,28 +158,35 @@ static int nr_get_csi_rs_signal(const PHY_VARS_NR_UE *ue,
                                 c16_t csi_rs_received_signal[][ue->frame_parms.samples_per_slot_wCP],
                                 uint32_t *rsrp,
                                 int *rsrp_dBm,
+                                uint32_t *noise_power,
                                 const c16_t rxdataF[][ue->frame_parms.samples_per_slot_wCP])
 {
   const NR_DL_FRAME_PARMS *fp = &ue->frame_parms;
   uint16_t meas_count = 0;
   uint32_t rsrp_sum = 0;
 
+  // Variables for calculating noise power
+  int64_t sum_nr = 0;
+  int64_t sum_nr2 = 0;
+  int64_t sum_ni = 0;
+  int64_t sum_ni2 = 0;
+  int n_count = 0;
+
   for (int ant_rx = 0; ant_rx < fp->nb_antennas_rx; ant_rx++) {
+    int k_prev = fp->ofdm_symbol_size;
 
-    for (int rb = csirs_config_pdu->start_rb; rb < (csirs_config_pdu->start_rb+csirs_config_pdu->nr_of_rbs); rb++) {
-
+    for (int rb = csirs_config_pdu->start_rb; rb < (csirs_config_pdu->start_rb + csirs_config_pdu->nr_of_rbs); rb++) {
       // for freq density 0.5 checks if even or odd RB
-      if(csirs_config_pdu->freq_density <= 1 && csirs_config_pdu->freq_density != (rb % 2)) {
+      if (csirs_config_pdu->freq_density <= 1 && csirs_config_pdu->freq_density != (rb % 2)) {
         continue;
       }
 
       for (int cdm_id = 0; cdm_id < csi_mapping->size; cdm_id++) {
-        for (int s = 0; s < CDM_group_size; s++)  {
-
+        for (int s = 0; s < CDM_group_size; s++) {
           // loop over frequency resource elements within a group
           for (int kp = 0; kp <= csi_mapping->kprime; kp++) {
-
-            uint16_t k = (fp->first_carrier_offset + (rb * NR_NB_SC_PER_RB) + csi_mapping->koverline[cdm_id] + kp) % fp->ofdm_symbol_size;
+            uint16_t k =
+                (fp->first_carrier_offset + (rb * NR_NB_SC_PER_RB) + csi_mapping->koverline[cdm_id] + kp) % fp->ofdm_symbol_size;
 
             // loop over time resource elements within a group
             for (int lp = 0; lp <= csi_mapping->lprime; lp++) {
@@ -190,10 +197,20 @@ static int nr_get_csi_rs_signal(const PHY_VARS_NR_UE *ue,
               rx_csi_rs_signal[k].r = rx_signal[k].r;
               rx_csi_rs_signal[k].i = rx_signal[k].i;
 
-              rsrp_sum += (((int32_t)(rx_csi_rs_signal[k].r)*rx_csi_rs_signal[k].r) +
-                           ((int32_t)(rx_csi_rs_signal[k].i)*rx_csi_rs_signal[k].i));
+              rsrp_sum += (((int32_t)(rx_csi_rs_signal[k].r) * rx_csi_rs_signal[k].r)
+                           + ((int32_t)(rx_csi_rs_signal[k].i) * rx_csi_rs_signal[k].i));
 
               meas_count++;
+
+              // For calculating noise power
+              for (int kh = k_prev + 1; kh < k; kh++) {
+                sum_nr += rx_signal[kh].r;
+                sum_nr2 += rx_signal[kh].r * rx_signal[kh].r;
+                sum_ni += rx_signal[kh].i;
+                sum_ni2 += rx_signal[kh].i * rx_signal[kh].i;
+                n_count++;
+              }
+              k_prev = k;
 
 #ifdef NR_CSIRS_DEBUG
               int dataF_offset = proc->nr_slot_rx * fp->samples_per_slot_wCP;
@@ -203,7 +220,7 @@ static int nr_get_csi_rs_signal(const PHY_VARS_NR_UE *ue,
                     "l,k (%2d,%4d) |\tport_tx %d (%4d,%4d)\tant_rx %d (%4d,%4d)\n",
                     symb,
                     k,
-                    port_tx+3000,
+                    port_tx + 3000,
                     tx_csi_rs_signal[k].r,
                     tx_csi_rs_signal[k].i,
                     ant_rx,
@@ -220,73 +237,54 @@ static int nr_get_csi_rs_signal(const PHY_VARS_NR_UE *ue,
     }
   }
 
-
-  *rsrp = rsrp_sum/meas_count;
+  *rsrp = rsrp_sum / meas_count;
   *rsrp_dBm = dB_fixed(*rsrp) + 30 - SQ15_SQUARED_NORM_FACTOR_DB
               - ((int)openair0_cfg_g[ue->rf_map.card].rx_gain[0] - (int)openair0_cfg_g[ue->rf_map.card].rx_gain_offset[0])
-              - dB_fixed(ue->frame_parms.ofdm_symbol_size);
+              - dB_fixed(fp->ofdm_symbol_size);
+
+  *noise_power =
+    sum_nr2 / n_count - (sum_nr / n_count) * (sum_nr / n_count) + sum_ni2 / n_count - (sum_ni / n_count) * (sum_ni / n_count);
 
 #ifdef NR_CSIRS_DEBUG
   LOG_I(NR_PHY, "RSRP = %i (%i dBm)\n", *rsrp, *rsrp_dBm);
+  LOG_I(NR_PHY, "Noise power estimation based on CSI-RS: %i\n", *noise_power);
 #endif
 
   return 0;
 }
 
-uint32_t calc_power_csirs(const uint16_t *x, const fapi_nr_dl_config_csirs_pdu_rel15_t *csirs_config_pdu)
-{
-  uint64_t sum_x = 0;
-  uint64_t sum_x2 = 0;
-  uint16_t size = 0;
-  for (int rb = 0; rb < csirs_config_pdu->nr_of_rbs; rb++) {
-    if (csirs_config_pdu->freq_density <= 1 && csirs_config_pdu->freq_density != ((rb + csirs_config_pdu->start_rb) % 2)) {
-      continue;
-    }
-    sum_x = sum_x + x[rb];
-    sum_x2 = sum_x2 + x[rb] * x[rb];
-    size++;
-  }
-  return sum_x2 / size - (sum_x / size) * (sum_x / size);
-}
-
-static int nr_csi_rs_channel_estimation(
-    const NR_DL_FRAME_PARMS *fp,
-    const fapi_nr_dl_config_csirs_pdu_rel15_t *csirs_config_pdu,
-    const nr_csi_info_t *nr_csi_info,
-    const c16_t **csi_rs_generated_signal,
-    const c16_t csi_rs_received_signal[][fp->samples_per_slot_wCP],
-    const csi_mapping_parms_t *csi_mapping,
-    const int CDM_group_size,
-    c16_t csi_rs_ls_estimated_channel[][csi_mapping->ports][fp->ofdm_symbol_size],
-    c16_t csi_rs_estimated_channel_freq[][csi_mapping->ports][fp->ofdm_symbol_size],
-    int16_t *log2_re,
-    int16_t *log2_maxh,
-    uint32_t *noise_power)
+static int nr_csi_rs_channel_estimation(const NR_DL_FRAME_PARMS *fp,
+                                        const fapi_nr_dl_config_csirs_pdu_rel15_t *csirs_config_pdu,
+                                        const nr_csi_info_t *nr_csi_info,
+                                        const c16_t **csi_rs_generated_signal,
+                                        const c16_t csi_rs_received_signal[][fp->samples_per_slot_wCP],
+                                        const csi_mapping_parms_t *csi_mapping,
+                                        const int CDM_group_size,
+                                        c16_t csi_rs_ls_estimated_channel[][csi_mapping->ports][fp->ofdm_symbol_size],
+                                        c16_t csi_rs_estimated_channel_freq[][csi_mapping->ports][fp->ofdm_symbol_size],
+                                        int16_t *log2_maxh)
 {
   const int meas_bitmap = csirs_config_pdu->measurement_bitmap;
   AssertFatal(meas_bitmap != 1, "No need to do CSI-RS channel estimation for only RSRP measurment\n");
-  *noise_power = 0;
   int maxh = 0;
-  int count = 0;
 
   for (int ant_rx = 0; ant_rx < fp->nb_antennas_rx; ant_rx++) {
 
     /// LS channel estimation
 
     const uint16_t stop_rb = csirs_config_pdu->start_rb + csirs_config_pdu->nr_of_rbs;
-    for(uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
+    for (uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
       memset(csi_rs_ls_estimated_channel[ant_rx][port_tx], 0, fp->ofdm_symbol_size * sizeof(c16_t));
     }
 
     for (int rb = csirs_config_pdu->start_rb; rb < stop_rb; rb++) {
       // for freq density 0.5 checks if even or odd RB
-      if(csirs_config_pdu->freq_density <= 1 && csirs_config_pdu->freq_density != (rb % 2)) {
+      if (csirs_config_pdu->freq_density <= 1 && csirs_config_pdu->freq_density != (rb % 2)) {
         continue;
       }
 
       for (int cdm_id = 0; cdm_id < csi_mapping->size; cdm_id++) {
-        for (int s = 0; s < CDM_group_size; s++)  {
-
+        for (int s = 0; s < CDM_group_size; s++) {
           uint16_t port_tx = s + csi_mapping->j[cdm_id] * CDM_group_size;
 
           // loop over frequency resource elements within a group
@@ -321,22 +319,26 @@ static int nr_csi_rs_channel_estimation(
     }
 
 #ifdef NR_CSIRS_DEBUG
-    for(int symb = 0; symb < fp->symbols_per_slot; symb++) {
-      if(!is_csi_rs_in_symbol(*csirs_config_pdu,symb)) {
+    for (int symb = 0; symb < fp->symbols_per_slot; symb++) {
+      if (!is_csi_rs_in_symbol(*csirs_config_pdu, symb)) {
         continue;
       }
-      for(int k = 0; k < fp->ofdm_symbol_size; k++) {
+      for (int k = 0; k < fp->ofdm_symbol_size; k++) {
         LOG_I(NR_PHY, "l,k (%2d,%4d) | ", symb, k);
-        for(uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
+        for (uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
           uint64_t symbol_offset = symb * fp->ofdm_symbol_size;
-          c16_t *tx_csi_rs_signal = (c16_t*)&csi_rs_generated_signal[port_tx][symbol_offset+dataF_offset];
-          c16_t *rx_csi_rs_signal = (c16_t*)&csi_rs_received_signal[ant_rx][symbol_offset];
+          c16_t *tx_csi_rs_signal = (c16_t *)&csi_rs_generated_signal[port_tx][symbol_offset + dataF_offset];
+          c16_t *rx_csi_rs_signal = (c16_t *)&csi_rs_received_signal[ant_rx][symbol_offset];
           c16_t *csi_rs_ls_estimated_channel16 = csi_rs_ls_estimated_channel[ant_rx][port_tx];
           printf("port_tx %d --> ant_rx %d, tx (%4d,%4d), rx (%4d,%4d), ls (%4d,%4d) | ",
-                 port_tx+3000, ant_rx,
-                 tx_csi_rs_signal[k].r, tx_csi_rs_signal[k].i,
-                 rx_csi_rs_signal[k].r, rx_csi_rs_signal[k].i,
-                 csi_rs_ls_estimated_channel16[k].r, csi_rs_ls_estimated_channel16[k].i);
+                 port_tx + 3000,
+                 ant_rx,
+                 tx_csi_rs_signal[k].r,
+                 tx_csi_rs_signal[k].i,
+                 rx_csi_rs_signal[k].r,
+                 rx_csi_rs_signal[k].i,
+                 csi_rs_ls_estimated_channel16[k].r,
+                 csi_rs_ls_estimated_channel16[k].i);
         }
         printf("\n");
       }
@@ -345,20 +347,18 @@ static int nr_csi_rs_channel_estimation(
 
     /// Channel interpolation
 
-    for(uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
+    for (uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
       memset(csi_rs_estimated_channel_freq[ant_rx][port_tx], 0, (fp->ofdm_symbol_size) * sizeof(c16_t));
     }
 
     for (int rb = csirs_config_pdu->start_rb; rb < stop_rb; rb++) {
       // for freq density 0.5 checks if even or odd RB
-      if(csirs_config_pdu->freq_density <= 1 && csirs_config_pdu->freq_density != (rb % 2)) {
+      if (csirs_config_pdu->freq_density <= 1 && csirs_config_pdu->freq_density != (rb % 2)) {
         continue;
       }
 
-      count++;
-
       uint16_t k = rb * NR_NB_SC_PER_RB;
-      for(uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
+      for (uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
         c16_t csi_rs_ls_estimated_channel16 = csi_rs_ls_estimated_channel[ant_rx][port_tx][k];
         c16_t *csi_rs_estimated_channel16 = &csi_rs_estimated_channel_freq[ant_rx][port_tx][k];
         if (k == 0) { // Start of OFDM symbol case or first occupied subcarrier case
@@ -375,59 +375,43 @@ static int nr_csi_rs_channel_estimation(
     if (meas_bitmap == 0)
       continue;
 
-    /// Power noise estimation
+    /// For log2_maxh computation
     AssertFatal(csirs_config_pdu->nr_of_rbs > 0, " nr_of_rbs needs to be greater than 0\n");
-    uint16_t noise_real[fp->nb_antennas_rx][csi_mapping->ports][csirs_config_pdu->nr_of_rbs];
-    uint16_t noise_imag[fp->nb_antennas_rx][csi_mapping->ports][csirs_config_pdu->nr_of_rbs];
     for (int rb = csirs_config_pdu->start_rb; rb < stop_rb; rb++) {
       if (csirs_config_pdu->freq_density <= 1 && csirs_config_pdu->freq_density != (rb % 2)) {
         continue;
       }
       uint16_t k = rb * NR_NB_SC_PER_RB;
-      for(uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
-        c16_t *csi_rs_ls_estimated_channel16 = &csi_rs_ls_estimated_channel[ant_rx][port_tx][k];
+      for (uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
         c16_t *csi_rs_estimated_channel16 = &csi_rs_estimated_channel_freq[ant_rx][port_tx][k];
-        noise_real[ant_rx][port_tx][rb-csirs_config_pdu->start_rb] = abs(csi_rs_ls_estimated_channel16->r-csi_rs_estimated_channel16->r);
-        noise_imag[ant_rx][port_tx][rb-csirs_config_pdu->start_rb] = abs(csi_rs_ls_estimated_channel16->i-csi_rs_estimated_channel16->i);
         maxh = cmax3(maxh, abs(csi_rs_estimated_channel16->r), abs(csi_rs_estimated_channel16->i));
       }
     }
-    for(uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
-      *noise_power += (calc_power_csirs(noise_real[ant_rx][port_tx], csirs_config_pdu) + calc_power_csirs(noise_imag[ant_rx][port_tx],csirs_config_pdu));
-    }
 
 #ifdef NR_CSIRS_DEBUG
-    for(int k = 0; k < fp->ofdm_symbol_size; k++) {
+    for (int k = 0; k < fp->ofdm_symbol_size; k++) {
       int rb = k / NR_NB_SC_PER_RB;
       LOG_I(NR_PHY, "(k = %4d) |\t", k);
-      for(uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
+      for (uint16_t port_tx = 0; port_tx < csi_mapping->ports; port_tx++) {
         c16_t *csi_rs_ls_estimated_channel16 = &csi_rs_ls_estimated_channel[ant_rx][port_tx][0];
         c16_t *csi_rs_estimated_channel16 = &csi_rs_estimated_channel_freq[ant_rx][port_tx][0];
-        printf("Channel port_tx %d --> ant_rx %d : ls (%4d,%4d), int (%4d,%4d), noise (%4d,%4d) | ",
+        printf("Channel port_tx %d --> ant_rx %d : ls (%4d,%4d), int (%4d,%4d) | ",
                port_tx + 3000,
                ant_rx,
                csi_rs_ls_estimated_channel16[k].r,
                csi_rs_ls_estimated_channel16[k].i,
                csi_rs_estimated_channel16[k].r,
-               csi_rs_estimated_channel16[k].i,
-               rb >= stop_rb ? 0 : noise_real[ant_rx][port_tx][rb - csirs_config_pdu->start_rb],
-               rb >= stop_rb ? 0 : noise_imag[ant_rx][port_tx][rb - csirs_config_pdu->start_rb]);
+               csi_rs_estimated_channel16[k].i);
       }
       printf("\n");
     }
 #endif
-
   }
 
   if (meas_bitmap > 1) {
-    *noise_power /= (fp->nb_antennas_rx * csi_mapping->ports);
     *log2_maxh = log2_approx(maxh - 1);
-    *log2_re = log2_approx(count - 1);
   }
 
-#ifdef NR_CSIRS_DEBUG
-  LOG_I(NR_PHY, "Noise power estimation based on CSI-RS: %i\n", *noise_power);
-#endif
   return 0;
 }
 
@@ -1242,6 +1226,7 @@ void nr_ue_csi_rs_procedures(PHY_VARS_NR_UE *ue,
   c16_t csi_rs_received_signal[frame_parms->nb_antennas_rx][frame_parms->samples_per_slot_wCP];
   uint32_t rsrp = 0;
   int rsrp_dBm = 0;
+  uint32_t noise_power = 0;
   nr_get_csi_rs_signal(ue,
                        proc,
                        csirs_config_pdu,
@@ -1251,26 +1236,23 @@ void nr_ue_csi_rs_procedures(PHY_VARS_NR_UE *ue,
                        csi_rs_received_signal,
                        &rsrp,
                        &rsrp_dBm,
+                       &noise_power,
                        rxdataF);
 
-  uint32_t noise_power = 0;
-  int16_t log2_re = 0;
   int16_t log2_maxh = 0;
   // if we need to measure only RSRP no need to do channel estimation
   if (csirs_config_pdu->measurement_bitmap != 1) {
     const bool use_trs_buff = (csirs_config_pdu->csi_type == 0 && res_idx == 0);
     nr_csi_rs_channel_estimation(frame_parms,
-                                csirs_config_pdu,
-                                csi_info,
-                                (const c16_t **)csi_info->csi_rs_generated_signal,
-                                csi_rs_received_signal,
-                                &mapping_parms,
-                                CDM_group_size,
-                                (use_trs_buff) ? trs_estimates : csi_rs_ls_estimated_channel,
-                                csi_rs_estimated_channel_freq,
-                                &log2_re,
-                                &log2_maxh,
-                                &noise_power);
+                                 csirs_config_pdu,
+                                 csi_info,
+                                 (const c16_t **)csi_info->csi_rs_generated_signal,
+                                 csi_rs_received_signal,
+                                 &mapping_parms,
+                                 CDM_group_size,
+                                 (use_trs_buff) ? trs_estimates : csi_rs_ls_estimated_channel,
+                                 csi_rs_estimated_channel_freq,
+                                 &log2_maxh);
   }
 
   // bit 1 in bitmap to indicate RI measurement

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
@@ -253,17 +253,14 @@ static void nr_dlsch_extract_rbs(uint32_t rxdataF_sz,
   }
 }
 
-/* Zero Forcing Rx function: nr_a_sum_b()
- * Compute the complex addition x=x+y
- *
- * */
+/*
+ * nr_a_sum_b(): Compute the complex addition x=x+y
+ */
 void nr_a_sum_b(c16_t *input_x, c16_t *input_y, unsigned short nb_rb)
 {
-  unsigned short rb;
   simde__m128i *x = (simde__m128i *)input_x;
   simde__m128i *y = (simde__m128i *)input_y;
-
-  for (rb=0; rb<nb_rb; rb++) {
+  for (int rb = 0; rb < nb_rb; rb++) {
     x[0] = simde_mm_adds_epi16(x[0], y[0]);
     x[1] = simde_mm_adds_epi16(x[1], y[1]);
     x[2] = simde_mm_adds_epi16(x[2], y[2]);
@@ -510,17 +507,6 @@ uint8_t nr_matrix_inverse(int32_t size,
   return(0);
 }
 
-/* Zero Forcing Rx function: nr_conjch0_mult_ch1()
- *
- *
- * */
-// TODO: This function is just a wrapper, can be removed.
-void nr_conjch0_mult_ch1(c16_t *ch0, c16_t *ch1, c16_t *ch0conj_ch1, unsigned short nb_rb, unsigned char output_shift0)
-{
-  //This function is used to compute multiplications in H_hermitian * H matrix
-  mult_cpx_conj_vector(ch0, ch1, ch0conj_ch1, 12 * nb_rb, output_shift0);
-}
-
 /*
  * MMSE Rx function: up to 4 layers
  */
@@ -556,11 +542,11 @@ static void nr_dlsch_mmse(uint32_t pdsch_buf_size_max,
       for (int aarx = 0; aarx < n_rx; aarx++)  {
         c16_t *ch0r = (c16_t *)dl_ch_estimates_ext[rtx * n_rx + aarx];
         c16_t *ch0c = (c16_t *)dl_ch_estimates_ext[ctx * n_rx + aarx];
-        nr_conjch0_mult_ch1(ch0r,
-                            ch0c,
-                            conjH_H_elements[aarx][ctx][rtx], // sic
-                            nb_rb_0,
-                            shift);
+        mult_cpx_conj_vector(ch0r,
+                             ch0c,
+                             conjH_H_elements[aarx][ctx][rtx], // sic
+                             nb_rb_0 * NR_NB_SC_PER_RB,
+                             shift);
         if (aarx != 0)
           nr_a_sum_b(conjH_H_elements[0][ctx][rtx], conjH_H_elements[aarx][ctx][rtx], nb_rb_0);
       }

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
@@ -32,7 +32,6 @@ typedef struct pdsch_scope_req_s {
 /** \brief This function initialises structures for DLSCH at UE
 */
 void nr_ue_dlsch_init(NR_UE_DLSCH_t *dlsch_list, int num_dlsch, uint8_t max_ldpc_iterations);
-void nr_conjch0_mult_ch1(c16_t *ch0, c16_t *ch1, c16_t *ch0conj_ch1, unsigned short nb_rb, unsigned char output_shift0);
 
 void set_first_last_pdcch_symb(const NR_UE_PDCCH_CONFIG *phy_pdcch_config, int symb_slot, int *first_symb, int *last_symb);
 

--- a/openair1/PHY/TOOLS/tools_defs.h
+++ b/openair1/PHY/TOOLS/tools_defs.h
@@ -232,6 +232,13 @@ extern "C" {
     };
   }
 
+  __attribute__((always_inline)) inline c64_t c64x16maddConjShift(const c16_t a, const c16_t b, const c64_t c, const int Shift) {
+    return (c64_t) {
+      .r = (((int64_t)a.r * b.r + (int64_t)a.i * b.i) >> Shift) + c.r,
+      .i = (((int64_t)a.r * b.i - (int64_t)a.i * b.r) >> Shift) + c.i
+    };
+  }
+
   __attribute__((always_inline)) inline c16_t c16x32div(const c32_t a, const int div) {
     return (c16_t) {
       .r = (int16_t)(a.r / div),

--- a/openair2/LAYER2/NR_MAC_UE/mac_defs.h
+++ b/openair2/LAYER2/NR_MAC_UE/mac_defs.h
@@ -416,8 +416,10 @@ typedef struct {
 typedef struct {
   int rsrp_dBm;
   uint8_t ri;
-  uint16_t i1;
-  uint8_t i2;
+  uint8_t i_1_1;
+  uint8_t i_1_2;
+  uint8_t i_1_3;
+  uint8_t i_2;
   uint8_t cqi;
 } NR_CSIRS_meas_t;
 

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
@@ -1660,8 +1660,10 @@ void nr_ue_process_l1_measurements(NR_UE_MAC_INST_t *mac, frame_t frame, int slo
     mac->ssb_measurements[ssb_index].ssb_sinr_dB = l1_measurements->sinr_dB;
   } else if (csi_meas) {
     mac->csirs_measurements.rsrp_dBm = l1_measurements->rsrp_dBm;
-    mac->csirs_measurements.i1 = l1_measurements->i1;
-    mac->csirs_measurements.i2 = l1_measurements->i2;
+    mac->csirs_measurements.i_1_1 = l1_measurements->i_1_1;
+    mac->csirs_measurements.i_1_2 = l1_measurements->i_1_2;
+    mac->csirs_measurements.i_1_3 = l1_measurements->i_1_3;
+    mac->csirs_measurements.i_2 = l1_measurements->i_2;
     mac->csirs_measurements.cqi = l1_measurements->cqi;
     mac->csirs_measurements.ri = l1_measurements->rank_indicator;
   }
@@ -2970,11 +2972,46 @@ static nfapi_nr_ue_csi_payload_t get_ssb_rsrp_payload(NR_UE_MAC_INST_t *mac,
   return csi;
 }
 
+// Pack i_1,1 || i_1,2 || i_1,3 into the X1 PMI field, with i_1,1 in the most significant bits
+// (ordering per TS 38.212 Sections 6.3.1.1.2 and 6.3.2.1.2).
+// Sub-field widths are inferred from the total pmi_x1_bitlen, which is unique across the Type1 Single Panel configurations
+// covered by the PMI estimator:
+//   ports | rank | pmi_x1_bitlen | i_1,1 | i_1,2 | i_1,3
+//     2   | 1,2  |       0       |   -   |   -   |   -
+//     4   |   1  |       3       |   3   |   0   |   0
+//     4   |   2  |       4       |   3   |   0   |   1
+//     8   |   1  |       6       |   3   |   3   |   0
+//     8   |   2  |       8       |   3   |   3   |   2
+static uint16_t pack_pmi_x1(int pmi_x1_bitlen, uint8_t i_1_1, uint8_t i_1_2, uint8_t i_1_3)
+{
+  int bits_12 = 0, bits_13 = 0;
+  switch (pmi_x1_bitlen) {
+    case 0:
+      return 0; // 2-port: no X1
+    case 3:
+      break; // 4-port rank 1
+    case 4:
+      bits_13 = 1;
+      break; // 4-port rank 2
+    case 6:
+      bits_12 = 3;
+      break; // 8-port rank 1
+    case 8:
+      bits_12 = 3;
+      bits_13 = 2;
+      break; // 8-port rank 2
+    default:
+      LOG_W(NR_MAC, "pack_pmi_x1: unsupported pmi_x1_bitlen %d (Type1 SinglePanel only)\n", pmi_x1_bitlen);
+      return 0;
+  }
+  return ((uint16_t)i_1_1 << (bits_12 + bits_13)) | ((uint16_t)i_1_2 << bits_13) | (uint16_t)i_1_3;
+}
+
 static nfapi_nr_ue_csi_payload_t get_csirs_RI_PMI_CQI_payload(NR_UE_MAC_INST_t *mac,
-                                                  const struct NR_CSI_ReportConfig *csi_reportconfig,
-                                                  const NR_CSI_ResourceConfigId_t csi_ResourceConfigId,
-                                                  const NR_CSI_MeasConfig_t *csi_MeasConfig,
-                                                  const CSI_mapping_t mapping_type)
+                                                              const struct NR_CSI_ReportConfig *csi_reportconfig,
+                                                              const NR_CSI_ResourceConfigId_t csi_ResourceConfigId,
+                                                              const NR_CSI_MeasConfig_t *csi_MeasConfig,
+                                                              const CSI_mapping_t mapping_type)
 {
   int p1_bits = 0;
   int p2_bits = 0;
@@ -2983,66 +3020,81 @@ static nfapi_nr_ue_csi_payload_t get_csirs_RI_PMI_CQI_payload(NR_UE_MAC_INST_t *
   AssertFatal(mapping_type != SUBBAND_ON_PUCCH, "CSI mapping for subband PMI and CQI not implemented\n");
 
   for (int csi_resourceidx = 0; csi_resourceidx < csi_MeasConfig->csi_ResourceConfigToAddModList->list.count; csi_resourceidx++) {
-
     struct NR_CSI_ResourceConfig *csi_resourceconfig = csi_MeasConfig->csi_ResourceConfigToAddModList->list.array[csi_resourceidx];
-    if (csi_resourceconfig->csi_ResourceConfigId == csi_ResourceConfigId) {
+    if (csi_resourceconfig->csi_ResourceConfigId != csi_ResourceConfigId)
+      continue;
 
-      for (int csi_idx = 0; csi_idx < csi_MeasConfig->nzp_CSI_RS_ResourceSetToAddModList->list.count; csi_idx++) {
-        if (csi_MeasConfig->nzp_CSI_RS_ResourceSetToAddModList->list.array[csi_idx]->nzp_CSI_ResourceSetId ==
-            *(csi_resourceconfig->csi_RS_ResourceSetList.choice.nzp_CSI_RS_SSB->nzp_CSI_RS_ResourceSetList->list.array[0])) {
+    for (int csi_idx = 0; csi_idx < csi_MeasConfig->nzp_CSI_RS_ResourceSetToAddModList->list.count; csi_idx++) {
+      if (csi_MeasConfig->nzp_CSI_RS_ResourceSetToAddModList->list.array[csi_idx]->nzp_CSI_ResourceSetId
+          != *(csi_resourceconfig->csi_RS_ResourceSetList.choice.nzp_CSI_RS_SSB->nzp_CSI_RS_ResourceSetList->list.array[0]))
+        continue;
 
-          nr_csi_report_t *csi_report = NULL;
-          for (int i = 0; i < MAX_CSI_REPORTCONFIG; i++) {
-            if (mac->csi_report_template[i].reportConfigId == csi_reportconfig->reportConfigId) {
-              csi_report = &mac->csi_report_template[i];
-              break;
-            }
-          }
-          AssertFatal(csi_report, "Couldn't find CSI report with ID %ld\n", csi_reportconfig->reportConfigId);
-          int cri_bitlen = csi_report->csi_meas_bitlen.cri_bitlen;
-          int ri_bitlen = csi_report->csi_meas_bitlen.ri_bitlen;
-          int pmi_x1_bitlen = csi_report->csi_meas_bitlen.pmi_x1_bitlen[mac->csirs_measurements.ri];
-          int pmi_x2_bitlen = csi_report->csi_meas_bitlen.pmi_x2_bitlen[mac->csirs_measurements.ri];
-          int cqi_bitlen = csi_report->csi_meas_bitlen.cqi_bitlen[mac->csirs_measurements.ri];
-          int padding_bitlen = 0;
-          // TODO: Improvements will be needed to cri_bitlen>0 and pmi_x1_bitlen>0
-          if (mapping_type == ON_PUSCH) {
-            p1_bits = cri_bitlen + ri_bitlen + cqi_bitlen;
-            p2_bits = pmi_x1_bitlen + pmi_x2_bitlen;
-            temp_payload_1 = (0/*mac->csi_measurements.cri*/ << (cqi_bitlen + ri_bitlen)) |
-                             (mac->csirs_measurements.ri << cqi_bitlen) |
-                             (mac->csirs_measurements.cqi);
-            temp_payload_2 = (mac->csirs_measurements.i1 << pmi_x2_bitlen) |
-                             mac->csirs_measurements.i2;
-          }
-          else {
-            p1_bits = nr_get_csi_bitlen(csi_report);
-            padding_bitlen = p1_bits - (cri_bitlen + ri_bitlen + pmi_x1_bitlen + pmi_x2_bitlen + cqi_bitlen);
-            temp_payload_1 = (0/*mac->csi_measurements.cri*/ << (cqi_bitlen + pmi_x2_bitlen + pmi_x1_bitlen + padding_bitlen + ri_bitlen)) |
-                             (mac->csirs_measurements.ri << (cqi_bitlen + pmi_x2_bitlen + pmi_x1_bitlen + padding_bitlen)) |
-                             (mac->csirs_measurements.i1 << (cqi_bitlen + pmi_x2_bitlen)) |
-                             (mac->csirs_measurements.i2 << (cqi_bitlen)) |
-                             (mac->csirs_measurements.cqi);
-          }
-
-          temp_payload_1 = reverse_bits(temp_payload_1, p1_bits);
-          temp_payload_2 = reverse_bits(temp_payload_2, p2_bits);
-          LOG_D(NR_MAC, "cri_bitlen = %d\n", cri_bitlen);
-          LOG_D(NR_MAC, "ri_bitlen = %d\n", ri_bitlen);
-          LOG_D(NR_MAC, "pmi_x1_bitlen = %d\n", pmi_x1_bitlen);
-          LOG_D(NR_MAC, "pmi_x2_bitlen = %d\n", pmi_x2_bitlen);
-          LOG_D(NR_MAC, "cqi_bitlen = %d\n", cqi_bitlen);
-          LOG_D(NR_MAC, "csi_part1_payload = 0x%lx\n", temp_payload_1);
-          LOG_D(NR_MAC, "csi_part2_payload = 0x%lx\n", temp_payload_2);
-          LOG_D(NR_MAC, "part1_bits = %d\n", p1_bits);
-          LOG_D(NR_MAC, "part2_bits = %d\n", p2_bits);
+      nr_csi_report_t *csi_report = NULL;
+      for (int i = 0; i < MAX_CSI_REPORTCONFIG; i++) {
+        if (mac->csi_report_template[i].reportConfigId == csi_reportconfig->reportConfigId) {
+          csi_report = &mac->csi_report_template[i];
           break;
         }
       }
+      AssertFatal(csi_report, "Couldn't find CSI report with ID %ld\n", csi_reportconfig->reportConfigId);
+
+      const uint8_t ri = mac->csirs_measurements.ri;
+      const int cri_bitlen = csi_report->csi_meas_bitlen.cri_bitlen;
+      const int ri_bitlen = csi_report->csi_meas_bitlen.ri_bitlen;
+      const int pmi_x1_bitlen = csi_report->csi_meas_bitlen.pmi_x1_bitlen[ri];
+      const int pmi_x2_bitlen = csi_report->csi_meas_bitlen.pmi_x2_bitlen[ri];
+      const int cqi_bitlen = csi_report->csi_meas_bitlen.cqi_bitlen[ri];
+      int padding_bitlen = 0;
+
+      // Reconstruct X1 from the separate i_1,1 / i_1,2 / i_1,3 fields; X2 is just i_2.
+      const uint16_t pmi_x1 =
+          pack_pmi_x1(pmi_x1_bitlen, mac->csirs_measurements.i_1_1, mac->csirs_measurements.i_1_2, mac->csirs_measurements.i_1_3);
+      const uint8_t pmi_x2 = mac->csirs_measurements.i_2;
+
+      // TODO: Improvements will be needed to cri_bitlen>0 and pmi_x1_bitlen>0
+      if (mapping_type == ON_PUSCH) {
+        p1_bits = cri_bitlen + ri_bitlen + cqi_bitlen;
+        p2_bits = pmi_x1_bitlen + pmi_x2_bitlen;
+        temp_payload_1 = ((uint64_t)0 /* cri */ << (cqi_bitlen + ri_bitlen)) | ((uint64_t)ri << cqi_bitlen)
+                         | (uint64_t)mac->csirs_measurements.cqi;
+        temp_payload_2 = ((uint64_t)pmi_x1 << pmi_x2_bitlen) | (uint64_t)pmi_x2;
+      } else {
+        p1_bits = nr_get_csi_bitlen(csi_report);
+        padding_bitlen = p1_bits - (cri_bitlen + ri_bitlen + pmi_x1_bitlen + pmi_x2_bitlen + cqi_bitlen);
+        temp_payload_1 = ((uint64_t)0 /* cri */ << (cqi_bitlen + pmi_x2_bitlen + pmi_x1_bitlen + padding_bitlen + ri_bitlen))
+                         | ((uint64_t)ri << (cqi_bitlen + pmi_x2_bitlen + pmi_x1_bitlen + padding_bitlen))
+                         | ((uint64_t)pmi_x1 << (cqi_bitlen + pmi_x2_bitlen)) | ((uint64_t)pmi_x2 << cqi_bitlen)
+                         | (uint64_t)mac->csirs_measurements.cqi;
+      }
+
+      temp_payload_1 = reverse_bits(temp_payload_1, p1_bits);
+      temp_payload_2 = reverse_bits(temp_payload_2, p2_bits);
+
+      LOG_D(NR_MAC, "cri_bitlen = %d\n", cri_bitlen);
+      LOG_D(NR_MAC, "ri_bitlen = %d\n", ri_bitlen);
+      LOG_D(NR_MAC,
+            "pmi_x1_bitlen = %d (i_1,1=%u i_1,2=%u i_1,3=%u -> X1=0x%x)\n",
+            pmi_x1_bitlen,
+            mac->csirs_measurements.i_1_1,
+            mac->csirs_measurements.i_1_2,
+            mac->csirs_measurements.i_1_3,
+            pmi_x1);
+      LOG_D(NR_MAC, "pmi_x2_bitlen = %d (i_2=%u)\n", pmi_x2_bitlen, pmi_x2);
+      LOG_D(NR_MAC, "cqi_bitlen = %d\n", cqi_bitlen);
+      LOG_D(NR_MAC, "csi_part1_payload = 0x%lx\n", temp_payload_1);
+      LOG_D(NR_MAC, "csi_part2_payload = 0x%lx\n", temp_payload_2);
+      LOG_D(NR_MAC, "part1_bits = %d\n", p1_bits);
+      LOG_D(NR_MAC, "part2_bits = %d\n", p2_bits);
+      break;
     }
   }
   AssertFatal(p1_bits <= 32 && p2_bits <= 32, "Not supporting CSI report with more than 32 bits\n");
-  nfapi_nr_ue_csi_payload_t csi = {.part1_payload = temp_payload_1, .part2_payload = temp_payload_2, .p1_bits = p1_bits, csi.p2_bits = p2_bits};
+  nfapi_nr_ue_csi_payload_t csi = {
+      .part1_payload = temp_payload_1,
+      .part2_payload = temp_payload_2,
+      .p1_bits = p1_bits,
+      .p2_bits = p2_bits,
+  };
   return csi;
 }
 


### PR DESCRIPTION
This MR extends the Rank Indicator (RI) and the Precoding Matrix Indicator (PMI) computation based on CSI-RS beyond the previously supported 2x2 MIMO configuration. The RI estimation logic now supports additional antenna configurations including:
- 2x4
- 2x8
- 4x2
- 8x2
- and other scenarios where RI computation for 2-layer MIMO was previously not implemented.

This removes warnings such as:
`[NR_PHY] Rank indicator computation is not implemented for 2 x 4 system`

Notes:
- Rank values above 2 are still not supported.

This Pull Request pertains to MR https://gitlab.eurecom.fr/oai/openairinterface5g/-/merge_requests/4143, whose comments will be addressed in this Pull Request.