### PR TITLE
Add cell-level E2SM-KPM measurements

### DIFF
--- a/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm.c
+++ b/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm.c
@@ -445,10 +445,16 @@ static const char* kpm_node_meas_du[] = {
   NULL,
 };
 
+static const char* kpm_node_meas_cu[] = {
+  "MR.NRScSSSINR",
+  NULL,
+};
+
 static const char* kpm_node_meas_gnb[] = {
   "CARR.PDSCHMCSDist",
   "CARR.PUSCHMCSDist",
   "L1M.SS-RSRP",
+  "MR.NRScSSSINR",
   NULL,
 };
 
@@ -486,11 +492,11 @@ static const meas_list ran_def_kpm[END_NGRAN_NODE_TYPE][END_RIC_SERVICE_REPORT] 
   {kpm_node_meas_gnb, NULL, NULL, kpm_meas_gnb, NULL},
   {NULL, NULL, NULL, NULL, NULL},
   {NULL, NULL, NULL, NULL, NULL},
-  {NULL, NULL, NULL, kpm_meas_cuup, NULL}, // at the moment, for CU, we use the same function as for CU-UP
+  {kpm_node_meas_cu, NULL, NULL, kpm_meas_cuup, NULL},
   {NULL, NULL, NULL, NULL, NULL},
   {kpm_node_meas_du, NULL, NULL, kpm_meas_du, NULL},
   {NULL, NULL, NULL, NULL, NULL},
-  {NULL, NULL, NULL, NULL, NULL}, // at the moment, no measurement is implemented in CU-CP
+  {kpm_node_meas_cu, NULL, NULL, NULL, NULL},
   {NULL, NULL, NULL, kpm_meas_cuup, NULL}
 };
 

--- a/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm.c
+++ b/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm.c
@@ -447,6 +447,7 @@ static const char* kpm_node_meas_du[] = {
 
 static const char* kpm_node_meas_cu[] = {
   "MR.NRScSSSINR",
+  "RRC.ConnMean",
   NULL,
 };
 
@@ -455,6 +456,7 @@ static const char* kpm_node_meas_gnb[] = {
   "CARR.PUSCHMCSDist",
   "L1M.SS-RSRP",
   "MR.NRScSSSINR",
+  "RRC.ConnMean",
   NULL,
 };
 

--- a/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm.c
+++ b/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm.c
@@ -440,11 +440,13 @@ bool read_kpm_sm(void* data)
 
 static const char* kpm_node_meas_du[] = {
   "CARR.PDSCHMCSDist",
+  "CARR.PUSCHMCSDist",
   NULL,
 };
 
 static const char* kpm_node_meas_gnb[] = {
   "CARR.PDSCHMCSDist",
+  "CARR.PUSCHMCSDist",
   NULL,
 };
 

--- a/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm.c
+++ b/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm.c
@@ -441,12 +441,14 @@ bool read_kpm_sm(void* data)
 static const char* kpm_node_meas_du[] = {
   "CARR.PDSCHMCSDist",
   "CARR.PUSCHMCSDist",
+  "L1M.SS-RSRP",
   NULL,
 };
 
 static const char* kpm_node_meas_gnb[] = {
   "CARR.PDSCHMCSDist",
   "CARR.PUSCHMCSDist",
+  "L1M.SS-RSRP",
   NULL,
 };
 

--- a/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.c
+++ b/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.c
@@ -15,6 +15,8 @@ e2_node_level_stats_t cp_node_level_stats(const e2_node_level_stats_t *src)
     .mac_stats.dl.used_prb_aggregate = src->mac_stats.dl.used_prb_aggregate,
     .mac_stats.ul.total_prb_aggregate = src->mac_stats.ul.total_prb_aggregate,
     .mac_stats.ul.used_prb_aggregate = src->mac_stats.ul.used_prb_aggregate,
+    .rrc_conn_count_sum = src->rrc_conn_count_sum,
+    .rrc_conn_count_samples = src->rrc_conn_count_samples,
   };
 
   return dst;
@@ -157,6 +159,35 @@ static meas_record_lst_t fill_MR_NRScSSSINR(const label_info_lst_t label,
 
   meas_record.value = INTEGER_MEAS_VALUE;
   meas_record.int_val = RC.nrrrc[0]->ss_sinr_cell_dist[bin];
+  return meas_record;
+}
+
+/* RRC.ConnMean — 3GPP TS 28.552 - section 5.1.1.4.1 */
+static meas_record_lst_t fill_RRC_ConnMean(__attribute__((unused)) const label_info_lst_t label,
+                                           __attribute__((unused)) uint32_t gran_period_ms,
+                                           __attribute__((unused)) cudu_ue_info_pair_t ue_info,
+                                           __attribute__((unused)) const size_t ue_idx,
+                                           e2_node_level_stats_t* node_stats)
+{
+  meas_record_lst_t meas_record = {.value = INTEGER_MEAS_VALUE};
+
+  node_stats[1].rrc_conn_count_sum     = RC.nrrrc[0]->rrc_conn_count_sum;
+  node_stats[1].rrc_conn_count_samples = RC.nrrrc[0]->rrc_conn_count_samples;
+
+  const uint64_t d_sum     = node_stats[1].rrc_conn_count_sum     - node_stats[0].rrc_conn_count_sum;
+  const uint64_t d_samples = node_stats[1].rrc_conn_count_samples - node_stats[0].rrc_conn_count_samples;
+
+  if (d_samples > 0) {
+    meas_record.int_val = (long)((d_sum + d_samples / 2) / d_samples);
+    node_stats[0].rrc_conn_count_sum     = node_stats[1].rrc_conn_count_sum;
+    node_stats[0].rrc_conn_count_samples = node_stats[1].rrc_conn_count_samples;
+  } else if (node_stats[1].rrc_conn_count_samples > 0) {
+    meas_record.int_val = (long)((node_stats[1].rrc_conn_count_sum + node_stats[1].rrc_conn_count_samples / 2)
+                                 / node_stats[1].rrc_conn_count_samples);
+  } else {
+    meas_record.int_val = 0;
+  }
+
   return meas_record;
 }
 
@@ -359,6 +390,7 @@ static kv_measure_t lst_measure[] = {
   {.key = "DRB.PdcpSduVolumeUL", .value = fill_DRB_PdcpSduVolumeUL },
   {.key = "L1M.SS-RSRP",         .value = fill_L1M_SS_RSRP },
   {.key = "MR.NRScSSSINR",       .value = fill_MR_NRScSSSINR },
+  {.key = "RRC.ConnMean",        .value = fill_RRC_ConnMean },
 #if defined (NGRAN_GNB_DU)
   {.key = "DRB.RlcSduDelayDl", .value =  fill_DRB_RlcSduDelayDl }, 
   {.key = "DRB.UEThpDl", .value =  fill_DRB_UEThpDl }, 

--- a/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.c
+++ b/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.c
@@ -6,6 +6,8 @@
 
 #include <search.h>
 
+#include "openair2/RRC/NR/rrc_gNB_UE_context.h"
+
 e2_node_level_stats_t cp_node_level_stats(const e2_node_level_stats_t *src)
 {
   e2_node_level_stats_t dst = {
@@ -127,6 +129,34 @@ static meas_record_lst_t fill_L1M_SS_RSRP(const label_info_lst_t label,
 
   meas_record.value = INTEGER_MEAS_VALUE;
   meas_record.int_val = (int64_t)count;
+  return meas_record;
+}
+
+/* MR.NRScSSSINR — 3GPP TS 28.552 - section 5.1.1.32 */
+static meas_record_lst_t fill_MR_NRScSSSINR(const label_info_lst_t label,
+                                            __attribute__((unused)) uint32_t gran_period_ms,
+                                            __attribute__((unused)) cudu_ue_info_pair_t ue_info,
+                                            __attribute__((unused)) const size_t ue_idx,
+                                            __attribute__((unused)) e2_node_level_stats_t* node_stats)
+{
+  meas_record_lst_t meas_record = {0};
+
+  if (label.distBinX == NULL) {
+    printf("[E2 AGENT][E2SM-KPM] MR.NRScSSSINR requested without distBinX label; "
+           "TS 28.552 5.1.1.32 is a distribution with no aggregate value, reporting NO_VALUE\n");
+    meas_record.value = NO_VALUE_MEAS_VALUE;
+    return meas_record;
+  }
+
+  if (*label.distBinX > NR_KPM_SS_SINR_NB_LEVELS - 1) {
+    printf("[E2 AGENT][E2SM-KPM] MR.NRScSSSINR: distBinX %u out of range [0..127], reporting NO_VALUE\n", *label.distBinX);
+    meas_record.value = NO_VALUE_MEAS_VALUE;
+    return meas_record;
+  }
+  const uint32_t bin = *label.distBinX;
+
+  meas_record.value = INTEGER_MEAS_VALUE;
+  meas_record.int_val = RC.nrrrc[0]->ss_sinr_cell_dist[bin];
   return meas_record;
 }
 
@@ -328,6 +358,7 @@ static kv_measure_t lst_measure[] = {
   {.key = "DRB.PdcpSduVolumeDL", .value = fill_DRB_PdcpSduVolumeDL },
   {.key = "DRB.PdcpSduVolumeUL", .value = fill_DRB_PdcpSduVolumeUL },
   {.key = "L1M.SS-RSRP",         .value = fill_L1M_SS_RSRP },
+  {.key = "MR.NRScSSSINR",       .value = fill_MR_NRScSSSINR },
 #if defined (NGRAN_GNB_DU)
   {.key = "DRB.RlcSduDelayDl", .value =  fill_DRB_RlcSduDelayDl }, 
   {.key = "DRB.UEThpDl", .value =  fill_DRB_UEThpDl }, 

--- a/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.c
+++ b/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.c
@@ -85,6 +85,51 @@ static meas_record_lst_t fill_DRB_PdcpSduVolumeUL(__attribute__((unused)) const 
   return meas_record;
 }
 
+/* L1M.SS-RSRP — 3GPP TS 28.552 - section 5.1.1.22.1 */
+static meas_record_lst_t fill_L1M_SS_RSRP(const label_info_lst_t label,
+                                          __attribute__((unused)) uint32_t gran_period_ms,
+                                          __attribute__((unused)) cudu_ue_info_pair_t ue_info,
+                                          __attribute__((unused)) const size_t ue_idx,
+                                          __attribute__((unused)) e2_node_level_stats_t* node_stats)
+{
+  meas_record_lst_t meas_record = {0};
+
+  if (label.distBinX == NULL) {
+    printf("[E2 AGENT][E2SM-KPM] L1M.SS-RSRP requested without distBinX label; "
+           "TS 28.552 5.1.1.22.1 is a distribution with no aggregate value, reporting NO_VALUE\n");
+    meas_record.value = NO_VALUE_MEAS_VALUE;
+    return meas_record;
+  }
+
+  if (*label.distBinX > NR_KPM_SS_RSRP_NB_LEVELS - 1) {
+    printf("[E2 AGENT][E2SM-KPM] L1M.SS-RSRP: distBinX %u out of range [0..127], reporting NO_VALUE\n", *label.distBinX);
+    meas_record.value = NO_VALUE_MEAS_VALUE;
+    return meas_record;
+  }
+  const uint32_t bin = *label.distBinX;
+
+  const NR_du_stats_t *du_stats = &RC.nrmac[0]->du_stats;
+
+  uint64_t count = 0;
+  if (label.ssbIndex != NULL) {
+    const uint32_t ssb_wire = *label.ssbIndex;
+    if (ssb_wire > NR_KPM_NB_SSB - 1) {
+      printf("[E2 AGENT][E2SM-KPM] L1M.SS-RSRP: ssbIndex %u out of range [0..63], reporting NO_VALUE\n", ssb_wire);
+      meas_record.value = NO_VALUE_MEAS_VALUE;
+      return meas_record;
+    }
+    const uint32_t ssb = ssb_wire;
+    count = du_stats->ss_rsrp_ssb_dist[ssb][bin];
+  } else {
+    for (int s = 0; s < NR_KPM_NB_SSB; s++)
+      count += du_stats->ss_rsrp_ssb_dist[s][bin];
+  }
+
+  meas_record.value = INTEGER_MEAS_VALUE;
+  meas_record.int_val = (int64_t)count;
+  return meas_record;
+}
+
 #if defined (NGRAN_GNB_DU)
 static uldlcounter_t last_rlc_pdu_total_bytes[MAX_MOBILES_PER_GNB] = {0};
 static uldlcounter_t last_total_prbs[MAX_MOBILES_PER_GNB] = {0};
@@ -280,8 +325,9 @@ static meas_record_lst_t fill_CARR_PUSCHMCSDist(const label_info_lst_t label,
 #endif
 
 static kv_measure_t lst_measure[] = {
-  {.key = "DRB.PdcpSduVolumeDL", .value = fill_DRB_PdcpSduVolumeDL }, 
+  {.key = "DRB.PdcpSduVolumeDL", .value = fill_DRB_PdcpSduVolumeDL },
   {.key = "DRB.PdcpSduVolumeUL", .value = fill_DRB_PdcpSduVolumeUL },
+  {.key = "L1M.SS-RSRP",         .value = fill_L1M_SS_RSRP },
 #if defined (NGRAN_GNB_DU)
   {.key = "DRB.RlcSduDelayDl", .value =  fill_DRB_RlcSduDelayDl }, 
   {.key = "DRB.UEThpDl", .value =  fill_DRB_UEThpDl }, 

--- a/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.c
+++ b/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.c
@@ -219,19 +219,29 @@ static meas_record_lst_t fill_CARR_PDSCHMCSDist(const label_info_lst_t label,
                                                 __attribute__((unused)) const size_t ue_idx,
                                                 __attribute__((unused))e2_node_level_stats_t* node_stats)
 {
-  meas_record_lst_t meas_record = {.value = INTEGER_MEAS_VALUE};
+  meas_record_lst_t meas_record = {0};
 
-  uint32_t bin_x = *label.distBinX, bin_y = *label.distBinY, bin_z = *label.distBinZ;
-
-  NR_du_stats_t* du_stats = &RC.nrmac[0]->du_stats;
-
-  if (bin_x <= 8 && bin_y <= 3 && bin_z <= 31) {
-    meas_record.int_val = du_stats->pdsch_mcs_dist[bin_x - 1][bin_y - 1][bin_z];
-  } else {
-    printf("[E2 AGENT] Unknown binX %d, binY %d, binZ %d for \"CARR.PDSCHMCSDist\" measurement\n", bin_x, bin_y, bin_z);
-    meas_record.int_val = 0;
+  if (label.distBinX == NULL || label.distBinY == NULL || label.distBinZ == NULL) {
+    printf("[E2 AGENT][E2SM-KPM] CARR.PDSCHMCSDist requested without distBinX/Y/Z labels; "
+           "TS 28.552 5.1.1.12.1 defines no aggregate value, reporting NO_VALUE\n");
+    meas_record.value = NO_VALUE_MEAS_VALUE;
+    return meas_record;
   }
 
+  const uint32_t bin_x = *label.distBinX;
+  const uint32_t bin_y = *label.distBinY;
+  const uint32_t bin_z = *label.distBinZ;
+
+  if (bin_x < 1 || bin_x > NR_KPM_MAX_LAYERS || bin_y < 1 || bin_y > NR_KPM_NB_MCS_TABLE_DL || bin_z > NR_KPM_NB_MCS - 1) {
+    printf("[E2 AGENT][E2SM-KPM] CARR.PDSCHMCSDist: bin out of range (X=%u Y=%u Z=%u), reporting NO_VALUE\n",
+           bin_x, bin_y, bin_z);
+    meas_record.value = NO_VALUE_MEAS_VALUE;
+    return meas_record;
+  }
+
+  const NR_du_stats_t* du_stats = &RC.nrmac[0]->du_stats;
+  meas_record.value = INTEGER_MEAS_VALUE;
+  meas_record.int_val = du_stats->pdsch_mcs_dist[bin_x - 1][bin_y - 1][bin_z];
   return meas_record;
 }
 #endif

--- a/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.c
+++ b/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.c
@@ -244,6 +244,39 @@ static meas_record_lst_t fill_CARR_PDSCHMCSDist(const label_info_lst_t label,
   meas_record.int_val = du_stats->pdsch_mcs_dist[bin_x - 1][bin_y - 1][bin_z];
   return meas_record;
 }
+
+/* CARR.PUSCHMCSDist — 3GPP TS 28.552 - section 5.1.1.12.2 */
+static meas_record_lst_t fill_CARR_PUSCHMCSDist(const label_info_lst_t label,
+                                                __attribute__((unused)) uint32_t gran_period_ms,
+                                                __attribute__((unused)) cudu_ue_info_pair_t ue_info,
+                                                __attribute__((unused)) const size_t ue_idx,
+                                                __attribute__((unused))e2_node_level_stats_t* node_stats)
+{
+  meas_record_lst_t meas_record = {0};
+
+  if (label.distBinX == NULL || label.distBinY == NULL || label.distBinZ == NULL) {
+    printf("[E2 AGENT][E2SM-KPM] CARR.PUSCHMCSDist requested without distBinX/Y/Z labels; "
+           "TS 28.552 5.1.1.12.2 defines no aggregate value, reporting NO_VALUE\n");
+    meas_record.value = NO_VALUE_MEAS_VALUE;
+    return meas_record;
+  }
+
+  const uint32_t bin_x = *label.distBinX;
+  const uint32_t bin_y = *label.distBinY;
+  const uint32_t bin_z = *label.distBinZ;
+
+  if (bin_x < 1 || bin_x > NR_KPM_MAX_LAYERS || bin_y > NR_KPM_NB_MCS_TABLE_UL - 1 || bin_z > NR_KPM_NB_MCS - 1) {
+    printf("[E2 AGENT][E2SM-KPM] CARR.PUSCHMCSDist: bin out of range (X=%u Y=%u Z=%u), reporting NO_VALUE\n",
+           bin_x, bin_y, bin_z);
+    meas_record.value = NO_VALUE_MEAS_VALUE;
+    return meas_record;
+  }
+
+  const NR_du_stats_t* du_stats = &RC.nrmac[0]->du_stats;
+  meas_record.value = INTEGER_MEAS_VALUE;
+  meas_record.int_val = du_stats->pusch_mcs_dist[bin_x - 1][bin_y][bin_z];
+  return meas_record;
+}
 #endif
 
 static kv_measure_t lst_measure[] = {
@@ -256,6 +289,7 @@ static kv_measure_t lst_measure[] = {
   {.key = "RRU.PrbTotDl", .value =  fill_RRU_PrbTotDl }, 
   {.key = "RRU.PrbTotUl", .value =  fill_RRU_PrbTotUl }, 
   {.key = "CARR.PDSCHMCSDist", .value = fill_CARR_PDSCHMCSDist },
+  {.key = "CARR.PUSCHMCSDist", .value = fill_CARR_PUSCHMCSDist },
 #endif
 }; 
 

--- a/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.h
+++ b/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm_subs.h
@@ -19,6 +19,9 @@ typedef struct {
 
 typedef struct {
   dlul_mac_stats_t mac_stats;
+
+  uint64_t rrc_conn_count_sum;
+  uint64_t rrc_conn_count_samples;
 } e2_node_level_stats_t;
 
 e2_node_level_stats_t cp_node_level_stats(const e2_node_level_stats_t *src);

--- a/openair2/E2AP/README.md
+++ b/openair2/E2AP/README.md
@@ -102,6 +102,7 @@ From 3GPP TS 28.552, we support the following list:
   * `RRU.PrbTotDl`
   * `RRU.PrbTotUl`
   * `CARR.PDSCHMCSDist`
+  * `CARR.PUSCHMCSDist`
 
 From `O-RAN.WG3.E2SM-KPM-version` specification, we implemented:
   * REPORT Service Style 4 ("Common condition-based, UE-level" - section 7.4.5) - fetch above measurements per each UE based on the common S-NSSAI `(1, 0xffffff)` condition

--- a/openair2/E2AP/README.md
+++ b/openair2/E2AP/README.md
@@ -101,6 +101,7 @@ From 3GPP TS 28.552, we support the following list:
   * `DRB.UEThpUl`
   * `RRU.PrbTotDl`
   * `RRU.PrbTotUl`
+  * `CARR.PDSCHMCSDist`
 
 From `O-RAN.WG3.E2SM-KPM-version` specification, we implemented:
   * REPORT Service Style 4 ("Common condition-based, UE-level" - section 7.4.5) - fetch above measurements per each UE based on the common S-NSSAI `(1, 0xffffff)` condition

--- a/openair2/E2AP/README.md
+++ b/openair2/E2AP/README.md
@@ -104,6 +104,7 @@ From 3GPP TS 28.552, we support the following list:
   * `CARR.PDSCHMCSDist`
   * `CARR.PUSCHMCSDist`
   * `L1M.SS-RSRP`
+  * `MR.NRScSSSINR`
 
 From `O-RAN.WG3.E2SM-KPM-version` specification, we implemented:
   * REPORT Service Style 4 ("Common condition-based, UE-level" - section 7.4.5) - fetch above measurements per each UE based on the common S-NSSAI `(1, 0xffffff)` condition

--- a/openair2/E2AP/README.md
+++ b/openair2/E2AP/README.md
@@ -103,6 +103,7 @@ From 3GPP TS 28.552, we support the following list:
   * `RRU.PrbTotUl`
   * `CARR.PDSCHMCSDist`
   * `CARR.PUSCHMCSDist`
+  * `L1M.SS-RSRP`
 
 From `O-RAN.WG3.E2SM-KPM-version` specification, we implemented:
   * REPORT Service Style 4 ("Common condition-based, UE-level" - section 7.4.5) - fetch above measurements per each UE based on the common S-NSSAI `(1, 0xffffff)` condition

--- a/openair2/E2AP/README.md
+++ b/openair2/E2AP/README.md
@@ -105,6 +105,7 @@ From 3GPP TS 28.552, we support the following list:
   * `CARR.PUSCHMCSDist`
   * `L1M.SS-RSRP`
   * `MR.NRScSSSINR`
+  * `RRC.ConnMean`
 
 From `O-RAN.WG3.E2SM-KPM-version` specification, we implemented:
   * REPORT Service Style 4 ("Common condition-based, UE-level" - section 7.4.5) - fetch above measurements per each UE based on the common S-NSSAI `(1, 0xffffff)` condition

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch.c
@@ -1261,6 +1261,11 @@ void post_process_dlsch(gNB_MAC_INST *nr_mac,
         tpc);
   DevAssert(sched_pdsch->rbSize > 0);
 
+  DevAssert(nrOfLayers >= 1 && nrOfLayers <= NR_KPM_MAX_LAYERS);
+  DevAssert(current_BWP->mcsTableIdx >= 0 && current_BWP->mcsTableIdx < NR_KPM_NB_MCS_TABLE_DL);
+  DevAssert(sched_pdsch->mcs < NR_KPM_NB_MCS);
+  nr_mac->du_stats.pdsch_mcs_dist[nrOfLayers - 1][current_BWP->mcsTableIdx][sched_pdsch->mcs] += sched_pdsch->rbSize;
+
   const int bwp_id = current_BWP->bwp_id;
   const int coresetid = sched_ctrl->coreset->controlResourceSetId;
 

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_uci.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_uci.c
@@ -604,6 +604,15 @@ static void evaluate_rsrp_report(NR_UE_info_t *UE,
   for (RSRP_report_t *r = rsrp_report->r; r < rsrp_report->r + rsrp_report->nb; r++)
     if (r->resource_id < MAX_NUM_OF_SSB)
       UE->beam_rsrp[r->resource_id] = r->RSRP;
+
+  if (reportQuantity_type == NR_CSI_ReportConfig__reportQuantity_PR_ssb_Index_RSRP) {
+    NR_du_stats_t *du_stats = &RC.nrmac[0]->du_stats;
+    for (RSRP_report_t *r = rsrp_report->r; r < rsrp_report->r + rsrp_report->nb; r++) {
+      const int level = r->RSRP + 157;
+      if (r->resource_id >= 0 && r->resource_id < NR_KPM_NB_SSB && level >= 0 && level < NR_KPM_SS_RSRP_NB_LEVELS)
+        du_stats->ss_rsrp_ssb_dist[r->resource_id][level]++;
+    }
+  }
 }
 
 static void evaluate_cri_report(uint8_t *payload, uint8_t cri_bitlen, int cumul_bits, NR_UE_sched_ctrl_t *sched_ctrl)

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -2201,9 +2201,9 @@ void post_process_ulsch(gNB_MAC_INST *nr_mac,
 
   T(T_GNB_MAC_UL, T_INT(UE->rnti), T_INT(frame), T_INT(slot), T_INT(sched_pusch->mcs), T_INT(sched_pusch->tb_size));
 
-  DevAssert(sched_pusch->nrOfLayers >= 1 && sched_pusch->nrOfLayers <= 8);
+  DevAssert(sched_pusch->nrOfLayers >= 1 && sched_pusch->nrOfLayers <= NR_KPM_MAX_LAYERS);
   DevAssert(current_BWP->mcs_table == 0 || current_BWP->mcs_table == 1 || current_BWP->mcs_table == 3);
-  DevAssert(sched_pusch->mcs >= 0 && sched_pusch->mcs <= 31);
+  DevAssert(sched_pusch->mcs < NR_KPM_NB_MCS);
   NR_du_stats_t *stats = &nr_mac->du_stats;
   stats->pusch_mcs_dist[sched_pusch->nrOfLayers - 1][current_BWP->mcs_table][sched_pusch->mcs] += sched_pusch->rbSize;
 

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -1145,6 +1145,10 @@ typedef struct {
 #define NR_KPM_NB_MCS_TABLE_UL  4  /* PUSCH MCS tables: 0, 1, 3  */
 #define NR_KPM_NB_MCS           32 /* MCS index: 0..31          */
 
+/* Dimensions of the L1M.SS-RSRP histogram (3GPP TS 28.552 §5.1.1.22.1). */
+#define NR_KPM_NB_SSB            64  /* SS/PBCH block index: 0..63              */
+#define NR_KPM_SS_RSRP_NB_LEVELS 128 /* SS-RSRP report level: 0..127, TS 38.133 */
+
 typedef struct NR_du_stats {
   /// cell-wide wide-band CQI distribution, see 28.552 5.1.1.11.1;
   /// 0-15 CQI, 1-8 RI, 1-3 CQI table
@@ -1157,6 +1161,10 @@ typedef struct NR_du_stats {
   /// cell-wide MCS distribution in PUSCH, see 28.552 5.1.1.12.1
   /// 1-8 RI, MCS table (0, 1, 3), 0-31 MCS value
   uint32_t pusch_mcs_dist[NR_KPM_MAX_LAYERS][NR_KPM_NB_MCS_TABLE_UL][NR_KPM_NB_MCS];
+
+  /// cell-wide L1 SS-RSRP distribution per SSB beam, see 28.552 5.1.1.22.1
+  /// 0-63 SSB index, 0-127 SS-RSRP report level (TS 38.133)
+  uint32_t ss_rsrp_ssb_dist[NR_KPM_NB_SSB][NR_KPM_SS_RSRP_NB_LEVELS];
 } NR_du_stats_t;
 
 /*! \brief top level eNB MAC structure */

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -1139,6 +1139,11 @@ typedef struct {
   NR_ControlResourceSet_t coreset;
 } NR_sched_ctrl_sib1_t;
 
+/* Dimensions of the per-cell MCS distribution histograms (3GPP TS 28.552 §5.1.1.12). */
+#define NR_KPM_MAX_LAYERS       8  /* RI: 1..8                  */
+#define NR_KPM_NB_MCS_TABLE_DL  3  /* PDSCH MCS tables: 1..3    */
+#define NR_KPM_NB_MCS           32 /* MCS index: 0..31          */
+
 typedef struct NR_du_stats {
   /// cell-wide wide-band CQI distribution, see 28.552 5.1.1.11.1;
   /// 0-15 CQI, 1-8 RI, 1-3 CQI table
@@ -1146,7 +1151,7 @@ typedef struct NR_du_stats {
 
   /// cell-wide MCS distribution in PDSCH, see 28.552 5.1.1.12.1
   /// 1-8 RI, 1-3 MCS table, 0-31 MCS value
-  uint32_t pdsch_mcs_dist[8][3][32];
+  uint32_t pdsch_mcs_dist[NR_KPM_MAX_LAYERS][NR_KPM_NB_MCS_TABLE_DL][NR_KPM_NB_MCS];
 
   /// cell-wide MCS distribution in PUSCH, see 28.552 5.1.1.12.1
   /// 1-8 RI, 1-2 MCS table, 0-31 MCS value

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -1142,6 +1142,7 @@ typedef struct {
 /* Dimensions of the per-cell MCS distribution histograms (3GPP TS 28.552 §5.1.1.12). */
 #define NR_KPM_MAX_LAYERS       8  /* RI: 1..8                  */
 #define NR_KPM_NB_MCS_TABLE_DL  3  /* PDSCH MCS tables: 1..3    */
+#define NR_KPM_NB_MCS_TABLE_UL  4  /* PUSCH MCS tables: 0, 1, 3  */
 #define NR_KPM_NB_MCS           32 /* MCS index: 0..31          */
 
 typedef struct NR_du_stats {
@@ -1154,8 +1155,8 @@ typedef struct NR_du_stats {
   uint32_t pdsch_mcs_dist[NR_KPM_MAX_LAYERS][NR_KPM_NB_MCS_TABLE_DL][NR_KPM_NB_MCS];
 
   /// cell-wide MCS distribution in PUSCH, see 28.552 5.1.1.12.1
-  /// 1-8 RI, 1-2 MCS table, 0-31 MCS value
-  uint32_t pusch_mcs_dist[8][2][32];
+  /// 1-8 RI, MCS table (0, 1, 3), 0-31 MCS value
+  uint32_t pusch_mcs_dist[NR_KPM_MAX_LAYERS][NR_KPM_NB_MCS_TABLE_UL][NR_KPM_NB_MCS];
 } NR_du_stats_t;
 
 /*! \brief top level eNB MAC structure */

--- a/openair2/RRC/NR/nr_rrc_defs.h
+++ b/openair2/RRC/NR/nr_rrc_defs.h
@@ -599,6 +599,9 @@ typedef struct sib2_config_s {
   bool deriveSSB_IndexFromCell;
 } sib2_config_t;
 
+/* MR.NRScSSSINR histogram dimension (3GPP TS 28.552 §5.1.1.32). */
+#define NR_KPM_SS_SINR_NB_LEVELS 128 /* SS-SINR report level: 0..127, TS 38.133 Table 10.1.16.1-1 */
+
 //---NR---(completely change)---------------------
 typedef struct gNB_RRC_INST_s {
 
@@ -645,6 +648,10 @@ typedef struct gNB_RRC_INST_s {
   // PDCP configuration parameters loaded during startup
   nr_pdcp_configuration_t pdcp_config;
   nr_rlc_configuration_t rlc_config;
+
+  /// cell-wide NR serving-cell SS-SINR distribution, see 28.552 5.1.1.32
+  /// 0-127 SS-SINR report level (TS 38.133)
+  uint32_t ss_sinr_cell_dist[NR_KPM_SS_SINR_NB_LEVELS];
 } gNB_RRC_INST;
 
 /** Forward declaration for UE log macros */

--- a/openair2/RRC/NR/nr_rrc_defs.h
+++ b/openair2/RRC/NR/nr_rrc_defs.h
@@ -652,6 +652,9 @@ typedef struct gNB_RRC_INST_s {
   /// cell-wide NR serving-cell SS-SINR distribution, see 28.552 5.1.1.32
   /// 0-127 SS-SINR report level (TS 38.133)
   uint32_t ss_sinr_cell_dist[NR_KPM_SS_SINR_NB_LEVELS];
+
+  uint64_t rrc_conn_count_sum;
+  uint64_t rrc_conn_count_samples;
 } gNB_RRC_INST;
 
 /** Forward declaration for UE log macros */

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -3514,6 +3514,18 @@ static bool write_rrc_stats(const gNB_RRC_INST *rrc)
   return true;
 }
 
+static void nr_rrc_sample_conn_count(gNB_RRC_INST *rrc)
+{
+  if (rrc == NULL)
+    return;
+  uint32_t count = 0;
+  rrc_gNB_ue_context_t *ue_context_p = NULL;
+  RB_FOREACH(ue_context_p, rrc_nr_ue_tree_s, &rrc->rrc_ue_head)
+    count++;
+  rrc->rrc_conn_count_sum += count;
+  rrc->rrc_conn_count_samples += 1;
+}
+
 void *rrc_gnb_task(void *args_p)
 {
   UNUSED(args_p);
@@ -3553,6 +3565,7 @@ void *rrc_gnb_task(void *args_p)
 
       case TIMER_HAS_EXPIRED:
         if (TIMER_HAS_EXPIRED(msg_p).timer_id == stats_timer_id) {
+          nr_rrc_sample_conn_count(RC.nrrrc[0]);
           if (!write_rrc_stats(RC.nrrrc[0]))
             timer_remove(stats_timer_id);
         } else {

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -1633,6 +1633,27 @@ fallback_rrc_setup:
   return;
 }
 
+static void nr_rrc_count_ss_sinr_dist(gNB_RRC_INST *rrc, const NR_MeasResults_t *mr)
+{
+  if (rrc == NULL || mr == NULL)
+    return;
+  if (mr->measResultServingMOList.list.count == 0 || mr->measResultServingMOList.list.array == NULL)
+    return;
+
+  for (int i = 0; i < mr->measResultServingMOList.list.count; i++) {
+    const NR_MeasResultServMO_t *serv_mo = mr->measResultServingMOList.list.array[i];
+    if (serv_mo == NULL)
+      continue;
+    const struct NR_MeasResultNR__measResult__cellResults *cr =
+        &serv_mo->measResultServingCell.measResult.cellResults;
+    if (cr->resultsSSB_Cell == NULL || cr->resultsSSB_Cell->sinr == NULL)
+      continue;
+    const long encoded = *cr->resultsSSB_Cell->sinr;
+    if (encoded >= 0 && encoded < NR_KPM_SS_SINR_NB_LEVELS)
+      rrc->ss_sinr_cell_dist[encoded]++;
+  }
+}
+
 static void process_Periodical_Measurement_Report(gNB_RRC_UE_t *ue_ctxt, NR_MeasurementReport_t *measurementReport)
 {
   ASN_STRUCT_FREE(asn_DEF_NR_MeasResults, ue_ctxt->measResults);
@@ -1815,8 +1836,11 @@ static void rrc_gNB_process_MeasurementReport(gNB_RRC_INST *rrc, gNB_RRC_UE_t *U
     return;
   }
 
-  if (report_config->choice.reportConfigNR->reportType.present == NR_ReportConfigNR__reportType_PR_periodical)
-    return process_Periodical_Measurement_Report(UE, measurementReport);
+  if (report_config->choice.reportConfigNR->reportType.present == NR_ReportConfigNR__reportType_PR_periodical) {
+    nr_rrc_count_ss_sinr_dist(rrc, &measurementReport->criticalExtensions.choice.measurementReport->measResults);
+    process_Periodical_Measurement_Report(UE, measurementReport);
+    return;
+  }
 
   if (report_config->choice.reportConfigNR->reportType.present == NR_ReportConfigNR__reportType_PR_eventTriggered)
     return process_Event_Based_Measurement_Report(rrc, UE, report_config->choice.reportConfigNR, measurementReport);


### PR DESCRIPTION
This PR adds five 3GPP TS 28.552 cell-level measurements, exposed through the E2SM-KPM service model.

The five metrics are:

| Metric | 3GPP TS 28.552 | Object class | Advertised by |
|--------|----------------|--------------|---------------|
| `CARR.PDSCHMCSDist` | §5.1.1.12.1 | NRCellDU | DU, monolithic gNB |
| `CARR.PUSCHMCSDist` | §5.1.1.12.2 | NRCellDU | DU, monolithic gNB |
| `L1M.SS-RSRP`       | §5.1.1.22.1 | Beam       | CU, CU-CP, monolithic gNB |
| `MR.NRScSSSINR`     | §5.1.1.32   | NRCellCU   | CU, CU-CP, monolithic gNB |
| `RRC.ConnMean`      | §5.1.1.4.1  | NRCellCU   | CU, monolithic gNB |

Each metric is delivered as one signed commit. 

## Metrics

### CARR.PDSCHMCSDist — §5.1.1.12.1
PRB-weighted distribution of the MCS used on PDSCH, modelled as a 3D histogram over (rank, MCS-table, MCS-index). The collection hook in the DL scheduling path increments the matching bin by the number of scheduled PDSCH RBs. Carried as
E2SM-KPM Style 1 / Indication Message Format 1 with the `distBinX/Y/Z` measurement labels.

### CARR.PUSCHMCSDist — §5.1.1.12.2
Uplink counterpart of the above, over (rank, MCS-table-family, MCS-index) for PUSCH. The UL scheduling hook increments the bin by the number of scheduled PUSCH RBs.

### L1M.SS-RSRP — §5.1.1.22.1
Distribution of the SS-RSRP reported by UEs, resolved per SSB beam. The RRC layer accumulates a per-beam histogram from each periodic Measurement Report; RSRP level `L` maps to `L − 157` dBm (TS 38.133 §10.1.6). The reader returns the
per-beam value when the `ssbIndex` label is present, or the cell-wide sum over beams otherwise.

### MR.NRScSSSINR — §5.1.1.32
Distribution of the NR serving-cell SS-SINR reported by UEs. The RRC layer accumulates a per-cell histogram from each periodic Measurement Report; level `L` maps to `(L − 46) / 2` dB (0.5 dB steps, TS 38.133 §10.1.16).

### RRC.ConnMean — §5.1.1.4.1
Mean number of UEs in RRC-CONNECTED state over the granularity period. The RRC task samples the connected-UE count at a fixed interval and accumulates a running `{sum, samples}`. The reported mean is the delta of that cumulative
accumulator between two consecutive readings.

## Notes

- All five metrics are carried as E2SM-KPM **Measurement Report Style 1**
- Distribution metrics use the standard `distBinX/Y/Z` (and `ssbIndex` where applicable) measurement labels; bins are 1-based on the wire and mapped to 0-based array indices. Where TS 28.552 defines no scalar aggregate, a request without the required label or a `noLabel` subscriptions, are answered with `NO_VALUE`.