### PR TITLE
Use FFT-shifted buffer in all PHY receiver functions

### DIFF
--- a/executables/nr-gnb.c
+++ b/executables/nr-gnb.c
@@ -25,7 +25,6 @@
 #include "PHY/INIT/nr_phy_init.h"
 #include "PHY/MODULATION/nr_modulation.h"
 #include "PHY/NR_TRANSPORT/nr_transport_proto.h"
-#include "PHY/TOOLS/tools_defs.h"
 #include "PHY/defs_RU.h"
 #include "PHY/defs_gNB.h"
 #include "PHY/defs_nr_common.h"
@@ -178,25 +177,26 @@ static void rx_func(processingData_L1_t *info)
     while (spsc_q_get(&gNB->prach_l1rx_queue, &p, sizeof(p)))
       L1_nr_prach_procedures(gNB, &p, &UL_INFO.rach_ind);
 
-    //WA: comment rotation in tx/rx
+    // apply the rx signal rotation here
     if (gNB->phase_comp) {
-      //apply the rx signal rotation here
-      int soffset = (slot_rx % RU_RX_SLOT_DEPTH) * gNB->frame_parms.symbols_per_slot * gNB->frame_parms.ofdm_symbol_size;
       const NR_DL_FRAME_PARMS *fp = &gNB->frame_parms;
+      const uint soffset = (slot_rx % RU_RX_SLOT_DEPTH) * fp->symbols_per_slot * fp->ofdm_symbol_size;
       for (int aa = 0; aa < fp->nb_antennas_rx; aa++) {
-        const uint max_symb = fp->Ncp == NR_EXTENDED ? 12 : 14;
-        for (int sym = 0; sym < max_symb; sym++)
-          apply_nr_rotation_symbol_RX(fp->symbols_per_slot,
-                                      fp->slots_per_subframe,
-                                      fp->timeshift_symbol_rotation,
-                                      fp->first_carrier_offset,
-                                      gNB->common_vars.rxdataF[aa] + soffset + sym * fp->ofdm_symbol_size,
-                                      fp->symbol_rotation[1],
-                                      fp->N_RB_UL,
-                                      slot_rx,
-                                      sym);
+        for (int sym = 0; sym < fp->symbols_per_slot; sym++) {
+          c16_t *this_symbol = gNB->common_vars.rxdataF[aa] + soffset + sym * fp->ofdm_symbol_size;
+          apply_nr_rotation_symbol_fftshifted_RX(fp->symbols_per_slot,
+                                                 fp->slots_per_subframe,
+                                                 fp->timeshift_symbol_rotation,
+                                                 this_symbol,
+                                                 fp->symbol_rotation[1],
+                                                 fp->N_RB_UL,
+                                                 slot_rx,
+                                                 sym);
+        }
       }
     }
+
+    // Call PHY Rx signal procedures
     phy_procedures_gNB_uespec_RX(gNB, frame_rx, slot_rx, &UL_INFO);
 
     // Call the scheduler
@@ -204,6 +204,7 @@ static void rx_func(processingData_L1_t *info)
     gNB->if_inst->NR_UL_indication(&UL_INFO);
     STOP_MEAS_FULL_SLOT(&gNB->ul_indication_stats, rx_slot_type, NR_UPLINK_SLOT);
 
+    // Signal the ru_thread on completion of using rxdataF in this slot
     notifiedFIFO_elt_t *res = newNotifiedFIFO_elt(sizeof(processingData_L1_t), 0, &gNB->L1_rx_out, NULL);
     processingData_L1_t *syncMsg = NotifiedFifoData(res);
     syncMsg->gNB = gNB;

--- a/openair1/PHY/INIT/nr_init.c
+++ b/openair1/PHY/INIT/nr_init.c
@@ -322,6 +322,8 @@ void nr_phy_config_request_sim(PHY_VARS_gNB *gNB,
   fp->ofdm_offset_divisor = UINT_MAX;
   init_symbol_rotation(fp);
   init_timeshift_rotation(fp->ofdm_symbol_size, fp->nb_prefix_samples, fp->ofdm_offset_divisor, fp->timeshift_symbol_rotation);
+  // freq domain data is FFT shifted so shift this too.
+  fftshift_inplace(fp->timeshift_symbol_rotation, fp->N_RB_UL * NR_NB_SC_PER_RB, fp->ofdm_symbol_size);
 
   gNB->configured = 1;
 }
@@ -374,6 +376,8 @@ void nr_phy_config_request(NR_PHY_Config_t *phy_config)
   fp->ofdm_offset_divisor = RC.gNB[Mod_id]->ofdm_offset_divisor;
   init_symbol_rotation(fp);
   init_timeshift_rotation(fp->ofdm_symbol_size, fp->nb_prefix_samples, fp->ofdm_offset_divisor, fp->timeshift_symbol_rotation);
+  // freq domain data is FFT shifted so shift this too.
+  fftshift_inplace(fp->timeshift_symbol_rotation, fp->N_RB_UL * NR_NB_SC_PER_RB, fp->ofdm_symbol_size);
 }
 
 static void init_DLSCH_struct(PHY_VARS_gNB *gNB)

--- a/openair1/PHY/MODULATION/nr_modulation.h
+++ b/openair1/PHY/MODULATION/nr_modulation.h
@@ -111,6 +111,15 @@ void init_timeshift_rotation(const int ofdm_symbol_size,
                              const uint ofdm_offset_divisor,
                              c16_t *timeshift_symbol_rotation);
 
+void apply_nr_rotation_symbol_fftshifted_RX(const int symbols_per_slot,
+                                            const int slots_per_subframe,
+                                            const c16_t *shift_rot,
+                                            c16_t *rxdataF,
+                                            const c16_t *rot,
+                                            const int nb_rb,
+                                            const int slot,
+                                            const int symbol);
+
 void apply_nr_rotation_symbol_RX(const int symbols_per_slot,
                                  const int slots_per_subframe,
                                  const c16_t *timeshift_symbol_rotation,

--- a/openair1/PHY/MODULATION/nr_modulation.h
+++ b/openair1/PHY/MODULATION/nr_modulation.h
@@ -150,11 +150,9 @@ void nr_layer_precoder_simd(const int n_layers,
                             const int re_cnt,
                             c16_t *txdataF_precoded);
 
-void fft_shift(const c16_t *in,
-               uint32_t in_symb_sz,
-               uint16_t num_prb,
-               c16_t *out,
-               uint16_t fft_size_out,
-               uint16_t start_symb,
-               uint16_t num_symb);
+// FFT shift routines
+void fftshift(const c16_t *in, c16_t *out, int nbins, int fft_size);
+void fftshift_inplace(c16_t *in, int nbins, int fft_size);
+void fftshift_inverse(const c16_t *in, c16_t *out, int nbins, int fft_size);
+void fftshift_inverse_inplace(c16_t *in, int nbins, int fft_size);
 #endif

--- a/openair1/PHY/MODULATION/ofdm_mod.c
+++ b/openair1/PHY/MODULATION/ofdm_mod.c
@@ -21,6 +21,7 @@ This section deals with basic functions for OFDM Modulation.
 #include "common/utils/LOG/vcd_signal_dumper.h"
 #include "modulation_common.h"
 #include "PHY/LTE_TRANSPORT/transport_common_proto.h"
+#include "platform_types.h"
 //#define DEBUG_OFDM_MOD
 
 // Use 64-byte alignment for IDFT output buffer to ensure no
@@ -306,26 +307,49 @@ void apply_nr_rotation_TX(const NR_DL_FRAME_PARMS *fp,
     }
   }
 }
-                       
-/* Do FFT-shift for symbols in the provided in buffer and writes to out buffer. */
-void fft_shift(const c16_t *in,
-               uint32_t in_symb_sz,
-               uint16_t num_prb,
-               c16_t *out,
-               uint16_t fft_size_out,
-               uint16_t start_symb,
-               uint16_t num_symb)
+
+void fftshift(const c16_t *in, c16_t *out, int nbins, int fft_size)
 {
-  const int num_samp_half = num_prb * NR_NB_SC_PER_RB / 2;
-  const int first_carrier_offset = fft_size_out - num_samp_half;
-  for (int s = start_symb; s < start_symb + num_symb; s++) {
-    // Copy negative freq component
-    uint32_t out_offset = s * fft_size_out + first_carrier_offset;
-    uint32_t in_offset = s * in_symb_sz;
-    memcpy(out + out_offset, in + in_offset, num_samp_half * sizeof(int32_t));
-    // Copy positive freq component
-    out_offset = s * fft_size_out;
-    in_offset = s * in_symb_sz + num_samp_half;
-    memcpy(out + out_offset, in + in_offset, num_samp_half * sizeof(int32_t));
-  }
+  const int half = nbins / 2; // half bw
+  // negative-freq half -> front
+  memcpy(out, in + fft_size - half, half * sizeof(c16_t));
+  // dc + positive-freq half -> next
+  memcpy(out + half, in, half * sizeof(c16_t));
+}
+
+void fftshift_inplace(c16_t *in, int nbins, int fft_size)
+{
+  const int half = nbins / 2; // half bw
+
+  c16_t tmp[half]; // holds the negative half
+
+  // save negative bins (they sit at the tail: indices N-half .. N-1)
+  memcpy(tmp, in + fft_size - half, half * sizeof(c16_t));
+  // slide DC + positive (and trailing zeros) to the right by half
+  memmove(in + half, in, (fft_size - half) * sizeof(c16_t));
+  // place negative bins at the front
+  memcpy(in, tmp, half * sizeof(c16_t));
+}
+
+void fftshift_inverse(const c16_t *in, c16_t *out, int nbins, int fft_size)
+{
+  const int half = nbins / 2; // half bw
+  // negative-freq half -> back
+  memcpy(out + fft_size - half, in, half * sizeof(c16_t));
+  // dc + positive-freq half -> front
+  memcpy(out, in + half, half * sizeof(c16_t));
+}
+
+void fftshift_inverse_inplace(c16_t *in, int nbins, int fft_size)
+{
+  const int half = nbins / 2; // # negative-freq bins
+
+  c16_t tmp[half]; // holds the negative half
+
+  // save negative bins (they sit at the tail: indices N-half .. N-1)
+  memcpy(tmp, in, half * sizeof(c16_t));
+  // slide DC + positive (and trailing zeros) to the left by half
+  memmove(in, in + half, (fft_size - half) * sizeof(c16_t));
+  // place negative bins at the back
+  memcpy(in + fft_size - half, tmp, half * sizeof(c16_t));
 }

--- a/openair1/PHY/MODULATION/slot_fep_nr.c
+++ b/openair1/PHY/MODULATION/slot_fep_nr.c
@@ -162,6 +162,22 @@ int nr_symbol_fep_ul(const NR_DL_FRAME_PARMS *fp,
   return 0;
 }
 
+void apply_nr_rotation_symbol_fftshifted_RX(const int symbols_per_slot,
+                                            const int slots_per_subframe,
+                                            const c16_t *shift_rot,
+                                            c16_t *rxdataF,
+                                            const c16_t *rot,
+                                            const int nb_rb,
+                                            const int slot,
+                                            const int symbol)
+{
+  const int symb_offset = (slot % slots_per_subframe) * symbols_per_slot;
+  c16_t rot2 = rot[symbol + symb_offset];
+  rot2.i = -rot2.i;
+  rotate_cpx_vector(rxdataF, rot2, rxdataF, nb_rb * NR_NB_SC_PER_RB, 15);
+  mult_cpx_vector(rxdataF, shift_rot, rxdataF, nb_rb * NR_NB_SC_PER_RB, 15);
+}
+
 void apply_nr_rotation_symbol_RX(const int symbols_per_slot,
                                  const int slots_per_subframe,
                                  const c16_t *shift_rot,
@@ -212,16 +228,21 @@ void nr_ofdm_demod_and_rx_rotation(c16_t **rxdata,
   for (int aa = 0; aa < nb_antennas; aa++) {
     for (uint8_t symbol = 0; symbol < fp->symbols_per_slot; symbol++) {
       if (was_symbol_used[symbol] == true) {
+        // OFDM Demod
         nr_symbol_fep_ul(fp, &rxdata[aa][0], &rxdataF[aa][slot_offsetF + symbol * fp->ofdm_symbol_size], symbol, slot, 0);
-        apply_nr_rotation_symbol_RX(fp->symbols_per_slot,
-                                    fp->slots_per_subframe,
-                                    fp->timeshift_symbol_rotation,
-                                    fp->first_carrier_offset,
-                                    &rxdataF[aa][slot_offsetF + symbol * fp->ofdm_symbol_size],
-                                    fp->symbol_rotation[linktype],
-                                    fp->N_RB_UL,
-                                    slot,
-                                    symbol);
+        // FFT-shift
+        fftshift_inplace(&rxdataF[aa][slot_offsetF + symbol * fp->ofdm_symbol_size],
+                         fp->N_RB_UL * NR_NB_SC_PER_RB,
+                         fp->ofdm_symbol_size);
+        // Phase compensation
+        apply_nr_rotation_symbol_fftshifted_RX(fp->symbols_per_slot,
+                                               fp->slots_per_subframe,
+                                               fp->timeshift_symbol_rotation,
+                                               &rxdataF[aa][slot_offsetF + symbol * fp->ofdm_symbol_size],
+                                               fp->symbol_rotation[linktype],
+                                               fp->N_RB_UL,
+                                               slot,
+                                               symbol);
       }
     }
   }

--- a/openair1/PHY/NR_ESTIMATION/nr_measurements_gNB.c
+++ b/openair1/PHY/NR_ESTIMATION/nr_measurements_gNB.c
@@ -142,18 +142,11 @@ void gNB_I0_measurements(PHY_VARS_gNB *gNB, int slot, int first_symb, int num_sy
     for (int rb = 0; rb < frame_parms->N_RB_UL; rb++) {
       if (rb_mask_ul[s][rb] == 0 && // check that rb was not used in this subframe
           !(I0_SKIP_DC && rb == frame_parms->N_RB_UL >> 1)) { // skip middle PRB because of artificial noise possibly created by FFT
-        int offset = offset0 + CIRCULAR_INC(frame_parms->first_carrier_offset, rb * NR_NB_SC_PER_RB, frame_parms->ofdm_symbol_size);
+        int offset = offset0 + rb * NR_NB_SC_PER_RB;
         nb_symb[rb]++;
         for (int aarx = 0; aarx < frame_parms->nb_antennas_rx; aarx++) {
           c16_t *ul_ch = &common_vars->rxdataF[aarx][offset];
-          int32_t signal_energy;
-          if (((frame_parms->N_RB_UL & 1) == 1) && (rb == (frame_parms->N_RB_UL >> 1))) {
-            signal_energy = signal_energy_nodc(ul_ch, 6);
-            ul_ch = &common_vars->rxdataF[aarx][offset0];
-            signal_energy += signal_energy_nodc(ul_ch, 6);
-          } else {
-            signal_energy = signal_energy_nodc(ul_ch, 12);
-          }
+          int32_t signal_energy = signal_energy_nodc(ul_ch, 12);
           // noise power per antenna/RB, symbols summed up
           tmp_n0_subband[aarx][rb] += signal_energy;
           LOG_D(NR_PHY,"slot %d symbol %d RB %d aarx %d n0_subband_power %d\n", slot, s, rb, aarx, signal_energy);

--- a/openair1/PHY/NR_ESTIMATION/nr_ul_channel_estimation.c
+++ b/openair1/PHY/NR_ESTIMATION/nr_ul_channel_estimation.c
@@ -3,6 +3,7 @@
  */
 
 #include "nr_common.h"
+#include "platform_types.h"
 #include <string.h>
 
 #include "nr_ul_estimation.h"
@@ -144,7 +145,7 @@ static void nr_pusch_antenna_processing(void *arg)
         c32_t ch = {0};
 
         for (int k_line = 0; k_line <= 1; k_line++) {
-          re_offset = (k0 + (n << 2) + (k_line << 1) + delta) % symbolSize;
+          re_offset = (k0 + (n << 2) + (k_line << 1) + delta);
           ch = c32x16maddShift(*pil, rxdataF[re_offset], ch, 16);
           pil++;
         }
@@ -647,7 +648,8 @@ int nr_srs_ls_channel_estimation(int ant,
   LOG_I(NR_PHY, "Calling %s function\n", __FUNCTION__);
 #endif
 
-  const uint64_t subcarrier_offset = first_carrier_offset + srs_pdu->bwp_start * NR_NB_SC_PER_RB;
+  const uint64_t subcarrier_offset_tx = first_carrier_offset + srs_pdu->bwp_start * NR_NB_SC_PER_RB;
+  const uint64_t subcarrier_offset = srs_pdu->bwp_start * NR_NB_SC_PER_RB;
 
   const uint8_t N_ap = 1 << srs_pdu->num_ant_ports;
   const uint8_t K_TC = 2 << srs_pdu->comb_size;
@@ -670,16 +672,19 @@ int nr_srs_ls_channel_estimation(int ant,
     UNUSED(ant);
 #endif
 
-    uint16_t subcarrier = CIRCULAR_INC(subcarrier_offset + nr_srs_info->k_0_p[p_index][srs_symb], 0, ofdm_symbol_size);
+    // Generated SRS signal is FFT shifted. TODO: Remove subcarrier_tx after UE tx implementation is changed.
+    uint subcarrier_tx = CIRCULAR_INC(subcarrier_offset_tx, nr_srs_info->k_0_p[p_index][srs_symb], ofdm_symbol_size);
+    uint16_t subcarrier = subcarrier_offset + nr_srs_info->k_0_p[p_index][srs_symb];
 
     c16_t ls_estimated = {0};
     for (int k = 0; k < M_sc_b_SRS; k++) {
       if (k % fd_cdm == 0) {
         ls_estimated = (c16_t){0, 0};
+        uint16_t subcarrier_cdm_tx = subcarrier_tx;
         uint16_t subcarrier_cdm = subcarrier;
 
         for (int cdm_idx = 0; cdm_idx < fd_cdm; cdm_idx++) {
-          c16_t generated_srs = srs_generated_signal[srs_symbol_offset + subcarrier_cdm];
+          c16_t generated_srs = srs_generated_signal[srs_symbol_offset + subcarrier_cdm_tx];
           c16_t received_srs = srs_received_signal[srs_symbol_offset + subcarrier_cdm];
           // We know that nr_srs_info->srs_generated_signal_bits bits are enough to represent the real and imaginary parts of
           // generated_srs. So we only need a nr_srs_info->srs_generated_signal_bits shift to ensure that the result fits into 16
@@ -687,7 +692,8 @@ int nr_srs_ls_channel_estimation(int ant,
           ls_estimated = c16maddConjShift(generated_srs, received_srs, ls_estimated, nr_srs_info->srs_generated_signal_bits);
 
           // Subcarrier increment
-          subcarrier_cdm = CIRCULAR_INC(subcarrier_cdm, K_TC, ofdm_symbol_size);
+          subcarrier_cdm_tx = CIRCULAR_INC(subcarrier_cdm_tx, K_TC, ofdm_symbol_size);
+          subcarrier_cdm = subcarrier_cdm + K_TC;
         }
       }
 
@@ -716,7 +722,8 @@ int nr_srs_ls_channel_estimation(int ant,
 #endif
 
       // Subcarrier increment
-      subcarrier = CIRCULAR_INC(subcarrier, K_TC, ofdm_symbol_size);
+      subcarrier_tx = CIRCULAR_INC(subcarrier_tx, K_TC, ofdm_symbol_size);
+      subcarrier = subcarrier + K_TC;
     } // for (int k = 0; k < M_sc_b_SRS; k++)
 
     // Delay estimation
@@ -730,7 +737,6 @@ int nr_srs_ls_channel_estimation(int ant,
 }
 
 void nr_srs_noise_power_estimation(uint16_t ofdm_symbol_size,
-                                   uint16_t first_carrier_offset,
                                    uint8_t N_symb_SRS,
                                    const nfapi_nr_srs_pdu_t *srs_pdu,
                                    const nr_srs_info_t *nr_srs_info,
@@ -739,36 +745,20 @@ void nr_srs_noise_power_estimation(uint16_t ofdm_symbol_size,
                                    uint32_t *noise_power,
                                    int16_t *noise_power_per_rb)
 {
-  const uint64_t subcarrier_offset = first_carrier_offset + srs_pdu->bwp_start * NR_NB_SC_PER_RB;
+  const uint64_t subcarrier_offset = srs_pdu->bwp_start * NR_NB_SC_PER_RB;
   const uint16_t m_SRS_b = get_m_srs(srs_pdu->config_index, srs_pdu->bandwidth_index);
   int tot_subcarriers = m_SRS_b * NR_NB_SC_PER_RB;
 
-  uint16_t subcarrier = CIRCULAR_INC(subcarrier_offset + nr_srs_info->k_0_p[0][0], 0, ofdm_symbol_size);
+  uint16_t subcarrier = subcarrier_offset + nr_srs_info->k_0_p[0][0];
 
-  if (subcarrier + tot_subcarriers < ofdm_symbol_size) {
-    *noise_power = signal_energy_nodc(&srs_received_noise[subcarrier], tot_subcarriers) / tot_subcarriers;
-  } else {
-    int size1 = ofdm_symbol_size - subcarrier;
-    int size2 = tot_subcarriers - size1;
-    uint64_t noise_power_p1 = signal_energy_nodc(&srs_received_noise[subcarrier], size1) * size1;
-    uint64_t noise_power_p2 = signal_energy_nodc(&srs_received_noise[0], size2) * size2;
-    *noise_power = (noise_power_p1 + noise_power_p2) / tot_subcarriers;
-  }
+  *noise_power = signal_energy_nodc(&srs_received_noise[subcarrier], tot_subcarriers);
 
   // Compute SNR per RB on symbol 0
-  subcarrier = CIRCULAR_INC(subcarrier_offset + nr_srs_info->k_0_p[0][0], 0, ofdm_symbol_size);
+  subcarrier = subcarrier_offset + nr_srs_info->k_0_p[0][0];
   for (int rb = 0; rb < m_SRS_b; rb++) {
-    if (subcarrier + NR_NB_SC_PER_RB < ofdm_symbol_size) {
-      noise_power_per_rb[rb] += signal_energy_nodc(&srs_received_noise[subcarrier], NR_NB_SC_PER_RB);
-    } else {
-      int size1 = ofdm_symbol_size - subcarrier;
-      int size2 = NR_NB_SC_PER_RB - size1;
-      uint32_t noise_power_per_rb1 = signal_energy_nodc(&srs_received_noise[subcarrier], size1) * size1;
-      uint32_t noise_power_per_rb2 = signal_energy_nodc(&srs_received_noise[0], size2) * size2;
-      noise_power_per_rb[rb] += (noise_power_per_rb1 + noise_power_per_rb2) / NR_NB_SC_PER_RB;
-    }
+    noise_power_per_rb[rb] += signal_energy_nodc(&srs_received_noise[subcarrier], NR_NB_SC_PER_RB);
     noise_power_per_rb[rb] = max(noise_power_per_rb[rb], 1);
-    subcarrier = CIRCULAR_INC(subcarrier, NR_NB_SC_PER_RB, ofdm_symbol_size);
+    subcarrier += NR_NB_SC_PER_RB;
 
 #ifdef SRS_DEBUG
     LOG_I(NR_PHY,
@@ -809,8 +799,9 @@ int nr_srs_channel_interpolation(int p_index,
   LOG_I(NR_PHY, "Calling %s function\n", __FUNCTION__);
 #endif
 
-  const uint64_t subcarrier_offset = first_carrier_offset + srs_pdu->bwp_start * NR_NB_SC_PER_RB;
+  const uint64_t subcarrier_offset = srs_pdu->bwp_start * NR_NB_SC_PER_RB;
   const uint64_t first_subcarrier = (first_carrier_offset - (ofdm_symbol_size >> 1)) + srs_pdu->bwp_start * NR_NB_SC_PER_RB;
+
   const uint8_t K_TC = 2 << srs_pdu->comb_size;
   const uint16_t m_SRS_b = get_m_srs(srs_pdu->config_index, srs_pdu->bandwidth_index);
   const uint16_t M_sc_b_SRS = m_SRS_b * NR_NB_SC_PER_RB / K_TC;
@@ -826,27 +817,25 @@ int nr_srs_channel_interpolation(int p_index,
     LOG_I(NR_PHY, "============================== SRS symbol index %d ===========================\n", srs_symb);
 #endif
 
-    // Additional 4 in the array size is needed to maintain 16 byte memory alignment required for AVX2 instructions in channel
-    // interpolation
-    c16_t srs_est[ofdm_symbol_size + 4] __attribute__((aligned(32)));
-    memset(srs_est, 0, (ofdm_symbol_size + 4) * sizeof(c16_t));
+    c16_t srs_est[ofdm_symbol_size] __attribute__((aligned(32)));
+    memset(srs_est, 0, (ofdm_symbol_size) * sizeof(c16_t));
 
-    // Estimate 16 byte memory alignment offset for the first SRS subcarrier to use AVX2 instructions in channel interpolation
-    uint8_t mem_offset =
-        (16 - (((intptr_t)&srs_est[first_subcarrier + nr_srs_info->k_0_p[p_index][srs_symb]]) & 0xF)) / sizeof(c16_t);
-
-    uint16_t subcarrier_abs = mem_offset + first_subcarrier + nr_srs_info->k_0_p[p_index][srs_symb];
+    // Start of buffer is 32 byte aligned.
+    uint16_t subcarrier_abs = 0;
     c16_t *srs_estimated_channel16 = &srs_est[subcarrier_abs];
 
-    uint16_t subcarrier = CIRCULAR_INC(subcarrier_offset + nr_srs_info->k_0_p[p_index][srs_symb], 0, ofdm_symbol_size);
+    uint16_t subcarrier = subcarrier_offset + nr_srs_info->k_0_p[p_index][srs_symb];
 
     int delay_idx = get_delay_idx(est_delay, MAX_DELAY_COMP);
     const c16_t *srs_delay_table = delay_table[delay_idx];
 
+    // Delay table might be FFT shift sensitive. Not sure.
+    uint16_t subcarrier_delay =
+        CIRCULAR_INC(first_carrier_offset, subcarrier_offset + nr_srs_info->k_0_p[p_index][srs_symb], ofdm_symbol_size);
     for (int k = 0; k < M_sc_b_SRS; k++) {
-
       // Apply delay
-      c16_t ls_estimated = c16mulShift(srs_ls_estimated_channel[srs_symbol_offset + subcarrier], srs_delay_table[subcarrier], 8);
+      c16_t ls_estimated =
+          c16mulShift(srs_ls_estimated_channel[srs_symbol_offset + subcarrier], srs_delay_table[subcarrier_delay], 8);
 
       // Channel interpolation
       if (srs_pdu->comb_size == 0) {
@@ -879,24 +868,32 @@ int nr_srs_channel_interpolation(int p_index,
       }
 
       // Subcarrier increment
-      subcarrier = CIRCULAR_INC(subcarrier, K_TC, ofdm_symbol_size);
+      subcarrier += K_TC;
+      subcarrier_delay = CIRCULAR_INC(subcarrier_delay, K_TC, ofdm_symbol_size);
       subcarrier_abs += K_TC;
     } // for (int k = 0; k < M_sc_b_SRS; k++)
 
     // Revert delay
     int inv_delay_idx = get_delay_idx(-est_delay, MAX_DELAY_COMP);
     const c16_t *srs_inv_delay_table = delay_table[inv_delay_idx];
-    subcarrier_abs = mem_offset + first_subcarrier + nr_srs_info->k_0_p[p_index][srs_symb];
-    subcarrier = CIRCULAR_INC(subcarrier_offset + nr_srs_info->k_0_p[p_index][0], 0, ofdm_symbol_size);
+    subcarrier_abs = 0;
+    subcarrier_delay =
+        CIRCULAR_INC(first_carrier_offset, subcarrier_offset + nr_srs_info->k_0_p[p_index][srs_symb], ofdm_symbol_size);
 
     for (int k = 0; k < K_TC * M_sc_b_SRS; k++) {
-      srs_est[subcarrier_abs] = c16mulShift(srs_est[subcarrier_abs], srs_inv_delay_table[subcarrier], 8);
+      srs_est[subcarrier_abs] = c16mulShift(srs_est[subcarrier_abs], srs_inv_delay_table[subcarrier_delay], 8);
       // Subcarrier increment
-      subcarrier = CIRCULAR_INC(subcarrier, 1, ofdm_symbol_size);
+      subcarrier_delay = CIRCULAR_INC(subcarrier_delay, 1, ofdm_symbol_size);
       subcarrier_abs++;
     }
 
-    memcpy(&srs_estimated_channel_freq[srs_symbol_offset], &srs_est[mem_offset], ofdm_symbol_size * sizeof(c16_t));
+    // Copy as DC in center.
+    const uint half_bw = ofdm_symbol_size - first_carrier_offset;
+    const uint neg_start = ofdm_symbol_size / 2 - half_bw + subcarrier_offset + nr_srs_info->k_0_p[p_index][srs_symb];
+    memset(&srs_estimated_channel_freq[srs_symbol_offset], 0, sizeof(c16_t) * neg_start);
+    memcpy(&srs_estimated_channel_freq[srs_symbol_offset + neg_start],
+           srs_est,
+           (ofdm_symbol_size - neg_start) * sizeof(c16_t));
 
     // Average srs channel estimates over multiple symbols
     int16_t scale_factor = (1 << 15) / N_symb_SRS;
@@ -906,14 +903,11 @@ int nr_srs_channel_interpolation(int p_index,
                                        ofdm_symbol_size);
 
 #ifdef SRS_DEBUG
-    subcarrier = CIRCULAR_INC(subcarrier_offset + nr_srs_info->k_0_p[p_index][srs_symb], 0, ofdm_symbol_size);
+    subcarrier = subcarrier_offset + nr_srs_info->k_0_p[p_index][srs_symb];
     subcarrier_abs = first_subcarrier + nr_srs_info->k_0_p[p_index][srs_symb];
 
     for (int k = 0; k < K_TC * M_sc_b_SRS; k++) {
       int subcarrier_log = subcarrier - subcarrier_offset;
-      if (subcarrier_log < 0) {
-        subcarrier_log = subcarrier_log + ofdm_symbol_size;
-      }
 
       if (subcarrier_log % 12 == 0) {
         LOG_I(NR_PHY,
@@ -934,7 +928,7 @@ int nr_srs_channel_interpolation(int p_index,
             srs_received_noise[srs_symbol_offset + subcarrier].i);
 
       // Subcarrier increment
-      subcarrier = CIRCULAR_INC(subcarrier, 1, ofdm_symbol_size);
+      subcarrier++;
       subcarrier_abs++;
     }
 #endif

--- a/openair1/PHY/NR_ESTIMATION/nr_ul_estimation.h
+++ b/openair1/PHY/NR_ESTIMATION/nr_ul_estimation.h
@@ -88,7 +88,6 @@ int nr_srs_channel_interpolation(int p_index,
                                  c16_t delay_table[2 * MAX_DELAY_COMP + 1][NR_MAX_OFDM_SYMBOL_SIZE]);
 
 void nr_srs_noise_power_estimation(uint16_t ofdm_symbol_size,
-                                   uint16_t first_carrier_offset,
                                    uint8_t N_symb_SRS,
                                    const nfapi_nr_srs_pdu_t *srs_pdu,
                                    const nr_srs_info_t *nr_srs_info,

--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
@@ -133,113 +133,61 @@ static void nr_ulsch_extract_rbs(c16_t *const rxF,
     int first_port = get_dmrs_port(0, pusch_pdu->dmrs_ports);
     delta = get_delta(first_port, pusch_pdu->dmrs_config_type);
   }
-  int start_re = CIRCULAR_INC(frame_parms->first_carrier_offset,
-                              (pusch_pdu->rb_start + pusch_pdu->bwp_start) * NR_NB_SC_PER_RB,
-                              frame_parms->ofdm_symbol_size);
+  int start_re = (pusch_pdu->rb_start + pusch_pdu->bwp_start) * NR_NB_SC_PER_RB;
   int nb_re_pusch = NR_NB_SC_PER_RB * pusch_pdu->rb_size;
   c16_t *rxF_ext = &rxFext[0];
   c16_t *ul_ch0 = &chF[choffset];
   c16_t *ul_ch0_ext = &chFext[0];
 
   if (is_ptrs) {
-    const uint fft_size = frame_parms->ofdm_symbol_size;
     const uint k_ptrs = pusch_pdu->pusch_ptrs.ptrs_freq_density;
     const uint k_rb_ref = get_ptrs_k_RB(pusch_pdu->rb_size, k_ptrs, rnti);
     const uint k_re_ref = pusch_pdu->pusch_ptrs.ptrs_ports_list[0].ptrs_re_offset;
     uint k = start_re;
-    uint idx = 0;
+    uint ch_idx = 0;
     for (uint rb = 0; rb < pusch_pdu->rb_size; rb++) {
       // RB doesn't have PTRS.
       if ((rb - k_rb_ref) % k_ptrs) {
-        // RB crosses DC.
-        if (k + NR_NB_SC_PER_RB > fft_size) {
-          const uint neg = k + NR_NB_SC_PER_RB - fft_size;
-          memcpy(rxF_ext, rxF + k, sizeof(c16_t) * neg);
-          memcpy(rxF_ext + neg, rxF, sizeof(c16_t) * (NR_NB_SC_PER_RB - neg));
-          // RB doesn't cross DC.
-        } else {
-          memcpy(rxF_ext, rxF + k, sizeof(c16_t) * NR_NB_SC_PER_RB);
-        }
+        memcpy(rxF_ext, rxF + k, sizeof(c16_t) * NR_NB_SC_PER_RB);
         rxF_ext += NR_NB_SC_PER_RB;
-        memcpy(ul_ch0_ext, ul_ch0 + idx, sizeof(c16_t) * NR_NB_SC_PER_RB);
+        memcpy(ul_ch0_ext, ul_ch0 + ch_idx, sizeof(c16_t) * NR_NB_SC_PER_RB);
         ul_ch0_ext += NR_NB_SC_PER_RB;
-        idx += NR_NB_SC_PER_RB;
         // RB has PTRS.
       } else {
-        for (uint re = 0; re < NR_NB_SC_PER_RB; re++) {
-          // RE is not PTRS.
-          if (re != k_re_ref) {
-            *rxF_ext++ = rxF[((k + re) % fft_size)];
-            *ul_ch0_ext++ = ul_ch0[idx];
-          }
-          idx++;
-        }
+        // before PTRS RE
+        const uint num_pre_ptrs = k_re_ref;
+        const size_t pre_sz = sizeof(c16_t) * num_pre_ptrs;
+        memcpy(rxF_ext, rxF + k, pre_sz);
+        memcpy(ul_ch0_ext, ul_ch0 + ch_idx, pre_sz);
+        // after PTRS RE
+        const uint num_post_ptrs = NR_NB_SC_PER_RB - k_re_ref - 1;
+        const size_t post_sz = sizeof(c16_t) * num_post_ptrs;
+        memcpy(rxF_ext + num_pre_ptrs, rxF + k + k_re_ref + 1, post_sz);
+        memcpy(ul_ch0_ext + num_pre_ptrs, ul_ch0 + ch_idx + k_re_ref + 1, post_sz);
+        rxF_ext += NR_NB_SC_PER_RB - 1;
+        ul_ch0_ext += NR_NB_SC_PER_RB - 1;
       }
+      ch_idx += NR_NB_SC_PER_RB;
       k += NR_NB_SC_PER_RB;
     }
   } else if (is_dmrs_symbol == 0) {
-    if (start_re + nb_re_pusch <= frame_parms->ofdm_symbol_size)
-      memcpy(rxF_ext, &rxF[start_re], nb_re_pusch * sizeof(c16_t));
-    else {
-      int neg_length = frame_parms->ofdm_symbol_size - start_re;
-      int pos_length = nb_re_pusch - neg_length;
-      memcpy(rxF_ext, &rxF[start_re], neg_length * sizeof(c16_t));
-      memcpy(&rxF_ext[neg_length], rxF, pos_length * sizeof(c16_t));
-    }
+    memcpy(rxF_ext, &rxF[start_re], nb_re_pusch * sizeof(c16_t));
     memcpy(ul_ch0_ext, ul_ch0, nb_re_pusch * sizeof(c16_t));
   } else if (pusch_pdu->dmrs_config_type == pusch_dmrs_type1) { // 6 REs / PRB
     AssertFatal(delta == 0 || delta == 1, "Illegal delta %d\n",delta);
     c16_t *rxF32 = &rxF[start_re];
-    if (start_re + nb_re_pusch < frame_parms->ofdm_symbol_size) {
-      for (int idx = 1 - delta; idx < nb_re_pusch; idx += 2) {
-        *rxF_ext++ = rxF32[idx];
-        *ul_ch0_ext++ = ul_ch0[idx];
-      }
-    }
-    else { // handle the two pieces around DC
-      int neg_length = frame_parms->ofdm_symbol_size - start_re;
-      int pos_length = nb_re_pusch - neg_length;
-      int idx, idx2;
-      for (idx = 1 - delta; idx < neg_length; idx += 2) {
-        *rxF_ext++ = rxF32[idx];
-        *ul_ch0_ext++= ul_ch0[idx];
-      }
-      rxF32 = rxF;
-      idx2 = idx;
-      for (idx = 1 - delta; idx < pos_length; idx += 2, idx2 += 2) {
-        *rxF_ext++ = rxF32[idx];
-        *ul_ch0_ext++ = ul_ch0[idx2];
-      }
+    for (int idx = 1 - delta; idx < nb_re_pusch; idx += 2) {
+      *rxF_ext++ = rxF32[idx];
+      *ul_ch0_ext++ = ul_ch0[idx];
     }
   } else if (pusch_pdu->dmrs_config_type == pusch_dmrs_type2) { // 8 REs / PRB
     AssertFatal(delta==0||delta==2||delta==4,"Illegal delta %d\n",delta);
-    if (start_re + nb_re_pusch < frame_parms->ofdm_symbol_size) {
-      for (int idx = 0; idx < nb_re_pusch; idx ++) {
-        if (idx % 6 == 2 * delta || idx % 6 == 2 * delta + 1)
-          continue;
-        *rxF_ext++ = rxF[idx];
-        *ul_ch0_ext++ = ul_ch0[idx];
-      }
-    }
-    else {
-      int neg_length = frame_parms->ofdm_symbol_size - start_re;
-      int pos_length = nb_re_pusch - neg_length;
-      c16_t *rxF64 = &rxF[start_re];
-      int idx, idx2;
-      for (idx = 0; idx < neg_length; idx ++) {
-        if (idx % 6 == 2 * delta || idx % 6 == 2 * delta + 1)
-          continue;
-        *rxF_ext++ = rxF64[idx];
-        *ul_ch0_ext++ = ul_ch0[idx];
-      }
-      rxF64 = rxF;
-      idx2 = idx;
-      for (idx = 0; idx < pos_length; idx++, idx2++) {
-        if (idx % 6 == 2 * delta || idx % 6 == 2 * delta + 1)
-          continue;
-        *rxF_ext++ = rxF64[idx];
-        *ul_ch0_ext++ = ul_ch0[idx2];
-      }
+    c16_t *rxF32 = &rxF[start_re];
+    for (int idx = 0; idx < nb_re_pusch; idx++) {
+      if (idx % 6 == 2 * delta || idx % 6 == 2 * delta + 1)
+        continue;
+      *rxF_ext++ = rxF32[idx];
+      *ul_ch0_ext++ = ul_ch0[idx];
     }
   }
 }
@@ -545,16 +493,13 @@ int nr_rx_pusch_group_tp(PHY_VARS_gNB *gNB,
                                               rel15_ul_ref->beamforming.prgs_list[0].dig_bf_interface_list[0].beam_idx,
                                               p->numSpatialStreamIndices > 0 ? p->spatialStreamIndices[0] : 0);
 
-  uint32_t bwp_start_subcarrier = CIRCULAR_INC(frame_parms->first_carrier_offset,
-                                               (rel15_ul_ref->rb_start + rel15_ul_ref->bwp_start) * NR_NB_SC_PER_RB,
-                                               frame_parms->ofdm_symbol_size);
+  uint32_t bwp_start_subcarrier = (rel15_ul_ref->rb_start + rel15_ul_ref->bwp_start) * NR_NB_SC_PER_RB;
   LOG_D(PHY,
-        "pusch %d.%d : bwp_start_subcarrier %d, rb_start %d, first_carrier_offset %d\n",
+        "pusch %d.%d : bwp_start_subcarrier %d, rb_start %d\n",
         frame,
         slot,
         bwp_start_subcarrier,
-        rel15_ul_ref->rb_start,
-        frame_parms->first_carrier_offset);
+        rel15_ul_ref->rb_start);
   LOG_D(PHY, "pusch %d.%d : ul_dmrs_symb_pos %x\n", frame, slot, rel15_ul_ref->ul_dmrs_symb_pos);
 
   // Softscope dumps the whole slot grid; clear unused symbols so they do not keep
@@ -695,7 +640,7 @@ int nr_rx_pusch_group_tp(PHY_VARS_gNB *gNB,
                        .dmrs_symb_pos = rel15_ul_ref->ul_dmrs_symb_pos,
                        .nid = fp->Nid_cell,
                        .nscid = rel15_ul_ref->scid,
-                       .first_carrier_offset = fp->first_carrier_offset,
+                       .first_carrier_offset = 0,
                        .ofdm_symbol_size = fp->ofdm_symbol_size,
                        .slot = slot,
                        .rnti = rel15_ul_ref->rnti};
@@ -735,8 +680,6 @@ int nr_rx_pusch_group_tp(PHY_VARS_gNB *gNB,
               false);
 
   int start_sc = (rel15_ul_ref->bwp_start + rel15_ul_ref->rb_start) * NR_NB_SC_PER_RB;
-  int middle_sc = frame_parms->ofdm_symbol_size - frame_parms->first_carrier_offset;
-  int end_sc = (start_sc + rel15_ul_ref->rb_size * NR_NB_SC_PER_RB - 1) % frame_parms->ofdm_symbol_size;
   for (int aa_pusch = 0; aa_pusch < num_sp_streams; aa_pusch++) {
     const int aarx = ant_port_start + aa_pusch;
     DevAssert(aarx < sizeofArray(joint_pv->ulsch_power));
@@ -746,16 +689,9 @@ int nr_rx_pusch_group_tp(PHY_VARS_gNB *gNB,
 
     for (uint8_t symbol = rel15_ul_ref->start_symbol_index; symbol < end_symbol; symbol++) {
       int offset0 = ((slot % RU_RX_SLOT_DEPTH) * frame_parms->symbols_per_slot + symbol) * frame_parms->ofdm_symbol_size;
-      int offset = offset0 + (frame_parms->first_carrier_offset + start_sc) % frame_parms->ofdm_symbol_size;
+      int offset = offset0 + start_sc;
       c16_t *ul_ch = &gNB->common_vars.rxdataF[aarx][offset];
-      if (end_sc < start_sc) {
-        int64_t symb_energy_aux = signal_energy_nodc(ul_ch, middle_sc - start_sc) * (middle_sc - start_sc);
-        ul_ch = &gNB->common_vars.rxdataF[aarx][offset0];
-        symb_energy_aux += (signal_energy_nodc(ul_ch, end_sc + 1) * (end_sc + 1));
-        symb_energy += symb_energy_aux / (rel15_ul_ref->rb_size * NR_NB_SC_PER_RB);
-      } else {
-        symb_energy += signal_energy_nodc(ul_ch, rel15_ul_ref->rb_size * NR_NB_SC_PER_RB);
-      }
+      symb_energy += signal_energy_nodc(ul_ch, rel15_ul_ref->rb_size * NR_NB_SC_PER_RB);
     }
     joint_pv->ulsch_power[aa_pusch] += (symb_energy / rel15_ul_ref->nr_of_symbols);
 

--- a/openair1/PHY/NR_TRANSPORT/pucch_rx.c
+++ b/openair1/PHY/NR_TRANSPORT/pucch_rx.c
@@ -5,6 +5,8 @@
 /*!
  * \brief Top-level routines for decoding the PUCCH physical channel
  */
+#include "PHY/defs_RU.h"
+#include "nr_common.h"
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
@@ -22,12 +24,9 @@
 #include "PHY/NR_TRANSPORT/nr_transport_proto.h"
 #include "PHY/NR_REFSIG/nr_refsig.h"
 #include "common/utils/LOG/log.h"
-#include "nfapi/oai_integration/vendor_ext.h"
-#include "nfapi/oai_integration/vendor_ext.h"
 #include "SCHED_NR/sched_nr.h"
 #include "bits.h"
 
-#include "T.h"
 #include "nr_phy_common.h"
 
 //#define DEBUG_NR_PUCCH_RX 1
@@ -219,17 +218,11 @@ void nr_decode_pucch0(PHY_VARS_gNB *gNB,
   for (int l = 0; l < nb_symbols; l++) {
     uint8_t l2 = l + pucch_pdu->start_symbol_index;
 
-    re_offset[l] = CIRCULAR_INC(frame_parms->first_carrier_offset, NR_NB_SC_PER_RB * prb_offset[l], symb_sz);
+    re_offset[l] = NR_NB_SC_PER_RB * prb_offset[l];
+
     for (int aa = 0; aa < num_sp_streams; aa++) {
-      c16_t rp[nb_re_pucch];
-      c16_t *tmp_rp = &rxdataF[aa][soffset + l2 * symb_sz];
-      if (re_offset[l] + nb_re_pucch > symb_sz) {
-        int neg_length = symb_sz - re_offset[l];
-        int pos_length = nb_re_pucch - neg_length;
-        memcpy(rp, &tmp_rp[re_offset[l]], neg_length * sizeof(*tmp_rp));
-        memcpy(&rp[neg_length], tmp_rp, pos_length * sizeof(*tmp_rp));
-      } else
-        memcpy(rp, &tmp_rp[re_offset[l]], nb_re_pucch * sizeof(*tmp_rp));
+      c16_t *tmp_rp = &rxdataF[aa][soffset + l2 * frame_parms->ofdm_symbol_size];
+      c16_t *rp = tmp_rp + re_offset[l];
 
       for (int n = 0; n < nb_re_pucch; n++) {
         xr[aa][l][n].r = (int32_t)x_re[l][n] * rp[n].r + (int32_t)x_im[l][n] * rp[n].i;
@@ -497,7 +490,7 @@ void nr_decode_pucch1(PHY_VARS_gNB *gNB,
   const int nb_symbols = pucch_pdu->nr_of_symbols;
   const int symb_sz = frame_parms->ofdm_symbol_size;
 
-  const int soffset = (slot & 3) * frame_parms->symbols_per_slot * symb_sz;
+  const int soffset = (slot % RU_RX_SLOT_DEPTH) * frame_parms->symbols_per_slot * symb_sz;
   // lprime is the index of the OFDM symbol in the slot that corresponds to the first OFDM symbol of the PUCCH transmission in the
   // slot given by [5, TS 38.213]
   const int lprime = pucch_pdu->start_symbol_index;
@@ -549,39 +542,15 @@ void nr_decode_pucch1(PHY_VARS_gNB *gNB,
   c16_t z_rx[16][MAX_SIZE_Z] = {0};
   c16_t z_dmrs_rx[16][MAX_SIZE_Z] = {0};
   c16_t z[16][12] = {0};
-  const int half_nb_rb_dl = frame_parms->N_RB_DL >> 1;
-  const bool nb_rb_is_even = (frame_parms->N_RB_DL & 1) == 0;
   for (int l = 0; l < nb_symbols; l++) { // extracting data and dmrs from rxdataF
-    if (intraSlotFrequencyHopping && (l >= floor(nb_symbols / 2))) { // intra-slot hopping enabled, we need
+    if (intraSlotFrequencyHopping && (l >= nb_symbols / 2)) { // intra-slot hopping enabled, we need
       // to calculate new offset PRB
       pucch_pdu->prb_start = pucch_pdu->bwp_start + pucch_pdu->second_hop_prb;
     }
-    int re_offset = (l + pucch_pdu->start_symbol_index) * symb_sz;
+    int re_offset = (l + pucch_pdu->start_symbol_index) * symb_sz + NR_NB_SC_PER_RB * pucch_pdu->prb_start;
 
-    if (nb_rb_is_even) {
-      if (pucch_pdu->prb_start < half_nb_rb_dl) // if number RBs in bandwidth is even and
-                                                // current PRB is lower band
-        re_offset += 12 * pucch_pdu->prb_start + frame_parms->first_carrier_offset;
-      else // if number RBs in bandwidth is even and current PRB is upper band
-        re_offset += 12 * (pucch_pdu->prb_start - half_nb_rb_dl);
-    } else {
-      if (pucch_pdu->prb_start < half_nb_rb_dl) // if number RBs in bandwidth is odd  and
-                                                // current PRB is lower band
-        re_offset += 12 * pucch_pdu->prb_start + frame_parms->first_carrier_offset;
-      else if (pucch_pdu->prb_start > half_nb_rb_dl) // if number RBs in bandwidth is odd
-                                                     // and current PRB is upper band
-        re_offset += 12 * (pucch_pdu->prb_start - half_nb_rb_dl) + 6;
-      else // if number RBs in bandwidth is odd  and current PRB contains DC
-        re_offset += 12 * pucch_pdu->prb_start + frame_parms->first_carrier_offset;
-    }
-
-    for (int n = 0; n < 12; n++) {
-      const int current_subcarrier = (l / 2) * 12 + n;
-      if (n == 6 && pucch_pdu->prb_start == half_nb_rb_dl && !nb_rb_is_even) {
-        // if number RBs in bandwidth is odd  and current PRB contains DC, we need to recalculate the offset when n=6 (for second
-        // half PRB)
-        re_offset = ((l + pucch_pdu->start_symbol_index) * symb_sz);
-      }
+    for (int n = 0; n < NR_NB_SC_PER_RB; n++) {
+      const int current_subcarrier = (l / 2) * NR_NB_SC_PER_RB + n;
 
       if (l % 2 == 1) // mapping PUCCH or DM-RS according to TS38.211 subclause 6.4.1.3.1
         for (int r = 0; r < n_rx; r++) {
@@ -1102,12 +1071,10 @@ void nr_decode_pucch2(PHY_VARS_gNB *gNB,
   int soffset = (slot % RU_RX_SLOT_DEPTH) * frame_parms->symbols_per_slot * symb_sz;
   uint16_t starting_prb = pucch_pdu->prb_start + pucch_pdu->bwp_start;
   int re_offset[nb_symbols];
-  re_offset[0] = CIRCULAR_INC(frame_parms->first_carrier_offset, NR_NB_SC_PER_RB * starting_prb, symb_sz);
+  re_offset[0] = NR_NB_SC_PER_RB * starting_prb;
   if (nb_symbols == 2) {
     if (pucch_pdu->freq_hop_flag)
-      re_offset[1] = CIRCULAR_INC(frame_parms->first_carrier_offset,
-                                  NR_NB_SC_PER_RB * (pucch_pdu->second_hop_prb + pucch_pdu->bwp_start),
-                                  symb_sz);
+      re_offset[1] = NR_NB_SC_PER_RB * (pucch_pdu->second_hop_prb + pucch_pdu->bwp_start);
     else
       re_offset[1] = re_offset[0];
   }
@@ -1125,14 +1092,7 @@ void nr_decode_pucch2(PHY_VARS_gNB *gNB,
     for (int symb = 0; symb < nb_symbols; symb++) {
       c16_t *tmp_rp = &rxdataF[aa][soffset + (l2 + symb) * symb_sz];
 
-      if (re_offset[symb] + nb_re_pucch < symb_sz) {
-        memcpy(rp[aa][symb], &tmp_rp[re_offset[symb]], nb_re_pucch * sizeof(c16_t));
-      } else {
-        int neg_length = symb_sz - re_offset[symb];
-        int pos_length = nb_re_pucch - neg_length;
-        memcpy(rp[aa][symb], &tmp_rp[re_offset[symb]], neg_length * sizeof(c16_t));
-        memcpy(&rp[aa][symb][neg_length], tmp_rp, pos_length * sizeof(c16_t));
-      }
+      memcpy(rp[aa][symb], &tmp_rp[re_offset[symb]], nb_re_pucch * sizeof(c16_t));
       pucch2_lev += signal_energy_nodc(rp[aa][symb], nb_re_pucch);
     }
   }

--- a/openair1/PHY/NR_TRANSPORT/srs_rx.c
+++ b/openair1/PHY/NR_TRANSPORT/srs_rx.c
@@ -64,7 +64,7 @@ int nr_get_srs_signal(PHY_VARS_gNB *gNB,
   const uint16_t n_symbols = (slot % RU_RX_SLOT_DEPTH) * frame_parms->symbols_per_slot; // number of symbols until this slot
   const uint8_t l0 = srs_pdu->time_start_position; // starting symbol in this slot (L2 sends absolute symbol index)
   const uint64_t symbol_offset = (n_symbols + l0) * frame_parms->ofdm_symbol_size;
-  const uint64_t subcarrier_offset = frame_parms->first_carrier_offset + srs_pdu->bwp_start * NR_NB_SC_PER_RB;
+  const uint64_t subcarrier_offset = srs_pdu->bwp_start * NR_NB_SC_PER_RB;
 
   const uint8_t N_ap = 1 << srs_pdu->num_ant_ports;
   const uint8_t N_symb_SRS = 1 << srs_pdu->num_symbols;
@@ -88,7 +88,7 @@ int nr_get_srs_signal(PHY_VARS_gNB *gNB,
         LOG_I(NR_PHY, ":::::::: OFDM symbol %d ::::::::\n", l0 + l_line);
 #endif
 
-        int subcarrier = CIRCULAR_INC(subcarrier_offset, nr_srs_info->k_0_p[p_index][l_line], frame_parms->ofdm_symbol_size);
+        uint32_t subcarrier = subcarrier_offset + nr_srs_info->k_0_p[p_index][l_line];
         uint16_t l_line_offset = l_line * frame_parms->ofdm_symbol_size;
 
         for (int k = 0; k < M_sc_b_SRS; k++) {
@@ -101,15 +101,11 @@ int nr_get_srs_signal(PHY_VARS_gNB *gNB,
           // Subcarriers without SRS symbols and only noise
           srs_received_noise[ant][l_line_offset + subcarrier] = rx_signal[l_line_offset + subcarrier + 1];
           for (int n = 1; n < K_TC; n++) {
-            uint subcarrier_n = CIRCULAR_INC(subcarrier, n, frame_parms->ofdm_symbol_size);
-            srs_received_noise[ant][l_line_offset + subcarrier_n] = rx_signal[l_line_offset + subcarrier_n];
+            srs_received_noise[ant][l_line_offset + subcarrier + n] = rx_signal[l_line_offset + subcarrier + n];
           }
 
 #ifdef SRS_DEBUG
           int subcarrier_log = subcarrier - subcarrier_offset;
-          if (subcarrier_log < 0) {
-            subcarrier_log = subcarrier_log + frame_parms->ofdm_symbol_size;
-          }
           if (subcarrier_log % 12 == 0) {
             LOG_I(NR_PHY, "------------ %d ------------\n", subcarrier_log / 12);
           }
@@ -121,7 +117,7 @@ int nr_get_srs_signal(PHY_VARS_gNB *gNB,
 #endif
 
           // Subcarrier increment
-          subcarrier = CIRCULAR_INC(subcarrier, K_TC, frame_parms->ofdm_symbol_size);
+          subcarrier += K_TC;
         } // for (int k = 0; k < M_sc_b_SRS; k++)
       } // for (int l_line = 0; l_line < N_symb_SRS; l_line++)
     } // for (int p_index = 0; p_index < N_ap; p_index++)

--- a/openair1/SCHED_NR/nr_ru_procedures.c
+++ b/openair1/SCHED_NR/nr_ru_procedures.c
@@ -277,13 +277,11 @@ void nr_fep(void *arg)
   int startSymbol = feprx_cmd->startSymbol;
   int endSymbol = feprx_cmd->endSymbol;
 
-  for (int l = startSymbol; l <= endSymbol; l++)
-    nr_symbol_fep_ul(feprx_cmd->fp,
-                     feprx_cmd->rxdata,
-                     &feprx_cmd->rxdataF[l * feprx_cmd->fp->ofdm_symbol_size],
-                     l,
-                     slot,
-                     feprx_cmd->sample_offet);
+  const NR_DL_FRAME_PARMS *fp = feprx_cmd->fp;
+  for (int l = startSymbol; l <= endSymbol; l++) {
+    nr_symbol_fep_ul(fp, feprx_cmd->rxdata, &feprx_cmd->rxdataF[l * fp->ofdm_symbol_size], l, slot, feprx_cmd->sample_offet);
+    fftshift_inplace(&feprx_cmd->rxdataF[l * fp->ofdm_symbol_size], fp->N_RB_UL * NR_NB_SC_PER_RB, fp->ofdm_symbol_size);
+  }
 
   completed_task_ans(feprx_cmd->ans);
 }

--- a/openair1/SCHED_NR/nr_ru_procedures.c
+++ b/openair1/SCHED_NR/nr_ru_procedures.c
@@ -8,6 +8,7 @@
 
 #include "PHY/defs_gNB.h"
 #include "common/platform_types.h"
+#include "nr/nr_common.h"
 #include "sched_nr.h"
 #include "PHY/MODULATION/modulation_common.h"
 #include "PHY/MODULATION/nr_modulation.h"
@@ -190,15 +191,13 @@ void nr_feptx(void *arg)
 
   // If there is no digital beamforming we just need to copy the data to RU
   if (ru->config.dbt_config.num_dig_beams == 0 || ru->gNB_list[0]->common_vars.analog_bf) {
-    // FFT shift
+    // Inverse FFT shift
     const NR_DL_FRAME_PARMS *fp = &ru->gNB_list[0]->frame_parms;
-    fft_shift(ru->gNB_list[0]->common_vars.txdataF[aa],
-              fp->ofdm_symbol_size,
-              fp->N_RB_DL,
-              (c16_t *)ru->common.txdataF_BF[aa],
-              fp->ofdm_symbol_size,
-              startSymbol,
-              numSymbols);
+    for (uint s = startSymbol; s < startSymbol + numSymbols; s++)
+      fftshift_inverse(ru->gNB_list[0]->common_vars.txdataF[aa] + s * fp->ofdm_symbol_size,
+                       (c16_t *)ru->common.txdataF_BF[aa] + s * fp->ofdm_symbol_size,
+                       fp->N_RB_DL * NR_NB_SC_PER_RB,
+                       fp->ofdm_symbol_size);
   } else {
     AssertFatal(false, "This needs to be fixed by using appropriate beams from config\n");
   }

--- a/openair1/SCHED_NR/phy_procedures_nr_gNB.c
+++ b/openair1/SCHED_NR/phy_procedures_nr_gNB.c
@@ -785,7 +785,6 @@ nr_srs_info_t nr_srs_rx_procedures(PHY_VARS_gNB *gNB,
     for (int ant_rx_ind = 0; ant_rx_ind < nb_antennas_rx; ant_rx_ind++) {
       uint32_t noise_power_per_ant = 0;
       nr_srs_noise_power_estimation(ofdm_symbol_size,
-                                    frame_parms->first_carrier_offset,
                                     N_symb_SRS,
                                     srs_pdu,
                                     &nr_srs_info,

--- a/openair1/SIMULATION/NR_PHY/dlsim.c
+++ b/openair1/SIMULATION/NR_PHY/dlsim.c
@@ -1167,18 +1167,13 @@ int main(int argc, char **argv)
           printf("slot_offset %d\n", slot_offset);
 
         //TODO: loop over slots
-        for (aa=0; aa<gNB->frame_parms.nb_antennas_tx; aa++) {
-          c16_t fft_in_buff[frame_parms->ofdm_symbol_size * frame_parms->symbols_per_slot] __attribute__((aligned(64)));
-          memset(fft_in_buff, 0, sizeof(fft_in_buff));
+        for (aa = 0; aa < gNB->frame_parms.nb_antennas_tx; aa++) {
           if (cyclic_prefix_type == 1) {
-            fft_shift(gNB->common_vars.txdataF[aa],
-                      frame_parms->ofdm_symbol_size,
-                      frame_parms->N_RB_DL,
-                      fft_in_buff,
-                      frame_parms->ofdm_symbol_size,
-                      0,
-                      12);
-            PHY_ofdm_mod((int *)fft_in_buff,
+            for (int i = 0; i < 12; i++)
+              fftshift_inverse_inplace(gNB->common_vars.txdataF[aa] + i * frame_parms->ofdm_symbol_size,
+                                       frame_parms->N_RB_DL * NR_NB_SC_PER_RB,
+                                       frame_parms->ofdm_symbol_size);
+            PHY_ofdm_mod((int *)gNB->common_vars.txdataF[aa],
                          (int *)&txdata[aa][slot_offset],
                          frame_parms->ofdm_symbol_size,
                          12,
@@ -1189,19 +1184,11 @@ int main(int argc, char **argv)
             for (int i = 0; i < 14; i++) {
               was_symbol_used[i] = true;
             }
-            fft_shift(gNB->common_vars.txdataF[aa],
-                      frame_parms->ofdm_symbol_size,
-                      frame_parms->N_RB_DL,
-                      fft_in_buff,
-                      frame_parms->ofdm_symbol_size,
-                      0,
-                      14);
-            nr_normal_prefix_mod(fft_in_buff,
-                                 &txdata[aa][slot_offset],
-                                 14,
-                                 frame_parms,
-                                 slot,
-                                 was_symbol_used);
+            for (int i = 0; i < 14; i++)
+              fftshift_inverse_inplace(gNB->common_vars.txdataF[aa] + i * frame_parms->ofdm_symbol_size,
+                                       frame_parms->N_RB_DL * NR_NB_SC_PER_RB,
+                                       frame_parms->ofdm_symbol_size);
+            nr_normal_prefix_mod(gNB->common_vars.txdataF[aa], &txdata[aa][slot_offset], 14, frame_parms, slot, was_symbol_used);
           }
         }
         if (n_trials==1) {

--- a/openair1/SIMULATION/NR_PHY/pbchsim.c
+++ b/openair1/SIMULATION/NR_PHY/pbchsim.c
@@ -500,8 +500,6 @@ int main(int argc, char **argv)
 
         int samp = get_samples_slot_timestamp(frame_parms, slot);
         for (aa = 0; aa < gNB->frame_parms.nb_antennas_tx; aa++) {
-          c16_t fft_in_buff[frame_parms->ofdm_symbol_size * frame_parms->symbols_per_slot] __attribute__((aligned(64)));
-          memset(fft_in_buff, 0, sizeof(fft_in_buff));
           if (cyclic_prefix_type == 1) {
             apply_nr_rotation_TX(frame_parms,
                                  gNB->common_vars.txdataF[aa],
@@ -512,15 +510,12 @@ int main(int argc, char **argv)
                                  0,
                                  12);
 
-            fft_shift(gNB->common_vars.txdataF[aa],
-                      frame_parms->ofdm_symbol_size,
-                      frame_parms->N_RB_DL,
-                      fft_in_buff,
-                      frame_parms->ofdm_symbol_size,
-                      0,
-                      12);
+            for (int i = 0; i < 12; i++)
+              fftshift_inverse_inplace(gNB->common_vars.txdataF[aa] + i * frame_parms->ofdm_symbol_size,
+                                       frame_parms->N_RB_DL * NR_NB_SC_PER_RB,
+                                       frame_parms->ofdm_symbol_size);
 
-            PHY_ofdm_mod((int *)fft_in_buff,
+            PHY_ofdm_mod((int *)gNB->common_vars.txdataF[aa],
                          (int *)&txdata[aa][samp],
                          frame_parms->ofdm_symbol_size,
                          12,
@@ -536,22 +531,19 @@ int main(int argc, char **argv)
                                  0,
                                  14);
 
-            fft_shift(gNB->common_vars.txdataF[aa],
-                      frame_parms->ofdm_symbol_size,
-                      frame_parms->N_RB_DL,
-                      fft_in_buff,
-                      frame_parms->ofdm_symbol_size,
-                      0,
-                      14);
+            for (int i = 0; i < 14; i++)
+              fftshift_inverse_inplace(gNB->common_vars.txdataF[aa] + i * frame_parms->ofdm_symbol_size,
+                                       frame_parms->N_RB_DL * NR_NB_SC_PER_RB,
+                                       frame_parms->ofdm_symbol_size);
 
-            PHY_ofdm_mod((int *)fft_in_buff,
+            PHY_ofdm_mod((int *)gNB->common_vars.txdataF[aa],
                          (int *)&txdata[aa][samp],
                          frame_parms->ofdm_symbol_size,
                          1,
                          frame_parms->nb_prefix_samples0,
                          CYCLIC_PREFIX);
 
-            PHY_ofdm_mod((int *)fft_in_buff + frame_parms->ofdm_symbol_size,
+            PHY_ofdm_mod((int *)gNB->common_vars.txdataF[aa] + frame_parms->ofdm_symbol_size,
                          (int *)&txdata[aa][samp + frame_parms->nb_prefix_samples0 + frame_parms->ofdm_symbol_size],
                          frame_parms->ofdm_symbol_size,
                          13,

--- a/openair1/SIMULATION/NR_PHY/pucchsim.c
+++ b/openair1/SIMULATION/NR_PHY/pucchsim.c
@@ -567,7 +567,7 @@ int main(int argc, char **argv)
         if (symb < startingSymbolIndex || symb >= startingSymbolIndex + nrofSymbols) {
           int i0 = symb * gNB->frame_parms.ofdm_symbol_size;
           for (int re = 0; re < N_RB_DL * 12; re++) {
-            i = i0 + ((gNB->frame_parms.first_carrier_offset + re) % gNB->frame_parms.ofdm_symbol_size);
+            i = i0 + re;
             for (int aarx = 0; aarx < n_rx; aarx++) {
               double nr = sqrt(sigma2 / 2) * gaussdouble(0.0, 1.0);
               double ni = sqrt(sigma2 / 2) * gaussdouble(0.0, 1.0);
@@ -600,8 +600,8 @@ int main(int argc, char **argv)
             rxr = rxr_tmp;
             double nr = sqrt(sigma2 / 2) * gaussdouble(0.0, 1.0);
             double ni = sqrt(sigma2 / 2) * gaussdouble(0.0, 1.0);
-            rxdataF[aarx][i].r = (int16_t)(tx_level_fp * (rxr + nr) / sqrt((double)txlev));
-            rxdataF[aarx][i].i = (int16_t)(tx_level_fp * (rxi + ni) / sqrt((double)txlev));
+            rxdataF[aarx][i0 + re].r = (int16_t)(tx_level_fp * (rxr + nr) / sqrt((double)txlev));
+            rxdataF[aarx][i0 + re].i = (int16_t)(tx_level_fp * (rxi + ni) / sqrt((double)txlev));
 
             if (n_trials == 1 && fabs(txr) > 0)
               printf("symb %d, re %d , aarx %d : txr %f, txi %f, chr %f, chi %f, nr %f, ni %f, rxr %f, rxi %f => %d,%d\n",

--- a/openair1/SIMULATION/NR_PHY/ulsim.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim.c
@@ -1579,9 +1579,8 @@ int main(int argc, char *argv[])
         UL_INFO.srs_ind.number_of_pdus = 0;
 
         //----------- OFDM Demodulation and RX rotation--------------------------
-        bool was_symbol_used[14] = {0};
-        int offset = (slot & 3) * gNB->frame_parms.symbols_per_slot * gNB->frame_parms.ofdm_symbol_size;
-        for (int i = 0; i < 14; i++) {
+        bool was_symbol_used[NR_SYMBOLS_PER_SLOT] = {0};
+        for (int i = 0; i < NR_SYMBOLS_PER_SLOT; i++) {
           was_symbol_used[i] = true;
         }
         nr_ofdm_demod_and_rx_rotation(rxdata,
@@ -1589,7 +1588,7 @@ int main(int argc, char *argv[])
                                       &gNB->frame_parms,
                                       gNB->frame_parms.nb_antennas_rx,
                                       slot,
-                                      offset,
+                                      0,
                                       link_type_ul,
                                       was_symbol_used);
 

--- a/radio/fhi_72/oaioran.c
+++ b/radio/fhi_72/oaioran.c
@@ -549,12 +549,6 @@ int xran_fh_rx_read_slot(ru_info_t *ru, int *frame, int *slot)
 
         uint8_t *src = (uint8_t *)ptr;
 
-        // even when the fragmentation occurs, nRBSize & nRBStart carry the same values in each prbMap
-        // therefore, I took the liberty to just extract these values from the first prbMap
-        int num_totalRB = pRbMap->prbMap[0].nRBSize;
-        int start_totalRB = pRbMap->prbMap[0].nRBStart;
-        int32_t local_dst[num_totalRB * N_SC_PER_PRB] __attribute__((aligned(64)));
-
         struct xran_prb_elm *pRbElm = &pRbMap->prbMap[0];
         struct xran_rx_packet_ctl *p_rx_packet_ctl = &pRbMap->sFrontHaulRxPacketCtrl[sym_idx];
         uint32_t one_rb_size =
@@ -583,7 +577,7 @@ int xran_fh_rx_read_slot(ru_info_t *ru, int *frame, int *slot)
               if (pRbElm->compMethod == XRAN_COMPMETHOD_NONE) {
                 // NOTE: gcc 11 knows how to generate AVX2 for this!
                 for (idx = 0; idx < (numRB * N_SC_PER_PRB) * 2; idx++)
-                  ((int16_t *)local_dst)[idx + startRB * N_SC_PER_PRB * 2] = ((int16_t)ntohs(((uint16_t *)src)[idx])) >> 2;
+                  ((int16_t *)pos)[idx + startRB * N_SC_PER_PRB * 2] = ((int16_t)ntohs(((uint16_t *)src)[idx])) >> 2;
               } else if (pRbElm->compMethod == XRAN_COMPMETHOD_BLKFLOAT) {
 #if defined(__i386__) || defined(__x86_64__)
                 struct xranlib_decompress_request bfp_decom_req = {};
@@ -597,12 +591,12 @@ int xran_fh_rx_read_slot(ru_info_t *ru, int *frame, int *slot)
                 bfp_decom_req.compMethod = pRbElm->compMethod;
                 bfp_decom_req.iqWidth = pRbElm->iqWidth;
 
-                bfp_decom_rsp.data_out = (int16_t *) (local_dst + startRB * N_SC_PER_PRB);
+                bfp_decom_rsp.data_out = (int16_t *)(pos + startRB * N_SC_PER_PRB);
                 bfp_decom_rsp.len = 0;
 
                 xranlib_decompress_avx512(&bfp_decom_req, &bfp_decom_rsp);
 #elif defined(__arm__) || defined(__aarch64__)
-                armral_bfp_decompression(pRbElm->iqWidth, numRB, (int8_t *)src, (int16_t *)(local_dst + startRB * N_SC_PER_PRB));
+                armral_bfp_decompression(pRbElm->iqWidth, numRB, (int8_t *)src, (int16_t *)(pos + startRB * N_SC_PER_PRB));
 #else
                 AssertFatal(1 == 0, "BFP compression not supported on this architecture");
 #endif
@@ -610,21 +604,6 @@ int xran_fh_rx_read_slot(ru_info_t *ru, int *frame, int *slot)
               } else {
                 printf("pRbElm->compMethod == %d is not supported\n", pRbElm->compMethod);
                 exit(-1);
-              }
-              if ((startRB + numRB) == (start_totalRB + num_totalRB)) {
-                int pos_len = 0;
-                int neg_len = 0;
-
-                if (start_totalRB < (num_totalRB >> 1)) // there are PRBs left of DC
-                  neg_len = min((num_totalRB * 6) - (start_totalRB * 12), num_totalRB * N_SC_PER_PRB);
-                pos_len = (num_totalRB * N_SC_PER_PRB) - neg_len;
-                // Calculation of the pointer for the section in the buffer.
-                // positive half
-                uint8_t *dst1 = (uint8_t *)(pos + (neg_len == 0 ? ((start_totalRB * N_SC_PER_PRB) - (num_totalRB * 6)) : 0));
-                // negative half
-                uint8_t *dst2 = (uint8_t *)(pos + (start_totalRB * N_SC_PER_PRB) + fftsize - (num_totalRB * 6));
-                memcpy((void *)dst2, (void *)local_dst, neg_len * 4);
-                memcpy((void *)dst1, (void *)&local_dst[neg_len], pos_len * 4);
               }
             }
           } // idxDesc


### PR DESCRIPTION
Similar to the transmit path, this PR changes rxdataF to hold FFT shifted data. So all PRBs are contiguous starting from PRB 0.