### PR TITLE
Mirror RLC indications for lock-free access from MAC

### DIFF
--- a/openair2/LAYER2/nr_rlc/nr_rlc_entity_am.c
+++ b/openair2/LAYER2/nr_rlc/nr_rlc_entity_am.c
@@ -741,8 +741,7 @@ err:
 #undef R
 }
 
-void nr_rlc_entity_am_recv_pdu(nr_rlc_entity_t *_entity,
-                               char *buffer, int size)
+static int recv_pdu(nr_rlc_entity_t *_entity, char *buffer, int size)
 {
 #define R(d) do { if (nr_rlc_pdu_decoder_in_error(&d)) goto err; } while (0)
   nr_rlc_entity_am_t *entity = (nr_rlc_entity_am_t *)_entity;
@@ -765,7 +764,8 @@ void nr_rlc_entity_am_recv_pdu(nr_rlc_entity_t *_entity,
 
   if (dc == 0) {
     LOG_D(RLC, "RLC received control PDU\n");
-    return process_control_pdu(entity, buffer, size);
+    process_control_pdu(entity, buffer, size);
+    return 0;
   }
 
   /* data PDU */
@@ -854,7 +854,7 @@ void nr_rlc_entity_am_recv_pdu(nr_rlc_entity_t *_entity,
     }
   }
 
-  return;
+  return 1;
 
 err:
   LOG_W(RLC, "RX error decoding PDU, discarding\n");
@@ -866,6 +866,10 @@ discard:
 
   entity->common.stats.rxpdu_dd_pkts++;
   entity->common.stats.rxpdu_dd_bytes += size;
+
+  /* Discarding leaves the RX state unchanged, but a poll can create a new
+   * pending STATUS report. Populate its empty cache in that case. */
+  return p && entity->common.bstatus.status_size == 0;
 
 #undef R
 }
@@ -1440,6 +1444,7 @@ static int generate_status(nr_rlc_entity_am_t *entity, char *buffer, int size)
 
   /* reset the trigger */
   entity->status_triggered = 0;
+  entity->common.bstatus.status_size = 0;
 
   /* start t_status_prohibit */
   entity->t_status_prohibit_start = entity->t_current;
@@ -1461,7 +1466,7 @@ static int status_to_report(nr_rlc_entity_am_t *entity)
 }
 
 static int missing_size(nr_rlc_entity_am_t *entity, missing_data_t *m,
-                        int *size, int maxsize)
+                        int *size)
 {
   int r_bits = entity->sn_field_length == 18 ? 3 : 1;
   int range_count = 0;
@@ -1470,7 +1475,6 @@ static int missing_size(nr_rlc_entity_am_t *entity, missing_data_t *m,
   int sn_end;
   int so_end;
   int sn_count;
-  missing_data_t m_nack;
 
   /* be careful to limit a range to 255 SNs, that is: cut if needed */
   sn_count = (m->sn_end - m->sn_start + entity->sn_modulus)
@@ -1507,16 +1511,6 @@ static int missing_size(nr_rlc_entity_am_t *entity, missing_data_t *m,
       so_end = 0xffff;
     }
 
-    /* check that there is room for a nack */
-    m_nack.sn_start = sn_start;
-    m_nack.so_start = so_start;
-    m_nack.sn_end = sn_end;
-    m_nack.so_end = so_end;
-    if (*size + nack_size(entity, &m_nack) > maxsize) {
-      m->next = NULL;
-      break;
-    }
-
     if (sn_start == sn_end) {
       if (so_start == 0 && so_end == 0xffff) {
         /* only nack_sn, no so_start/end, no nack range */
@@ -1543,16 +1537,12 @@ static int missing_size(nr_rlc_entity_am_t *entity, missing_data_t *m,
   return range_count;
 }
 
-static int status_size(nr_rlc_entity_am_t *entity, int maxsize)
+static int status_size(nr_rlc_entity_am_t *entity)
 {
   missing_data_t  m;
   nr_rlc_pdu_t    *cur;
   int             nack_count = 0;
   int             size;
-
-  /* if not enough room, do nothing */
-  if (maxsize < 3)
-    return 0;
 
   /* minimum 3 bytes */
   size = 3;
@@ -1566,12 +1556,19 @@ static int status_size(nr_rlc_entity_am_t *entity, int maxsize)
     if (m.sn_start == -1)
       break;
 
-    nack_count += missing_size(entity, &m, &size, maxsize);
+    nack_count += missing_size(entity, &m, &size);
 
     cur = m.next;
   }
 
   return size;
+}
+
+void nr_rlc_entity_am_recv_pdu(nr_rlc_entity_t *entity, char *buffer, int size)
+{
+  nr_rlc_entity_am_t *am_entity = (nr_rlc_entity_am_t *)entity;
+  if (recv_pdu(entity, buffer, size) && am_entity->status_triggered)
+    am_entity->common.bstatus.status_size = status_size(am_entity);
 }
 
 /*************************************************************************/
@@ -1766,13 +1763,11 @@ static int generate_tx_pdu(nr_rlc_entity_am_t *entity, char *buffer, int size)
 nr_rlc_entity_buffer_status_t nr_rlc_entity_am_buffer_status(
     nr_rlc_entity_t *_entity, int maxsize)
 {
+  UNUSED(maxsize);
   nr_rlc_entity_am_t *entity = (nr_rlc_entity_am_t *)_entity;
   nr_rlc_entity_buffer_status_t ret;
 
-  if (status_to_report(entity))
-    ret.status_size = status_size(entity, maxsize);
-  else
-    ret.status_size = 0;
+  ret.status_size = status_to_report(entity) ? entity->common.bstatus.status_size : 0;
 
   ret.tx_size = entity->common.bstatus.tx_size;
   ret.retx_size = entity->common.bstatus.retx_size;
@@ -1969,6 +1964,8 @@ static void check_t_reassembly(nr_rlc_entity_am_t *entity)
   /* trigger status report */
   entity->status_triggered = 1;
 
+  entity->common.bstatus.status_size = status_size(entity);
+
   if (sn_compare_rx(entity, entity->rx_next_highest,
                     (entity->rx_highest_status+1) % entity->sn_modulus) > 0 ||
       (entity->rx_next_highest ==
@@ -2082,6 +2079,7 @@ static void clear_entity(nr_rlc_entity_am_t *entity)
 
   entity->common.bstatus.tx_size   = 0;
   entity->common.bstatus.retx_size = 0;
+  entity->common.bstatus.status_size = 0;
 }
 
 void nr_rlc_entity_am_reestablishment(nr_rlc_entity_t *_entity)


### PR DESCRIPTION
# RLC buffer-status mirror for lock-free, walk-free MAC access

Currently, dlsch accesses RLC twice per UE per slot (in `nr_mac_rlc_status_ind()` and `nr_mac_rlc_data_req()`), takes the RLC lock every time, and then walks the whole RX PDU list every time. This causes large slowdowns of the scheduler when scaling the number of UEs.

This PR fixes it by introducing a mirror of the per-LC RLC buffer occupancy which is pushed to the MAC for lock-free access. `status_size` is maintained incrementally on PDU arrival, which avoids the walk.

Currently, there is a temporary DevAssert to verify in the CI that the new size computation is the same as before, it should be removed before merging, and we could also remove the following functions then: `status_size()`, `next_missing()`, `get_next_rx_pdu()`, `get_first_rx_pdu()`.

## Benchmark

Measured with `nr_dlbench`, with `-A <depth>` which adds a AM receive window of `depth` out-of-order SNs and re-polls it every slot.  (this measures the mean time spent in the dlsch scheduler in us)


| UEs | AM depth | develop | with this PR |
|----:|---------:|--------:|-------------:|
| 8   | 0 (UM)   |   4.8   |     4.7      |
| 8   | 100      |  24.4   |    10.0      |
| 8   | 300      |  52.5   |     9.8      |
| 8   | 500      |  76.9   |     9.8      |
| 16  | 0 (UM)   |   8.5   |     8.4      |
| 16  | 100      |  43.7   |    13.3      |
| 16  | 300      |  97.0   |    13.4      |
| 16  | 500      | 150.0   |    14.0      |

Assisted-by: Claude-Code:Opus-4.8