### PR TITLE
CI: Add label check and signature verification in GitHub Actions

### DIFF
--- a/.github/workflows/jenkins-dispatch.yml
+++ b/.github/workflows/jenkins-dispatch.yml
@@ -109,8 +109,9 @@ jobs:
   require-maintainer-approval:
     needs: detect-changes
 
-    if: needs.detect-changes.outputs.protected_files_changed == 'true'
-
+    if: |
+      always() &&
+      needs.detect-changes.outputs.protected_files_changed == 'true'
     runs-on: ubuntu-24.04
 
     environment:

--- a/.github/workflows/jenkins-dispatch.yml
+++ b/.github/workflows/jenkins-dispatch.yml
@@ -17,12 +17,43 @@ permissions:
   pull-requests: write
 
 jobs:
+  check-labels:
+    runs-on: ubuntu-24.04
+
+    if: github.event_name == 'pull_request_target'
+
+    steps:
+      - name: Check for mandatory CI label
+        run: |
+          PR_LABELS=$(echo '${{ toJson(github.event.pull_request.labels) }}' | jq -r '.[].name')
+
+          for label in \
+            "${{ vars.BUILD_ONLY_LABEL }}" \
+            "${{ vars.DOC_LABEL }}" \
+            "${{ vars.NR_LABEL }}" \
+            "${{ vars.NRUE_LABEL }}" \
+            "${{ vars.LTE_LABEL }}" \
+            "${{ vars.CI_LABEL }}" \
+            "${{ vars.RETRIGGER_CI_LABEL }}"; do
+            if echo "$PR_LABELS" | grep -qxF "$label"; then
+              exit 0
+            fi
+          done
+
+          exit 1
+
   detect-changes:
+    needs: check-labels
     runs-on: ubuntu-24.04
 
     if: |
-      github.event.action != 'labeled' ||
-      github.event.label.name == vars.RETRIGGER_CI_LABEL
+      always() && (
+        github.event_name == 'push' ||
+        needs.check-labels.result == 'success'
+      ) && (
+        github.event.action != 'labeled' ||
+        github.event.label.name == vars.RETRIGGER_CI_LABEL
+      )
 
     outputs:
       protected_files_changed: ${{ steps.filter.outputs.protected }}
@@ -61,6 +92,7 @@ jobs:
 
   trigger-jenkins:
     needs:
+      - check-labels
       - detect-changes
       - require-maintainer-approval
 

--- a/.github/workflows/jenkins-dispatch.yml
+++ b/.github/workflows/jenkins-dispatch.yml
@@ -17,7 +17,36 @@ permissions:
   pull-requests: write
 
 jobs:
+  verify-signed-commits:
+    runs-on: ubuntu-24.04
+
+    if: github.event_name == 'pull_request_target'
+
+    steps:
+      - name: Check all commits are signed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          UNSIGNED=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits \
+            --paginate --jq '[.[] | select(.commit.verification.verified == false) | .sha[:7]] | join(", ")')
+
+          if [ -n "$UNSIGNED" ]; then
+            echo -e "$UNSIGNED commits are missing signature"
+            gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "$(cat <<EOF
+          **Validation:**
+          The following commit(s) are missing signature:
+
+          $UNSIGNED
+
+          Please use 'git commit -S' to sign your commits.
+          For detailed instructions, refer to the [CONTRIBUTING.md](https://github.com/duranta-project/openairinterface5g/blob/develop/CONTRIBUTING.md) file at the root of this repository or [GitHub Docs](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+          EOF
+          )"
+            exit 1
+          fi
+
   check-labels:
+    needs: verify-signed-commits
     runs-on: ubuntu-24.04
 
     if: github.event_name == 'pull_request_target'

--- a/.github/workflows/jenkins-dispatch.yml
+++ b/.github/workflows/jenkins-dispatch.yml
@@ -166,8 +166,24 @@ jobs:
             -H "X-Github-Hook-Installation-Target-Type: repository" \
             --data @/tmp/filtered_payload.json
 
+  cleanup:
+    needs:
+      - verify-signed-commits
+      - check-labels
+      - detect-changes
+      - require-maintainer-approval
+      - trigger-jenkins
+
+    if: always() && github.event_name == 'pull_request_target'
+
+    runs-on: ubuntu-24.04
+
+    steps:
       - name: Remove retrigger-ci label
-        if: always() && github.event.action == 'labeled' && github.event.label.name == vars.RETRIGGER_CI_LABEL
-        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "${{ vars.RETRIGGER_CI_LABEL }}"
+        run: |
+          PR_LABELS=$(echo '${{ toJson(github.event.pull_request.labels) }}' | jq -r '.[].name')
+          if echo "$PR_LABELS" | grep -qxF "${{ vars.RETRIGGER_CI_LABEL }}"; then
+            gh pr edit ${{ github.event.pull_request.number }} --remove-label "${{ vars.RETRIGGER_CI_LABEL }}" --repo ${{ github.repository }}
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
-# Contributing to OpenAirInterface
+# Contributing to Duranta
 
 We want to make contributing to this project as easy and transparent as possible.
 
@@ -18,41 +18,134 @@ We want to make contributing to this project as easy and transparent as possible
 
 ## Commit Guidelines
 
+Every pull request must pass two CI checks before it can be merged:
+
+1. **[Developer Certificate of Origin (DCO)](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)**:
+   Each commit must include a `Signed-off-by:` trailer in the commit message.
+   Use `git commit -s` (or `--signoff`).
+
+2. **[Verified commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)**:
+   Each commit must be cryptographically signed using SSH or GPG keys to confirm
+   its origin.
+
 ### Signing Commits
 
-To sign commits:
+GitHub supports commit signing using either SSH keys or GPG keys.
+For more information, see the
+[GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
-You can also get the verified label on your commits via using [SSH keys or GPG
-keys](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+Before configuring commit signing:
 
-```
-# Edit .git/config in the git repository you are working on
-# Add the user section
+- Generate an SSH key pair or GPG key pair.
+- Add your public key to your GitHub account.
+- Verify your GitHub email address (required for “Verified” commits to work).
+- If using SSH signing, ensure the key is registered in GitHub for:
+    - Authentication (SSH and GPG keys)
+    - Signing commits (Signing Keys)
+
+> **NOTE:**
+> Adding an SSH key for repo access does not automatically enable commit signing.
+> The key must also be added under GitHub's Signing Keys settings.
+
+
+To ensure commits show as Verified on GitHub:
+
+- Your `git config user.email` must match a GitHub email
+- That email must be verified in your GitHub account
+
+For more information, see the
+[GitHub Docs](https://docs.github.com/en/account-and-profile/how-tos/email-preferences/verifying-your-email-address)
+
+Configure your repository's `.git/config`:
+
+```ini
+# Edit the git configuration
+
 [user]
     name = YOUR NAME
-    email = YOUR EMAIL ADDRESS
+    email = YOUR VERIFIED EMAIL ADDRESS
 
-# If you use a signing key, use the below configuration instead
-[user]
-    name = YOUR NAME
-    email = YOUR EMAIL ADDRESS
-    signingkey = LOCATION OF SSH KEYS or GPG KEY
+    # REQUIRED for commit signing
+    # Use ONE signing method (SSH or GPG)
+
+    signingkey = YOUR_SIGNING_KEY
+
+    # Examples:
+    # SSH signing:
+    # signingkey = ~/.ssh/id_ed25519.pub
+
+    # GPG signing:
+    # signingkey = YOUR_GPG_KEY_ID
 
 [gpg]
-    format = ssh
+    # REQUIRED: defines signing method (SSH or GPG)
+
+    format = YOUR_SIGNING_FORMAT
+
+    # Examples:
+    # SSH signing:
+    # format = ssh
+
+    # GPG signing:
+    # format = openpgp
 
 [commit]
     gpgsign = true
 ```
 
-> **NOTE:** If your commits are not signed the CI framework will not accept the PR.
+> The private key is used automatically by SSH/Git when signing commits (SSH only).
 
+#### Verifying Signed Commits
+
+You can verify that commits are properly signed locally using:
+
+```bash
+git log --show-signature
+```
+
+GitHub should also display a Verified badge next to signed commits once the
+signing key has been correctly configured in your account.
+
+##### SSH Signature Verification (`allowed_signers`)
+
+For SSH commit signing, local Git verification may require an `allowed_signers`
+file. This is only used for local verification in Git and is not required
+by GitHub.
+
+If you see errors such as:
+
+```text
+No principal matched
+Can't check signature
+error: gpg.ssh.allowedSignersFile needs to be configured
+```
+you may need to configure it.
+
+Create the file and add your signing identity:
+
+```bash
+mkdir -p ~/.config/git
+touch ~/.config/git/allowed_signers
+echo "user@example.com ssh-ed25519 AAAACexamplekeystringhere" > ~/.config/git/allowed_signers
+```
+
+Enable it in local repository Git config:
+
+```bash
+git config gpg.ssh.allowedSignersFile ~/.config/git/allowed_signers
+```
+
+> **NOTE:**
+> This is only for local Git signature verification and does not affect GitHub,
+> or remote repository behavior.
+
+> **NOTE:** If your commits are not signed, the CI framework will not accept the PR.
 For more information regarding contribution guidelines
 please check [this document](doc/code-style-contrib.md)
 
 ## License
 
-By contributing to OpenAirInterface, you agree that your contributions will be
+By contributing to Duranta, you agree that your contributions will be
 licensed under
 
 1. [CSSL v1.0 license](LICENSES/preferred/CSSL-v1.0.txt): for RAN and UE


### PR DESCRIPTION
TODO: 

- [x] Update contributing guidelines for signing of commits
- [x] Check for unsigned commits in the github actions workflow
- [x] Skip CI when no mandatory CI label present on the PR
- [x] Always remove `retrigger-ci` label when present - Like post-always or post-cleanup


Testing PR, on `jfiedlerova` fork: 
1. commit signature: https://github.com/jfiedlerova/openairinterface5g/pull/31#issuecomment-4743137098

<img width="2345" height="1697" alt="image" src="https://github.com/user-attachments/assets/0eb23e4d-9d49-40de-a58d-dfdb3c50ba78" />

2. To always remove the `retrigger-ci` label: [GitHub Actions Run #1](https://github.com/jfiedlerova/openairinterface5g/actions/runs/27767940607/job/82159778125), [GitHub Actions Run #2](https://github.com/jfiedlerova/openairinterface5g/actions/runs/27768264102), [GitHub Actions Run #3](https://github.com/jfiedlerova/openairinterface5g/actions/runs/27769630762): https://github.com/jfiedlerova/openairinterface5g/pull/31

3. In case of missing mandatory labels, https://github.com/jfiedlerova/openairinterface5g/actions/runs/28595375541/job/84789328408

<img width="2325" height="1151" alt="image" src="https://github.com/user-attachments/assets/6980a7d7-1663-4fb7-82b2-72cb5b3fe609" />

When adding again one of the mandatory labels, like `documentation`, https://github.com/jfiedlerova/openairinterface5g/actions/runs/28596301504/job/84792521919

4. For Push events: The `check-labels` and `verify-signed-commits` are skipped and then rest of the jobs continue as shown here -> https://github.com/jfiedlerova/openairinterface5g/actions/runs/28647207409, https://github.com/jfiedlerova/openairinterface5g/actions/runs/28658340108/job/84993409338