### PR TITLE
nr_rlc, NR_UE RRC: fix SRB1 RLC NULL window on RRCSetup fallback

### DIFF
--- a/openair2/LAYER2/NR_MAC_UE/main_ue_nr.c
+++ b/openair2/LAYER2/NR_MAC_UE/main_ue_nr.c
@@ -280,6 +280,13 @@ void release_mac_configuration(NR_UE_MAC_INST_t *mac, NR_UE_MAC_reset_cause_t ca
       asn_sequence_del(&mac->lc_ordered_list, i - 1, 1);
   }
 
+  /* §5.3.3.4: drop the dedicated per-RB MAC logical channels (SRB0/CCCH not listed here). SRB1 is
+   * re-added by the subsequent masterCellGroup; SRB2/DRBs stay gone until post-security. */
+  if (cause == RRC_SETUP_REESTAB_RESUME) {
+    for (int i = mac->lc_ordered_list.count; i > 0; i--)
+      asn_sequence_del(&mac->lc_ordered_list, i - 1, 1);
+  }
+
   asn1cFreeStruc(asn_DEF_NR_CrossCarrierSchedulingConfig, sc->crossCarrierSchedulingConfig);
   asn1cFreeStruc(asn_DEF_NR_SRS_CarrierSwitching, sc->carrierSwitching);
   asn1cFreeStruc(asn_DEF_NR_UplinkConfig, sc->supplementaryUplink);

--- a/openair2/LAYER2/nr_rlc/nr_rlc_oai_api.c
+++ b/openair2/LAYER2/nr_rlc/nr_rlc_oai_api.c
@@ -705,9 +705,18 @@ void nr_rlc_reconfigure_entity(int ue_id, int lc_id, NR_RLC_Config_t *rlc_Config
   nr_rlc_manager_unlock(nr_rlc_ue_manager);
 }
 
-void nr_rlc_add_srb(int ue_id, int srb_id, const NR_RLC_BearerConfig_t *rlc_BearerConfig)
+static void set_srb_lcid2rb(nr_rlc_ue_t *ue, const NR_RLC_BearerConfig_t *rlc_BearerConfig)
 {
-  NR_RLC_Config_t *r = rlc_BearerConfig->rlc_Config;
+  AssertFatal(rlc_BearerConfig->servedRadioBearer
+                  && (rlc_BearerConfig->servedRadioBearer->present == NR_RLC_BearerConfig__servedRadioBearer_PR_srb_Identity),
+              "servedRadioBearer for SRB mandatory present when setting up an SRB RLC entity\n");
+  int local_id = rlc_BearerConfig->logicalChannelIdentity - 1; // LCID 0 for SRB 0 not mapped
+  ue->lcid2rb[local_id].type = NR_LCID_SRB;
+  ue->lcid2rb[local_id].choice.srb_id = rlc_BearerConfig->servedRadioBearer->choice.srb_Identity;
+}
+
+static nr_rlc_entity_t *new_nr_rlc_srb_am_entity(nr_rlc_ue_t *ue, const NR_RLC_Config_t *r)
+{
   int t_status_prohibit;
   int t_poll_retransmit;
   int poll_pdu;
@@ -715,9 +724,6 @@ void nr_rlc_add_srb(int ue_id, int srb_id, const NR_RLC_BearerConfig_t *rlc_Bear
   int max_retx_threshold;
   int t_reassembly;
   int sn_field_length;
-
-  LOG_D(RLC, "Trying to add SRB %d\n", srb_id);
-  AssertFatal(srb_id > 0 && srb_id < 4, "Invalid srb id %d\n", srb_id);
 
   if (r && r->present == NR_RLC_Config_PR_am) {
     struct NR_RLC_Config__am *am;
@@ -744,31 +750,55 @@ void nr_rlc_add_srb(int ue_id, int srb_id, const NR_RLC_BearerConfig_t *rlc_Bear
     sn_field_length = 12;
   }
 
+  return new_nr_rlc_entity_am(RLC_RX_MAXSIZE,
+                              RLC_TX_MAXSIZE,
+                              deliver_sdu,
+                              ue,
+                              successful_delivery,
+                              ue,
+                              max_retx_reached,
+                              ue,
+                              t_poll_retransmit,
+                              t_reassembly,
+                              t_status_prohibit,
+                              poll_pdu,
+                              poll_byte,
+                              max_retx_threshold,
+                              sn_field_length);
+}
+
+void nr_rlc_add_srb(int ue_id, int srb_id, const NR_RLC_BearerConfig_t *rlc_BearerConfig)
+{
+  LOG_D(RLC, "Trying to add SRB %d\n", srb_id);
+  AssertFatal(srb_id > 0 && srb_id < 4, "Invalid srb id %d\n", srb_id);
+
   nr_rlc_manager_lock(nr_rlc_ue_manager);
   nr_rlc_ue_t *ue = nr_rlc_manager_get_ue(nr_rlc_ue_manager, ue_id);
-  AssertFatal(rlc_BearerConfig->servedRadioBearer &&
-              (rlc_BearerConfig->servedRadioBearer->present ==
-              NR_RLC_BearerConfig__servedRadioBearer_PR_srb_Identity),
-              "servedRadioBearer for SRB mandatory present when setting up an SRB RLC entity\n");
-  int local_id = rlc_BearerConfig->logicalChannelIdentity - 1; // LCID 0 for SRB 0 not mapped
-  ue->lcid2rb[local_id].type = NR_LCID_SRB;
-  ue->lcid2rb[local_id].choice.srb_id = rlc_BearerConfig->servedRadioBearer->choice.srb_Identity;
-  if (ue->srb[srb_id-1] != NULL) {
+  set_srb_lcid2rb(ue, rlc_BearerConfig);
+  if (ue->srb[srb_id - 1] != NULL) {
     LOG_E(RLC, "SRB %d already exists for UE %d, do nothing\n", srb_id, ue_id);
   } else {
-    nr_rlc_entity_t *nr_rlc_am = new_nr_rlc_entity_am(RLC_RX_MAXSIZE,
-                                                      RLC_TX_MAXSIZE,
-                                                      deliver_sdu, ue,
-                                                      successful_delivery, ue,
-                                                      max_retx_reached, ue,
-                                                      t_poll_retransmit,
-                                                      t_reassembly, t_status_prohibit,
-                                                      poll_pdu, poll_byte, max_retx_threshold,
-                                                      sn_field_length);
-    nr_rlc_ue_add_srb_rlc_entity(ue, srb_id, nr_rlc_am);
-
+    nr_rlc_ue_add_srb_rlc_entity(ue, srb_id, new_nr_rlc_srb_am_entity(ue, rlc_BearerConfig->rlc_Config));
     LOG_I(RLC, "Added srb %d to UE %d\n", srb_id, ue_id);
   }
+  nr_rlc_manager_unlock(nr_rlc_ue_manager);
+}
+
+void nr_rlc_replace_srb(int ue_id, int srb_id, const NR_RLC_BearerConfig_t *rlc_BearerConfig)
+{
+  LOG_D(RLC, "Trying to replace SRB %d\n", srb_id);
+  AssertFatal(srb_id > 0 && srb_id < 4, "Invalid srb id %d\n", srb_id);
+
+  nr_rlc_manager_lock(nr_rlc_ue_manager);
+  nr_rlc_ue_t *ue = nr_rlc_manager_get_ue(nr_rlc_ue_manager, ue_id);
+  set_srb_lcid2rb(ue, rlc_BearerConfig);
+  if (ue->srb[srb_id - 1] != NULL) {
+    ue->srb[srb_id - 1]->delete_entity(ue->srb[srb_id - 1]);
+    ue->srb[srb_id - 1] = NULL;
+    LOG_D(RLC, "Released stale SRB %d for UE %d before re-establishing it from the new config\n", srb_id, ue_id);
+  }
+  nr_rlc_ue_add_srb_rlc_entity(ue, srb_id, new_nr_rlc_srb_am_entity(ue, rlc_BearerConfig->rlc_Config));
+  LOG_I(RLC, "Added srb %d to UE %d\n", srb_id, ue_id);
   nr_rlc_manager_unlock(nr_rlc_ue_manager);
 }
 

--- a/openair2/LAYER2/nr_rlc/nr_rlc_oai_api.h
+++ b/openair2/LAYER2/nr_rlc/nr_rlc_oai_api.h
@@ -59,6 +59,8 @@ rlc_op_status_t nr_rlc_data_req(const protocol_ctxt_t *const ctxt_pP,
 void nr_mac_rlc_status_ind(uint16_t ue_id, frame_t frame, int n_ch, const logical_chan_id_t *ch, mac_rlc_status_resp_t *ret);
 
 void nr_rlc_add_srb(int ue_id, int srb_id, const NR_RLC_BearerConfig_t *rlc_BearerConfig);
+/* UE-only atomic release+establish of an SRB RLC entity (TS 38.331 §5.3.3.4 fallback); see definition. */
+void nr_rlc_replace_srb(int ue_id, int srb_id, const NR_RLC_BearerConfig_t *rlc_BearerConfig);
 void nr_rlc_add_drb(int ue_id, int drb_id, const NR_RLC_BearerConfig_t *rlc_BearerConfig);
 
 void nr_rlc_set_rlf_handler(int ue_id, rlf_handler_t rlf_h);

--- a/openair2/RRC/NR_UE/rrc_UE.c
+++ b/openair2/RRC/NR_UE/rrc_UE.c
@@ -916,7 +916,12 @@ static void nr_rrc_manage_rlc_bearers(NR_UE_RRC_INST_t *rrc, const NR_CellGroupC
                     "Invalid RB for RLC configuration\n");
         if (rlc_bearer->servedRadioBearer->present == NR_RLC_BearerConfig__servedRadioBearer_PR_srb_Identity) {
           NR_SRB_Identity_t srb_id = rlc_bearer->servedRadioBearer->choice.srb_Identity;
-          nr_rlc_add_srb(rrc->ue_id, srb_id, rlc_bearer);
+          if (rrc->pending_rlc_replace[lcid]) {
+            rrc->pending_rlc_replace[lcid] = false;
+            nr_rlc_replace_srb(rrc->ue_id, srb_id, rlc_bearer);
+          } else {
+            nr_rlc_add_srb(rrc->ue_id, srb_id, rlc_bearer);
+          }
           nr_rlc_set_rlf_handler(rrc->ue_id, nr_rrc_signal_maxrtxindication);
         } else { // DRB
           NR_DRB_Identity_t drb_id = rlc_bearer->servedRadioBearer->choice.drb_Identity;
@@ -931,6 +936,11 @@ static void nr_rrc_manage_rlc_bearers(NR_UE_RRC_INST_t *rrc, const NR_CellGroupC
       }
     }
   }
+
+  for (int i = 0; i < NR_MAX_NUM_LCID; i++)
+    AssertFatal(!rrc->pending_rlc_replace[i],
+                "RLC entity for LCID %d was kept alive for atomic replace but the cell group config did not re-create it\n",
+                i);
 }
 
 static void nr_ue_meas_reset(meas_t *meas_cell, bool csi_meas)
@@ -1725,8 +1735,10 @@ NR_UE_RRC_INST_t* nr_rrc_init_ue(char* uecap_file, int instance_id, int num_ant_
     set_DRB_status(rrc, j, RB_NOT_PRESENT);
   // SRB0 activated by default
   rrc->Srb[0] = RB_ESTABLISHED;
-  for (int j = 0; j < NR_MAX_NUM_LCID; j++)
+  for (int j = 0; j < NR_MAX_NUM_LCID; j++) {
     rrc->active_RLC_entity[j] = false;
+    rrc->pending_rlc_replace[j] = false;
+  }
 
   for (int i = 0; i < NB_CNX_UE; i++) {
     rrcPerNB_t *ptr = &rrc->perNB[i];
@@ -2173,7 +2185,17 @@ static void nr_rrc_rrcsetup_fallback(NR_UE_RRC_INST_t *rrc)
       nr_pdcp_release_srb(rrc->ue_id, i);
     }
   }
+  /* §5.3.3.4: release the RLC of every RB except SRB0. SRB1 is the only RB the RRCSetup
+   * masterCellGroup immediately re-creates, so to avoid the bug-#128 NULL window we keep SRB1's
+   * entity alive here and defer its release to an atomic replace on the add-path (nr_rlc_replace_srb);
+   * mark it with pending_rlc_replace[] and clear active_RLC_entity[1] so the add-path (not reconfigure)
+   * runs. SRB2/SRB3/DRBs have no such window and are released normally. */
   for (int i = 1; i < NR_MAX_NUM_LCID; i++) {
+    if (i == 1 && rrc->active_RLC_entity[1]) {
+      rrc->active_RLC_entity[1] = false;
+      rrc->pending_rlc_replace[1] = true;
+      continue;
+    }
     nr_rrc_release_rlc_entity(rrc, i);
   }
   nr_sdap_delete_ue_entities(rrc->ue_id);

--- a/openair2/RRC/NR_UE/rrc_defs.h
+++ b/openair2/RRC/NR_UE/rrc_defs.h
@@ -220,6 +220,9 @@ typedef struct NR_UE_RRC_INST_s {
   NR_RB_status_t Srb[NR_NUM_SRB];
   NR_RB_status_t status_DRBs[MAX_DRBS_PER_UE];
   bool active_RLC_entity[NR_MAX_NUM_LCID];
+  /* §5.3.3.4 fallback only: entity kept alive across teardown, released via atomic replace on the
+   * add-path. Set in nr_rrc_rrcsetup_fallback(), consumed in nr_rrc_manage_rlc_bearers() */
+  bool pending_rlc_replace[NR_MAX_NUM_LCID];
 
   /* KgNB as computed from parameters within USIM card */
   uint8_t kgnb[32];


### PR DESCRIPTION
In TS 38.331 §5.3.3.4 fallback (an RRCSetup answering an RRCReestablishmentRequest/RRCResumeRequest), the UE freed SRB1's RLC entity on the RRC thread and re-created it later, from the masterCellGroup, in a separate nr_rlc_manager lock scope. Between the time it was freed and re-created, the slot-thread UL scheduler observed LCID 1 entity == NULL and logged "Radio Bearer (channel ID 1) is NULL".

This commit fixed the race on the RLC side, where the manager lock lives. Added nr_rlc_replace_srb(), which frees the old entity and builds a fresh one under a single lock hold, so the scheduler observes either the old the new entity, never the NULL in between. The lock is required because the scheduler dereferences the entity, so lock-free swap would be a use-after-free bug. To keep the swap atomic, the fallback keeps SRB1's entity alive and defers its release to the masterCellGroup add-path, flagged via pending_rlc_replace[].

Tagging @luispereira106 and @GuidoCasati since they were originally assigned to the issue. 
Closes: #128