### PR TITLE
Fapi cc cleanup

### DIFF
--- a/nfapi/oai_integration/aerial/fapi_nvIPC.c
+++ b/nfapi/oai_integration/aerial/fapi_nvIPC.c
@@ -61,6 +61,7 @@ void nvIPC_send_stop_request()
 
 static uint16_t old_sfn[NFAPI_PHY_MAX];
 static uint16_t old_slot[NFAPI_PHY_MAX];
+static nvipc_params_t aerial_params;
 ////////////////////////////////////////////////////////////////////////
 // Handle an RX message
 static int ipc_handle_rx_msg(nv_ipc_msg_t *msg)
@@ -88,7 +89,7 @@ static int ipc_handle_rx_msg(nv_ipc_msg_t *msg)
    vnf_p7_t *vnf_p7_config = (vnf_p7_t *)((vnf_info *)vnf_config->user_data)->p7_vnfs->config;
     switch (fapi_msg.message_id) {
       case NFAPI_NR_PHY_MSG_TYPE_PARAM_RESPONSE ... NFAPI_NR_PHY_MSG_TYPE_ERROR_INDICATION:
-        vnf_nr_handle_p4_p5_message(msg->msg_buf, msg->msg_len, 0, vnf_config);
+        vnf_nr_handle_p4_p5_message(msg->msg_buf, msg->msg_len, msg->cell_id, vnf_config);
         break;
       // P7 Messages
       case NFAPI_NR_PHY_MSG_TYPE_RX_DATA_INDICATION: {
@@ -335,11 +336,14 @@ void *epoll_recv_task(void *arg)
   if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, ev.data.fd, &ev) == -1) {
     LOG_E(NFAPI_VNF, "%s epoll_ctl failed\n", __func__);
   }
-  // From here on out the thread is ready to receive data, simulate the reception
-  // of a PARAM.response to get the VNF to send a CONFIG.request
-  nfapi_nr_param_response_scf_t resp_msg = {.header.message_id = NFAPI_NR_PHY_MSG_TYPE_PARAM_RESPONSE};
-  nfapi_vnf_config_t * vnf_config = get_config();
-  vnf_config->nr_param_resp(vnf_config, 0, &resp_msg);
+  // Simulate one PARAM.response per configured PHY to trigger a CONFIG.request
+  // for each cell.  aerial_params is populated by nvIPC_Init before this thread starts.
+  nfapi_vnf_config_t *vnf_config = get_config();
+  for (int i = 0; i < aerial_params.num_phys; i++) {
+    nfapi_nr_param_response_scf_t resp_msg = {.header.message_id = NFAPI_NR_PHY_MSG_TYPE_PARAM_RESPONSE,
+                                             .header.phy_id = i};
+    vnf_config->nr_param_resp(vnf_config, i, &resp_msg);
+  }
   while (((vnf_t *)vnf_config)->terminate == false) {
     LOG_D(NFAPI_VNF, "%s: epoll_wait fd_rx=%d ...\n", __func__, ipc_rx_event_fd);
 
@@ -411,6 +415,7 @@ int nvIPC_Init(nvipc_params_t nvipc_params_s)
     return -1;
   }
   LOG_I(NFAPI_VNF, "%s: create IPC interface successful\n", __func__);
+  aerial_params = nvipc_params_s;
   sleep(1);
   create_recv_thread(nvipc_params_s.nvipc_poll_core);
   return 0;

--- a/nfapi/oai_integration/aerial/fapi_nvIPC.c
+++ b/nfapi/oai_integration/aerial/fapi_nvIPC.c
@@ -59,8 +59,8 @@ void nvIPC_send_stop_request()
 }
 
 
-static uint16_t old_sfn = 0;
-static uint16_t old_slot = 0;
+static uint16_t old_sfn[NFAPI_PHY_MAX];
+static uint16_t old_slot[NFAPI_PHY_MAX];
 ////////////////////////////////////////////////////////////////////////
 // Handle an RX message
 static int ipc_handle_rx_msg(nv_ipc_msg_t *msg)
@@ -88,7 +88,7 @@ static int ipc_handle_rx_msg(nv_ipc_msg_t *msg)
    vnf_p7_t *vnf_p7_config = (vnf_p7_t *)((vnf_info *)vnf_config->user_data)->p7_vnfs->config;
     switch (fapi_msg.message_id) {
       case NFAPI_NR_PHY_MSG_TYPE_PARAM_RESPONSE ... NFAPI_NR_PHY_MSG_TYPE_ERROR_INDICATION:
-        vnf_nr_handle_p4_p5_message(msg->msg_buf, msg->msg_len, 1, vnf_config);
+        vnf_nr_handle_p4_p5_message(msg->msg_buf, msg->msg_len, 0, vnf_config);
         break;
       // P7 Messages
       case NFAPI_NR_PHY_MSG_TYPE_RX_DATA_INDICATION: {
@@ -134,22 +134,28 @@ static int ipc_handle_rx_msg(nv_ipc_msg_t *msg)
           NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s: Failed to unpack message\n", __FUNCTION__);
         } else {
           NFAPI_TRACE(NFAPI_TRACE_DEBUG, "%s: Handling NR SLOT Indication\n", __FUNCTION__);
+          // use transport-level cell_id (0-based) from the nvIPC header —
+          // ind.header.phy_id is not reliably populated by cuBB in incoming messages;
+          // normalize it here so downstream callbacks can rely on it
+          uint8_t phy_id = msg->cell_id;
+          AssertFatal(phy_id < NFAPI_PHY_MAX, "phy_id %d exceeds NFAPI_PHY_MAX %d\n", phy_id, NFAPI_PHY_MAX);
+          ind.header.phy_id = phy_id;
           // check if the sfn/slot unpacked come wrong at any time, should be old + 1 (slot 0 -- 19, sfn 0 -- 1023)
-          // add 1 to current sfn number
-          uint16_t old_slot_plus = ((old_slot + 1) % 20);
-          uint16_t old_sfn_plus = old_slot_plus == 0 ? ((old_sfn + 1) % 1024) : old_sfn;
+          uint16_t old_slot_plus = ((old_slot[phy_id] + 1) % 20);
+          uint16_t old_sfn_plus = old_slot_plus == 0 ? ((old_sfn[phy_id] + 1) % 1024) : old_sfn[phy_id];
           if (old_slot_plus != ind.slot || old_sfn_plus != ind.sfn) {
             LOG_E(NFAPI_VNF,
                   "\n============================================================================\n"
-                  "sfn slot doesn't match unpacked one! L2->L1 %d.%d  vs L1->L2 %d.%d  \n"
+                  "sfn slot doesn't match unpacked one! PHY %d L2->L1 %d.%d  vs L1->L2 %d.%d  \n"
                   "============================================================================\n",
-                  old_sfn,
-                  old_slot,
+                  phy_id,
+                  old_sfn[phy_id],
+                  old_slot[phy_id],
                   ind.sfn,
                   ind.slot);
           }
-          old_sfn = ind.sfn;
-          old_slot = ind.slot;
+          old_sfn[phy_id] = ind.sfn;
+          old_slot[phy_id] = ind.slot;
           if (vnf_p7_config->_public.nr_slot_indication) {
             (vnf_p7_config->_public.nr_slot_indication)(&ind);
           }
@@ -210,7 +216,7 @@ bool aerial_nr_send_p5_message(vnf_t *vnf, uint16_t p5_idx, nfapi_nr_p4_p5_messa
   if (pnf) {
     // Create the message
     nv_ipc_msg_t send_msg = {.msg_id = msg->message_id,
-                             .cell_id = 0,
+                             .cell_id = msg->phy_id,
                              // By default, P5 uses only message pool.
                              .data_pool = NV_IPC_MEMPOOL_CPU_MSG,
                              .data_len = 0,
@@ -333,7 +339,7 @@ void *epoll_recv_task(void *arg)
   // of a PARAM.response to get the VNF to send a CONFIG.request
   nfapi_nr_param_response_scf_t resp_msg = {.header.message_id = NFAPI_NR_PHY_MSG_TYPE_PARAM_RESPONSE};
   nfapi_vnf_config_t * vnf_config = get_config();
-  vnf_config->nr_param_resp(vnf_config, 1, &resp_msg);
+  vnf_config->nr_param_resp(vnf_config, 0, &resp_msg);
   while (((vnf_t *)vnf_config)->terminate == false) {
     LOG_D(NFAPI_VNF, "%s: epoll_wait fd_rx=%d ...\n", __func__, ipc_rx_event_fd);
 
@@ -414,7 +420,6 @@ int oai_fapi_ul_tti_req(nfapi_nr_ul_tti_request_t *ul_tti_req)
 {
   nfapi_vnf_p7_config_t *p7_config = get_p7_vnf_config();
 
-  ul_tti_req->header.phy_id = 1; // DJP HACK TODO FIXME - need to pass this around!!!!
   ul_tti_req->header.message_id = NFAPI_NR_PHY_MSG_TYPE_UL_TTI_REQUEST;
 
   bool retval = p7_config->send_p7_msg(get_p7_vnf(), &ul_tti_req->header);
@@ -434,7 +439,6 @@ int oai_fapi_ul_tti_req(nfapi_nr_ul_tti_request_t *ul_tti_req)
 int oai_fapi_ul_dci_req(nfapi_nr_ul_dci_request_t *ul_dci_req)
 {
   nfapi_vnf_p7_config_t *p7_config = get_p7_vnf_config();
-  ul_dci_req->header.phy_id = 1; // DJP HACK TODO FIXME - need to pass this around!!!!
   ul_dci_req->header.message_id = NFAPI_NR_PHY_MSG_TYPE_UL_DCI_REQUEST;
 
   bool retval = p7_config->send_p7_msg(get_p7_vnf(), &ul_dci_req->header);
@@ -449,7 +453,6 @@ int oai_fapi_ul_dci_req(nfapi_nr_ul_dci_request_t *ul_dci_req)
 int oai_fapi_tx_data_req(nfapi_nr_tx_data_request_t *tx_data_req)
 {
   nfapi_vnf_p7_config_t *p7_config = get_p7_vnf_config();
-  tx_data_req->header.phy_id = 1; // DJP HACK TODO FIXME - need to pass this around!!!!
   tx_data_req->header.message_id = NFAPI_NR_PHY_MSG_TYPE_TX_DATA_REQUEST;
 
   bool retval = p7_config->send_p7_msg(get_p7_vnf(), &tx_data_req->header);
@@ -466,7 +469,6 @@ int oai_fapi_dl_tti_req(nfapi_nr_dl_tti_request_t *dl_config_req)
 {
   nfapi_vnf_p7_config_t *p7_config = get_p7_vnf_config();
   dl_config_req->header.message_id = NFAPI_NR_PHY_MSG_TYPE_DL_TTI_REQUEST;
-  dl_config_req->header.phy_id = 1; // DJP HACK TODO FIXME - need to pass this around!!!!
 
   bool retval = p7_config->send_p7_msg(get_p7_vnf(), &dl_config_req->header);
   dl_config_req->dl_tti_request_body.nPDUs = 0;
@@ -478,10 +480,11 @@ int oai_fapi_dl_tti_req(nfapi_nr_dl_tti_request_t *dl_config_req)
   return retval;
 }
 
-int oai_fapi_send_end_request(uint32_t frame, uint32_t slot)
+int oai_fapi_send_end_request(uint32_t frame, uint32_t slot, uint8_t phy_id)
 {
   nfapi_vnf_p7_config_t *p7_config = get_p7_vnf_config();
-  nfapi_nr_slot_indication_scf_t nr_slot_resp = {.header.message_id = 0x8F, .sfn = frame, .slot = slot};
+  nfapi_nr_slot_indication_scf_t nr_slot_resp = {
+      .header.message_id = 0x8F, .header.phy_id = phy_id, .sfn = frame, .slot = slot};
 
   bool retval = p7_config->send_p7_msg(get_p7_vnf(), &nr_slot_resp.header);
   if (!retval) {

--- a/nfapi/oai_integration/aerial/fapi_nvIPC.c
+++ b/nfapi/oai_integration/aerial/fapi_nvIPC.c
@@ -86,6 +86,12 @@ static int ipc_handle_rx_msg(nv_ipc_msg_t *msg)
       return -1;
     }
 
+    // use transport-level cell_id (0-based) from the nvIPC header —
+    // the opaque handle (phy_id) is not reliably populated by cuBB in incoming messages;
+    // stamp it into the packed header so downstream unpackers can rely on it
+    uint8_t phy_id = msg->cell_id;
+    AssertFatal(phy_id < NFAPI_PHY_MAX, "phy_id %d exceeds NFAPI_PHY_MAX %d\n", phy_id, NFAPI_PHY_MAX);
+    ((uint8_t *)msg->msg_buf)[1] = phy_id;
    vnf_p7_t *vnf_p7_config = (vnf_p7_t *)((vnf_info *)vnf_config->user_data)->p7_vnfs->config;
     switch (fapi_msg.message_id) {
       case NFAPI_NR_PHY_MSG_TYPE_PARAM_RESPONSE ... NFAPI_NR_PHY_MSG_TYPE_ERROR_INDICATION:
@@ -97,6 +103,7 @@ static int ipc_handle_rx_msg(nv_ipc_msg_t *msg)
         int dataBufLen = msg->data_len;
         uint8_t *data_end = msg->data_buf + dataBufLen;
         nfapi_nr_rx_data_indication_t ind;
+        ind.header.phy_id = phy_id;
         ind.header.message_id = fapi_msg.message_id;
         ind.header.message_length = fapi_msg.message_length;
         aerial_unpack_nr_rx_data_indication(
@@ -122,6 +129,7 @@ static int ipc_handle_rx_msg(nv_ipc_msg_t *msg)
         int dataBufLen = msg->data_len;
         uint8_t *data_end = msg->data_buf + dataBufLen;
         nfapi_nr_srs_indication_t ind;
+        ind.header.phy_id = phy_id;
         aerial_unpack_nr_srs_indication(&pReadPackedMessage, end, &pReadData, data_end, &ind);
         if (vnf_p7_config->_public.nr_srs_indication) {
           (vnf_p7_config->_public.nr_srs_indication)(&ind);
@@ -135,11 +143,6 @@ static int ipc_handle_rx_msg(nv_ipc_msg_t *msg)
           NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s: Failed to unpack message\n", __FUNCTION__);
         } else {
           NFAPI_TRACE(NFAPI_TRACE_DEBUG, "%s: Handling NR SLOT Indication\n", __FUNCTION__);
-          // use transport-level cell_id (0-based) from the nvIPC header —
-          // ind.header.phy_id is not reliably populated by cuBB in incoming messages;
-          // normalize it here so downstream callbacks can rely on it
-          uint8_t phy_id = msg->cell_id;
-          AssertFatal(phy_id < NFAPI_PHY_MAX, "phy_id %d exceeds NFAPI_PHY_MAX %d\n", phy_id, NFAPI_PHY_MAX);
           ind.header.phy_id = phy_id;
           // check if the sfn/slot unpacked come wrong at any time, should be old + 1 (slot 0 -- 19, sfn 0 -- 1023)
           uint16_t old_slot_plus = ((old_slot[phy_id] + 1) % 20);

--- a/nfapi/oai_integration/aerial/fapi_nvIPC.h
+++ b/nfapi/oai_integration/aerial/fapi_nvIPC.h
@@ -17,6 +17,12 @@
 
 #include "openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h"
 
+/* Maximum number of PHY instances supported by this layer.
+ * Aliases NFAPI_CC_MAX which itself tracks NFAPI_MAX_CC; using
+ * NFAPI_PHY_MAX here makes clear that this is a per-PHY (not
+ * per-carrier-component) limit at the cuBB transport boundary. */
+#define NFAPI_PHY_MAX NFAPI_CC_MAX
+
 int get_cpu_msg_buf_size();
 int get_cpu_data_buf_size();
 bool allocate_msg(nv_ipc_msg_t* send_msg);
@@ -24,7 +30,7 @@ void release_msg(nv_ipc_msg_t* send_msg);
 bool send_nvipc_msg(nv_ipc_msg_t* send_msg);
 bool aerial_nr_send_p5_message(vnf_t *vnf, uint16_t p5_idx, nfapi_nr_p4_p5_message_header_t *msg, uint32_t msg_len);
 int nvIPC_Init(nvipc_params_t nvipc_params_s);
-int oai_fapi_send_end_request(uint32_t frame, uint32_t slot);
+int oai_fapi_send_end_request(uint32_t frame, uint32_t slot, uint8_t PHY_id);
 int oai_fapi_ul_tti_req(nfapi_nr_ul_tti_request_t *ul_tti_req);
 int oai_fapi_ul_dci_req(nfapi_nr_ul_dci_request_t *ul_dci_req);
 int oai_fapi_tx_data_req(nfapi_nr_tx_data_request_t *tx_data_req);

--- a/nfapi/oai_integration/nfapi_vnf.c
+++ b/nfapi/oai_integration/nfapi_vnf.c
@@ -920,6 +920,16 @@ int phy_nr_slot_indication(nfapi_nr_slot_indication_scf_t *ind)
   ifi->NR_slot_indication(ind, &sched_response);
 
 #ifdef ENABLE_AERIAL
+    // The scheduler does not stamp the cell identity onto the requests it produces,
+    // so carry it over from the indication that triggered this slot. Once the MAC
+    // sets it in reset_sched_response(), these four assignments can simply go away
+    // and the senders keep reading it off the message.
+    const uint8_t PHY_id = ind->header.phy_id;
+    sched_response.DL_req.header.phy_id = PHY_id;
+    sched_response.UL_tti_req.header.phy_id = PHY_id;
+    sched_response.TX_req.header.phy_id = PHY_id;
+    sched_response.UL_dci_req.header.phy_id = PHY_id;
+
     bool send_slt_resp = false;
     if (sched_response.DL_req.dl_tti_request_body.nPDUs> 0) {
       oai_fapi_dl_tti_req(&sched_response.DL_req);
@@ -938,7 +948,7 @@ int phy_nr_slot_indication(nfapi_nr_slot_indication_scf_t *ind)
       send_slt_resp = true;
     }
     if (send_slt_resp) {
-      oai_fapi_send_end_request(ind->sfn, ind->slot);
+      oai_fapi_send_end_request(ind->sfn, ind->slot, PHY_id);
     }
 #else
   if (sched_response.DL_req.dl_tti_request_body.nPDUs > 0)
@@ -1417,6 +1427,9 @@ int nr_param_resp_cb(nfapi_vnf_config_t *config, int p5_idx, nfapi_nr_param_resp
   vnf_p7_info *p7_vnf = vnf->p7_vnfs;
   pnf_info *pnf = vnf->pnfs;
   phy_info *phy = pnf->phys;
+#ifdef ENABLE_AERIAL
+  phy->id = p5_idx;
+#endif
   nfapi_nr_config_request_scf_t *req = &RC.nrmac[0]->config[0]; // check
 #ifndef ENABLE_AERIAL
   struct sockaddr_in pnf_p7_sockaddr;
@@ -1847,7 +1860,7 @@ void configure_nr_nfapi_vnf(const char *vnf_addr, uint16_t vnf_p5_port, uint16_t
   nfapi_vnf_pnf_info_t *pnf = (nfapi_vnf_pnf_info_t *)malloc(sizeof(nfapi_vnf_pnf_info_t));
   NFAPI_TRACE(NFAPI_TRACE_INFO, "MALLOC nfapi_vnf_pnf_info_t for pnf_list pnf:%p\n", pnf);
   memset(pnf, 0, sizeof(nfapi_vnf_pnf_info_t));
-  pnf->p5_idx = 1;
+  pnf->p5_idx = 0;
   pnf->connected = 1;
   // Add needed parameters
 

--- a/nfapi/oai_integration/nfapi_vnf.c
+++ b/nfapi/oai_integration/nfapi_vnf.c
@@ -1428,9 +1428,19 @@ int nr_param_resp_cb(nfapi_vnf_config_t *config, int p5_idx, nfapi_nr_param_resp
   pnf_info *pnf = vnf->pnfs;
   phy_info *phy = pnf->phys;
 #ifdef ENABLE_AERIAL
-  phy->id = p5_idx;
+  // Aerial has no P5 handshake, so no phy_id was ever allocated through
+  // nfapi_vnf_allocate_phy(): take the (0-based) cell id the message carries.
+  // On the native path phy->id already holds the id allocated in
+  // pnf_nr_param_resp_cb() and registered in config->phy_list; overwriting it
+  // here would break the nfapi_vnf_phy_info_list_find() lookup done by
+  // nfapi_nr_vnf_config_req().
+  phy->id = resp->header.phy_id;
 #endif
-  nfapi_nr_config_request_scf_t *req = &RC.nrmac[0]->config[0]; // check
+  // NB: indexed by p5_idx, not resp->header.phy_id. Both are the 0-based cell id on
+  // Aerial, but the native nFAPI path is still 1-based (nfapi_vnf_allocate_phy() starts
+  // at 1), and config[] has NFAPI_CC_MAX == 1 entries. Switch to the message's phy_id
+  // once the native path is converted to 0-based indexing.
+  nfapi_nr_config_request_scf_t *req = &RC.nrmac[0]->config[p5_idx];
 #ifndef ENABLE_AERIAL
   struct sockaddr_in pnf_p7_sockaddr;
   phy->remote_port = resp->nfapi_config.p7_pnf_port.value;
@@ -1857,32 +1867,16 @@ void configure_nr_nfapi_vnf(const char *vnf_addr, uint16_t vnf_p5_port, uint16_t
   config->pack_func = &fapi_nr_p5_message_pack;
   config->send_p5_msg = &aerial_nr_send_p5_message;
   NFAPI_TRACE(NFAPI_TRACE_INFO, "[VNF] Created VNF NFAPI start thread %s\n", __FUNCTION__);
-  nfapi_vnf_pnf_info_t *pnf = (nfapi_vnf_pnf_info_t *)malloc(sizeof(nfapi_vnf_pnf_info_t));
-  NFAPI_TRACE(NFAPI_TRACE_INFO, "MALLOC nfapi_vnf_pnf_info_t for pnf_list pnf:%p\n", pnf);
-  memset(pnf, 0, sizeof(nfapi_vnf_pnf_info_t));
-  pnf->p5_idx = 0;
-  pnf->connected = 1;
-  // Add needed parameters
-
-  pnf_info *pnf_info = vnf->pnfs;
-
-  for (int i = 0; i < 1; ++i) {
-    phy_info phy;
-    memset(&phy, 0, sizeof(phy));
-    phy.index = 0;
-    NFAPI_TRACE(NFAPI_TRACE_INFO, "[VNF] (PHY:%d) phy_config_idx:%d\n", i, 0);
-    nfapi_vnf_allocate_phy(config, 1, &(phy.id));
-
-    for (int j = 0; j < 1; ++j) {
-      NFAPI_TRACE(NFAPI_TRACE_INFO, "[VNF] (PHY:%d) (RF%d) %d\n", i, j, 0);
-      phy.rfs[0] = 0;
-    }
-
-    pnf_info->phys[0] = phy;
+  // One pnf list entry per configured PHY so that aerial_nr_send_p5_message()
+  // can route CONFIG/START requests by phy_id.
+  uint8_t num_phys = RC.nrmac[0]->nvipc_params_s.num_phys;
+  for (int i = 0; i < num_phys; i++) {
+    nfapi_vnf_pnf_info_t *pnf = calloc(1, sizeof(*pnf));
+    pnf->p5_idx = i;
+    pnf->connected = 1;
+    nfapi_vnf_pnf_list_add(config, pnf);
+    NFAPI_TRACE(NFAPI_TRACE_INFO, "Registered aerial PNF entry for phy_id %d\n", i);
   }
-
-
-  nfapi_vnf_pnf_list_add(config, pnf);
 
   vnf_p7_info *p7_vnf = vnf->p7_vnfs;
 

--- a/nfapi/open-nFAPI/fapi/src/nr_fapi.c
+++ b/nfapi/open-nFAPI/fapi/src/nr_fapi.c
@@ -187,7 +187,9 @@ bool fapi_nr_message_header_unpack(void *pMessageBuf,
   uint8_t *end = pMessageBuf + messageBufLen;
   // process the header
   int result =
-      (pull8(&pReadPackedMessage, &fapi_msg.num_msg, end) && pull8(&pReadPackedMessage, (uint8_t *)&header->phy_id, end)
+      (pull8(&pReadPackedMessage, &fapi_msg.num_msg, end) && pull8(&pReadPackedMessage, &fapi_msg.opaque_handle, end)
        && pull16(&pReadPackedMessage, &header->message_id, end) && pull32(&pReadPackedMessage, &header->message_length, end));
+  // the SCF opaque handle byte carries the phy_id
+  header->phy_id = fapi_msg.opaque_handle;
   return result != 0;
 }

--- a/nfapi/open-nFAPI/fapi/src/nr_fapi.c
+++ b/nfapi/open-nFAPI/fapi/src/nr_fapi.c
@@ -187,7 +187,7 @@ bool fapi_nr_message_header_unpack(void *pMessageBuf,
   uint8_t *end = pMessageBuf + messageBufLen;
   // process the header
   int result =
-      (pull8(&pReadPackedMessage, &fapi_msg.num_msg, end) && pull8(&pReadPackedMessage, &fapi_msg.opaque_handle, end)
+      (pull8(&pReadPackedMessage, &fapi_msg.num_msg, end) && pull8(&pReadPackedMessage, (uint8_t *)&header->phy_id, end)
        && pull16(&pReadPackedMessage, &header->message_id, end) && pull32(&pReadPackedMessage, &header->message_length, end));
   return result != 0;
 }

--- a/nfapi/open-nFAPI/fapi/src/nr_fapi_p5.c
+++ b/nfapi/open-nFAPI/fapi/src/nr_fapi_p5.c
@@ -84,7 +84,7 @@ int fapi_nr_p5_message_pack(void *pMessageBuf,
 
   // PHY API message header
   push8(1, &pWritePackedMessage, pPackMessageEnd); // Number of messages
-  push8(0, &pWritePackedMessage, pPackMessageEnd); // Opaque handle
+  push8(pMessageHeader->phy_id, &pWritePackedMessage, pPackMessageEnd); // Opaque handle
 
   // PHY API Message structure
   push16(pMessageHeader->message_id, &pWritePackedMessage, pPackMessageEnd); // Message type ID

--- a/nfapi/open-nFAPI/fapi/src/nr_fapi_p7.c
+++ b/nfapi/open-nFAPI/fapi/src/nr_fapi_p7.c
@@ -129,7 +129,6 @@ bool fapi_nr_p7_message_unpack(void *pMessageBuf,
 {
   int result = 0;
   nfapi_nr_p7_message_header_t *pMessageHeader = (nfapi_nr_p7_message_header_t *)pUnpackedBuf;
-  fapi_message_header_t fapi_hdr;
   AssertFatal(pMessageBuf != NULL && pUnpackedBuf != NULL, "P7 unpack supplied pointers are null");
 
   AssertFatal(messageBufLen >= NFAPI_HEADER_LENGTH && unpackedBufLen >= sizeof(fapi_message_header_t),
@@ -137,14 +136,12 @@ bool fapi_nr_p7_message_unpack(void *pMessageBuf,
               messageBufLen,
               unpackedBufLen);
 
-  if (!fapi_nr_message_header_unpack(pMessageBuf, NFAPI_HEADER_LENGTH, &fapi_hdr, sizeof(fapi_message_header_t), 0)) {
+  if (!fapi_nr_message_header_unpack(pMessageBuf, NFAPI_HEADER_LENGTH, pMessageHeader, sizeof(fapi_message_header_t), 0)) {
     // failed to read the header
     return false;
   }
   uint8_t *pReadPackedMessage = pMessageBuf + NFAPI_HEADER_LENGTH;
   uint8_t *end = (uint8_t *)pMessageBuf + messageBufLen;
-  pMessageHeader->message_length = fapi_hdr.message_length;
-  pMessageHeader->message_id = fapi_hdr.message_id;
   if ((uint8_t *)(pMessageBuf + pMessageHeader->message_length) > end) {
     NFAPI_TRACE(NFAPI_TRACE_ERROR, "P7 unpack message length is greater than the message buffer \n");
     return false;

--- a/nfapi/open-nFAPI/fapi/src/nr_fapi_p7.c
+++ b/nfapi/open-nFAPI/fapi/src/nr_fapi_p7.c
@@ -96,7 +96,7 @@ int fapi_nr_p7_message_pack(void *pMessageBuf, void *pPackedBuf, uint32_t packed
   // Message type ID [2,3]
   // Message Length [4,5,6,7]
   // Message Body [8,...]
-  if (!(push8(1, &pWritePackedMessage, pPackMessageEnd) && push8(0, &pWritePackedMessage, pPackMessageEnd)
+  if (!(push8(1, &pWritePackedMessage, pPackMessageEnd) && push8(pMessageHeader->phy_id, &pWritePackedMessage, pPackMessageEnd)
         && push16(pMessageHeader->message_id, &pWritePackedMessage, pPackMessageEnd))) {
     NFAPI_TRACE(NFAPI_TRACE_ERROR, "P7 Pack header failed\n");
     return -1;

--- a/nfapi/tests/p5/CMakeLists.txt
+++ b/nfapi/tests/p5/CMakeLists.txt
@@ -12,3 +12,11 @@ foreach (fapi_p5_message IN LISTS _fapi_p5_messages)
     add_test(nr_fapi_${fapi_p5_message}_test nr_fapi_${fapi_p5_message}_test)
     set_tests_properties(nr_fapi_${fapi_p5_message}_test PROPERTIES LABELS "${Test_Labels}")
 endforeach ()
+
+add_executable(nr_fapi_p5_phy_id_test nr_fapi_p5_phy_id_test.c)
+target_link_libraries(nr_fapi_p5_phy_id_test PUBLIC nr_fapi_p5)
+target_link_libraries(nr_fapi_p5_phy_id_test PRIVATE pthread UTIL ${T_LIB} minimal_lib)
+add_dependencies(tests nr_fapi_p5_phy_id_test)
+
+add_test(nr_fapi_p5_phy_id_test nr_fapi_p5_phy_id_test)
+set_tests_properties(nr_fapi_p5_phy_id_test PROPERTIES LABELS "${Test_Labels}")

--- a/nfapi/tests/p5/nr_fapi_p5_phy_id_test.c
+++ b/nfapi/tests/p5/nr_fapi_p5_phy_id_test.c
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+#include "nfapi/tests/nr_fapi_test.h"
+#include "nr_fapi_p5.h"
+#include "nr_fapi_p5_utils.h"
+
+// The phy_id is carried on the wire in the opaque handle byte of the FAPI
+// message header (SCF 222 §3.3.1.1), so only values 0..255 survive the round trip.
+static void test_phy_id_roundtrip(uint16_t phy_id)
+{
+  nfapi_nr_start_request_scf_t req = {.header.message_id = NFAPI_NR_PHY_MSG_TYPE_START_REQUEST, .header.phy_id = phy_id};
+  uint8_t msg_buf[65535];
+  int pack_result = fapi_nr_p5_message_pack(&req, sizeof(req), msg_buf, sizeof(msg_buf), NULL);
+  // START.request message body length is 0
+  DevAssert(pack_result == 0 + NFAPI_HEADER_LENGTH);
+  // the opaque handle is the second byte of the packed header
+  DevAssert(msg_buf[1] == phy_id);
+
+  // test the header-peek unpack
+  nfapi_nr_p4_p5_message_header_t peek_hdr = {0};
+  int unpack_header_result = fapi_nr_message_header_unpack(msg_buf, NFAPI_HEADER_LENGTH, &peek_hdr, sizeof(peek_hdr), 0);
+  DevAssert(unpack_header_result >= 0);
+  DevAssert(peek_hdr.phy_id == phy_id);
+  DevAssert(peek_hdr.message_id == req.header.message_id);
+
+  // test the full message unpack
+  nfapi_nr_start_request_scf_t unpacked_req = {0};
+  int unpack_result =
+      fapi_nr_p5_message_unpack(msg_buf, peek_hdr.message_length + NFAPI_HEADER_LENGTH, &unpacked_req, sizeof(unpacked_req), NULL);
+  DevAssert(unpack_result >= 0);
+  DevAssert(unpacked_req.header.phy_id == phy_id);
+  DevAssert(eq_start_request(&unpacked_req, &req));
+  free_start_request(&unpacked_req);
+  free_start_request(&req);
+}
+
+int main()
+{
+  fapi_test_init();
+
+  for (uint16_t phy_id = 0; phy_id <= UINT8_MAX; phy_id++) {
+    test_phy_id_roundtrip(phy_id);
+  }
+  // All tests successful!
+  return 0;
+}

--- a/nfapi/tests/p7/CMakeLists.txt
+++ b/nfapi/tests/p7/CMakeLists.txt
@@ -11,6 +11,14 @@ foreach (fapi_p7_message IN LISTS _fapi_p7_messages)
     add_test(nr_fapi_${fapi_p7_message}_test nr_fapi_${fapi_p7_message}_test)
     set_tests_properties(nr_fapi_${fapi_p7_message}_test PROPERTIES LABELS "${Test_Labels}")
 endforeach ()
+add_executable(nr_fapi_p7_phy_id_test nr_fapi_p7_phy_id_test.c)
+target_link_libraries(nr_fapi_p7_phy_id_test PUBLIC nr_fapi_p7)
+target_link_libraries(nr_fapi_p7_phy_id_test PRIVATE pthread UTIL ${T_LIB} minimal_lib)
+add_dependencies(tests nr_fapi_p7_phy_id_test)
+
+add_test(nr_fapi_p7_phy_id_test nr_fapi_p7_phy_id_test)
+set_tests_properties(nr_fapi_p7_phy_id_test PROPERTIES LABELS "${Test_Labels}")
+
 # Add the dci label for the dci payload test
 set(dci_labels dci ${Test_Labels})
 set_tests_properties(nr_fapi_dci_inversion_test PROPERTIES LABELS "dci ${Test_Labels}")

--- a/nfapi/tests/p7/nr_fapi_p7_phy_id_test.c
+++ b/nfapi/tests/p7/nr_fapi_p7_phy_id_test.c
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+#include "nfapi/tests/nr_fapi_test.h"
+#include "nr_fapi_p7.h"
+#include "nr_fapi_p7_utils.h"
+
+// The phy_id is carried on the wire in the opaque handle byte of the FAPI
+// message header (SCF 222 §3.3.1.1), so only values 0..255 survive the round trip.
+static void test_phy_id_roundtrip(uint16_t phy_id)
+{
+  nfapi_nr_slot_indication_scf_t req = {.header.message_id = NFAPI_NR_PHY_MSG_TYPE_SLOT_INDICATION, .header.phy_id = phy_id};
+  req.sfn = rand16_range(0, 1023);
+  req.slot = rand16_range(0, 159);
+  uint8_t msg_buf[1024];
+  int pack_result = fapi_nr_p7_message_pack(&req, msg_buf, sizeof(msg_buf), NULL);
+  // Should always return 4 (2 bytes sfn + 2 bytes slot)
+  DevAssert(pack_result == 4);
+  // the opaque handle is the second byte of the packed header
+  DevAssert(msg_buf[1] == phy_id);
+
+  // test the header-peek unpack
+  nfapi_nr_p7_message_header_t peek_hdr = {0};
+  int unpack_header_result = fapi_nr_message_header_unpack(msg_buf, NFAPI_HEADER_LENGTH, &peek_hdr, sizeof(peek_hdr), 0);
+  DevAssert(unpack_header_result >= 0);
+  DevAssert(peek_hdr.phy_id == phy_id);
+  DevAssert(peek_hdr.message_id == req.header.message_id);
+
+  // test the full message unpack
+  nfapi_nr_slot_indication_scf_t unpacked_req = {0};
+  int unpack_result =
+      fapi_nr_p7_message_unpack(msg_buf, peek_hdr.message_length + NFAPI_HEADER_LENGTH, &unpacked_req, sizeof(unpacked_req), 0);
+  DevAssert(unpack_result >= 0);
+  DevAssert(unpacked_req.header.phy_id == phy_id);
+  DevAssert(eq_slot_indication(&unpacked_req, &req));
+  free_slot_indication(&unpacked_req);
+  free_slot_indication(&req);
+}
+
+int main()
+{
+  fapi_test_init();
+
+  for (uint16_t phy_id = 0; phy_id <= UINT8_MAX; phy_id++) {
+    test_phy_id_roundtrip(phy_id);
+  }
+  // All tests successful!
+  return 0;
+}

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -1699,6 +1699,7 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg)
         nvipc_params_t nvipc_p = {
           .nvipc_shm_prefix = strdup(*gpd(params, np, MACRLC_TRANSPORT_S_SHM_PREFIX)->strptr),
           .nvipc_poll_core = *gpd(params, np, MACRLC_TRANSPORT_S_POLL_CORE)->i8ptr,
+          .num_phys = 1,
         };
         RC.nrmac[j]->nvipc_params_s = nvipc_p;
         LOG_I(GNB_APP, "Configuring VNF for Aerial connection with prefix %s\n", nvipc_p.nvipc_shm_prefix);

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -1160,6 +1160,7 @@ typedef struct f1_config_t {
 typedef struct {
   char *nvipc_shm_prefix;
   int8_t nvipc_poll_core;
+  uint8_t num_phys;
 } nvipc_params_t;
 
 typedef struct {


### PR DESCRIPTION
See https://gitlab.eurecom.fr/oai/openairinterface5g/-/merge_requests/4090

First MR in preparation for multi-cell support in L2 (follows [!4073](https://github.com/oai/openairinterface5g/-/merge_requests/4073)) This MR unifies the Aerial FAPI/nvIPC interface for correct per-cell routing and lays the groundwork for driving multiple cells from a single L2 process.
P7 send functions use the phy_id from the header, resolving the TODO FIXME stubs with hardcoded values.
old_sfn/old_slot promoted from static scalars to NFAPI_PHY_MAX-sized arrays for independent per-cell slot tracking.
All phy_id/cell_id values are consistently 0-based across the Aerial boundary, eliminating all ±1 conversions.
P5 bootstrap infrastructure for multi-cell support
num_phys added to nvipc_params_t; configure_nr_nfapi_vnf creates one pnf_list entry per PHY and epoll_recv_task injects one fake PARAM.RESPONSE per PHY, triggering a separate CONFIG.REQUEST for each cell.
nr_param_resp_cb uses config[p5_idx] and incoming P5 responses are dispatched via msg->cell_id, consistent with P7 routing.

 

- [x] Single-cell behaviour is fully preserved (num_phys = 1).
- [x] Two-cell path partially validated via nvIPC capture showing two CONFIG.REQUEST messages being sent to L1.