### PR TITLE
fix (f1ap): DRB-Information criticality and non-dynamic fiveQI handling in DU

### DIFF
--- a/common/5g_platform_types.h
+++ b/common/5g_platform_types.h
@@ -39,8 +39,9 @@ typedef enum { NON_DYNAMIC, DYNAMIC } fiveQI_t;
 /* 5QI (5G QoS Identifier) - 3GPP TS 23.501 §5.7.2.1
  * Range: 0..255
  * - Standardized 5QI values: have one-to-one mapping to standardized 5G QoS characteristics (Table 5.7.4-1)
- * - Pre-configured 5QI values: pre-configured in the AN
- * - Dynamically assigned 5QI values: require signaling of QoS characteristics as part of QoS profile */
+ * - Pre-configured 5QI values: pre-configured in the AN (not in Table 5.7.4-1)
+ * - Dynamically assigned 5QI values: require signaling of QoS characteristics as part of QoS profile
+ * OAI implements standardized non-dynamic 5QI only. */
 #define MIN_FIVEQI 0
 #define MAX_STANDARDIZED_FIVEQI 90
 #define MAX_FIVEQI 255

--- a/openair2/E1AP/lib/e1ap_bearer_context_management.c
+++ b/openair2/E1AP/lib/e1ap_bearer_context_management.c
@@ -233,10 +233,16 @@ bool e1_decode_qos_flow_to_setup(qos_flow_to_setup_t *out, const E1AP_QoS_Flow_Q
   const E1AP_QoSFlowLevelQoSParameters_t *qosParams = &in->qoSFlowLevelQoSParameters;
   const E1AP_QoS_Characteristics_t *qoS_Characteristics = &qosParams->qoS_Characteristics;
   switch (qoS_Characteristics->present) {
-    case E1AP_QoS_Characteristics_PR_non_Dynamic_5QI:
+    case E1AP_QoS_Characteristics_PR_non_Dynamic_5QI: {
+      const int fiveqi = qoS_Characteristics->choice.non_Dynamic_5QI->fiveQI;
+      if (fiveqi < MIN_FIVEQI || fiveqi > MAX_FIVEQI) {
+        PRINT_ERROR("non-dynamic fiveQI %d out of range %d..%d\n", fiveqi, MIN_FIVEQI, MAX_FIVEQI);
+        return false;
+      }
       qos_char->qos_type = NON_DYNAMIC;
-      qos_char->non_dynamic.fiveqi = qoS_Characteristics->choice.non_Dynamic_5QI->fiveQI;
+      qos_char->non_dynamic.fiveqi = fiveqi;
       break;
+    }
     case E1AP_QoS_Characteristics_PR_dynamic_5QI: {
       E1AP_Dynamic5QIDescriptor_t *dynamic5QI = qoS_Characteristics->choice.dynamic_5QI;
       qos_char->qos_type = DYNAMIC;

--- a/openair2/F1AP/lib/f1ap_ue_context.c
+++ b/openair2/F1AP/lib/f1ap_ue_context.c
@@ -757,7 +757,7 @@ static F1AP_DRBs_ToBeSetupMod_List_t encode_drbs_to_setupmod(int n, const f1ap_d
     F1AP_QoSInformation_ExtIEs_t *qos_ext_ie = calloc_or_fail(1, sizeof(*qos_ext_ie));
     it->qoSInformation.choice.choice_extension = (struct F1AP_ProtocolIE_SingleContainer *)qos_ext_ie;
     qos_ext_ie->id = F1AP_ProtocolIE_ID_id_DRB_Information;
-    qos_ext_ie->criticality = F1AP_Criticality_reject;
+    qos_ext_ie->criticality = F1AP_Criticality_ignore;
     qos_ext_ie->value.present = F1AP_QoSInformation_ExtIEs__value_PR_DRB_Information;
     qos_ext_ie->value.choice.DRB_Information = encode_drb_info_nr(&drb->nr);
 

--- a/openair2/F1AP/lib/f1ap_ue_context.c
+++ b/openair2/F1AP/lib/f1ap_ue_context.c
@@ -434,7 +434,12 @@ static bool decode_qos_flow_param(const F1AP_QoSFlowLevelQoSParameters_t *f1ap, 
   if (f1ap->qoS_Characteristics.present == F1AP_QoS_Characteristics_PR_non_Dynamic_5QI) {
     out->qos_type = NON_DYNAMIC;
     const F1AP_NonDynamic5QIDescriptor_t *nondyn = f1ap->qoS_Characteristics.choice.non_Dynamic_5QI;
-    out->nondyn.fiveQI = nondyn->fiveQI;
+    const int fiveqi = nondyn->fiveQI;
+    if (fiveqi < MIN_FIVEQI || fiveqi > MAX_FIVEQI) {
+      PRINT_ERROR("non-dynamic fiveQI %d out of range %d..%d\n", fiveqi, MIN_FIVEQI, MAX_FIVEQI);
+      return false;
+    }
+    out->nondyn.fiveQI = fiveqi;
   } else {
     _EQ_CHECK_INT(f1ap->qoS_Characteristics.present, F1AP_QoS_Characteristics_PR_dynamic_5QI);
     const F1AP_Dynamic5QIDescriptor_t *d = f1ap->qoS_Characteristics.choice.dynamic_5QI;

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
@@ -265,8 +265,8 @@ static int get_non_dynamic_priority(int fiveqi)
   for (int i = 0; i < sizeofArray(qos_fiveqi); ++i)
     if (qos_fiveqi[i] == fiveqi)
       return qos_priority[i];
-  AssertFatal(false, "illegal 5QI value %d\n", fiveqi);
-  return 0;
+  LOG_W(NR_MAC, "unsupported non-dynamic 5QI %d\n", fiveqi);
+  return -1;
 }
 
 static NR_QoS_config_t get_qos_config(const f1ap_qos_flow_param_t *qos)
@@ -319,6 +319,8 @@ static int handle_ue_context_drbs_setup(NR_UE_info_t *UE,
     int prio = 100;
     for (int q = 0; q < drb->nr.flows_len; ++q) {
       c.qos_config[q] = get_qos_config(&drb->nr.flows[q].param);
+      if (c.qos_config[q].priority < 0)
+        continue;
       prio = min(prio, c.qos_config[q].priority);
     }
     c.priority = prio;

--- a/openair2/RRC/NR/rrc_gNB_NGAP.c
+++ b/openair2/RRC/NR/rrc_gNB_NGAP.c
@@ -1080,6 +1080,7 @@ static void nr_rrc_apply_qos_add_modify(gNB_RRC_INST *rrc,
     const non_dynamic_5qi_t *in_non_dynamic = &q_in->qos_characteristics.non_dynamic;
     const dynamic_5qi_t *in_dynamic = &q_in->qos_characteristics.dynamic;
     if (q_in->fiveQI_type == NON_DYNAMIC && !is_5qi_standardized(in_non_dynamic->fiveQI)) {
+      // This is a pre-configured 5QI, not a standardized non-dynamic value: not implemented
       LOG_W(NR_RRC,
             "QoS flow QFI=%d: 5QI %u is not a standardized value (1-9, 65-90). Skipping QoS flow.\n",
             q_in->qfi,

--- a/openair2/RRC/NR/rrc_gNB_radio_bearers.c
+++ b/openair2/RRC/NR/rrc_gNB_radio_bearers.c
@@ -84,8 +84,8 @@ nr_rrc_qos_t *add_qos(seq_arr_t *qos, const pdusession_level_qos_parameter_t *in
     return existing;
   }
 
-  // Validate 5QI value (TS 23.501 allows dynamically assigned 5QIs)
   if (in->fiveQI_type == NON_DYNAMIC && !is_5qi_standardized(in->qos_characteristics.non_dynamic.fiveQI)) {
+    // This is a pre-configured 5QI, not a standardized non-dynamic value: not implemented
     LOG_W(NR_RRC,
           "QoS flow QFI=%d: 5QI %d is not a standardized value. Skipping QoS flow.\n",
           in->qfi,


### PR DESCRIPTION
Aligns OAI F1AP encoding with TS 38.473 for `DRB-Information` criticality on UE Context Modification, and clarifies how non-dynamic `fiveQI` is handled across F1AP/E1AP decode and CU RRC.

Non-dynamic fiveQI may name standardized or pre-configured profiles on the wire (`0..255`). F1/E1 libs now accept the full ASN range and reject only out-of-range values. Pre-configured and other non-standardized non-dynamic 5QI remain unsupported at RRC via the existing `is_5qi_standardized()` skip.

DU is now gracefully handling unsupported 5QIs instead of crashing.

Closes: #212