### PR TITLE
CI: Replace GH1 with DGX Spark3 for Aerial 100Mhz CI test and upgrade to Aerial 26-1

### DIFF
--- a/ci-scripts/ci_infra.yaml
+++ b/ci-scripts/ci_infra.yaml
@@ -110,7 +110,7 @@ oc-cn5g-00103-ho:
   LogCollect: "! scripts/oc-cn5g-logcollect.sh /opt/oai-cn5g-fed-develop-2025-jan oaicicd-core-for-ho %%log_dir%%"
 
 oc-cn5g-20897-aerial:
-  Host: gracehopper1-oai
+  Host: dgx3-oai
   NetworkScript: echo "inet 172.21.6.105"
   RunIperf3Server: False
   Deploy: "! scripts/oc-cn5g-deploy.sh /opt/oai-cn5g-fed-develop-2025-jan oaicicd-core-for-nvidia-aerial"

--- a/ci-scripts/conf_files/gnb-vnf.sa.band78.273prb.aerial.conf
+++ b/ci-scripts/conf_files/gnb-vnf.sa.band78.273prb.aerial.conf
@@ -170,8 +170,8 @@ gNBs =
 
     NETWORK_INTERFACES :
     {
-        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "172.21.16.53";
-        GNB_IPV4_ADDRESS_FOR_NGU                 = "172.21.16.53";
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "172.21.19.113";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "172.21.19.113";
         GNB_PORT_FOR_S1U                         = 2152; # Spec 2152
     };
 

--- a/ci-scripts/conf_files/gnb-vnf.sa.band78.273prb.aerial.ul-heavy.conf
+++ b/ci-scripts/conf_files/gnb-vnf.sa.band78.273prb.aerial.ul-heavy.conf
@@ -28,7 +28,6 @@ gNBs =
     do_CSIRS              = 1;
     do_SRS                = "aperiodic";
     min_rxtxtime          = 2;
-
     servingCellConfigCommon = (
     {
  #spCellConfigCommon

--- a/ci-scripts/conf_files/gnb-vnf.sa.band78.273prb.aerial.ul-heavy.conf
+++ b/ci-scripts/conf_files/gnb-vnf.sa.band78.273prb.aerial.ul-heavy.conf
@@ -170,8 +170,8 @@ gNBs =
 
     NETWORK_INTERFACES :
     {
-        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "172.21.16.53";
-        GNB_IPV4_ADDRESS_FOR_NGU                 = "172.21.16.53";
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "172.21.19.113";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "172.21.19.113";
         GNB_PORT_FOR_S1U                         = 2152; # Spec 2152
     };
 
@@ -180,19 +180,17 @@ gNBs =
 
 MACRLCs = (
 {
-  remote_s_address = "127.0.0.1"; // pnf addr [!]
-  local_s_address  = "127.0.0.2"; // vnf addr
-  local_s_portc    = 50001; // vnf p5 port
-  local_s_portd    = 50011; // vnf p7 port [!]
-  tr_s_preference             = "aerial";
-  tr_n_preference             = "local_RRC";
-  pucch_RSSI_Threshold        = -250;
-  pusch_RSSI_Threshold        = -250;
-  pusch_TargetSNRx10          = 280;
-  pucch_TargetSNRx10          = 200;
-  dl_max_mcs = 28;
-  ul_max_mcs = 28;
-  ul_min_mcs = 9;
+  remote_s_address     = "127.0.0.1"; // pnf addr [!]
+  local_s_address      = "127.0.0.2"; // vnf addr
+  local_s_portc        = 50001; // vnf p5 port
+  local_s_portd        = 50011; // vnf p7 port [!]
+  tr_s_preference      = "aerial";
+  tr_n_preference      = "local_RRC";
+  pucch_RSSI_Threshold = -250;
+  pusch_RSSI_Threshold = -250;
+  pusch_TargetSNRx10   = 280;
+  pucch_TargetSNRx10   = 200;
+  ul_min_mcs           = 9;
 }
 );
 
@@ -216,13 +214,13 @@ security = {
 
 log_config :
 {
-  global_log_level                      ="info";
-  hw_log_level                          ="info";
-  phy_log_level                         ="info";
-  mac_log_level                         ="info";
-  rlc_log_level                         ="info";
-  pdcp_log_level                        ="info";
-  rrc_log_level                         ="info";
-  ngap_log_level                        ="debug";
-  f1ap_log_level                        ="debug";
+  global_log_level ="info";
+  hw_log_level     ="info";
+  phy_log_level    ="info";
+  mac_log_level    ="info";
+  rlc_log_level    ="info";
+  pdcp_log_level   ="info";
+  rrc_log_level    ="info";
+  ngap_log_level   ="debug";
+  f1ap_log_level   ="debug";
 };

--- a/ci-scripts/scripts/set-wnc-params.sh
+++ b/ci-scripts/scripts/set-wnc-params.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 
-if [ -z "$1" ]; then
-    echo "Usage: $0 <bandwidth> [reboot]"
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Usage: $0 <bandwidth> <peer-mac> [reboot]"
     exit 1
 fi
 
 BANDWIDTH="$1"
-DO_REBOOT="$2"
+PEER_MAC="$2"
+DO_REBOOT="$3"
+
 RU_IP="10.10.0.115"
 HOST="root@$RU_IP"
 LOGFILE="/tmp/radio_config_$(date +%Y%m%d_%H%M%S).log"
 
 echo "=== Starting at $(date) ===" | tee "$LOGFILE"
 echo "Target bandwidth: $BANDWIDTH" | tee -a "$LOGFILE"
+echo "Target peer MAC: $PEER_MAC" | tee -a "$LOGFILE"
 echo "Reboot before configuration: ${DO_REBOOT:-no}" | tee -a "$LOGFILE"
 
 if [ "$DO_REBOOT" == "reboot" ]; then
@@ -27,7 +30,6 @@ expect "#"
 send "reboot\r"
 expect "Continue?"
 send "Y\r"
-# We expect disconnect now
 expect eof
 EOF
 
@@ -39,10 +41,11 @@ EOF
         echo "SSH port 22 not open, waiting 5 seconds..." | tee -a "$LOGFILE"
         sleep 5
     done
+
     echo "✓ SSH port 22 is open on $RU_IP" | tee -a "$LOGFILE"
 fi
 
-echo "=== Applying bandwidth configuration ===" | tee -a "$LOGFILE"
+echo "=== Applying radio configuration ===" | tee -a "$LOGFILE"
 
 expect <<EOF | tee -a "$LOGFILE" > /dev/null 2>&1
 set timeout 10
@@ -61,6 +64,9 @@ expect "(conf-rf 1)#"
 send "bandwidth ${BANDWIDTH}\r"
 
 expect "(conf-rf 1)#"
+send "transport peer-mac ${PEER_MAC}\r"
+
+expect "(conf-rf 1)#"
 send "exit\r"
 
 expect "(config)#"
@@ -76,19 +82,23 @@ expect "#"
 send "exit\r"
 EOF
 
-echo "=== Checking bandwidth in running-config ===" | tee -a "$LOGFILE"
+echo "=== Checking configuration in running-config ===" | tee -a "$LOGFILE"
 
 FOUND_BW=$(grep -E "bandwidth[[:space:]]+[0-9]+" "$LOGFILE" \
     | tail -n 1 \
     | awk '{print $2}' \
     | tr -d '\r[:space:]')
 
-if [ "$FOUND_BW" -eq "$BANDWIDTH" ]; then
-    echo "✓ SUCCESS: Bandwidth correctly set to $FOUND_BW" | tee -a "$LOGFILE"
+FOUND_MAC=$(grep -E "transport peer-mac[[:space:]]+" "$LOGFILE" \
+    | tail -n 1 \
+    | awk '{print $3}' \
+    | tr -d '\r[:space:]')
+
+if [ "$FOUND_BW" -eq "$BANDWIDTH" ] && [ "$FOUND_MAC" = "$PEER_MAC" ]; then
+    echo "✓ SUCCESS: Bandwidth correctly set to $FOUND_BW and peer MAC correctly set to $FOUND_MAC" | tee -a "$LOGFILE"
     rm "$LOGFILE"
     exit 0
 else
-    echo "✖ ERROR: Expected bandwidth $BANDWIDTH but found: $FOUND_BW" | tee -a "$LOGFILE"
+    echo "✖ ERROR: Expected bandwidth $BANDWIDTH and peer MAC $PEER_MAC but found bandwidth $FOUND_BW and peer MAC $FOUND_MAC" | tee -a "$LOGFILE"
     exit 1
 fi
-

--- a/ci-scripts/xml_files/container_sa_aerial_quectel.xml
+++ b/ci-scripts/xml_files/container_sa_aerial_quectel.xml
@@ -15,11 +15,10 @@
 
   <testCase>
     <class>Custom_Script</class>
-    <always_exec>true</always_exec>
-    <desc>Configure 100 MHz bandwidth on WNC RU</desc>
+    <desc>Configure 100 MHz bandwidth and set the DGX3 MAC address on WNC RU</desc>
     <node>gracehopper1-oai</node>
-    <script>scripts/set-wnc-bandwidth.sh</script>
-    <args>100</args>
+    <script>scripts/set-wnc-params.sh</script>
+    <args>100 4c:bb:47:7e:58:aa</args>
   </testCase>
 
   <testCase>
@@ -132,6 +131,15 @@
     <desc>Clean Test Images on Test Server</desc>
     <node>dgx3-oai</node>
     <images>oai-gnb-aerial</images>
+  </testCase>
+
+  <testCase>
+    <class>Custom_Script</class>
+    <always_exec>true</always_exec>
+    <desc>Configure 100 MHz bandwidth and set GH1 MAC address (default) on WNC RU</desc>
+    <node>gracehopper1-oai</node>
+    <script>scripts/set-wnc-params.sh</script>
+    <args>100 c4:70:bd:57:24:cc</args>
   </testCase>
 
 </testCaseList>

--- a/ci-scripts/xml_files/container_sa_aerial_quectel.xml
+++ b/ci-scripts/xml_files/container_sa_aerial_quectel.xml
@@ -8,7 +8,7 @@
   <testCase>
     <class>Pull_Local_Registry</class>
     <desc>Pull Images from Local Registry</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
     <images>oai-gnb-aerial</images>
     <tag_prefix>arm_</tag_prefix>
   </testCase>
@@ -32,13 +32,13 @@
   <testCase>
     <class>Create_Workspace</class>
     <desc>Create new Workspace</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
   </testCase>
 
   <testCase>
     <class>Deploy_Object</class>
     <desc>Deploy PNF/Nvidia CUBB in a container</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
     <yaml_path>ci-scripts/yaml_files/sa_gnb_aerial</yaml_path>
     <services>nv-cubb</services>
   </testCase>
@@ -46,7 +46,7 @@
   <testCase>
     <class>Deploy_Object</class>
     <desc>Deploy VNF in a container</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
     <yaml_path>ci-scripts/yaml_files/sa_gnb_aerial</yaml_path>
     <services>oai-gnb-aerial</services>
   </testCase>
@@ -119,7 +119,7 @@
     <class>Undeploy_Object</class>
     <always_exec>true</always_exec>
     <desc>Undeploy gNB</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
     <yaml_path>ci-scripts/yaml_files/sa_gnb_aerial</yaml_path>
     <analysis>
       <services>oai-gnb-aerial=EndsWithBye</services>
@@ -130,7 +130,7 @@
     <class>Clean_Test_Server_Images</class>
     <always_exec>true</always_exec>
     <desc>Clean Test Images on Test Server</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
     <images>oai-gnb-aerial</images>
   </testCase>
 

--- a/ci-scripts/xml_files/container_sa_aerial_quectel_ul_heavy.xml
+++ b/ci-scripts/xml_files/container_sa_aerial_quectel_ul_heavy.xml
@@ -15,11 +15,10 @@
 
   <testCase>
     <class>Custom_Script</class>
-    <always_exec>true</always_exec>
-    <desc>Configure 100 MHz bandwidth on WNC RU</desc>
+    <desc>Configure 100 MHz bandwidth and set the DGX3 MAC address on WNC RU</desc>
     <node>gracehopper1-oai</node>
-    <script>scripts/set-wnc-bandwidth.sh</script>
-    <args>100</args>
+    <script>scripts/set-wnc-params.sh</script>
+    <args>100 4c:bb:47:7e:58:aa</args>
   </testCase>
 
   <testCase>
@@ -121,6 +120,15 @@
     <desc>Clean Test Images on Test Server</desc>
     <node>dgx3-oai</node>
     <images>oai-gnb-aerial</images>
+  </testCase>
+
+  <testCase>
+    <class>Custom_Script</class>
+    <always_exec>true</always_exec>
+    <desc>Configure 100 MHz bandwidth and set GH1 MAC address (default) on WNC RU</desc>
+    <node>gracehopper1-oai</node>
+    <script>scripts/set-wnc-params.sh</script>
+    <args>100 c4:70:bd:57:24:cc</args>
   </testCase>
 
 </testCaseList>

--- a/ci-scripts/xml_files/container_sa_aerial_quectel_ul_heavy.xml
+++ b/ci-scripts/xml_files/container_sa_aerial_quectel_ul_heavy.xml
@@ -8,7 +8,7 @@
   <testCase>
     <class>Pull_Local_Registry</class>
     <desc>Pull Images from Local Registry</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
     <images>oai-gnb-aerial</images>
     <tag_prefix>arm_</tag_prefix>
   </testCase>
@@ -32,13 +32,13 @@
   <testCase>
     <class>Create_Workspace</class>
     <desc>Create new Workspace</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
   </testCase>
 
   <testCase>
     <class>Deploy_Object</class>
     <desc>Deploy PNF/Nvidia CUBB in a container</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
     <yaml_path>ci-scripts/yaml_files/sa_gnb_aerial_ul</yaml_path>
     <services>nv-cubb</services>
   </testCase>
@@ -46,7 +46,7 @@
   <testCase>
     <class>Deploy_Object</class>
     <desc>Deploy VNF in a container</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
     <yaml_path>ci-scripts/yaml_files/sa_gnb_aerial_ul</yaml_path>
     <services>oai-gnb-aerial</services>
   </testCase>
@@ -108,7 +108,7 @@
     <class>Undeploy_Object</class>
     <always_exec>true</always_exec>
     <desc>Undeploy gNB</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
     <yaml_path>ci-scripts/yaml_files/sa_gnb_aerial_ul</yaml_path>
     <analysis>
       <services>oai-gnb-aerial=EndsWithBye</services>
@@ -119,7 +119,7 @@
     <class>Clean_Test_Server_Images</class>
     <always_exec>true</always_exec>
     <desc>Clean Test Images on Test Server</desc>
-    <node>gracehopper1-oai</node>
+    <node>dgx3-oai</node>
     <images>oai-gnb-aerial</images>
   </testCase>
 

--- a/ci-scripts/xml_files/container_sa_b200_nrue_jetson.xml
+++ b/ci-scripts/xml_files/container_sa_b200_nrue_jetson.xml
@@ -39,10 +39,10 @@
 
   <testCase>
     <class>Custom_Script</class>
-    <desc>Configure 30 MHz bandwidth on WNC RU</desc>
+    <desc>Configure 30 MHz bandwidth and GH1 MAC address on WNC RU</desc>
     <node>gracehopper1-oai</node>
-    <script>scripts/set-wnc-bandwidth.sh</script>
-    <args>30</args>
+    <script>scripts/set-wnc-params.sh</script>
+    <args>30 c4:70:bd:57:24:cc</args>
   </testCase>
 
   <testCase>
@@ -159,10 +159,10 @@
   <testCase>
     <class>Custom_Script</class>
     <always_exec>true</always_exec>
-    <desc>Configure 100 MHz bandwidth on WNC RU</desc>
+    <desc>Configure 100 MHz bandwidth and GH1 MAC address on WNC RU</desc>
     <node>gracehopper1-oai</node>
-    <script>scripts/set-wnc-bandwidth.sh</script>
-    <args>100</args>
+    <script>scripts/set-wnc-params.sh</script>
+    <args>100 c4:70:bd:57:24:cc</args>
   </testCase>
 
   <testCase>

--- a/ci-scripts/yaml_files/sa_gnb_aerial/cuphycontroller_P5G_WNC_DGX.yaml
+++ b/ci-scripts/yaml_files/sa_gnb_aerial/cuphycontroller_P5G_WNC_DGX.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 aerial_sdk_version: 26-1-cubb
-l2adapter_filename: l2_adapter_config_P5G_GH.yaml
+l2adapter_filename: l2_adapter_config_P5G_DGX.yaml
 aerial_metrics_backend_address: 127.0.0.1:8081
 
 # CPU core shared by all low-priority threads
@@ -36,13 +36,13 @@ cuphydriver_config:
   fh_stats_dump_cpu_core: -1
   pdump_client_thread: -1
   use_green_contexts: 0
-  use_batched_memcpy: 0 # Experimental feature; requires >= CUDA 12.8
-  mps_sm_pusch: 100
+  use_batched_memcpy: 1 # Experimental feature; requires >= CUDA 12.8
+  mps_sm_pusch: 40
   mps_sm_pucch: 2
   mps_sm_prach: 2
-  mps_sm_ul_order: 20
-  mps_sm_pdsch: 102
-  mps_sm_pdcch: 10
+  mps_sm_ul_order: 12
+  mps_sm_pdsch: 46
+  mps_sm_pdcch: 12
   mps_sm_pbch: 2
   mps_sm_gpu_comms: 16
   mps_sm_srs: 16
@@ -61,8 +61,8 @@ cuphydriver_config:
     - 0
     # Set GPUID to the GPU sharing the PCIe switch as NIC
     # run nvidia-smi topo -m to find out which GPU
-  workers_ul: [4,5]
-  workers_dl: [6,7,8]
+  workers_ul: [5,6]
+  workers_dl: [7,8,9]
   debug_worker: -1
   workers_sched_priority: 95
   prometheus_thread: -1
@@ -76,11 +76,13 @@ cuphydriver_config:
   ul_order_timeout_gpu_ns: 3000000
   ul_order_timeout_gpu_srs_ns: 5200000
   ul_srs_aggr3_task_launch_offset_ns: 500000
-  ul_order_timeout_gpu_log_enable: 0
+  ul_order_timeout_gpu_log_enable: 1 # 1
   ul_order_max_rx_pkts: 512
   ul_order_rx_pkts_timeout_ns: 100000
   cplane_disable: 0
   gpu_init_comms_dl: 1
+  gpu_init_comms_via_cpu: 1
+  cpu_init_comms: 0
   cell_group: 1
   cell_group_num: 1
   fix_beta_dl: 0
@@ -112,14 +114,14 @@ cuphydriver_config:
   ul_rx_pkt_tracing_level: 0
   ul_rx_pkt_tracing_level_srs: 0
   pmu_metrics: 0 #Enable and select PMU metrics, 0=disabled, 1=General Counters (platform agnostic), 2=Topdown Metrics (Grace only), 3=Cache Metrics (Grace only)
-  enable_h2d_copy_thread: 1
+  enable_h2d_copy_thread: 0
   h2d_copy_thread_cpu_affinity : 11
   h2d_copy_thread_sched_priority : 95 #0->SCHED_OTHER, >0->Actual
   split_ul_cuda_streams: 0 # 1=Put UL slot 4 and slot 5 on different streams for DDDSUUDDDD pattern
   serialize_pucch_pusch: 0 # 1=Force serialization of PUSCH/PUCCH
                            # Note: for Early Harq (EH) order is PUSCH EH -> PUCCH -> PUSCH non EH
                            #       for non-Early Harq order is PUCCH -> all PUSCH processing
-  aggr_obj_non_avail_th: 5 # Threshold for consecutive non-availability of Aggregated objects(UL/DL) or DL/UL buffers
+  aggr_obj_non_avail_th: 5 # Threshold for consecutive non-availability of Aggregated objects(UL/DL) or DL/UL buffers 
   dl_wait_th_ns:
     - 500000  #H2D copy wait threshold
     - 4000000 #cuPHY DL channel wait threshold
@@ -131,7 +133,7 @@ cuphydriver_config:
   enable_srs: 1
   ue_mode: 0
   mCh_segment_proc_enable: 0
-  pusch_aggr_per_ctx: 9
+  pusch_aggr_per_ctx: 3
   prach_aggr_per_ctx: 2
   pucch_aggr_per_ctx: 4
   srs_aggr_per_ctx: 3
@@ -225,3 +227,4 @@ cuphydriver_config:
       ul_gain_calibration: 78.68
       lower_guard_bw: 845
       tv_pusch: cuPhyChEstCoeffs.h5
+

--- a/ci-scripts/yaml_files/sa_gnb_aerial/cuphycontroller_P5G_WNC_DGX.yaml
+++ b/ci-scripts/yaml_files/sa_gnb_aerial/cuphycontroller_P5G_WNC_DGX.yaml
@@ -38,12 +38,12 @@ cuphydriver_config:
   use_green_contexts: 0
   use_batched_memcpy: 1 # Experimental feature; requires >= CUDA 12.8
   mps_sm_pusch: 40
-  mps_sm_pucch: 2
-  mps_sm_prach: 2
+  mps_sm_pucch: 4
+  mps_sm_prach: 4
   mps_sm_ul_order: 12
   mps_sm_pdsch: 46
   mps_sm_pdcch: 12
-  mps_sm_pbch: 2
+  mps_sm_pbch: 4
   mps_sm_gpu_comms: 16
   mps_sm_srs: 16
   pdsch_fallback: 0

--- a/ci-scripts/yaml_files/sa_gnb_aerial/docker-compose.yaml
+++ b/ci-scripts/yaml_files/sa_gnb_aerial/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       timeout: 5s
       retries: 5
   oai-gnb-aerial:
-    cpuset: "15-19"
+    cpuset: "17-19"
     image: ${REGISTRY-oaisoftwarealliance/}${GNB_IMG:-oai-gnb-aerial}:${TAG:-develop}
     depends_on:
       nv-cubb:

--- a/ci-scripts/yaml_files/sa_gnb_aerial/docker-compose.yaml
+++ b/ci-scripts/yaml_files/sa_gnb_aerial/docker-compose.yaml
@@ -21,11 +21,11 @@ services:
       - /dev/hugepages:/dev/hugepages
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
       - /run/systemd/system:/run/systemd/system
-      - ./cuphycontroller_P5G_WNC_GH.yaml:/opt/nvidia/cuBB/cuPHY-CP/cuphycontroller/config/cuphycontroller_P5G_WNC_GH.yaml
+      - ./cuphycontroller_P5G_WNC_DGX.yaml:/opt/nvidia/cuBB/cuPHY-CP/cuphycontroller/config/cuphycontroller_P5G_WNC_DGX.yaml
       - /var/log/aerial:/var/log/aerial
     userns_mode: host
     ipc: "shareable"
-    image: nv-cubb:26-1
+    image: nv-cubb:26-1-dgx
     environment:
       - cuBB_SDK=/opt/nvidia/cuBB
     command: bash -c "/opt/nvidia/cuBB/run-l1.sh"
@@ -50,6 +50,7 @@ services:
       USE_ADDITIONAL_OPTIONS: --log_config.global_log_options level,nocolor,utc_time
     network_mode: host
     shm_size: 4096m
+    stdin_open: true
     tty: true
     volumes:
       - ../../conf_files/gnb-vnf.sa.band78.273prb.aerial.conf:/opt/oai-gnb/etc/gnb.conf

--- a/ci-scripts/yaml_files/sa_gnb_aerial/docker-compose.yaml
+++ b/ci-scripts/yaml_files/sa_gnb_aerial/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       timeout: 5s
       retries: 5
   oai-gnb-aerial:
-    cpuset: "13-16"
+    cpuset: "15-19"
     image: ${REGISTRY-oaisoftwarealliance/}${GNB_IMG:-oai-gnb-aerial}:${TAG:-develop}
     depends_on:
       nv-cubb:

--- a/ci-scripts/yaml_files/sa_gnb_aerial_ul/cuphycontroller_P5G_WNC_DGX_ul.yaml
+++ b/ci-scripts/yaml_files/sa_gnb_aerial_ul/cuphycontroller_P5G_WNC_DGX_ul.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 aerial_sdk_version: 26-1-cubb
-l2adapter_filename: l2_adapter_config_P5G_GH.yaml
+l2adapter_filename: l2_adapter_config_P5G_DGX.yaml
 aerial_metrics_backend_address: 127.0.0.1:8081
 
 # CPU core shared by all low-priority threads
@@ -36,14 +36,14 @@ cuphydriver_config:
   fh_stats_dump_cpu_core: -1
   pdump_client_thread: -1
   use_green_contexts: 0
-  use_batched_memcpy: 0 # Experimental feature; requires >= CUDA 12.8
-  mps_sm_pusch: 100
-  mps_sm_pucch: 2
-  mps_sm_prach: 2
-  mps_sm_ul_order: 20
-  mps_sm_pdsch: 102
-  mps_sm_pdcch: 10
-  mps_sm_pbch: 2
+  use_batched_memcpy: 1 # Experimental feature; requires >= CUDA 12.8
+  mps_sm_pusch: 40
+  mps_sm_pucch: 4
+  mps_sm_prach: 4
+  mps_sm_ul_order: 12
+  mps_sm_pdsch: 46
+  mps_sm_pdcch: 12
+  mps_sm_pbch: 4
   mps_sm_gpu_comms: 16
   mps_sm_srs: 16
   pdsch_fallback: 0
@@ -61,8 +61,8 @@ cuphydriver_config:
     - 0
     # Set GPUID to the GPU sharing the PCIe switch as NIC
     # run nvidia-smi topo -m to find out which GPU
-  workers_ul: [4,5]
-  workers_dl: [6,7,8]
+  workers_ul: [5,6]
+  workers_dl: [7,8,9]
   debug_worker: -1
   workers_sched_priority: 95
   prometheus_thread: -1
@@ -76,11 +76,13 @@ cuphydriver_config:
   ul_order_timeout_gpu_ns: 3000000
   ul_order_timeout_gpu_srs_ns: 5200000
   ul_srs_aggr3_task_launch_offset_ns: 500000
-  ul_order_timeout_gpu_log_enable: 0
+  ul_order_timeout_gpu_log_enable: 1 # 1
   ul_order_max_rx_pkts: 512
   ul_order_rx_pkts_timeout_ns: 100000
   cplane_disable: 0
   gpu_init_comms_dl: 1
+  gpu_init_comms_via_cpu: 1
+  cpu_init_comms: 0
   cell_group: 1
   cell_group_num: 1
   fix_beta_dl: 0
@@ -112,7 +114,7 @@ cuphydriver_config:
   ul_rx_pkt_tracing_level: 0
   ul_rx_pkt_tracing_level_srs: 0
   pmu_metrics: 0 #Enable and select PMU metrics, 0=disabled, 1=General Counters (platform agnostic), 2=Topdown Metrics (Grace only), 3=Cache Metrics (Grace only)
-  enable_h2d_copy_thread: 1
+  enable_h2d_copy_thread: 0
   h2d_copy_thread_cpu_affinity : 11
   h2d_copy_thread_sched_priority : 95 #0->SCHED_OTHER, >0->Actual
   split_ul_cuda_streams: 0 # 1=Put UL slot 4 and slot 5 on different streams for DDDSUUDDDD pattern
@@ -131,7 +133,7 @@ cuphydriver_config:
   enable_srs: 1
   ue_mode: 0
   mCh_segment_proc_enable: 0
-  pusch_aggr_per_ctx: 3
+  pusch_aggr_per_ctx: 9
   prach_aggr_per_ctx: 2
   pucch_aggr_per_ctx: 4
   srs_aggr_per_ctx: 3

--- a/ci-scripts/yaml_files/sa_gnb_aerial_ul/docker-compose.yaml
+++ b/ci-scripts/yaml_files/sa_gnb_aerial_ul/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       timeout: 5s
       retries: 5
   oai-gnb-aerial:
-    cpuset: "17-19"
+    cpuset: "15-19"
     image: ${REGISTRY-oaisoftwarealliance/}${GNB_IMG:-oai-gnb-aerial}:${TAG:-develop}
     depends_on:
       nv-cubb:

--- a/ci-scripts/yaml_files/sa_gnb_aerial_ul/docker-compose.yaml
+++ b/ci-scripts/yaml_files/sa_gnb_aerial_ul/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       timeout: 5s
       retries: 5
   oai-gnb-aerial:
-    cpuset: "15-19"
+    cpuset: "17-19"
     image: ${REGISTRY-oaisoftwarealliance/}${GNB_IMG:-oai-gnb-aerial}:${TAG:-develop}
     depends_on:
       nv-cubb:

--- a/ci-scripts/yaml_files/sa_gnb_aerial_ul/docker-compose.yaml
+++ b/ci-scripts/yaml_files/sa_gnb_aerial_ul/docker-compose.yaml
@@ -21,11 +21,11 @@ services:
       - /dev/hugepages:/dev/hugepages
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
       - /run/systemd/system:/run/systemd/system
-      - ./cuphycontroller_P5G_WNC_GH_ul.yaml:/opt/nvidia/cuBB/cuPHY-CP/cuphycontroller/config/cuphycontroller_P5G_WNC_GH.yaml
+      - ./cuphycontroller_P5G_WNC_DGX_ul.yaml:/opt/nvidia/cuBB/cuPHY-CP/cuphycontroller/config/cuphycontroller_P5G_WNC_DGX.yaml
       - /var/log/aerial:/var/log/aerial
     userns_mode: host
     ipc: "shareable"
-    image: nv-cubb:26-1
+    image: nv-cubb:26-1-dgx
     environment:
       - cuBB_SDK=/opt/nvidia/cuBB
     command: bash -c "/opt/nvidia/cuBB/run-l1.sh"
@@ -35,7 +35,7 @@ services:
       timeout: 5s
       retries: 5
   oai-gnb-aerial:
-    cpuset: "13-16"
+    cpuset: "17-19"
     image: ${REGISTRY-oaisoftwarealliance/}${GNB_IMG:-oai-gnb-aerial}:${TAG:-develop}
     depends_on:
       nv-cubb:
@@ -50,6 +50,7 @@ services:
       USE_ADDITIONAL_OPTIONS: --log_config.global_log_options level,nocolor,utc_time
     network_mode: host
     shm_size: 4096m
+    stdin_open: true
     tty: true
     volumes:
       - ../../conf_files/gnb-vnf.sa.band78.273prb.aerial.ul-heavy.conf:/opt/oai-gnb/etc/gnb.conf


### PR DESCRIPTION
- [x] Add new nvIPC library on GH3 to build docker images. 
- [x] Set transport peer-mac on WNC back to GH1 MAC once DGX3 test is done

CI runs: 
- https://jenkins-oai.eurecom.fr/job/RAN-SA-AERIAL-DGX-CN5G/18/
- https://jenkins-oai.eurecom.fr/job/RAN-SA-AERIAL-OAIUE-CN5G/1461/

TBD:
- [x] nv-cubb reports `nvipc_version=25.3.0 OK`  in https://jenkins-oai.eurecom.fr/job/RAN-SA-AERIAL-DGX-CN5G/18/ --> is OK
```
16:07:34.459074 CON phy_init 0 [NVIPC.DEBUG] nv_ipc_debug_open: prefix=nvipc fapi_type=1 nvipc_version=25.3.0 OK
```
- [x] How to enable 2 layers in UL? --> Resolved, missing `-DSCF_FAPI_10_04_SRS=ON` flag when nv-cubb image was built

Testing:
- 100 MHz BW on DGX Spark with 26-1, without SRS enabled - works OK
- 100 MHz BW on DGX Spark with 26-1, with periodic SRS enabled - doesn't work, many HARQ related errors
- 30 Mhz BW on GH with 26-1 works OK

Test: https://jenkins-oai.eurecom.fr/job/RAN-SA-AERIAL-DGX-CN5G/20/artifact/test_results-RAN-SA-AERIAL-DGX-CN5G.html
