### PR TITLE
Improve UE SSB detection during initial sync

### DIFF
--- a/openair1/PHY/MODULATION/slot_fep_nr.c
+++ b/openair1/PHY/MODULATION/slot_fep_nr.c
@@ -57,13 +57,8 @@ int nr_slot_fep(PHY_VARS_NR_UE *ue,
               frame_parms->symbols_per_slot - 1);
   AssertFatal(slot < frame_parms->slots_per_frame, "slot_fep: Ns must be between 0 and %d\n", frame_parms->slots_per_frame - 1);
 
-  bool is_sl = (linktype == link_type_sl);
-  bool is_synchronized = (ue) ? ue->is_synchronized : false;
   unsigned int nb_prefix_samples = frame_parms->nb_prefix_samples;
-  unsigned int nb_prefix_samples0 = (is_synchronized || is_sl) ? frame_parms->nb_prefix_samples0 : nb_prefix_samples;
-
-  // For Sidelink 16 frames worth of samples is processed to find SSB, for 5G-NR 2.
-  const unsigned int total_samples = (is_sl) ? 16 * frame_parms->samples_per_frame : 2 * frame_parms->samples_per_frame;
+  unsigned int nb_prefix_samples0 = frame_parms->nb_prefix_samples0;
 
   unsigned int rx_offset = get_samples_slot_timestamp(frame_parms, slot);
   const unsigned int abs_symbol = slot * frame_parms->symbols_per_slot + symbol;
@@ -90,17 +85,7 @@ int nr_slot_fep(PHY_VARS_NR_UE *ue,
   c16_t *rxdataF_symb_ptr[frame_parms->nb_antennas_rx];
   for (unsigned char aa = 0; aa < frame_parms->nb_antennas_rx; aa++) {
     rxdataF_symb_ptr[aa] = &rxdataF[aa][frame_parms->ofdm_symbol_size * symbol];
-    // This happens only during initial sync
-    if (rx_offset + frame_parms->ofdm_symbol_size > total_samples) {
-      // we have to wrap on the end
-      memcpy(&tmp_dft_in[aa][0], &rxdata[aa][rx_offset], (total_samples - rx_offset) * sizeof(int32_t));
-      memcpy(&tmp_dft_in[aa][total_samples - rx_offset],
-             &rxdata[aa][0],
-             (frame_parms->ofdm_symbol_size - (total_samples - rx_offset)) * sizeof(int32_t));
-      rxdata_symb_ptr[aa] = tmp_dft_in[aa];
-    } else {
-      rxdata_symb_ptr[aa] = &rxdata[aa][rx_offset];
-    }
+    rxdata_symb_ptr[aa] = &rxdata[aa][rx_offset];
 
     if (ue && ue->cont_fo_comp) {
       start_meas_nr_ue_phy(ue, RX_FO_COMPENSATION_STATS);

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -160,6 +160,24 @@ static void generate_table(nr_ssb_search_params_t *params,
                           symbol_rotation);
 }
 
+static c16_t *data_in_buffer_edge(c16_t *rxdata, uint32_t rxdata_size, uint32_t sample_offset, uint32_t fft_size)
+{
+  if (sample_offset + fft_size <= rxdata_size)
+    return NULL;
+
+  LOG_I(NR_PHY,
+        "SSB found in edge of rxdata buffer. Circling back to begining. Buf size: %d, offset: %d, fft size: %d\n",
+        rxdata_size,
+        sample_offset,
+        fft_size);
+  c16_t *buf = malloc16(sizeof(*buf) * fft_size);
+  const int num_rxdata_end = (rxdata_size - sample_offset);
+  const int num_rxdata_start = fft_size - num_rxdata_end;
+  memcpy(buf, rxdata + sample_offset, num_rxdata_end * sizeof(*buf));
+  memcpy(buf + num_rxdata_end, rxdata, num_rxdata_start * sizeof(*buf));
+  return buf;
+}
+
 static void do_time_to_freq(nr_ssb_search_params_t *params, uint32_t sample_offset)
 {
   c16_t timeshift_symbol_rotation[params->ofdm_symbol_size];
@@ -176,9 +194,15 @@ static void do_time_to_freq(nr_ssb_search_params_t *params, uint32_t sample_offs
     rx_offset += symb * (params->nb_prefix_samples + params->ofdm_symbol_size);
     // use OFDM symbol from within 1/8th of the CP to avoid ISI
     rx_offset -= params->nb_prefix_samples / params->ofdm_offset_divisor;
+    rx_offset %= params->rxdata_size;
     for (unsigned char aa = 0; aa < params->nb_antennas_rx; aa++) {
       c16_t *rxF = rxdataF[symb][aa];
-      dft(dftsize, (int16_t *)&params->rxdata[aa][rx_offset], (int16_t *)rxF, 1);
+      /* When the signal is in the edge of search window then circle back to the
+       * beginning because the signal is periodic. */
+      c16_t *rx_edge = data_in_buffer_edge(params->rxdata[aa], params->rxdata_size, rx_offset, params->ofdm_symbol_size);
+      c16_t *rx = (rx_edge) ? rx_edge : &params->rxdata[aa][rx_offset];
+      dft(dftsize, (int16_t *)rx, (int16_t *)rxF, 1);
+      free_and_zero(rx_edge);
       apply_nr_rotation_symbol_RX(params->symbols_per_slot,
                                   params->slots_per_subframe,
                                   timeshift_symbol_rotation,
@@ -219,16 +243,6 @@ bool nr_search_ssb_common(nr_ssb_search_params_t *params)
 #ifdef DEBUG_INITIAL_SYNCH
   LOG_I(PHY, "Initial sync : Estimated PSS position %d, Nid2 %d, ssb offset %d\n", sync_pos, nid2, ssb_offset);
 #endif
-
-  // Check that SSB fits within buffer
-  if (ssb_time_offset + NR_N_SYMBOLS_SSB * (params->ofdm_symbol_size + params->nb_prefix_samples) >= params->rxdata_size) {
-    LOG_D(PHY,
-          "SSB extends beyond buffer boundary (sync_pos %d, ssb_offset %d, buffer_size %d)\n",
-          params->pss_res.pos,
-          ssb_time_offset,
-          params->rxdata_size);
-    return false;
-  }
 
   // Apply frequency offset compensation if requested
   if (params->apply_freq_offset && params->pss_res.freq_offset != 0) {
@@ -294,76 +308,66 @@ static void nr_scan_ssb(void *arg)
   if (ssbInfo->freqOffset)
     compensate_freq_offset(rxdata, fp->nb_antennas_rx, ssbInfo->rxdata_sz, ssbInfo->freqOffset, fp->samples_per_subframe * 1000);
 
-  for (int frame_id = 0; frame_id < ssbInfo->nFrames && !ssbInfo->syncRes.cell_detected; frame_id++) {
-    c16_t *rxdataShift[fp->nb_antennas_rx];
-    for (int i = 0; i < fp->nb_antennas_rx; i++)
-      rxdataShift[i] = rxdata[i] + fp->samples_per_frame * frame_id;
+  nr_ssb_search_params_t search_params = {
+      .dl_CarrierFreq = fp->dl_CarrierFreq,
+      .sampling_rate = fp->samples_per_subframe * 1000,
+      .slots_per_frame = fp->slots_per_frame,
+      .slots_per_subframe = fp->slots_per_subframe,
+      .numerology_index = fp->numerology_index,
+      .ofdm_symbol_size = fp->ofdm_symbol_size,
+      .ofdm_offset_divisor = fp->ofdm_offset_divisor,
+      .nb_antennas_rx = fp->nb_antennas_rx,
+      .symbols_per_slot = fp->symbols_per_slot,
+      .first_carrier_offset = fp->first_carrier_offset,
+      .N_RB_DL = fp->N_RB_DL,
+      .rxdata_size = ssbInfo->nFrames * fp->samples_per_frame,
+      .rxdata = rxdata,
+      .nb_prefix_samples = fp->nb_prefix_samples,
+      .nb_prefix_samples0 = fp->nb_prefix_samples0,
+      .ssb_start_subcarrier = ssbInfo->gscnInfo.ssbFirstSC,
+      .subcarrier_spacing = fp->subcarrier_spacing,
+      .samples_per_slot_wCP = fp->samples_per_slot_wCP,
+      .target_nid_cell = ssbInfo->targetNidCell,
+      .exclude_nid_cell = -1, // No exclusion for initial sync
+      .apply_freq_offset = ssbInfo->foFlag,
+      .fo_flag = ssbInfo->foFlag,
+      .rxdataF = rxdataF,
+      .pssTime = pssTime,
+  };
 
-    nr_ssb_search_params_t search_params = {
-        .dl_CarrierFreq = fp->dl_CarrierFreq,
-        .sampling_rate = fp->samples_per_subframe * 1000,
-        .slots_per_frame = fp->slots_per_frame,
-        .slots_per_subframe = fp->slots_per_subframe,
-        .numerology_index = fp->numerology_index,
-        .ofdm_symbol_size = fp->ofdm_symbol_size,
-        .ofdm_offset_divisor = fp->ofdm_offset_divisor,
-        .nb_antennas_rx = fp->nb_antennas_rx,
-        .symbols_per_slot = fp->symbols_per_slot,
-        .first_carrier_offset = fp->first_carrier_offset,
-        .N_RB_DL = fp->N_RB_DL,
-        .rxdata_size = fp->samples_per_frame,
-        .rxdata = rxdataShift,
-        .nb_prefix_samples = fp->nb_prefix_samples,
-        .nb_prefix_samples0 = fp->nb_prefix_samples0,
-        .ssb_start_subcarrier = ssbInfo->gscnInfo.ssbFirstSC,
-        .subcarrier_spacing = fp->subcarrier_spacing,
-        .samples_per_slot_wCP = fp->samples_per_slot_wCP,
-        .target_nid_cell = ssbInfo->targetNidCell,
-        .exclude_nid_cell = -1, // No exclusion for initial sync
-        .apply_freq_offset = ssbInfo->foFlag,
-        .fo_flag = ssbInfo->foFlag,
-        .rxdataF = rxdataF,
-        .pssTime = pssTime,
-    };
+  ssbInfo->syncRes.cell_detected = nr_search_ssb_common(&search_params);
 
-    ssbInfo->syncRes.frame_id = frame_id;
-    ssbInfo->syncRes.cell_detected = nr_search_ssb_common(&search_params);
-
-    if (!ssbInfo->syncRes.cell_detected) {
-      continue;
-    }
-
-    ssbInfo->ssbOffset = search_params.pss_res.pos - search_params.nb_prefix_samples;
-    ssbInfo->nidCell = search_params.sss_res.nid_cell;
+  ssbInfo->ssbOffset = search_params.pss_res.pos - search_params.nb_prefix_samples;
+  ssbInfo->syncRes.frame_id = ssbInfo->ssbOffset / fp->samples_per_frame;
+  ssbInfo->nidCell = search_params.sss_res.nid_cell;
 
 #ifdef DEBUG_INITIAL_SYNCH
-    LOG_I(PHY,
-          "TDD Normal prefix: sss detection result; %d, CellId %d metric %d, phase %d, measured offset %d\n",
-          ssbInfo->syncRes.cell_detected,
-          ssbInfo->nidCell,
-          sss_metric,
-          sss_phase,
-          ssbInfo->syncRes.rx_offset);
+  LOG_I(PHY,
+        "TDD Normal prefix: sss detection result; %d, CellId %d metric %d, phase %d, measured offset %d\n",
+        ssbInfo->syncRes.cell_detected,
+        ssbInfo->nidCell,
+        sss_metric,
+        sss_phase,
+        ssbInfo->syncRes.rx_offset);
 #endif
-    ssbInfo->freqOffset += search_params.pss_res.freq_offset + search_params.sss_res.freq_offset;
+  ssbInfo->freqOffset += search_params.pss_res.freq_offset + search_params.sss_res.freq_offset;
 
-    if (ssbInfo->syncRes.cell_detected) { // we got sss channel
-      ssbInfo->syncRes.cell_detected = nr_pbch_detection(ssbInfo->proc,
-                                                         ssbInfo->fp,
-                                                         ssbInfo->nidCell,
-                                                         1,
-                                                         ssbInfo->gscnInfo.ssbFirstSC,
-                                                         &ssbInfo->halfFrameBit,
-                                                         &ssbInfo->ssbIndex,
-                                                         &ssbInfo->symbolOffset,
-                                                         &ssbInfo->pbchResult,
-                                                         rxdataF); // start pbch detection at first symbol after pss
-      if (ssbInfo->syncRes.cell_detected) {
-        uint32_t rsrp_avg = nr_ue_calculate_ssb_rsrp(ssbInfo->fp, rxdataF[2], ssbInfo->gscnInfo.ssbFirstSC);
-        int rsrp_db_per_re = 10 * log10(rsrp_avg);
-        ssbInfo->adjust_rxgain = TARGET_RX_POWER - rsrp_db_per_re;
-        LOG_I(PHY, "pbch rx ok. rsrp:%d dB/RE, adjust_rxgain:%d dB\n", rsrp_db_per_re, ssbInfo->adjust_rxgain);
-      }
+  if (ssbInfo->syncRes.cell_detected) { // we got sss channel
+    ssbInfo->syncRes.cell_detected = nr_pbch_detection(ssbInfo->proc,
+                                                       ssbInfo->fp,
+                                                       ssbInfo->nidCell,
+                                                       1,
+                                                       ssbInfo->gscnInfo.ssbFirstSC,
+                                                       &ssbInfo->halfFrameBit,
+                                                       &ssbInfo->ssbIndex,
+                                                       &ssbInfo->symbolOffset,
+                                                       &ssbInfo->pbchResult,
+                                                       rxdataF); // start pbch detection at first symbol after pss
+    if (ssbInfo->syncRes.cell_detected) {
+      uint32_t rsrp_avg = nr_ue_calculate_ssb_rsrp(ssbInfo->fp, rxdataF[2], ssbInfo->gscnInfo.ssbFirstSC);
+      int rsrp_db_per_re = 10 * log10(rsrp_avg);
+      ssbInfo->adjust_rxgain = TARGET_RX_POWER - rsrp_db_per_re;
+      LOG_I(PHY, "pbch rx ok. rsrp:%d dB/RE, adjust_rxgain:%d dB\n", rsrp_db_per_re, ssbInfo->adjust_rxgain);
     }
   }
 
@@ -489,7 +493,7 @@ nr_initial_sync_t nr_initial_sync(UE_nr_rxtx_proc_t *proc,
       res->syncRes.rx_offset = fp->samples_per_frame - sync_pos_frame + res->ssbOffset;
       ue->init_sync_frame += 1;
     } else {
-      res->syncRes.rx_offset = res->ssbOffset - sync_pos_frame;
+      res->syncRes.rx_offset = (res->ssbOffset - sync_pos_frame) % fp->samples_per_frame;
     }
 
     LOG_I(PHY, "[UE%d] In synch, rx_offset %d samples\n", ue->Mod_id, res->syncRes.rx_offset);

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync_sl.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync_sl.c
@@ -157,12 +157,12 @@ static int sl_nr_pss_correlation(PHY_VARS_NR_UE *UE, int frame_index)
 static void sl_nr_extract_sss(PHY_VARS_NR_UE *ue,
                               int32_t *tot_metric,
                               uint8_t *phase_max,
-                              c16_t rxdataF[][ue->SL_UE_PHY_PARAMS.sl_frame_params.samples_per_slot_wCP])
+                              NR_DL_FRAME_PARMS *sl_fp,
+                              c16_t rxdataF[][sl_fp->nb_antennas_rx][sl_fp->ofdm_symbol_size])
 {
   c16_t pss_ext[SL_NR_MAX_RX_ANTENNA][SL_NR_NUM_PSS_SYMBOLS][SL_NR_PSS_SEQUENCE_LENGTH];
   c16_t sss_ext[SL_NR_MAX_RX_ANTENNA][SL_NR_NUM_SSS_SYMBOLS][SL_NR_PSS_SEQUENCE_LENGTH];
   uint8_t Nid2 = ue->SL_UE_PHY_PARAMS.sync_params.N_sl_id2;
-  NR_DL_FRAME_PARMS *sl_fp = &ue->SL_UE_PHY_PARAMS.sl_frame_params;
   int16_t *d;
   uint16_t Nid1 = 0;
   c16_t *rxF_ext;
@@ -190,7 +190,7 @@ static void sl_nr_extract_sss(PHY_VARS_NR_UE *ue,
             sym);
 
       for (int i = 0; i < SL_NR_PSS_SEQUENCE_LENGTH; i++) {
-        rxF_ext[i] = rxdataF[aarx][sym * ofdm_symbol_size + k];
+        rxF_ext[i] = rxdataF[sym][aarx][k];
         k++;
         if (k == ofdm_symbol_size)
           k = 0;
@@ -427,28 +427,26 @@ nr_initial_sync_t sl_nr_slss_search(PHY_VARS_NR_UE *UE, UE_nr_rxtx_proc_t *proc,
           }
         }
 
-        NR_DL_FRAME_PARMS *frame_parms = &UE->SL_UE_PHY_PARAMS.sl_frame_params;
-        const uint32_t rxdataF_sz = frame_parms->samples_per_slot_wCP;
-        __attribute__((aligned(32))) c16_t rxdataF[frame_parms->nb_antennas_rx][rxdataF_sz];
+        NR_DL_FRAME_PARMS *fp = &UE->SL_UE_PHY_PARAMS.sl_frame_params;
+        __attribute__((aligned(32))) c16_t rxdataF[SL_NR_NUMSYM_SLSS_NORMAL_CP][fp->nb_antennas_rx][fp->ofdm_symbol_size];
 
         /* In order to achieve correct processing for NR prefix samples is forced to 0 and then restored after function call */
         int16_t psbch_e_rx[SL_NR_POLAR_PSBCH_E_NORMAL_CP + 2] = {0};
         int16_t psbch_unClipped[SL_NR_POLAR_PSBCH_E_NORMAL_CP + 2] = {0};
         int psbch_e_rx_offset = 0;
 
-        for (int symbol = 0; symbol < SL_NR_NUMSYM_SLSS_NORMAL_CP; symbol++) {
-          nr_slot_fep(UE,
-                      frame_parms,
-                      proc->nr_slot_rx,
-                      symbol,
-                      rxdataF,
-                      link_type_sl,
-                      sync_params->ssb_offset,
-                      UE->common_vars.rxdata);
+        {
+          __attribute__((aligned(32))) c16_t tmp[fp->nb_antennas_rx][fp->samples_per_slot_wCP];
+          for (int symbol = 0; symbol < SL_NR_NUMSYM_SLSS_NORMAL_CP; symbol++) {
+            nr_slot_fep(UE, fp, proc->nr_slot_rx, symbol, tmp, link_type_sl, sync_params->ssb_offset, UE->common_vars.rxdata);
+            // TODO: remove the memcpy after symbol based receiver is integrated
+            for (int aarx = 0; aarx < fp->nb_antennas_rx; aarx++) {
+              memcpy(rxdataF[symbol][aarx], &tmp[aarx][symbol * fp->ofdm_symbol_size], sizeof(c16_t) * fp->ofdm_symbol_size);
+            }
+          }
         }
 
-        /* TODO: change this function to use new rxdataF format */
-        sl_nr_extract_sss(UE, &metric_tdd_ncp, &phase_tdd_ncp, rxdataF);
+        sl_nr_extract_sss(UE, &metric_tdd_ncp, &phase_tdd_ncp, fp, rxdataF);
 
         // save detected cell id to psbch
         rx_slss_id = UE->SL_UE_PHY_PARAMS.sync_params.N_sl_id;
@@ -456,34 +454,29 @@ nr_initial_sync_t sl_nr_slss_search(PHY_VARS_NR_UE *UE, UE_nr_rxtx_proc_t *proc,
         uint8_t decoded_output[4];
 
         for (int symbol = 0; symbol < SL_NR_NUMSYM_SLSS_NORMAL_CP - 1;) {
-          __attribute__((aligned(32))) struct complex16 dl_ch_estimates[frame_parms->nb_antennas_rx][frame_parms->ofdm_symbol_size];
-          __attribute__((aligned(32))) c16_t rxdataF_symb[frame_parms->nb_antennas_rx][frame_parms->ofdm_symbol_size];
-          for (int aarx = 0; aarx < frame_parms->nb_antennas_rx; aarx++) {
-            /* TODO: Change sl sss extract to follow the new rxdataF format */
-            memcpy(rxdataF_symb[aarx],
-                   &rxdataF[aarx][symbol * frame_parms->ofdm_symbol_size],
-                   sizeof(c16_t) * frame_parms->ofdm_symbol_size);
-            nr_pbch_channel_estimation(frame_parms,
+          __attribute__((aligned(32))) struct complex16 dl_ch_estimates[fp->nb_antennas_rx][fp->ofdm_symbol_size];
+          for (int aarx = 0; aarx < fp->nb_antennas_rx; aarx++) {
+            nr_pbch_channel_estimation(fp,
                                        &UE->SL_UE_PHY_PARAMS,
                                        dl_ch_estimates[aarx],
                                        proc,
                                        symbol,
                                        0,
                                        0,
-                                       frame_parms->ssb_start_subcarrier,
-                                       rxdataF_symb[aarx],
+                                       fp->ssb_start_subcarrier,
+                                       rxdataF[symbol][aarx],
                                        true,
                                        rx_slss_id);
           }
-          nr_generate_psbch_llr(frame_parms,
-                                rxdataF_symb,
+          nr_generate_psbch_llr(fp,
+                                rxdataF[symbol],
                                 dl_ch_estimates,
                                 symbol,
                                 &psbch_e_rx_offset,
                                 psbch_e_rx,
                                 psbch_unClipped);
 
-          UE->adjust_rxgain = nr_sl_psbch_rsrp_measurements(UE, sl_ue, frame_parms, symbol, rxdataF, false);
+          UE->adjust_rxgain = nr_sl_psbch_rsrp_measurements(UE, sl_ue, fp, symbol, rxdataF[symbol], false);
 
           symbol = (symbol == 0) ? 5 : symbol + 1;
         }

--- a/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
+++ b/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
@@ -1131,8 +1131,8 @@ int pbch_processing(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, nr_phy_da
   if (check_meas_to_perform(ue, nr_slot_rx)) {
     measurements->meas_request_pending = true;
 
-    // Copy rxdata
-    uint32_t rxdata_size = (2 * (fp->samples_per_frame) + fp->ofdm_symbol_size);
+    /* Copy rxdata. When UE is in sync, only one frame worth samples is retained in the buffer. */
+    uint32_t rxdata_size = fp->samples_per_frame + fp->ofdm_symbol_size;
     size_t total_size = sizeof(nr_meas_task_args_t) + fp->nb_antennas_rx * rxdata_size * sizeof(c16_t);
     nr_meas_task_args_t *args = malloc_or_fail(total_size);
     args->proc = *proc;

--- a/openair1/SIMULATION/NR_PHY/pbchsim.c
+++ b/openair1/SIMULATION/NR_PHY/pbchsim.c
@@ -93,6 +93,58 @@ void nr_fill_rx_indication(fapi_nr_rx_indication_t *rx_ind,
 {
 }
 
+static void apply_ch_effect_and_noise(double sigma2,
+                                      double eps,
+                                      double **r_re,
+                                      double **r_im,
+                                      unsigned int nb_rx,
+                                      unsigned int n_samp_tx,
+                                      unsigned int n_samp_rx,
+                                      double fs,
+                                      double cfo,
+                                      double *ip,
+                                      unsigned int time_offset,
+                                      c16_t **txdata,
+                                      c16_t **rxdata)
+{
+  for (int aa = 0; aa < nb_rx; aa++) {
+    memset(r_re[aa], 0, sizeof(double) * n_samp_rx);
+    memset(r_im[aa], 0, sizeof(double) * n_samp_rx);
+    for (int i = 0; i < n_samp_tx; i++) {
+      unsigned int t = (time_offset + i) % n_samp_rx;
+      r_re[aa][t] = (double)txdata[aa][i].r;
+      r_im[aa][t] = (double)txdata[aa][i].i;
+    }
+  }
+
+  if (eps != 0.0)
+    rf_rx(r_re, // real part of txdata
+          r_im, // imag part of txdata
+          NULL, // interference real part
+          NULL, // interference imag part
+          0, // interference power
+          nb_rx, // number of rx antennas
+          n_samp_rx, // number of samples in frame
+          1.0e9 / fs, // sampling time (ns)
+          cfo, // frequency offset in Hz
+          0.0, // drift (not implemented)
+          0.0, // noise figure (not implemented)
+          0.0, // rx gain in dB ?
+          200, // 3rd order non-linearity in dB ?
+          ip, // initial phase
+          30.0e3, // phase noise cutoff in kHz
+          -500.0, // phase noise amplitude in dBc
+          0.0, // IQ imbalance (dB),
+          0.0); // IQ phase imbalance (rad)
+
+  for (int aa = 0; aa < nb_rx; aa++) {
+    for (int i = 0; i < n_samp_rx; i++) {
+      rxdata[aa][i].r = (short)(r_re[aa][i] + sqrt(sigma2 / 2) * gaussdouble(0.0, 1.0));
+      rxdata[aa][i].i = (short)(r_im[aa][i] + sqrt(sigma2 / 2) * gaussdouble(0.0, 1.0));
+    }
+  }
+}
+
 configmodule_interface_t *uniqCfg = NULL;
 int main(int argc, char **argv)
 {
@@ -105,7 +157,7 @@ int main(int argc, char **argv)
   double cfo=0;
   uint8_t snr1set=0;
   c16_t **txdata;
-  double **s_re,**s_im,**r_re,**r_im;
+  double **r_re, **r_im;
   //double iqim = 0.0;
   double ip =0.0;
   //unsigned char pbch_pdu[6];
@@ -159,6 +211,8 @@ int main(int argc, char **argv)
 
   float target_error_rate = 0.01;
 
+  bool test_ssb_end = true;
+
   cpuf = get_cpu_freq_GHz();
 
   if ((uniqCfg = load_configmodule(argc, argv, CONFIG_ENABLECMDLINEONLY)) == 0) {
@@ -166,7 +220,7 @@ int main(int argc, char **argv)
   }
 
   int c;
-  while ((c = getopt(argc, argv, "--:O:c:F:g:hIL:m:M:n:N:o:P:R:s:S:x:y:z:")) != -1) {
+  while ((c = getopt(argc, argv, "--:O:c:F:g:hIL:m:M:n:N:o:P:R:s:S:wx:y:z:")) != -1) {
     /* ignore long options starting with '--', option '-O' and their arguments that are handled by configmodule */
     /* with this opstring getopt returns 1 for non-option arguments, refer to 'man 3 getopt' */
     if (c == 1 || c == '-' || c == 'O')
@@ -317,6 +371,10 @@ int main(int argc, char **argv)
       break;
       */
 
+    case 'w':
+      test_ssb_end = false;
+      break;
+
     case 'x':
       transmission_mode=atoi(optarg);
 
@@ -373,6 +431,7 @@ int main(int argc, char **argv)
       printf("-s Starting SNR, runs from SNR0 to SNR0 + 10 dB if not -S given. If -n 1, then just SNR is simulated\n");
       printf("-S Ending SNR, runs from SNR0 to SNR1\n");
       //printf("-t Delay spread for multipath channel\n");
+      printf("-w Don't test Initial Sync with SSB between end and beginning of rxdata\n");
       printf("-x Transmission mode (1,2,6 for the moment)\n");
       printf("-y Number of TX antennas used in eNB\n");
       printf("-z Number of RX antennas used in UE\n");
@@ -446,19 +505,13 @@ int main(int argc, char **argv)
   frame_length_complex_samples = frame_parms->samples_per_subframe*NR_NUMBER_OF_SUBFRAMES_PER_FRAME;
   frame_length_complex_samples_no_prefix = frame_parms->samples_per_subframe_wCP;
 
-  s_re = malloc(2*sizeof(double*));
-  s_im = malloc(2*sizeof(double*));
   r_re = malloc(2*sizeof(double*));
   r_im = malloc(2*sizeof(double*));
   txdata = calloc(2, sizeof(c16_t*));
 
   for (i=0; i<2; i++) {
-
-
-    s_re[i] = malloc16_clear(frame_length_complex_samples*sizeof(double));
-    s_im[i] = malloc16_clear(frame_length_complex_samples*sizeof(double));
-    r_re[i] = malloc16_clear(frame_length_complex_samples*sizeof(double));
-    r_im[i] = malloc16_clear(frame_length_complex_samples*sizeof(double));
+    r_re[i] = malloc16_clear(2 * frame_length_complex_samples * sizeof(double));
+    r_im[i] = malloc16_clear(2 * frame_length_complex_samples * sizeof(double));
     printf("Allocating %d samples for txdata\n",frame_length_complex_samples);
     txdata[i] = malloc16_clear(frame_length_complex_samples * sizeof(c16_t));
   }
@@ -605,71 +658,131 @@ int main(int argc, char **argv)
     n_errors_payload = 0;
 
     for (trial = 0; trial < n_trials && !stop; trial++) {
-
-      for (i=0; i<frame_length_complex_samples; i++) {
-        for (aa=0; aa<frame_parms->nb_antennas_tx; aa++) {
-          r_re[aa][i] = (double)txdata[aa][i].r;
-          r_im[aa][i] = (double)txdata[aa][i].i;
-        }
-      }
-
-      // multipath channel
-      //multipath_channel(gNB2UE,s_re,s_im,r_re,r_im,frame_length_complex_samples,0);
-      
       //AWGN
       sigma2_dB = 20*log10((double)AMP/4)-SNR;
       sigma2 = pow(10,sigma2_dB/10);
       //printf("sigma2 %f (%f dB), tx_lev %f (%f dB)\n",sigma2,sigma2_dB,txlev,10*log10((double)txlev));
 
-      if(eps!=0.0)
-        rf_rx(r_re,  // real part of txdata
-           r_im,  // imag part of txdata
-           NULL,  // interference real part
-           NULL, // interference imag part
-           0,  // interference power
-           frame_parms->nb_antennas_rx,  // number of rx antennas
-           frame_length_complex_samples,  // number of samples in frame
-           1.0e9/fs,   //sampling time (ns)
-           cfo,	// frequency offset in Hz
-           0.0, // drift (not implemented)
-           0.0, // noise figure (not implemented)
-           0.0, // rx gain in dB ?
-           200, // 3rd order non-linearity in dB ?
-           &ip, // initial phase
-           30.0e3,  // phase noise cutoff in kHz
-           -500.0, // phase noise amplitude in dBc
-           0.0,  // IQ imbalance (dB),
-	   0.0); // IQ phase imbalance (rad)
+      uint8_t ssb_index = 0;
+      while (!((SSB_positions >> ssb_index) & 0x01))
+        ssb_index++; // to select the first transmitted ssb
+      int ssb_start_symb = nr_get_ssb_start_symbol(frame_parms, ssb_index);
 
-      for (i=0; i<frame_length_complex_samples; i++) {
-        for (aa=0; aa<frame_parms->nb_antennas_rx; aa++) {
-          UE->common_vars.rxdata[aa][i].r = (short)(r_re[aa][i] + sqrt(sigma2 / 2) * gaussdouble(0.0, 1.0));
-          UE->common_vars.rxdata[aa][i].i = (short)(r_im[aa][i] + sqrt(sigma2 / 2) * gaussdouble(0.0, 1.0));
-        }
-      }
-
-      if (n_trials==1) {
-        LOG_M("rxsig0.m", "rxs0", UE->common_vars.rxdata[0], frame_parms->samples_per_frame, 1, 1);
-        if (gNB->frame_parms.nb_antennas_tx > 1)
-          LOG_M("rxsig1.m", "rxs1", UE->common_vars.rxdata[1], frame_parms->samples_per_frame, 1, 1);
-      }
       if (UE->is_synchronized == 0) {
         UE_nr_rxtx_proc_t proc = {0};
         nr_gscn_info_t gscnInfo[MAX_GSCN_BAND] = {0};
         const int numGscn = 1;
         gscnInfo[0].ssbFirstSC = frame_parms->ssb_start_subcarrier;
-        nr_initial_sync_t ret = nr_initial_sync(&proc, UE, 1, gscnInfo, numGscn);
-        printf("nr_initial_sync1 returns %s\n", ret.cell_detected ? "cell detected" : "cell not detected");
+        apply_ch_effect_and_noise(sigma2,
+                                  eps,
+                                  r_re,
+                                  r_im,
+                                  frame_parms->nb_antennas_rx,
+                                  frame_length_complex_samples,
+                                  2 * frame_length_complex_samples,
+                                  fs,
+                                  cfo,
+                                  &ip,
+                                  0,
+                                  txdata,
+                                  UE->common_vars.rxdata);
+
+        nr_initial_sync_t ret = nr_initial_sync(&proc, UE, 2, gscnInfo, numGscn);
+        printf("nr_initial_sync1 returns %s in frame id: %d, offset %d\n",
+               ret.cell_detected ? "cell detected" : "cell not detected",
+               ret.frame_id,
+               ret.rx_offset);
         if (!ret.cell_detected)
           n_errors++;
-      }
-      else {
+
+        // Simulate SSB between first and second frame
+        // |------frame 1------|------frame 2------|
+        //                  |-ssb-|
+        int ssb_slot = ssb_start_symb / frame_parms->symbols_per_slot;
+        uint32_t ssb_start_offset =
+            get_samples_slot_timestamp(frame_parms, ssb_slot)
+            + get_samples_symbol_timestamp(frame_parms, ssb_slot, ssb_start_symb % frame_parms->symbols_per_slot);
+        int shift = frame_parms->samples_per_frame - ssb_start_offset;
+        shift -= 2 * (frame_parms->ofdm_symbol_size + frame_parms->nb_prefix_samples); // 2 symbols of SSB in next frame
+        uint32_t rxdata_size = 2 * frame_parms->samples_per_frame;
+        apply_ch_effect_and_noise(sigma2,
+                                  eps,
+                                  r_re,
+                                  r_im,
+                                  frame_parms->nb_antennas_rx,
+                                  frame_length_complex_samples,
+                                  rxdata_size,
+                                  fs,
+                                  cfo,
+                                  &ip,
+                                  shift,
+                                  txdata,
+                                  UE->common_vars.rxdata);
+
+        // Run init sync
+        ret = nr_initial_sync(&proc, UE, 2, gscnInfo, numGscn);
+        printf("nr_initial_sync in end of first frame returns %s in frame id: %d, offset %d\n",
+               ret.cell_detected ? "cell detected" : "cell not detected",
+               ret.frame_id,
+               ret.rx_offset);
+        if (!ret.cell_detected)
+          n_errors++;
+
+        if (test_ssb_end) {
+          // Simulate SSB between end and beginning of rxdata buffer
+          // |------frame 1------|------frame 2------|
+          // sb-|                                  |-s
+          shift += frame_parms->samples_per_frame;
+          apply_ch_effect_and_noise(sigma2,
+                                    eps,
+                                    r_re,
+                                    r_im,
+                                    frame_parms->nb_antennas_rx,
+                                    frame_length_complex_samples,
+                                    rxdata_size,
+                                    fs,
+                                    cfo,
+                                    &ip,
+                                    shift,
+                                    txdata,
+                                    UE->common_vars.rxdata);
+
+          // Run init sync
+          ret = nr_initial_sync(&proc, UE, 2, gscnInfo, numGscn);
+          printf("nr_initial_sync in end of second frame returns %s in frame id: %d, offset %d\n",
+                 ret.cell_detected ? "cell detected" : "cell not detected",
+                 ret.frame_id,
+                 ret.rx_offset);
+        }
+        if (!ret.cell_detected)
+          n_errors++;
+      } else {
+        apply_ch_effect_and_noise(sigma2,
+                                  eps,
+                                  r_re,
+                                  r_im,
+                                  frame_parms->nb_antennas_rx,
+                                  frame_length_complex_samples,
+                                  2 * frame_length_complex_samples,
+                                  fs,
+                                  cfo,
+                                  &ip,
+                                  0,
+                                  txdata,
+                                  UE->common_vars.rxdata);
+
+        if (n_trials == 1) {
+          LOG_M("rxsig0.m", "rxs0", UE->common_vars.rxdata[0], frame_parms->samples_per_frame, 1, 1);
+          if (gNB->frame_parms.nb_antennas_tx > 1)
+            LOG_M("rxsig1.m", "rxs1", UE->common_vars.rxdata[1], frame_parms->samples_per_frame, 1, 1);
+        }
+
         UE_nr_rxtx_proc_t proc={0};
 
         uint8_t ssb_index = 0;
         while (!((SSB_positions >> ssb_index) & 0x01))
           ssb_index++; // to select the first transmitted ssb
-        UE->symbol_offset = nr_get_ssb_start_symbol(frame_parms, ssb_index);
+        UE->symbol_offset = ssb_start_symb;
 
         int ssb_slot = (UE->symbol_offset/14)+(n_hf*(frame_parms->slots_per_frame>>1));
         proc.nr_slot_rx = ssb_slot;
@@ -775,15 +888,11 @@ int main(int argc, char **argv)
   free(UE);
 
   for (i=0; i<2; i++) {
-    free(s_re[i]);
-    free(s_im[i]);
     free(r_re[i]);
     free(r_im[i]);
     free(txdata[i]);
   }
 
-  free(s_re);
-  free(s_im);
   free(r_re);
   free(r_im);
   free(txdata);

--- a/openair1/SIMULATION/tests/CMakeLists.txt
+++ b/openair1/SIMULATION/tests/CMakeLists.txt
@@ -84,12 +84,12 @@ add_physim_test(physim.5g.polartest.test4 "UCI polar test,11-bit CRC" polartest 
 ####################################################################################
 
 add_physim_test(physim.5g.nr_pbchsim.106rb.test1 "PBCH-only, 106 PRB, NID 2" nr_pbchsim -s-11 -S-8 -n30 -R106 -N2)
-add_physim_test(physim.5g.nr_pbchsim.106rb.test2 "PBCH and synchronization, 106PBR" nr_pbchsim -s-11 -S-8 -n30 -o8000 -I -R106)
+add_physim_test(physim.5g.nr_pbchsim.106rb.test2 "PBCH and synchronization, 106PBR" nr_pbchsim -s-11 -S-8 -n30 -o8000 -I -R106 -w)
 add_physim_test(physim.5g.nr_pbchsim.106rb.test3 "PBCH and synchronization, 106PBR, SSB SC OFFSET 6" nr_pbchsim -s-11 -S-8 -n30 -R106 -c6)
 add_physim_test(physim.5g.nr_pbchsim.217rb.test1 "PBCH-only, 217 PRB" nr_pbchsim -s-10 -S-8 -n30 -R217)
-add_physim_test(physim.5g.nr_pbchsim.217rb.test2 "PBCH and synchronization, 217 RPB" nr_pbchsim -s-10 -S-8 -n30 -o8000 -I -R217)
+add_physim_test(physim.5g.nr_pbchsim.217rb.test2 "PBCH and synchronization, 217 RPB" nr_pbchsim -s-10 -S-8 -n30 -o8000 -I -R217 -w)
 add_physim_test(physim.5g.nr_pbchsim.273rb.test1 "PBCH-only, 273 PRB" nr_pbchsim -s-10 -S-8 -n30 -R273)
-add_physim_test(physim.5g.nr_pbchsim.273rb.test2 "PBCH and synchronization, 273 PRB" nr_pbchsim -s-10 -S-8 -n30 -o8000 -I -R273)
+add_physim_test(physim.5g.nr_pbchsim.273rb.test2 "PBCH and synchronization, 273 PRB" nr_pbchsim -s-10 -S-8 -n30 -o8000 -I -R273 -w)
 add_physim_test(physim.5g.nr_pbchsim.otherSCS.test1 "PBCH-only, 15Khz, 5Mhz" nr_pbchsim -s-10 -S-8 -n30 -m0 -R25)
 add_physim_test(physim.5g.nr_pbchsim.otherSCS.test2 "PBCH-only, 120Khz, 50Mhz" nr_pbchsim -s-10 -S-8 -n30 -m3 -R32)
 


### PR DESCRIPTION
## Problem
During initial sync we search for PSS in time within a window of two frames (one frame at a time). In develop, this works only when the whole SSB is inside a frame. But when the SSB is

1. In the frame boundary of first frame:
```
|------frame 0------|------frame 1------|
                 |-ssb-|
```
2. In the frame boundary of second frame:
```
|------frame 0------|------frame 1------|
sb-|                                  |-s
```
the search is skipped. The next search attempt would also have the SSB in the same position because we always read 2 frames while performing a search. So the UE would never sync to the gNB and we have to restart the UE hoping the next time the SSB would be fully within a frame.

## Fix
We do the PSS search with a search window of two frames together instead of one frame at a time. Modified `nr_pbchsim` to simulate the above two cases and validate the synchronization.

### Caveat
When SSB is partially in the end of the search window (case 2), the beginning of the window has the previous SSB. So the PSS and SSS might be two frames apart in time and in the presence of relatively large CFO, we might not detect the SSS. Hence, I disable the test of case 2 in `nr_pbchsim` when simulating a CFO.