### PR TITLE
fix (nas): parse UE Registration Reject and add NAS connection release

### DIFF
--- a/openair3/NAS/NR_UE/5GS/5GMM/MSG/CMakeLists.txt
+++ b/openair3/NAS/NR_UE/5GS/5GMM/MSG/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(fgs_5gmm_lib OBJECT
     fgs_service_request.c
     fgmm_service_accept.c
     fgmm_service_reject.c
+    fgmm_registration_reject.c
     RegistrationRequest.c
     RegistrationAccept.c
     fgmm_identity_request.c

--- a/openair3/NAS/NR_UE/5GS/5GMM/MSG/fgmm_registration_reject.c
+++ b/openair3/NAS/NR_UE/5GS/5GMM/MSG/fgmm_registration_reject.c
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include "fgmm_registration_reject.h"
+#include "common/platform_types.h"
+#include "common/utils/ds/byte_array.h"
+#include "common/utils/eq_check.h"
+#include "fgmm_lib.h"
+
+#define REGISTRATION_REJECT_MIN_LEN 1
+
+/** @brief Encode Registration Reject (8.2.7 of 3GPP TS 24.501) */
+int encode_fgs_registration_reject(byte_array_t *buffer, const fgs_registration_reject_msg_t *msg)
+{
+  if (buffer->len < REGISTRATION_REJECT_MIN_LEN) {
+    PRINT_ERROR("Failed to encode Registration Reject: missing Cause IE!\n");
+    return -1;
+  }
+
+  return encode_fgs_nas_cause(buffer, &msg->cause);
+}
+
+/** @brief Decode Registration Reject (8.2.7 of 3GPP TS 24.501) — mandatory 5GMM cause only */
+int decode_fgs_registration_reject(fgs_registration_reject_msg_t *msg, const byte_array_t *buffer)
+{
+  if (buffer->len < REGISTRATION_REJECT_MIN_LEN) {
+    PRINT_ERROR("Nothing to decode: missing Cause IE!\n");
+    return -1;
+  }
+
+  int decoded = decode_fgs_nas_cause(&msg->cause, buffer);
+  if (decoded < 0) {
+    return -1;
+  }
+
+  if (buffer->len > decoded) {
+    PRINT_ERROR("Optional Registration Reject IEs present but not handled\n");
+  }
+
+  return decoded;
+}
+
+bool eq_registration_reject(const fgs_registration_reject_msg_t *a, const fgs_registration_reject_msg_t *b)
+{
+  _EQ_CHECK_INT(a->cause, b->cause);
+  return true;
+}
+
+void free_fgs_registration_reject(fgs_registration_reject_msg_t *msg)
+{
+  UNUSED(msg);
+}

--- a/openair3/NAS/NR_UE/5GS/5GMM/MSG/fgmm_registration_reject.h
+++ b/openair3/NAS/NR_UE/5GS/5GMM/MSG/fgmm_registration_reject.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#ifndef FGS_REGISTRATION_REJECT_H
+#define FGS_REGISTRATION_REJECT_H
+
+#include "fgmm_lib.h"
+#include "common/utils/ds/byte_array.h"
+
+typedef struct {
+  cause_id_t cause;
+} fgs_registration_reject_msg_t;
+
+int decode_fgs_registration_reject(fgs_registration_reject_msg_t *msg, const byte_array_t *buffer);
+int encode_fgs_registration_reject(byte_array_t *buffer, const fgs_registration_reject_msg_t *msg);
+bool eq_registration_reject(const fgs_registration_reject_msg_t *a, const fgs_registration_reject_msg_t *b);
+void free_fgs_registration_reject(fgs_registration_reject_msg_t *msg);
+
+#endif /* FGS_REGISTRATION_REJECT_H */

--- a/openair3/NAS/NR_UE/5GS/tests/nas_lib_test.c
+++ b/openair3/NAS/NR_UE/5GS/tests/nas_lib_test.c
@@ -12,6 +12,7 @@
 #include "fgs_service_request.h"
 #include "fgmm_service_accept.h"
 #include "fgmm_service_reject.h"
+#include "fgmm_registration_reject.h"
 #include "fgmm_authentication_failure.h"
 #include "FGSNASSecurityModeReject.h"
 #include "fgmm_authentication_reject.h"
@@ -258,6 +259,33 @@ static void test_service_reject(void)
   free_fgs_service_reject(&orig);
 }
 
+/** @brief Test NAS Registration Reject enc/dec (plain AMF reject: cause only) */
+static void test_registration_reject(void)
+{
+  fgs_registration_reject_msg_t orig = {
+      .cause = Illegal_UE,
+  };
+
+  uint8_t expected_enc[] = {0x03};
+
+  uint8_t buf[64] = {0};
+  byte_array_t buffer = {.buf = buf, .len = sizeof(expected_enc)};
+
+  int encoded_length = encode_fgs_registration_reject(&buffer, &orig);
+  AssertFatal(encoded_length == sizeofArray(expected_enc),
+              "encode_fgs_registration_reject() failed: %d != %ld\n",
+              encoded_length,
+              sizeofArray(expected_enc));
+  AssertFatal(memcmp(buffer.buf, expected_enc, buffer.len) == 0, "Encoding mismatch!\n");
+
+  fgs_registration_reject_msg_t dec = {0};
+  int decoded_length = decode_fgs_registration_reject(&dec, &buffer);
+  AssertFatal(decoded_length >= 0, "decode_fgs_registration_reject() failed\n");
+  AssertFatal(eq_registration_reject(&orig, &dec),
+              "test_registration_reject() failed: original and decoded messages do not match\n");
+  free_fgs_registration_reject(&dec);
+}
+
 /** @brief Test NAS Authentication Failure enc/dec */
 static void test_auth_failure(void)
 {
@@ -373,6 +401,7 @@ int main()
   test_service_request();
   test_service_accept();
   test_service_reject();
+  test_registration_reject();
   test_auth_failure();
   test_auth_reject();
   test_security_mode_reject();

--- a/openair3/NAS/NR_UE/nr_nas_msg.c
+++ b/openair3/NAS/NR_UE/nr_nas_msg.c
@@ -49,6 +49,7 @@
 #include "fgs_nas_utils.h"
 #include "fgmm_service_accept.h"
 #include "fgmm_service_reject.h"
+#include "fgmm_registration_reject.h"
 #include "fgmm_authentication_reject.h"
 #include "ds/byte_array.h"
 #include "key_nas_deriver.h"
@@ -128,6 +129,9 @@ static bool unprotected_allowed(byte_array_t buffer, fgs_nas_msg_t msg_type)
     case FGS_DEREGISTRATION_ACCEPT_UE_ORIGINATING: // for non switch off: deregistration type IE set to NORMAL_DEREGISTRATION
       return true;
     case FGS_REGISTRATION_REJECT:
+      // unprotected if the 5GMM cause is not #76 (9.11.3.2)
+      return buffer.len >= sizeof(fgmm_msg_header_t) + 1
+             && buffer.buf[3] != Not_authorized_for_this_CAG_or_authorized_for_CAG_cells_only;
     case FGS_SERVICE_REJECT:
       // unprotected if the 5GMM cause is not #76
       return buffer.buf[4] != Not_authorized_for_this_CAG_or_authorized_for_CAG_cells_only;
@@ -2115,6 +2119,64 @@ static void handle_service_reject(nr_ue_nas_t *nas, const byte_array_t *buffer)
   LOG_E(NAS, "Received NAS Service Reject message with cause %s\n", fgmm_cause_s[msg.cause].text);
 }
 
+/** @brief Handle Registration Reject (8.2.7 / 5.5.1.2.5 of 3GPP TS 24.501)
+ * @todo Per §5.5.1.2.5: forbidden PLMN/TAI, registration attempt counter
+ * @todo N1 NAS signalling release per §5.3.1.3
+ * @todo Optional IEs T3346/T3502, EAP per §5.4.1.2.2.11 */
+static void handle_registration_reject(nr_ue_nas_t *nas, const byte_array_t *buffer)
+{
+  DevAssert(buffer && buffer->buf);
+  if (nas->termination_procedure) {
+    return; // already in termination procedure, ignore registration reject
+  }
+
+  fgs_registration_reject_msg_t msg = {0};
+
+  if (buffer->len < sizeof(fgmm_msg_header_t)) {
+    LOG_E(NAS, "Failed to extract Registration Reject message body: buffer length too short\n");
+    return;
+  }
+
+  const uint8_t *pdu_buffer = buffer->buf;
+  uint32_t msg_length = buffer->len;
+  const uint8_t *end = pdu_buffer + msg_length;
+
+  if (pdu_buffer[1] != PLAIN_5GS_MSG) {
+    fgs_nas_message_security_header_t sp_header = {0};
+    int decoded = decode_5gs_security_protected_header(&sp_header, pdu_buffer, msg_length);
+    if (decoded < 0) {
+      LOG_E(NAS, "Registration Reject: failed to decode security protected header\n");
+      return;
+    }
+    pdu_buffer += decoded;
+  }
+
+  fgmm_msg_header_t mm_header = {0};
+  int decoded = decode_5gmm_msg_header(&mm_header, pdu_buffer, end - pdu_buffer);
+  if (decoded < 0) {
+    LOG_E(NAS, "Registration Reject: failed to decode NAS message header\n");
+    return;
+  }
+  if (mm_header.message_type != FGS_REGISTRATION_REJECT) {
+    LOG_E(NAS, "Expected NAS message type FGS_REGISTRATION_REJECT, got %#x\n", mm_header.message_type);
+    return;
+  }
+  pdu_buffer += decoded;
+
+  const byte_array_t ba = {.buf = (uint8_t *)pdu_buffer, .len = end - pdu_buffer};
+  if (decode_fgs_registration_reject(&msg, &ba) < 0) {
+    LOG_E(NAS, "Registration Reject: failed to decode NAS message body\n");
+    free_fgs_registration_reject(&msg);
+    return;
+  }
+
+  LOG_E(NAS, "Received Registration Reject cause: %s\n", print_info(msg.cause, fgmm_cause_s, sizeofArray(fgmm_cause_s)));
+  free_fgs_registration_reject(&msg);
+  nas->fiveGMM_state = FGS_DEREGISTERED;
+  nas->termination_procedure = true;
+  send_nas_detach_req(nas, false);
+}
+
 void *nas_nrue(void *args_p)
 {
   UNUSED(args_p);
@@ -2308,23 +2370,9 @@ void *nas_nrue(void *args_p)
           case FGS_PDU_SESSION_ESTABLISHMENT_REJ:
             LOG_E(NAS, "Received PDU Session Establishment reject\n");
             break;
-          case FGS_REGISTRATION_REJECT: {
-
-            if (pdu_length < 18) {
-              LOG_E(NAS, "Received Registration reject message too short\n");
-              break;
-            }
-
-            uint8_t cause = pdu_buffer[17];
-            if (cause >= sizeof(cause_text_info) / sizeof(cause_text_info[0])) {
-              LOG_E(NAS, "Received Registration reject cause %d unknown\n", cause);
-              break;
-            }
-
-            LOG_E(NAS, "Received Registration reject cause: %s\n", cause_text_info[cause].text);
-            exit(1);
+          case FGS_REGISTRATION_REJECT:
+            handle_registration_reject(nas, &buffer);
             break;
-          }
           case FGS_SERVICE_ACCEPT: {
             handle_service_accept(nas, &buffer);
             break;


### PR DESCRIPTION
The nrUE NAS task read the Registration Reject cause at a hardcoded offset and called exit(1). This commits adds processing of plain/security-protected 5GMM headers, decoding of the mandatory cause per TS 24.501 §8.2.7, set 5GMM state.

Softmodem is stopped via termination_procedure and local AS detach (send_nas_detach_req without wait_release -> 1) RRC IDLE 2) NR_NAS_CONN_RELEASE_IND 3) itti_wait_tasks_unblock).

Changes:
- Add fgmm_registration_reject enc/dec
- Add handle_registration_reject()
- Replace inline FGS_REGISTRATION_REJECT case
- Fix unprotected_allowed() for plain Registration Reject
- Add nas_lib_test round-trip (Illegal_UE / 0x03)

Note: optional IEs (T3346, T3502, EAP) not decoded, §5.5.1.2.5 procedure TODO

Closes: #174