### PR TITLE
fix(vrtsim): Reduce OS scheduler pressure caused by vrtsim timing thread

### DIFF
--- a/radio/vrtsim/vrtsim.c
+++ b/radio/vrtsim/vrtsim.c
@@ -272,7 +272,7 @@ static void *vrtsim_timing_job(void *arg)
       shm_td_iq_channel_produce_samples(vrtsim_state->channel, samples_to_produce);
       last_sample_index = sample_index;
     }
-    usleep(1);
+    usleep(20);
   }
   return 0;
 }


### PR DESCRIPTION
Increase the usleep to 20 uS to reduce the pressure on the OS scheduler. This reduces the number of context switches and increases performance. The value 20uS is approximately half a symbol in mu1 and shouldn't cause too much extra delay.