### PR TITLE
minorfix(imscope): moving alignas from struct type to atomic variable

### DIFF
--- a/openair1/PHY/TOOLS/imscope/imscope_record.cpp
+++ b/openair1/PHY/TOOLS/imscope/imscope_record.cpp
@@ -24,13 +24,13 @@
 #define MAX_KBYTES_WRITTEN_PER_SESSION (1000 * 1000)
 
 ImScopeDataWrapper scope_array[EXTRA_SCOPE_TYPES];
-typedef struct alignas(hardware_destructive_interference_size) ImScopeDumpInstruction {
+typedef struct ImScopeDumpInstruction {
   int slot;
   int frame;
   const char *cause;
 } ImScopeDumpInstruction;
 
-std::atomic<ImScopeDumpInstruction> dump_instruction;
+alignas(hardware_destructive_interference_size) std::atomic<ImScopeDumpInstruction> dump_instruction;
 ImScopeDumpInstruction void_instruction({-1, -1, nullptr});
 
 extern "C" void imscope_record_autoinit(void *dataptr)


### PR DESCRIPTION
I was receiving the note below when I built with "imscope_record", so this is the simplest PR to avoid the psABI note while signing the new individual CLA.  

[194/11156] Building CXX object openair1/PHY/TOOLS/imscope/CMakeFiles/imscope_record.dir/imscope_record.cpp.o
In file included from /home/turker/Documents/OpenAirInterface/26w25/openair1/PHY/defs_nr_UE.h:12,
                 from /home/turker/Documents/OpenAirInterface/26w25/openair1/PHY/TOOLS/imscope/imscope_internal.h:12,
                 from /home/turker/Documents/OpenAirInterface/26w25/openair1/PHY/TOOLS/imscope/imscope_record.cpp:5:
/usr/include/c++/13/atomic: In member function ‘_Tp std::atomic<_Tp>::exchange(_Tp, std::memory_order) [with _Tp = ImScopeDumpInstruction]’:
/usr/include/c++/13/atomic:311:7: note: the ABI for passing parameters with 64-byte alignment has changed in GCC 4.6
  311 |       exchange(_Tp __i, memory_order __m = memory_order_seq_cst) noexcept
      |       ^~~~~~~~