### PR TITLE
Bugfix PUCCH Format 2

### DIFF
--- a/openair1/PHY/NR_UE_TRANSPORT/pucch_nr.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/pucch_nr.c
@@ -733,26 +733,15 @@ void nr_generate_pucch2(c16_t **txdataF,
     const int seq_sz = ((startingPRB + pucch_pdu->prb_size) * NR_PUCCH_DMRS_RB * DMRS_MOD_ORDER + 31) / 32;
     uint32_t *seq = gold_cache(temp_x2, seq_sz);
     for (int rb=0; rb<pucch_pdu->prb_size; rb++) {
-      //startingPRB = startingPRB + rb;
-      const bool nb_rb_is_even = frame_parms->N_RB_DL & 1;
+      const bool nb_rb_is_even = !(frame_parms->N_RB_DL & 1);
       const int halfRBs = frame_parms->N_RB_DL / 2;
       const int baseRB = rb + startingPRB;
-      int re_offset = (l + startingSymbolIndex) * frame_parms->ofdm_symbol_size + 12 * baseRB;
-      if (nb_rb_is_even) {
-        if (baseRB < halfRBs) // if number RBs in bandwidth is even and current PRB is lower band
-          re_offset += frame_parms->first_carrier_offset;
-        else
-          re_offset -= halfRBs;
-      } else {
-        if (baseRB < halfRBs) // if number RBs in bandwidth is odd  and current PRB is lower band
-          re_offset += frame_parms->first_carrier_offset;
-        else if (baseRB > halfRBs) // if number RBs in bandwidth is odd  and current PRB is upper band
-          re_offset += -halfRBs + 6;
-        else
-          re_offset += frame_parms->first_carrier_offset;
-      }
+      int re_offset = (l + startingSymbolIndex) * frame_parms->ofdm_symbol_size + NR_NB_SC_PER_RB * baseRB;
+      if (baseRB > halfRBs)
+        re_offset -= (nb_rb_is_even) ? (halfRBs * NR_NB_SC_PER_RB) : (halfRBs * NR_NB_SC_PER_RB + 6);
+      else
+        re_offset += frame_parms->first_carrier_offset;
 
-      //txptr = &txdataF[0][re_offset];
       int k=0;
 #ifdef DEBUG_NR_PUCCH_TX
       int kk=0;

--- a/openair2/NR_UE_PHY_INTERFACE/NR_IF_Module.c
+++ b/openair2/NR_UE_PHY_INTERFACE/NR_IF_Module.c
@@ -54,7 +54,7 @@ void print_ue_mac_stats(const module_id_t mod, const int frame_rx, const int slo
   cur += snprintf(cur, end - cur, "    DL harq: %lu", mac->stats.dl.rounds[0]);
   int nb;
   for (nb = NR_MAX_HARQ_ROUNDS_FOR_STATS - 1; nb > 1; nb--)
-    if (mac->stats.ul.rounds[nb])
+    if (mac->stats.dl.rounds[nb])
       break;
   for (int i = 1; i < nb + 1; i++)
     cur += snprintf(cur, end - cur, "/%lu", mac->stats.dl.rounds[i]);


### PR DESCRIPTION
Fix RE offset computation in PUCCH format 2 generation. This fixes DL retx with OCUDU in the CI.