### PR TITLE
Clean up openair0_device, remove eth_params usage in L2/L3

### DIFF
--- a/common/utils/simple_executable.h
+++ b/common/utils/simple_executable.h
@@ -31,7 +31,6 @@
 #include <arpa/inet.h>
 #include <common/utils/assertions.h>
 #include <common/utils/LOG/log.h>
-#include "common_lib.h"
 
 #ifdef T
   #undef T

--- a/executables/lte-enb.c
+++ b/executables/lte-enb.c
@@ -18,7 +18,6 @@
 #include "SCHED/sched_eNB.h"
 #include "PHY/LTE_TRANSPORT/transport_proto.h"
 #include "nfapi/oai_integration/vendor_ext.h"
-#include "radio/COMMON/common_lib.h"
 
 #include "PHY/if4_tools.h"
 #include "PHY/LTE_ESTIMATION/lte_estimation.h"

--- a/executables/lte-ru.c
+++ b/executables/lte-ru.c
@@ -33,7 +33,6 @@
 #include "SCHED/sched_common.h"
 #include "common/utils/LOG/log.h"
 #include "common/utils/LOG/vcd_signal_dumper.h"
-#include "radio/COMMON/common_lib.h"
 #include "radio/ETHERNET/ethernet_lib.h"
 
 /* these variables have to be defined before including ENB_APP/enb_paramdef.h */

--- a/executables/lte-softmodem.c
+++ b/executables/lte-softmodem.c
@@ -18,7 +18,6 @@
 #include "common/ran_context.h"
 #include "common/config/config_userapi.h"
 #include "common/utils/load_module_shlib.h"
-#include "radio/COMMON/common_lib.h"
 #include "radio/ETHERNET/if_defs.h"
 
 #include <openair1/PHY/phy_extern_ue.h>

--- a/executables/lte-softmodem.h
+++ b/executables/lte-softmodem.h
@@ -23,7 +23,6 @@
 #include <sys/sysinfo.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include "radio/COMMON/common_lib.h"
 #include "assertions.h"
 #include "PHY/types.h"
 #include "PHY/defs_eNB.h"

--- a/executables/lte-uesoftmodem.c
+++ b/executables/lte-uesoftmodem.c
@@ -19,7 +19,6 @@
 #include "common/ran_context.h"
 #include "common/config/config_userapi.h"
 #include "common/utils/load_module_shlib.h"
-#include "radio/COMMON/common_lib.h"
 #include "radio/ETHERNET/if_defs.h"
 
 #include "PHY/phy_vars_ue.h"

--- a/executables/main_nr_ru.c
+++ b/executables/main_nr_ru.c
@@ -10,7 +10,6 @@
 #include "common/config/config_userapi.h"
 #include "common/utils/load_module_shlib.h"
 #include "common/ran_context.h"
-#include "radio/COMMON/common_lib.h"
 #include "radio/ETHERNET/if_defs.h"
 #include "PHY/phy_vars.h"
 #include "PHY/phy_extern.h"

--- a/executables/main_ru.c
+++ b/executables/main_ru.c
@@ -22,7 +22,6 @@
 #include "common/utils/load_module_shlib.h"
 
 
-#include "radio/COMMON/common_lib.h"
 #include "radio/ETHERNET/if_defs.h"
 
 #include "PHY/phy_vars.h"

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -18,7 +18,6 @@
 #include "common/utils/fsn.h"
 #include "common/ran_context.h"
 
-#include "radio/COMMON/common_lib.h"
 #include "radio/ETHERNET/ethernet_lib.h"
 
 #include "PHY/defs_nr_common.h"

--- a/executables/nr-softmodem-common.h
+++ b/executables/nr-softmodem-common.h
@@ -28,7 +28,6 @@
 #include <unistd.h>
 
 #include <sys/sysinfo.h>
-#include "radio/COMMON/common_lib.h"
 #include "assertions.h"
 
 /* help strings definition for command line options, used in CMDLINE_XXX_DESC macros and printed when -h option is used */

--- a/executables/nr-softmodem.c
+++ b/executables/nr-softmodem.c
@@ -60,7 +60,6 @@ unsigned short config_frames[4] = {2,9,11,13};
 #include "nr-softmodem-common.h"
 #include "openair2/E1AP/e1ap_common.h"
 #include "pdcp.h"
-#include "radio/COMMON/common_lib.h"
 #include "s1ap_eNB.h"
 #include "sctp_eNB_task.h"
 #include "system.h"

--- a/executables/nr-uesoftmodem.c
+++ b/executables/nr-uesoftmodem.c
@@ -18,7 +18,6 @@
 #include "common/config/config_userapi.h"
 #include "common/utils/load_module_shlib.h"
 #include "common/utils/nr/nr_common.h"
-#include "radio/COMMON/common_lib.h"
 #include "radio/ETHERNET/if_defs.h"
 #include "openair1/PHY/MODULATION/nr_modulation.h"
 #include "PHY/CODING/nrLDPC_coding/nrLDPC_coding_interface.h"

--- a/executables/ru_control.c
+++ b/executables/ru_control.c
@@ -24,7 +24,6 @@
 #include "PHY/types.h"
 
 #include "PHY/defs_common.h"
-#include "radio/COMMON/common_lib.h"
 #include "radio/ETHERNET/ethernet_lib.h"
 
 #include "PHY/if4_tools.h"

--- a/executables/ru_control.c
+++ b/executables/ru_control.c
@@ -561,7 +561,8 @@ void* ru_thread_control( void* param )
 					 
 		//if (ru->is_slave == 1) lte_sync_time_init(&ru->frame_parms);
 
-		if (ru->rfdevice.is_init != 1) openair0_device_load(&ru->rfdevice,&ru->openair0_cfg);
+    int ret = openair0_device_load(&ru->rfdevice, &ru->openair0_cfg);
+    AssertFatal(ret == 0, "could not load device library\n");
 		
 		if (ru->rfdevice.trx_config_func) AssertFatal((ru->rfdevice.trx_config_func(&ru->rfdevice,&ru->openair0_cfg)==0), 
 							      "Failed to configure RF device for RU %d\n",ru->idx);

--- a/nfapi/oai_integration/nfapi_vnf.c
+++ b/nfapi/oai_integration/nfapi_vnf.c
@@ -1747,10 +1747,13 @@ void stop_nr_nfapi_vnf()
   }
 }
 
-void configure_nr_nfapi_vnf(eth_params_t params)
+void configure_nr_nfapi_vnf(const char *vnf_addr, uint16_t vnf_p5_port, uint16_t vnf_p7_port)
 {
 #ifndef ENABLE_AERIAL
   nfapi_setmode(NFAPI_MODE_VNF);
+#else
+  UNUSED(vnf_addr);
+  UNUSED(vnf_p7_port);
 #endif
   vnf_info *vnf = calloc(1, sizeof(vnf_info));
   memset(vnf->p7_vnfs, 0, sizeof(vnf->p7_vnfs));
@@ -1759,22 +1762,21 @@ void configure_nr_nfapi_vnf(eth_params_t params)
   vnf->p7_vnfs[0].aperiodic_timing_enabled = 0;
   vnf->p7_vnfs[0].periodic_timing_period = 1;
   vnf->p7_vnfs[0].config = nfapi_vnf_p7_config_create();
-  AssertFatal(params.remote_portc == 0 && params.remote_portd == 0, "remote ports not used, use 0\n");
 #ifndef ENABLE_AERIAL
   NFAPI_TRACE(NFAPI_TRACE_INFO,
               "[VNF] %s() vnf->p7_vnfs[0].config:%p VNF ADDRESS:%s:%d\n",
               __FUNCTION__,
               vnf->p7_vnfs[0].config,
-              params.my_addr,
-              params.my_portc);
-  strcpy(vnf->p7_vnfs[0].local_addr, params.my_addr);
-  vnf->p7_vnfs[0].local_port = params.my_portd;
+              vnf_addr,
+              vnf_p5_port);
+  strcpy(vnf->p7_vnfs[0].local_addr, vnf_addr);
+  vnf->p7_vnfs[0].local_port = vnf_p7_port;
 #endif
   vnf->p7_vnfs[0].mac = malloc(sizeof(mac_t));
   config = nfapi_vnf_config_create();
   config->malloc = malloc;
   config->free = free;
-  config->vnf_p5_port = params.my_portc;
+  config->vnf_p5_port = vnf_p5_port;
   config->vnf_ipv4 = 1;
   config->vnf_ipv6 = 0;
   config->pnf_list = 0;

--- a/nfapi/oai_integration/nfapi_vnf.h
+++ b/nfapi/oai_integration/nfapi_vnf.h
@@ -4,7 +4,6 @@
 
 #ifndef NFAPI_VNF_H_
 #define NFAPI_VNF_H_
-#include <common_lib.h>
 
 #include "nfapi_vnf_interface.h"
 typedef struct {

--- a/nfapi/oai_integration/nfapi_vnf.h
+++ b/nfapi/oai_integration/nfapi_vnf.h
@@ -130,7 +130,7 @@ typedef struct {
 } vnf_info;
 
 void configure_nfapi_vnf(char *vnf_addr, int vnf_p5_port, char *pnf_ip_addr, int pnf_p7_port, int vnf_p7_port);
-void configure_nr_nfapi_vnf(eth_params_t params);
+void configure_nr_nfapi_vnf(const char *vnf_addr, uint16_t vnf_p5_port, uint16_t vnf_p7_port);
 void stop_nr_nfapi_vnf();
 nfapi_vnf_config_t *get_config();
 vnf_p7_t *get_p7_vnf();

--- a/openair1/PHY/LTE_UE_TRANSPORT/initial_sync.c
+++ b/openair1/PHY/LTE_UE_TRANSPORT/initial_sync.c
@@ -14,7 +14,6 @@
 #include "PHY/MODULATION/modulation_UE.h"
 #include "PHY/LTE_ESTIMATION/lte_estimation.h"
 #include "PHY/LTE_REFSIG/lte_refsig.h"
-#include "common_lib.h"
 #include "PHY/INIT/phy_init.h"
 
 extern openair0_config_t openair0_cfg[];

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -12,7 +12,6 @@
 #include "SCHED_NR_UE/defs.h"
 #include "common/utils/nr/nr_common.h"
 
-#include "common_lib.h"
 #include <math.h>
 
 #include "PHY/NR_REFSIG/pss_nr.h"

--- a/openair1/PHY/TOOLS/calibration_scope.h
+++ b/openair1/PHY/TOOLS/calibration_scope.h
@@ -1,5 +1,7 @@
 #ifndef CALIB_SCOPE_H
 #define CALIB_SCOPE_H
 
+#include "common_lib.h"
+
 void CalibrationInitScope(void **samplesRx, openair0_device_t *rfdevice);
 #endif

--- a/openair1/PHY/TOOLS/calibration_test.c
+++ b/openair1/PHY/TOOLS/calibration_test.c
@@ -107,8 +107,6 @@ int main(int argc, char **argv) {
     .eth_params=NULL,
     //! record player data, definition in record_player.h
     .recplay_state=NULL,
-    /* !brief Indicates if device already initialized */
-    .is_init=0,
     /*!brief Can be used by driver to hold internal structure*/
     .priv=NULL,
     /* Functions API, which are called by the application*/

--- a/openair1/PHY/defs_L1_NB_IoT.h
+++ b/openair1/PHY/defs_L1_NB_IoT.h
@@ -16,7 +16,6 @@
 #include <malloc.h>
 #include <string.h>
 #include <math.h>
-#include "common_lib.h"
 #include "openair2/PHY_INTERFACE/IF_Module_NB_IoT.h"
 #include "defs_eNB.h"
 //#include <complex.h>
@@ -93,7 +92,6 @@ static inline void* malloc16_clear( size_t size )
 #include "PHY/LTE_TRANSPORT/defs_NB_IoT.h"
 #include <pthread.h>
 
-#include "radio/COMMON/common_lib.h"
 #include "common/openairinterface5g_limits.h"
 
 #define NUM_DCI_MAX_NB_IoT 32

--- a/openair1/PHY/defs_common.h
+++ b/openair1/PHY/defs_common.h
@@ -29,7 +29,6 @@
 #include <malloc.h>
 #include <string.h>
 #include <math.h>
-#include "common_lib.h"
 #include <common/utils/LOG/log.h>
 #include "assertions.h"
 

--- a/openair1/PHY/defs_eNB.h
+++ b/openair1/PHY/defs_eNB.h
@@ -30,7 +30,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "common_lib.h"
 #include "defs_common.h"
 #include "defs_RU.h"
 #include "impl_defs_top.h"

--- a/openair1/PHY/defs_nr_UE.h
+++ b/openair1/PHY/defs_nr_UE.h
@@ -25,7 +25,6 @@
 #include <malloc.h>
 #include <string.h>
 #include <math.h>
-#include "common_lib.h"
 #include "fapi_nr_ue_interface.h"
 #include "assertions.h"
 #include "common/utils/barrier/barrier.h"
@@ -71,7 +70,6 @@
 #endif
 
 #include <pthread.h>
-#include "radio/COMMON/common_lib.h"
 #include "NR_IF_Module.h"
 
 /// Context data structure for gNB subframe processing

--- a/openair1/SIMULATION/NR_PHY/dlsim.c
+++ b/openair1/SIMULATION/NR_PHY/dlsim.c
@@ -57,7 +57,6 @@
 #include "common/utils/T/T.h"
 #include "common/utils/nr/nr_common.h"
 #include "common/utils/var_array.h"
-#include "common_lib.h"
 #include "e1ap_messages_types.h"
 #include "fapi_nr_ue_interface.h"
 #include "nfapi_interface.h"

--- a/openair1/SIMULATION/NR_PHY/prachsim.c
+++ b/openair1/SIMULATION/NR_PHY/prachsim.c
@@ -40,7 +40,6 @@
 #include "common/utils/LOG/log.h"
 #include "common/utils/T/T.h"
 #include "common/utils/load_module_shlib.h"
-#include "common_lib.h"
 #include "defs.h"
 #include "executables/nr-uesoftmodem.h"
 #include "fapi_nr_ue_interface.h"

--- a/openair1/SIMULATION/NR_PHY/ulsim.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim.c
@@ -122,17 +122,6 @@ int8_t nr_rrc_RA_succeeded(const module_id_t mod_id, const uint8_t gNB_index) {
   return 0;
 }
 
-int DU_send_INITIAL_UL_RRC_MESSAGE_TRANSFER(module_id_t     module_idP,
-                                            int             CC_idP,
-                                            int             UE_id,
-                                            rnti_t          rntiP,
-                                            const uint8_t   *sduP,
-                                            sdu_size_t      sdu_lenP,
-                                            const uint8_t   *sdu2P,
-                                            sdu_size_t      sdu2_lenP) {
-  return 0;
-}
-
 void nr_derive_key(int alg_type, uint8_t alg_id, const uint8_t key[32], uint8_t out[16])
 {
   (void)alg_type;

--- a/openair1/SIMULATION/NR_PHY/ulsim.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim.c
@@ -58,7 +58,6 @@
 #include "common/utils/nr/nr_common.h"
 #include "common/utils/threadPool/thread-pool.h"
 #include "common/utils/var_array.h"
-#include "common_lib.h"
 #include "e1ap_messages_types.h"
 #include "executables/nr-uesoftmodem.h"
 #include "fapi_nr_ue_constants.h"

--- a/openair1/SIMULATION/TOOLS/sim.h
+++ b/openair1/SIMULATION/TOOLS/sim.h
@@ -5,6 +5,7 @@
 #ifndef __SIMULATION_TOOLS_DEFS_H__
 #define __SIMULATION_TOOLS_DEFS_H__
 #include "PHY/defs_common.h"
+#include "common_lib.h"
 #include <pthread.h>
 /** @defgroup _numerical_ Useful Numerical Functions
  *@{

--- a/openair2/E1AP/e1ap.c
+++ b/openair2/E1AP/e1ap.c
@@ -457,12 +457,12 @@ int e1apCUCP_handle_BEARER_CONTEXT_RELEASE_COMPLETE(sctp_assoc_t assoc_id, e1ap_
   return 0;
 }
 
-static instance_t cuup_task_create_gtpu_instance_to_du(eth_params_t *IPaddrs)
+static instance_t cuup_task_create_gtpu_instance_to_du(const e1ap_net_config_t *c)
 {
   openAddr_t tmp = {0};
-  strncpy(tmp.originHost, IPaddrs->my_addr, sizeof(tmp.originHost) - 1);
-  sprintf(tmp.originService, "%d", IPaddrs->my_portd);
-  sprintf(tmp.destinationService, "%d", IPaddrs->remote_portd);
+  strncpy(tmp.originHost, c->localAddressF1U, sizeof(tmp.originHost) - 1);
+  sprintf(tmp.originService, "%d", c->localPortF1U);
+  sprintf(tmp.destinationService, "%d", c->remotePortF1U);
   return gtpv1Init(tmp);
 }
 
@@ -531,13 +531,8 @@ static void e1_task_handle_sctp_association_resp(E1_t type,
     e1ap_upcp_inst_t *inst = getCxtE1(instance);
     inst->cuup.assoc_id = sctp_new_association_resp->assoc_id;
 
-    e1ap_net_config_t *nc = &inst->net_config;
-    eth_params_t IPaddr = {0};
-    IPaddr.my_addr = nc->localAddressF1U;
-    IPaddr.my_portd = nc->localPortF1U;
-    IPaddr.remote_portd = nc->remotePortF1U;
     if (getCxtE1(instance)->gtpInstF1U < 0)
-      getCxtE1(instance)->gtpInstF1U = cuup_task_create_gtpu_instance_to_du(&IPaddr);
+      getCxtE1(instance)->gtpInstF1U = cuup_task_create_gtpu_instance_to_du(&inst->net_config);
     if (getCxtE1(instance)->gtpInstF1U < 0)
       LOG_E(E1AP, "Failed to create CUUP F1-U UDP listener\n");
     cuup_init_n3(instance);

--- a/openair2/ENB_APP/enb_config.c
+++ b/openair2/ENB_APP/enb_config.c
@@ -175,16 +175,16 @@ void RCconfig_macrlc(void)
 
       if (strcmp(*(MacRLC_ParamList.paramarray[j][MACRLC_TRANSPORT_S_PREFERENCE_IDX].strptr), "local_L1") == 0) {
       } else if (strcmp(*(MacRLC_ParamList.paramarray[j][MACRLC_TRANSPORT_S_PREFERENCE_IDX].strptr), "nfapi") == 0) {
-        RC.mac[j]->eth_params_s.my_addr                  = strdup(*(MacRLC_ParamList.paramarray[j][MACRLC_LOCAL_S_ADDRESS_IDX].strptr));
-        RC.mac[j]->eth_params_s.remote_addr              = strdup(*(MacRLC_ParamList.paramarray[j][MACRLC_REMOTE_S_ADDRESS_IDX].strptr));
-        RC.mac[j]->eth_params_s.my_portc                 = *(MacRLC_ParamList.paramarray[j][MACRLC_LOCAL_S_PORTC_IDX].iptr);
-        RC.mac[j]->eth_params_s.remote_portc             = *(MacRLC_ParamList.paramarray[j][MACRLC_REMOTE_S_PORTC_IDX].iptr);
-        RC.mac[j]->eth_params_s.my_portd                 = *(MacRLC_ParamList.paramarray[j][MACRLC_LOCAL_S_PORTD_IDX].iptr);
-        RC.mac[j]->eth_params_s.remote_portd             = *(MacRLC_ParamList.paramarray[j][MACRLC_REMOTE_S_PORTD_IDX].iptr);
-        RC.mac[j]->eth_params_s.transp_preference        = ETH_UDP_MODE;
-        LOG_I(ENB_APP,"**************** vnf_port:%d\n", RC.mac[j]->eth_params_s.my_portc);
-        configure_nfapi_vnf(RC.mac[j]->eth_params_s.my_addr, RC.mac[j]->eth_params_s.my_portc,RC.mac[j]->eth_params_s.remote_addr,RC.mac[j]->eth_params_s.remote_portd,RC.mac[j]->eth_params_s.my_portd);
-        LOG_I(ENB_APP,"**************** RETURNED FROM configure_nfapi_vnf() vnf_port:%d\n", RC.mac[j]->eth_params_s.my_portc);
+        char *my_addr = *(MacRLC_ParamList.paramarray[j][MACRLC_LOCAL_S_ADDRESS_IDX].strptr);
+        char *remote_addr = *(MacRLC_ParamList.paramarray[j][MACRLC_REMOTE_S_ADDRESS_IDX].strptr);
+        int my_portc = *(MacRLC_ParamList.paramarray[j][MACRLC_LOCAL_S_PORTC_IDX].iptr);
+        // remote_portc not used
+        //int remote_portc = *(MacRLC_ParamList.paramarray[j][MACRLC_REMOTE_S_PORTC_IDX].iptr);
+        int my_portd = *(MacRLC_ParamList.paramarray[j][MACRLC_LOCAL_S_PORTD_IDX].iptr);
+        int remote_portd = *(MacRLC_ParamList.paramarray[j][MACRLC_REMOTE_S_PORTD_IDX].iptr);
+        LOG_I(ENB_APP,"**************** vnf_port:%d\n", my_portc);
+        configure_nfapi_vnf(my_addr, my_portc, remote_addr, remote_portd, my_portd);
+        LOG_I(ENB_APP,"**************** RETURNED FROM configure_nfapi_vnf() vnf_port:%d\n", my_portc);
       } else { // other midhaul
         AssertFatal(1==0,"MACRLC %d: %s unknown southbound midhaul\n",j,*(MacRLC_ParamList.paramarray[j][MACRLC_TRANSPORT_S_PREFERENCE_IDX].strptr));
       }

--- a/openair2/F1AP/f1ap_cu_task.c
+++ b/openair2/F1AP/f1ap_cu_task.c
@@ -14,6 +14,7 @@
 #include "f1ap_cu_task.h"
 #include "openair2/RRC/NR/nr_rrc_defs.h"
 #include <openair3/ocp-gtpu/gtp_itf.h>
+#include "common_lib.h"
 
 static instance_t cu_task_create_gtpu_instance(const char *bind_addr, uint16_t local_port, uint16_t remote_port)
 {

--- a/openair2/F1AP/f1ap_cu_task.c
+++ b/openair2/F1AP/f1ap_cu_task.c
@@ -15,11 +15,12 @@
 #include "openair2/RRC/NR/nr_rrc_defs.h"
 #include <openair3/ocp-gtpu/gtp_itf.h>
 
-static instance_t cu_task_create_gtpu_instance(eth_params_t *IPaddrs) {
+static instance_t cu_task_create_gtpu_instance(const char *bind_addr, uint16_t local_port, uint16_t remote_port)
+{
   openAddr_t tmp= {0};
-  strncpy(tmp.originHost, IPaddrs->my_addr, sizeof(tmp.originHost)-1);
-  sprintf(tmp.originService, "%d", IPaddrs->my_portd);
-  sprintf(tmp.destinationService, "%d", IPaddrs->remote_portd);
+  strncpy(tmp.originHost, bind_addr, sizeof(tmp.originHost)-1);
+  sprintf(tmp.originService, "%d", local_port);
+  sprintf(tmp.destinationService, "%d", remote_port);
   return gtpv1Init(tmp);
 }
 
@@ -77,27 +78,28 @@ static void cu_task_send_sctp_init_req(instance_t instance, char *my_addr)
 
 void *F1AP_CU_task(void *arg)
 {
-  UNUSED(arg);
+  DevAssert(arg != NULL);
   MessageDef *received_msg = NULL;
   int         result;
   LOG_I(F1AP, "Starting F1AP at CU\n");
   // no RLC in CU, initialize mem pool for PDCP
   itti_mark_task_ready(TASK_CU_F1);
-  eth_params_t *IPaddrs;
-
-  // Hardcoded instance id!
-  IPaddrs = &RC.nrrrc[0]->eth_params_s;
+  f1ap_cu_conf_t *c = arg;
+  DevAssert(c->type == ngran_gNB_CU || c->type == ngran_gNB_CUCP);
 
   const int instance = 0;
   createF1inst(instance, NULL, NULL);
-  cu_task_send_sctp_init_req(instance, IPaddrs->my_addr);
+  cu_task_send_sctp_init_req(instance, c->bind_addr);
 
-  if (RC.nrrrc[instance]->node_type != ngran_gNB_CUCP) {
-    getCxt(instance)->gtpInst = cu_task_create_gtpu_instance(IPaddrs);
+  if (c->type != ngran_gNB_CUCP) {
+    getCxt(instance)->gtpInst = cu_task_create_gtpu_instance(c->bind_addr, c->local_f1u_port, c->remote_f1u_port);
     AssertFatal(getCxt(instance)->gtpInst > 0, "Failed to create CU F1-U UDP listener");
   } else {
     LOG_I(F1AP, "In F1AP connection, don't start GTP-U, as we have also E1AP\n");
   }
+
+  free(c->bind_addr);
+  free(c);
 
   while (1) {
     itti_receive_msg(TASK_CU_F1, &received_msg);

--- a/openair2/F1AP/f1ap_cu_task.h
+++ b/openair2/F1AP/f1ap_cu_task.h
@@ -5,6 +5,17 @@
 #ifndef F1AP_CU_TASK_H_
 #define F1AP_CU_TASK_H_
 
+#include <stdint.h>
+#include "common/ngran_types.h"
+
+typedef struct f1ap_cu_conf {
+  ngran_node_t type;
+  char *bind_addr;
+  // if type == ngran_gNB_CU, will create GTP
+  uint16_t local_f1u_port;
+  uint16_t remote_f1u_port;
+} f1ap_cu_conf_t;
+
 void *F1AP_CU_task(void *arg);
 
 #endif /* F1AP_CU_TASK_H_ */

--- a/openair2/GNB_APP/gnb_app.c
+++ b/openair2/GNB_APP/gnb_app.c
@@ -20,7 +20,6 @@
 #include "sctp_eNB_task.h"
 #include "openair3/ocp-gtpu/gtp_itf.h"
 #include "PHY/INIT/phy_init.h" 
-#include "f1ap_cu_task.h"
 #include "f1ap_du_task.h"
 #include "nfapi/oai_integration/vendor_ext.h"
 #include <openair2/LAYER2/nr_pdcp/nr_pdcp.h>
@@ -95,17 +94,6 @@ void *gNB_app_task(void *args_p)
   ngran_node_t node_type = get_node_type();
 
   if (RC.nb_nr_inst > 0) {
-    if (node_type == ngran_gNB_CUCP ||
-        node_type == ngran_gNB_CU ||
-        node_type == ngran_eNB_CU ||
-        node_type == ngran_ng_eNB_CU) {
-
-      if (itti_create_task(TASK_CU_F1, F1AP_CU_task, NULL) < 0) {
-        LOG_E(F1AP, "Create task for F1AP CU failed\n");
-        AssertFatal(1==0,"exiting");
-      }
-    }
-
     if (node_type == ngran_gNB_CUCP) {
       if (itti_create_task(TASK_CUCP_E1, E1AP_CUCP_task, NULL) < 0)
         AssertFatal(false, "Create task for E1AP CP failed\n");

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -1671,15 +1671,22 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg)
       } else if (strcmp(*gpd(params, np, MACRLC_TRANSPORT_N_PREFERENCE)->strptr, "f1") == 0
                  || strcmp(*gpd(params, np, MACRLC_TRANSPORT_N_PREFERENCE)->strptr, "cudu") == 0) {
         char **f1caddr = gpd(params, np, MACRLC_LOCAL_N_ADDRESS)->strptr;
-        RC.nrmac[j]->eth_params_n.my_addr = strdup(*f1caddr);
         char **f1uaddr = gpd(params, np, MACRLC_LOCAL_N_ADDRESS_F1U)->strptr;
-        RC.nrmac[j]->f1u_addr = f1uaddr != NULL ? strdup(*f1uaddr) : strdup(*f1caddr);
-        RC.nrmac[j]->eth_params_n.remote_addr = strdup(*gpd(params, np, MACRLC_REMOTE_N_ADDRESS)->strptr);
-        RC.nrmac[j]->eth_params_n.my_portc = 0; // not used
-        RC.nrmac[j]->eth_params_n.remote_portc = 0; // not used
-        RC.nrmac[j]->eth_params_n.my_portd = *gpd(params, np, MACRLC_LOCAL_N_PORTD)->iptr;
-        RC.nrmac[j]->eth_params_n.remote_portd = *gpd(params, np, MACRLC_REMOTE_N_PORTD)->iptr;
-        RC.nrmac[j]->eth_params_n.transp_preference = ETH_UDP_MODE;
+        f1ap_net_config_t nc = {
+          .CU_f1_ip_address = strdup(*gpd(params, np, MACRLC_REMOTE_N_ADDRESS)->strptr),
+          .DU_f1c_ip_address = strdup(*f1caddr),
+          .DU_f1u_ip_address = f1uaddr != NULL ? strdup(*f1uaddr) : strdup(*f1caddr),
+          .DUport = *gpd(params, np, MACRLC_LOCAL_N_PORTD)->iptr,
+          .CUport = *gpd(params, np, MACRLC_REMOTE_N_PORTD)->iptr,
+        };
+        RC.nrmac[j]->net_config = nc;
+        LOG_I(F1AP,
+              "F1-C DU IPaddr %s, connect to F1-C CU %s, binding GTP to %s ports local %d remote %d\n",
+              nc.DU_f1c_ip_address,
+              nc.CU_f1_ip_address,
+              nc.DU_f1u_ip_address,
+              nc.DUport,
+              nc.CUport);
       } else { // other midhaul
         AssertFatal(1 == 0, "MACRLC %d: %s unknown northbound midhaul\n", j, *gpd(params, np, MACRLC_TRANSPORT_N_PREFERENCE)->strptr);
       }

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -33,7 +33,6 @@
 #include "common/openairinterface5g_limits.h"
 #include "common/ran_context.h"
 #include "common/utils/T/T.h"
-#include "common_lib.h"
 #include "constr_TYPE.h"
 #include "enb_paramdef.h"
 #include "executables/softmodem-common.h"

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -60,6 +60,7 @@
 #include "x2ap_messages_types.h"
 #include "gnb_config_common.h"
 #include "positioning_nr_paramdef.h"
+#include "f1ap_cu_task.h"
 
 static int DEFBANDS[] = {7};
 static int DEFENBS[] = {0};
@@ -2388,13 +2389,17 @@ gNB_RRC_INST *RCconfig_NRRRC()
       LOG_I(GNB_APP,"F1AP: gNB_CU_id[%d] %d\n", k, rrc->node_id);
       rrc->node_name = strdup(*(GNBParamList.paramarray[0][GNB_GNB_NAME_IDX].strptr));
       LOG_I(GNB_APP,"F1AP: gNB_CU_name[%d] %s\n", k, rrc->node_name);
-      rrc->eth_params_s.my_addr                  = strdup(*(GNBParamList.paramarray[i][GNB_LOCAL_S_ADDRESS_IDX].strptr));
-      rrc->eth_params_s.remote_addr              = strdup(*(GNBParamList.paramarray[i][GNB_REMOTE_S_ADDRESS_IDX].strptr));
-      rrc->eth_params_s.my_portc                 = *(GNBParamList.paramarray[i][GNB_LOCAL_S_PORTC_IDX].uptr);
-      rrc->eth_params_s.remote_portc             = *(GNBParamList.paramarray[i][GNB_REMOTE_S_PORTC_IDX].uptr);
-      rrc->eth_params_s.my_portd                 = *(GNBParamList.paramarray[i][GNB_LOCAL_S_PORTD_IDX].uptr);
-      rrc->eth_params_s.remote_portd             = *(GNBParamList.paramarray[i][GNB_REMOTE_S_PORTD_IDX].uptr);
-      rrc->eth_params_s.transp_preference        = ETH_UDP_MODE;
+      f1ap_cu_conf_t *c = calloc_or_fail(1, sizeof(*c));
+      c->type = rrc->node_type;
+      c->bind_addr = strdup(*(GNBParamList.paramarray[i][GNB_LOCAL_S_ADDRESS_IDX].strptr));
+      c->local_f1u_port = *GNBParamList.paramarray[i][GNB_LOCAL_S_PORTD_IDX].uptr;
+      c->remote_f1u_port = *GNBParamList.paramarray[i][GNB_REMOTE_S_PORTD_IDX].uptr;
+      // GNB_REMOTE_S_ADDRESS_IDX not used
+      // GNB_LOCAL_S_PORTC_IDX not used
+      // GNB_REMOTE_S_PORTC_IDX not used
+      ittiTask_parms_t p = {.args_to_start_routine = c};
+      int rc = itti_create_task(TASK_CU_F1, F1AP_CU_task, &p);
+      AssertFatal(rc == 0, "Create task for F1AP CU failed\n");
     }
     
     // search if in active list

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -1686,15 +1686,10 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg)
 
       if (strcmp(*gpd(params, np, MACRLC_TRANSPORT_S_PREFERENCE)->strptr, "local_L1") == 0) {
       } else if (strcmp(*gpd(params, np, MACRLC_TRANSPORT_S_PREFERENCE)->strptr, "nfapi") == 0) {
-        eth_params_t p = {
-          .my_addr = strdup(*gpd(params, np, MACRLC_LOCAL_S_ADDRESS)->strptr),
-          .remote_addr = strdup(*gpd(params, np, MACRLC_REMOTE_S_ADDRESS)->strptr),
-          .my_portc = *gpd(params, np, MACRLC_LOCAL_S_PORTC)->iptr,
-          .remote_portc = 0, // not used
-          .my_portd = *gpd(params, np, MACRLC_LOCAL_S_PORTD)->iptr,
-          .remote_portd = 0, // not used
-        };
-        configure_nr_nfapi_vnf(p);
+        const char *vnf_addr = *gpd(params, np, MACRLC_LOCAL_S_ADDRESS)->strptr;
+        uint16_t p5_port = *gpd(params, np, MACRLC_LOCAL_S_PORTC)->iptr;
+        uint16_t p7_port = *gpd(params, np, MACRLC_LOCAL_S_PORTD)->iptr;
+        configure_nr_nfapi_vnf(vnf_addr, p5_port, p7_port);
       } else if(strcmp(*gpd(params, np, MACRLC_TRANSPORT_S_PREFERENCE)->strptr, "aerial") == 0){
 #ifdef ENABLE_AERIAL
         nvipc_params_t nvipc_p = {
@@ -1703,8 +1698,8 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg)
         };
         RC.nrmac[j]->nvipc_params_s = nvipc_p;
         LOG_I(GNB_APP, "Configuring VNF for Aerial connection with prefix %s\n", nvipc_p.nvipc_shm_prefix);
-        eth_params_t p = {0}; // not actually used but API requires it
-        configure_nr_nfapi_vnf(p);
+        // parameters are for socket-based communication, irrelevant for Aerial
+        configure_nr_nfapi_vnf(NULL, 0xffff, 0xffff);
 
 #endif
       } else { // other midhaul

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -2396,19 +2396,6 @@ gNB_RRC_INST *RCconfig_NRRRC()
       rrc->eth_params_s.remote_portd             = *(GNBParamList.paramarray[i][GNB_REMOTE_S_PORTD_IDX].uptr);
       rrc->eth_params_s.transp_preference        = ETH_UDP_MODE;
     }
-
-    if (strcmp(*(GNBParamList.paramarray[i][GNB_TRANSPORT_S_PREFERENCE_IDX].strptr), "local_mac") == 0) {
-      
-    } else if (strcmp(*(GNBParamList.paramarray[i][GNB_TRANSPORT_S_PREFERENCE_IDX].strptr), "cudu") == 0) {
-      rrc->eth_params_s.my_addr                  = strdup(*(GNBParamList.paramarray[i][GNB_LOCAL_S_ADDRESS_IDX].strptr));
-      rrc->eth_params_s.remote_addr              = strdup(*(GNBParamList.paramarray[i][GNB_REMOTE_S_ADDRESS_IDX].strptr));
-      rrc->eth_params_s.my_portc                 = *(GNBParamList.paramarray[i][GNB_LOCAL_S_PORTC_IDX].uptr);
-      rrc->eth_params_s.remote_portc             = *(GNBParamList.paramarray[i][GNB_REMOTE_S_PORTC_IDX].uptr);
-      rrc->eth_params_s.my_portd                 = *(GNBParamList.paramarray[i][GNB_LOCAL_S_PORTD_IDX].uptr);
-      rrc->eth_params_s.remote_portd             = *(GNBParamList.paramarray[i][GNB_REMOTE_S_PORTD_IDX].uptr);
-      rrc->eth_params_s.transp_preference        = ETH_UDP_MODE;
-    } else { // other midhaul
-    }       
     
     // search if in active list
     

--- a/openair2/LAYER2/MAC/mac.h
+++ b/openair2/LAYER2/MAC/mac.h
@@ -1269,8 +1269,6 @@ typedef struct {
 /*! \brief top level eNB MAC structure */
 
 typedef struct eNB_MAC_INST_s {
-  /// Ethernet parameters for fronthaul interface
-  eth_params_t eth_params_s;
   ///
   module_id_t Mod_id;
   /// frame counter

--- a/openair2/LAYER2/MAC/mac.h
+++ b/openair2/LAYER2/MAC/mac.h
@@ -52,8 +52,6 @@
 #include "PHY/defs_common.h" // for PRACH_RESOURCES_t
 #include "PHY/LTE_TRANSPORT/transport_common.h"
 
-#include "radio/COMMON/common_lib.h"
-
 /** @defgroup _mac  MAC
  * @ingroup _oai2
  * @{

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul_f1ap.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul_f1ap.c
@@ -16,24 +16,15 @@
 #include "lib/f1ap_interface_management.h"
 #include "lib/f1ap_ue_context.h"
 
-static f1ap_net_config_t read_DU_IP_config(const eth_params_t* f1_params, const char *f1u_ip_addr)
+static f1ap_net_config_t cp_net_config(const f1ap_net_config_t* c)
 {
-  AssertFatal(f1_params->my_portc == 0 && f1_params->remote_portc == 0, "portc not supported, must be 0\n");
-  f1ap_net_config_t nc = {0};
-
-  nc.CU_f1_ip_address= strdup(f1_params->remote_addr);
-  nc.CUport = f1_params->remote_portd;
-
-  nc.DU_f1c_ip_address = strdup(f1_params->my_addr);
-  nc.DU_f1u_ip_address = strdup(f1u_ip_addr);
-  nc.DUport = f1_params->my_portd;
-  LOG_I(F1AP,
-        "F1-C DU IPaddr %s, connect to F1-C CU %s, binding GTP to %s\n",
-        nc.DU_f1c_ip_address,
-        nc.CU_f1_ip_address,
-        nc.DU_f1u_ip_address);
-
-  // sctp_in_streams/sctp_out_streams are given by SCTP layer
+  f1ap_net_config_t nc = {
+    .CU_f1_ip_address = strdup(c->CU_f1_ip_address),
+    .DU_f1c_ip_address = strdup(c->DU_f1c_ip_address),
+    .DU_f1u_ip_address = strdup(c->DU_f1u_ip_address),
+    .CUport = c->CUport,
+    .DUport = c->DUport,
+  };
   return nc;
 }
 
@@ -55,7 +46,7 @@ static void f1_setup_request_f1ap(const f1ap_setup_req_t *req)
   MessageDef *msg = itti_alloc_new_message(TASK_MAC_GNB, 0, F1AP_DU_REGISTER_REQ);
   f1ap_setup_req_t f1ap_setup = cp_f1ap_setup_request(req);
   F1AP_DU_REGISTER_REQ(msg).setup_req = f1ap_setup;
-  F1AP_DU_REGISTER_REQ(msg).net_config = read_DU_IP_config(&RC.nrmac[0]->eth_params_n, RC.nrmac[0]->f1u_addr);
+  F1AP_DU_REGISTER_REQ(msg).net_config = cp_net_config(&RC.nrmac[0]->net_config);
   itti_send_msg_to_task(TASK_DU_F1, 0, msg);
 }
 

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -42,7 +42,7 @@
   } while (0)
 
 /* Commmon */
-#include "radio/COMMON/common_lib.h"
+#include "COMMON/f1ap_messages_types.h"
 #include "common/platform_constants.h"
 #include "common/ran_context.h"
 #include "collection/linear_alloc.h"
@@ -1166,10 +1166,8 @@ typedef struct NR_du_stats {
 
 /*! \brief top level eNB MAC structure */
 typedef struct gNB_MAC_INST_s {
-  /// Ethernet parameters for northbound midhaul interface
-  eth_params_t                    eth_params_n;
-  /// address for F1U to bind, ports in eth_params_n
-  char *f1u_addr;
+  /// F1-C/U network configuration (addresses and ports)
+  f1ap_net_config_t net_config;
   /// Nvipc parameters for FAPI interface with Aerial
   nvipc_params_t nvipc_params_s;
   /// Module

--- a/openair2/PHY_INTERFACE/IF_Module.h
+++ b/openair2/PHY_INTERFACE/IF_Module.h
@@ -11,10 +11,10 @@
 
 #include <stdint.h>
 #include <sched.h>
+#include <pthread.h>
 //#include "openair1/PHY/LTE_TRANSPORT/transport_eNB.h"
 #include "nfapi_interface.h"
 #include "common/platform_types.h"
-#include <radio/COMMON/common_lib.h>
 
 #define MAX_NUM_DL_PDU 100
 #define MAX_NUM_UL_PDU 100

--- a/openair2/RRC/LTE/rrc_defs.h
+++ b/openair2/RRC/LTE/rrc_defs.h
@@ -706,8 +706,6 @@ typedef struct {
 
 
 typedef struct eNB_RRC_INST_s {
-  /// southbound midhaul configuration
-  eth_params_t                    eth_params_s;
   char                            *node_name;
   uint32_t                        node_id;
   rrc_eNB_carrier_data_t          carrier[MAX_NUM_CCs];

--- a/openair2/RRC/NR/nr_rrc_defs.h
+++ b/openair2/RRC/NR/nr_rrc_defs.h
@@ -606,7 +606,6 @@ typedef struct gNB_RRC_INST_s {
   uint32_t                                            node_id;
   char                                               *node_name;
   int                                                 module_id;
-  eth_params_t                                        eth_params_s;
   uid_allocator_t                                     uid_allocator;
   RB_HEAD(rrc_nr_ue_tree_s, rrc_gNB_ue_context_s) rrc_ue_head; // ue_context tree key search by rnti
 

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -39,7 +39,6 @@
 #include "common/platform_constants.h"
 #include "common/ran_context.h"
 #include "common/utils/nr/nr_common.h"
-#include "common_lib.h"
 #include "constr_SEQUENCE.h"
 #include "constr_TYPE.h"
 #include "cucp_cuup_if.h"

--- a/openair3/UICC/usim_interface.h
+++ b/openair3/UICC/usim_interface.h
@@ -14,7 +14,6 @@
 #include <common/utils/LOG/log.h>
 #include <common/utils/load_module_shlib.h>
 #include <common/config/config_userapi.h>
-#include "common_lib.h"
 #include "pdu_session.h"
 
 /* 3GPP glossary

--- a/radio/AW2SORI/oaiori.c
+++ b/radio/AW2SORI/oaiori.c
@@ -410,7 +410,8 @@ int aw2s_startstreaming(openair0_device_t *device)
     printf("ORI_ObjectStateModify: %s\n", ORI_Result_Print(RE_result));
   }
 
-  device->fhstate.active = 1;
+  eth_state_t *eth = device->priv;
+  eth->fhstate.active = 1;
   return (0);
 }
 

--- a/radio/COMMON/common_lib.h
+++ b/radio/COMMON/common_lib.h
@@ -320,19 +320,6 @@ typedef struct {
   bool write_thread_exit;
 } openair0_thread_t;
 
-typedef struct fhstate_s {
-  openair0_timestamp_t TS[8];
-  openair0_timestamp_t TS0;
-  openair0_timestamp_t olddeltaTS[8];
-  openair0_timestamp_t oldTS[8];
-  openair0_timestamp_t TS_read;
-  int first_read;
-  uint32_t *buff[8];
-  uint32_t buff_size;
-  int r[8];
-  int active;
-} fhstate_t;
-
 #define WRITE_QUEUE_SZ 20
 typedef struct {
   bool initDone;
@@ -378,9 +365,6 @@ struct openair0_device {
   recplay_state_t *recplay_state;
   /*!brief Can be used by driver to hold internal structure*/
   void *priv;
-
-  /*!brief pointer to FH state, used in ECPRI split 8*/
-  fhstate_t fhstate;
 
   /* Functions API, which are called by the application*/
 

--- a/radio/COMMON/common_lib.h
+++ b/radio/COMMON/common_lib.h
@@ -384,15 +384,6 @@ struct openair0_device {
   /*!brief pointer to FH state, used in ECPRI split 8*/
   fhstate_t fhstate;
 
-  /*!brief Used in ECPRI split 8 to indicate numerator of sampling rate ratio*/
-  int sampling_rate_ratio_n;
-
-  /*!brief Used in ECPRI split 8 to indicate denominator of sampling rate ratio*/
-  int sampling_rate_ratio_d;
-
-  /*!brief Used in ECPRI split 8 to indicate the TX/RX timing offset*/
-  int txrx_offset;
-
   /* Functions API, which are called by the application*/
 
   /*! \brief Called to start the transceiver. Return 0 if OK, < 0 if error

--- a/radio/COMMON/common_lib.h
+++ b/radio/COMMON/common_lib.h
@@ -376,8 +376,6 @@ struct openair0_device {
   eth_params_t *eth_params;
   //! record player data, definition in record_player.h
   recplay_state_t *recplay_state;
-  /* !brief Indicates if device already initialized */
-  int is_init;
   /*!brief Can be used by driver to hold internal structure*/
   void *priv;
 

--- a/radio/ETHERNET/eth_udp.c
+++ b/radio/ETHERNET/eth_udp.c
@@ -308,13 +308,19 @@ void *trx_eth_write_udp_cmd(udpTXelem_t *udpTXelem)
   *(uint8_t *)(buff2 + 1) = 64;
 
   openair0_timestamp_t TS = timestamp + fhstate->TS0;
-  TS = (6*device->sampling_rate_ratio_d*TS)/device->sampling_rate_ratio_n;
-  TS -= device->txrx_offset; 
-  int TSinc = (6*256*device->sampling_rate_ratio_d)/device->sampling_rate_ratio_n;
+  TS = (6 * eth->sampling_rate_ratio_d * TS) / eth->sampling_rate_ratio_n;
+  TS -= eth->txrx_offset;
+  int TSinc = (6 * 256 * eth->sampling_rate_ratio_d) / eth->sampling_rate_ratio_n;
   int len=256;
-  LOG_D(NR_PHY,"in eth send: TS %llu (%llu),txrx_offset %d,d %d, n %d, buff[0] %p buff[1] %p\n",
-        (unsigned long long)TS,(unsigned long long)timestamp,device->txrx_offset,device->sampling_rate_ratio_d,device->sampling_rate_ratio_n,
-	buff[0],buff[1]);
+  LOG_D(NR_PHY,
+        "in eth send: TS %llu (%llu),txrx_offset %d,d %d, n %d, buff[0] %p buff[1] %p\n",
+        (unsigned long long)TS,
+        (unsigned long long)timestamp,
+        eth->txrx_offset,
+        eth->sampling_rate_ratio_d,
+        eth->sampling_rate_ratio_n,
+        buff[0],
+        buff[1]);
   for (int offset=0;offset<nsamps;offset+=256,TS+=TSinc) {
     // OAI modified SEQ_ID (4 bytes)
     *(uint64_t *)(buff2 + 6) = TS;
@@ -406,11 +412,17 @@ void *udp_read_thread(void *arg)
   int aid;
   udp_ctx_t *u = (udp_ctx_t *)arg;
   openair0_device_t *device=u->device;
+  eth_state_t *eth = device->priv;
   fhstate_t *fhstate = &device->fhstate;
   char buffer[UDP_PACKET_SIZE_BYTES(256)];
   int first_read=0;
   while (oai_exit == 0) {
-    LOG_I(PHY,"UDP read thread %d on core %d, waiting for start sampling_rate_d %d, sampling_rate_n %d\n",u->thread_id,sched_getcpu(),device->sampling_rate_ratio_n,device->sampling_rate_ratio_d);
+    LOG_I(PHY,
+          "UDP read thread %d on core %d, waiting for start sampling_rate_d %d, sampling_rate_n %d\n",
+          u->thread_id,
+          sched_getcpu(),
+          eth->sampling_rate_ratio_n,
+          eth->sampling_rate_ratio_d);
     while (fhstate->active > 0) {
       ssize_t count = recvfrom(((eth_state_t*)device->priv)->sockfdd[0],
                                buffer,sizeof(buffer),0,
@@ -434,7 +446,7 @@ void *udp_read_thread(void *arg)
       aid = *(uint16_t*)(&buffer[ECPRICOMMON_BYTES]);
       TS  = *(openair0_timestamp_t *)(&buffer[ECPRICOMMON_BYTES+ECPRIPCID_BYTES]);
       // convert TS to samples, /6 for AW2S @ 30.72 Ms/s, this is converted for other sample rates in OAI application
-      TS = (device->sampling_rate_ratio_n*TS)/(device->sampling_rate_ratio_d*6);
+      TS = (eth->sampling_rate_ratio_n * TS) / (eth->sampling_rate_ratio_d * 6);
       AssertFatal(aid < 8,"Cannot handle more than 8 antennas, got aid %d\n",aid);
       fhstate->r[aid]=1;
       if (aid==0 && first_read == 0) fhstate->TS0 = TS;

--- a/radio/ETHERNET/eth_udp.c
+++ b/radio/ETHERNET/eth_udp.c
@@ -280,7 +280,7 @@ void *trx_eth_write_udp_cmd(udpTXelem_t *udpTXelem)
   int bytes_sent=0;
   eth_state_t *eth = (eth_state_t*)device->priv;
   int sendto_flag =0;
-  fhstate_t *fhstate = &device->fhstate;
+  fhstate_t *fhstate = &eth->fhstate;
 
   //sendto_flag|=flags;
   eth->tx_nsamps=nsamps;
@@ -413,7 +413,7 @@ void *udp_read_thread(void *arg)
   udp_ctx_t *u = (udp_ctx_t *)arg;
   openair0_device_t *device=u->device;
   eth_state_t *eth = device->priv;
-  fhstate_t *fhstate = &device->fhstate;
+  fhstate_t *fhstate = &eth->fhstate;
   char buffer[UDP_PACKET_SIZE_BYTES(256)];
   int first_read=0;
   while (oai_exit == 0) {
@@ -476,7 +476,8 @@ void *udp_read_thread(void *arg)
 
 int trx_eth_read_udp(openair0_device_t *device, openair0_timestamp_t *timestamp, uint32_t **buff, int nsamps)
 {
-  fhstate_t *fhstate = &device->fhstate;
+  eth_state_t *eth = device->priv;
+  fhstate_t *fhstate = &eth->fhstate;
   openair0_timestamp_t prev_read_TS= fhstate->TS_read;
   volatile openair0_timestamp_t min_TS;
   // block until FH is ready

--- a/radio/ETHERNET/ethernet_lib.c
+++ b/radio/ETHERNET/ethernet_lib.c
@@ -32,579 +32,569 @@ int load_lib(openair0_device_t *device, openair0_config_t *openair0_cfg, eth_par
 
 int trx_eth_start(openair0_device_t *device)
 {
-    eth_state_t *eth = (eth_state_t*)device->priv;
+  eth_state_t *eth = (eth_state_t *)device->priv;
 
-    if (eth->flags == ETH_UDP_IF5_ECPRI_MODE) {
-       AssertFatal(device->thirdparty_init != NULL, "device->thirdparty_init is null\n");
-       AssertFatal(device->thirdparty_init(device) == 0, "third-party init failed\n");
-       device->openair0_cfg->samples_per_packet = 256;
-       eth->num_fd = 1; //max(device->openair0_cfg->rx_num_channels,device->openair0_cfg->tx_num_channels);
-       udp_ctx_t *u[1 + eth->num_fd];
-       eth->utx = malloc_or_fail(sizeof(eth->utx));
-       for (int i = 0; i < eth->num_fd; i++) {
-         u[i] = malloc_or_fail(sizeof(udp_ctx_t));
-         u[i]->thread_id = i;
-         u[i]->device = device;
-         printf("UDP Read Thread %d on core %d\n", i, device->openair0_cfg->rxfh_cores[i]);
-         threadCreate(&u[i]->pthread,
-                      udp_read_thread,
-                      u[i],
-                      "udp read thread",
-                      device->openair0_cfg->rxfh_cores[i],
-                      OAI_PRIORITY_RT_MAX);
-         eth->utx[i] = malloc_or_fail(sizeof(udp_ctx_t));
-         eth->utx[i]->thread_id = i;
-         eth->utx[i]->device = device;
-         printf("UDP Write Thread %d on core %d\n", i, device->openair0_cfg->txfh_cores[i]);
-         threadCreate(&eth->utx[i]->pthread,
-                      udp_write_thread,
-                      eth->utx[i],
-                      "udp write thread",
-                      device->openair0_cfg->txfh_cores[i],
-                      OAI_PRIORITY_RT_MAX);
-       }
-       device->sampling_rate_ratio_n=1;
-       device->sampling_rate_ratio_d=1;
-       if (device->openair0_cfg->nr_flag==1) { // This check if RRU knows about NR numerologies
-          if (device->openair0_cfg->num_rb_dl <= 162 && device->openair0_cfg->num_rb_dl > 106) {
-             device->sampling_rate_ratio_n = 2;
-	     device->txrx_offset=5500;
-	  }
-          else if (device->openair0_cfg->num_rb_dl <= 106 && device->openair0_cfg->num_rb_dl > 51) {
-             device->sampling_rate_ratio_d=3;
-	     device->sampling_rate_ratio_n=4;
-	     device->txrx_offset=3750;
-	  }
-          else if (device->openair0_cfg->num_rb_dl == 51) {
-             device->sampling_rate_ratio_n=1;
-	     device->sampling_rate_ratio_d=1;
-	     device->txrx_offset=7500;
-	  }
-          else AssertFatal(1==0,"num_rb_dl %d not ok with ECPRI\n",device->openair0_cfg->num_rb_dl);
-       }
-       else {
-          if (device->openair0_cfg->num_rb_dl == 100 || device->openair0_cfg->num_rb_dl == 51) {
-             device->sampling_rate_ratio_d = 1;
-	     device->txrx_offset=7500;
-	  }
-          else if (device->openair0_cfg->num_rb_dl == 75) {
-             device->sampling_rate_ratio_d = 4; 
-	     device->sampling_rate_ratio_n=3;
-	     device->txrx_offset=7500;
-	  }
-          else if (device->openair0_cfg->num_rb_dl == 50) {
-             device->sampling_rate_ratio_d = 2;
-	     device->txrx_offset=7500;
-	  }
-          else if (device->openair0_cfg->num_rb_dl == 25) {
-             device->sampling_rate_ratio_d = 4;
-	     device->txrx_offset=7500;
-	  }
-          else AssertFatal(1==0,"num_rb_dl %d not ok with ECPRI\n",device->openair0_cfg->num_rb_dl);
-       }
-#ifdef USE_TX_TPOOL       
-       int threadCnt = device->openair0_cfg->tx_num_channels;
-       if (threadCnt < 2) LOG_E(PHY,"Number of threads for gNB should be more than 1. Allocated only %d\n",threadCnt);
-       char pool[80];
-       sprintf(pool,"-1");
-       int s_offset = 0;
-       for (int icpu=1; icpu<threadCnt; icpu++) {
-          sprintf(pool+2+s_offset,",-1");
-          s_offset += 3;
-       }
-       device->threadPool = (tpool_t*)malloc(sizeof(tpool_t));
-       initTpool(pool, device->threadPool, cpumeas(CPUMEAS_GETSTATE));
-#endif
-   }
-   /* initialize socket */
-    if (eth->flags == ETH_RAW_MODE) {
-        printf("Setting ETHERNET to ETH_RAW_IF5_MODE\n");
-        if (eth_socket_init_raw(device)!=0)   return -1;
-        /* RRU gets device configuration - RAU sets device configuration*/
-
-        printf("Setting Timenout to 999999 usecs\n");
-        if(ethernet_tune (device,RCV_TIMEOUT,999999)!=0)  return -1;
-
-        /*
-        if (device->host_type == RAU_HOST) {
-          if(eth_set_dev_conf_raw(device)!=0)  return -1;
-        } else {
-          if(eth_get_dev_conf_raw(device)!=0)  return -1;
-          }*/
-
-        /* adjust MTU wrt number of samples per packet */
-        if(eth->compression == ALAW_COMPRESS) {
-            if(ethernet_tune (device,MTU_SIZE,RAW_PACKET_SIZE_BYTES_ALAW(device->openair0_cfg->samples_per_packet))!=0)  return -1;
-        } else {
-            if(ethernet_tune (device,MTU_SIZE,RAW_PACKET_SIZE_BYTES(device->openair0_cfg->samples_per_packet))!=0)  return -1;
-        }
-        if(ethernet_tune (device,RCV_TIMEOUT,999999)!=0)  return -1;
-    } else if (eth->flags == ETH_RAW_IF4p5_MODE) {
-
-        printf("Setting ETHERNET to ETH_RAW_IF4p5_MODE\n");
-        if (eth_socket_init_raw(device)!=0)   return -1;
-
-        printf("Setting Timenout to 999999 usecs\n");
-        if(ethernet_tune (device,RCV_TIMEOUT,999999)!=0)  return -1;
-
-        /*
-        if (device->host_type == RAU_HOST) {
-          if(eth_set_dev_conf_raw_IF4p5(device)!=0)  return -1;
-        } else {
-          if(eth_get_dev_conf_raw_IF4p5(device)!=0)  return -1;
-        }
-        */
-
-        /* adjust MTU wrt number of samples per packet */
-        if(ethernet_tune (device,MTU_SIZE,RAW_IF4p5_PRACH_SIZE_BYTES)!=0)  return -1;
-
-        if(ethernet_tune (device,RCV_TIMEOUT,999999)!=0)  return -1;
-    } else if (eth->flags == ETH_UDP_IF4p5_MODE) {
-        printf("Setting ETHERNET to UDP_IF4p5_MODE\n");
-        if (eth_socket_init_udp(device)!=0)   return -1;
-
-        printf("Setting Timeout to 999999 usecs\n");
-        if(ethernet_tune (device,RCV_TIMEOUT,999999)!=0)  return -1;
-
-        /*
-        if (device->host_type == RAU_HOST) {
-          if(eth_set_dev_conf_udp(device)!=0)  return -1;
-        } else {
-          if(eth_get_dev_conf_udp(device)!=0)  return -1;
-        }
-        */
-
-        /* adjust MTU wrt number of samples per packet */
-	//        if(ethernet_tune (device,MTU_SIZE,UDP_IF4p5_PRACH_SIZE_BYTES)!=0)  return -1;
-
-
-
-
-    } else {
-        printf("Setting ETHERNET to UDP_IF5_MODE\n");
-        if (eth_socket_init_udp(device)!=0)   return -1;
-
-        /*
-        if (device->host_type == RAU_HOST) {
-          if(eth_set_dev_conf_udp(device)!=0)  return -1;
-        } else {
-          if(eth_get_dev_conf_udp(device)!=0)  return -1;
-          }*/
-
-        //if(ethernet_tune (device,MTU_SIZE,UDP_IF4p5_PRACH_SIZE_BYTES)!=0)  return -1;
-
-        if(ethernet_tune (device,RCV_TIMEOUT,999999)!=0)  return -1;
+  if (eth->flags == ETH_UDP_IF5_ECPRI_MODE) {
+    AssertFatal(device->thirdparty_init != NULL, "device->thirdparty_init is null\n");
+    AssertFatal(device->thirdparty_init(device) == 0, "third-party init failed\n");
+    device->openair0_cfg->samples_per_packet = 256;
+    eth->num_fd = 1; // max(device->openair0_cfg->rx_num_channels,device->openair0_cfg->tx_num_channels);
+    udp_ctx_t *u[1 + eth->num_fd];
+    eth->utx = malloc_or_fail(sizeof(eth->utx));
+    for (int i = 0; i < eth->num_fd; i++) {
+      u[i] = malloc_or_fail(sizeof(udp_ctx_t));
+      u[i]->thread_id = i;
+      u[i]->device = device;
+      printf("UDP Read Thread %d on core %d\n", i, device->openair0_cfg->rxfh_cores[i]);
+      threadCreate(&u[i]->pthread,
+                   udp_read_thread,
+                   u[i],
+                   "udp read thread",
+                   device->openair0_cfg->rxfh_cores[i],
+                   OAI_PRIORITY_RT_MAX);
+      eth->utx[i] = malloc_or_fail(sizeof(udp_ctx_t));
+      eth->utx[i]->thread_id = i;
+      eth->utx[i]->device = device;
+      printf("UDP Write Thread %d on core %d\n", i, device->openair0_cfg->txfh_cores[i]);
+      threadCreate(&eth->utx[i]->pthread,
+                   udp_write_thread,
+                   eth->utx[i],
+                   "udp write thread",
+                   device->openair0_cfg->txfh_cores[i],
+                   OAI_PRIORITY_RT_MAX);
     }
-    /* apply additional configuration */
-    if(ethernet_tune (device, SND_BUF_SIZE,67108864)!=0)  return -1;
-    if(ethernet_tune (device, RCV_BUF_SIZE,67108864)!=0)  return -1;
-    if(ethernet_tune (device, KERNEL_SND_BUF_MAX_SIZE, 67108864)!=0)  return -1;
-    if(ethernet_tune (device, KERNEL_RCV_BUF_MAX_SIZE, 67108864)!=0)  return -1;
-    if(ethernet_tune (device, TX_Q_LEN, 10000)!=0)  return -1;
+    device->sampling_rate_ratio_n = 1;
+    device->sampling_rate_ratio_d = 1;
+    if (device->openair0_cfg->nr_flag == 1) { // This check if RRU knows about NR numerologies
+      if (device->openair0_cfg->num_rb_dl <= 162 && device->openair0_cfg->num_rb_dl > 106) {
+        device->sampling_rate_ratio_n = 2;
+        device->txrx_offset = 5500;
+      } else if (device->openair0_cfg->num_rb_dl <= 106 && device->openair0_cfg->num_rb_dl > 51) {
+        device->sampling_rate_ratio_d = 3;
+        device->sampling_rate_ratio_n = 4;
+        device->txrx_offset = 3750;
+      } else if (device->openair0_cfg->num_rb_dl == 51) {
+        device->sampling_rate_ratio_n = 1;
+        device->sampling_rate_ratio_d = 1;
+        device->txrx_offset = 7500;
+      } else
+        AssertFatal(1 == 0, "num_rb_dl %d not ok with ECPRI\n", device->openair0_cfg->num_rb_dl);
+    } else {
+      if (device->openair0_cfg->num_rb_dl == 100 || device->openair0_cfg->num_rb_dl == 51) {
+        device->sampling_rate_ratio_d = 1;
+        device->txrx_offset = 7500;
+      } else if (device->openair0_cfg->num_rb_dl == 75) {
+        device->sampling_rate_ratio_d = 4;
+        device->sampling_rate_ratio_n = 3;
+        device->txrx_offset = 7500;
+      } else if (device->openair0_cfg->num_rb_dl == 50) {
+        device->sampling_rate_ratio_d = 2;
+        device->txrx_offset = 7500;
+      } else if (device->openair0_cfg->num_rb_dl == 25) {
+        device->sampling_rate_ratio_d = 4;
+        device->txrx_offset = 7500;
+      } else
+        AssertFatal(1 == 0, "num_rb_dl %d not ok with ECPRI\n", device->openair0_cfg->num_rb_dl);
+    }
+#ifdef USE_TX_TPOOL
+    int threadCnt = device->openair0_cfg->tx_num_channels;
+    if (threadCnt < 2)
+      LOG_E(PHY, "Number of threads for gNB should be more than 1. Allocated only %d\n", threadCnt);
+    char pool[80];
+    sprintf(pool, "-1");
+    int s_offset = 0;
+    for (int icpu = 1; icpu < threadCnt; icpu++) {
+      sprintf(pool + 2 + s_offset, ",-1");
+      s_offset += 3;
+    }
+    device->threadPool = (tpool_t *)malloc(sizeof(tpool_t));
+    initTpool(pool, device->threadPool, cpumeas(CPUMEAS_GETSTATE));
+#endif
+  }
+  /* initialize socket */
+  if (eth->flags == ETH_RAW_MODE) {
+    printf("Setting ETHERNET to ETH_RAW_IF5_MODE\n");
+    if (eth_socket_init_raw(device) != 0)
+      return -1;
+    /* RRU gets device configuration - RAU sets device configuration*/
 
+    printf("Setting Timenout to 999999 usecs\n");
+    if (ethernet_tune(device, RCV_TIMEOUT, 999999) != 0)
+      return -1;
 
-    return 0;
+    /*
+    if (device->host_type == RAU_HOST) {
+      if(eth_set_dev_conf_raw(device)!=0)  return -1;
+    } else {
+      if(eth_get_dev_conf_raw(device)!=0)  return -1;
+      }*/
+
+    /* adjust MTU wrt number of samples per packet */
+    if (eth->compression == ALAW_COMPRESS) {
+      if (ethernet_tune(device, MTU_SIZE, RAW_PACKET_SIZE_BYTES_ALAW(device->openair0_cfg->samples_per_packet)) != 0)
+        return -1;
+    } else {
+      if (ethernet_tune(device, MTU_SIZE, RAW_PACKET_SIZE_BYTES(device->openair0_cfg->samples_per_packet)) != 0)
+        return -1;
+    }
+    if (ethernet_tune(device, RCV_TIMEOUT, 999999) != 0)
+      return -1;
+  } else if (eth->flags == ETH_RAW_IF4p5_MODE) {
+    printf("Setting ETHERNET to ETH_RAW_IF4p5_MODE\n");
+    if (eth_socket_init_raw(device) != 0)
+      return -1;
+
+    printf("Setting Timenout to 999999 usecs\n");
+    if (ethernet_tune(device, RCV_TIMEOUT, 999999) != 0)
+      return -1;
+
+    /*
+    if (device->host_type == RAU_HOST) {
+      if(eth_set_dev_conf_raw_IF4p5(device)!=0)  return -1;
+    } else {
+      if(eth_get_dev_conf_raw_IF4p5(device)!=0)  return -1;
+    }
+    */
+
+    /* adjust MTU wrt number of samples per packet */
+    if (ethernet_tune(device, MTU_SIZE, RAW_IF4p5_PRACH_SIZE_BYTES) != 0)
+      return -1;
+
+    if (ethernet_tune(device, RCV_TIMEOUT, 999999) != 0)
+      return -1;
+  } else if (eth->flags == ETH_UDP_IF4p5_MODE) {
+    printf("Setting ETHERNET to UDP_IF4p5_MODE\n");
+    if (eth_socket_init_udp(device) != 0)
+      return -1;
+
+    printf("Setting Timeout to 999999 usecs\n");
+    if (ethernet_tune(device, RCV_TIMEOUT, 999999) != 0)
+      return -1;
+
+    /*
+    if (device->host_type == RAU_HOST) {
+      if(eth_set_dev_conf_udp(device)!=0)  return -1;
+    } else {
+      if(eth_get_dev_conf_udp(device)!=0)  return -1;
+    }
+    */
+
+    /* adjust MTU wrt number of samples per packet */
+    //        if(ethernet_tune (device,MTU_SIZE,UDP_IF4p5_PRACH_SIZE_BYTES)!=0)  return -1;
+
+  } else {
+    printf("Setting ETHERNET to UDP_IF5_MODE\n");
+    if (eth_socket_init_udp(device) != 0)
+      return -1;
+
+    /*
+    if (device->host_type == RAU_HOST) {
+      if(eth_set_dev_conf_udp(device)!=0)  return -1;
+    } else {
+      if(eth_get_dev_conf_udp(device)!=0)  return -1;
+      }*/
+
+    // if(ethernet_tune (device,MTU_SIZE,UDP_IF4p5_PRACH_SIZE_BYTES)!=0)  return -1;
+
+    if (ethernet_tune(device, RCV_TIMEOUT, 999999) != 0)
+      return -1;
+  }
+  /* apply additional configuration */
+  if (ethernet_tune(device, SND_BUF_SIZE, 67108864) != 0)
+    return -1;
+  if (ethernet_tune(device, RCV_BUF_SIZE, 67108864) != 0)
+    return -1;
+  if (ethernet_tune(device, KERNEL_SND_BUF_MAX_SIZE, 67108864) != 0)
+    return -1;
+  if (ethernet_tune(device, KERNEL_RCV_BUF_MAX_SIZE, 67108864) != 0)
+    return -1;
+  if (ethernet_tune(device, TX_Q_LEN, 10000) != 0)
+    return -1;
+
+  return 0;
 }
 
 void trx_eth_end(openair0_device_t *device)
 {
-    eth_state_t *eth = (eth_state_t*)device->priv;
-    /* destroys socket only for the processes that call the eth_end fuction-- shutdown() for beaking the pipe */
-    for (int i=0;i<eth->num_fd;i++)
-      if ( close(eth->sockfdd[i]) <0 ) {
-          perror("ETHERNET: Failed to close socket");
-          exit(0);
-      } else {
-          printf("[%s] socket has been successfully closed.\n",(device->host_type == RAU_HOST)? "RAU":"RRU");
-      }
+  eth_state_t *eth = (eth_state_t *)device->priv;
+  /* destroys socket only for the processes that call the eth_end fuction-- shutdown() for beaking the pipe */
+  for (int i = 0; i < eth->num_fd; i++)
+    if (close(eth->sockfdd[i]) < 0) {
+      perror("ETHERNET: Failed to close socket");
+      exit(0);
+    } else {
+      printf("[%s] socket has been successfully closed.\n", (device->host_type == RAU_HOST) ? "RAU" : "RRU");
+    }
 }
 
 int trx_eth_stop(openair0_device_t *device)
 {
-  eth_state_t *eth = (eth_state_t*)device->priv;
-  
+  eth_state_t *eth = (eth_state_t *)device->priv;
+
   if (eth->flags == ETH_UDP_IF5_ECPRI_MODE) {
     AssertFatal(device->thirdparty_cleanup != NULL, "device->thirdparty_cleanup is null\n");
     AssertFatal(device->thirdparty_cleanup(device) == 0, "third-party cleanup failed\n");
   }
-  return(0);
+  return (0);
 }
 
 int trx_eth_set_freq(openair0_device_t *device, openair0_config_t *openair0_cfg)
 {
-    return(0);
+  return (0);
 }
 
 int trx_eth_set_gains(openair0_device_t *device, openair0_config_t *openair0_cfg)
 {
-    return(0);
+  return (0);
 }
 
 int trx_eth_get_stats(openair0_device_t *device)
 {
-    return(0);
+  return (0);
 }
 
 int trx_eth_reset_stats(openair0_device_t *device)
 {
-    return(0);
+  return (0);
 }
 
 int trx_eth_write_init(openair0_device_t *device)
 {
-    return 0;
+  return 0;
 }
 
 int ethernet_tune(openair0_device_t *device, unsigned int option, int value)
 {
-    eth_state_t *eth = (eth_state_t*)device->priv;
-    struct timeval timeout;
-    struct ifreq ifr;
-    char system_cmd[256];
-    int ret=0;
-    //  int i=0;
+  eth_state_t *eth = (eth_state_t *)device->priv;
+  struct timeval timeout;
+  struct ifreq ifr;
+  char system_cmd[256];
+  int ret = 0;
+  //  int i=0;
 
-    /****************** socket level options ************************/
-    switch(option) {
-    case SND_BUF_SIZE:  /* transmit socket buffer size */
-      for (int i=0;i<eth->num_fd;i++)
-        if (setsockopt(eth->sockfdd[i],
-                       SOL_SOCKET,
-                       SO_SNDBUF,
-                       &value,sizeof(value))) {
-            perror("[ETHERNET] setsockopt()");
+  /****************** socket level options ************************/
+  switch (option) {
+    case SND_BUF_SIZE: /* transmit socket buffer size */
+      for (int i = 0; i < eth->num_fd; i++)
+        if (setsockopt(eth->sockfdd[i], SOL_SOCKET, SO_SNDBUF, &value, sizeof(value))) {
+          perror("[ETHERNET] setsockopt()");
         } else {
-            printf("send buffer size= %d bytes\n",value);
+          printf("send buffer size= %d bytes\n", value);
         }
       break;
 
-    case RCV_BUF_SIZE:   /* receive socket buffer size */
-      for (int i=0;i<eth->num_fd;i++) {
-        if (setsockopt(eth->sockfdd[i],
-                       SOL_SOCKET,
-                       SO_RCVBUF,
-                       &value,sizeof(value))) {
-            perror("[ETHERNET] setsockopt()");
+    case RCV_BUF_SIZE: /* receive socket buffer size */
+      for (int i = 0; i < eth->num_fd; i++) {
+        if (setsockopt(eth->sockfdd[i], SOL_SOCKET, SO_RCVBUF, &value, sizeof(value))) {
+          perror("[ETHERNET] setsockopt()");
         } else {
-            printf("receive bufffer size= %d bytes\n",value);
+          printf("receive bufffer size= %d bytes\n", value);
         }
       }
       break;
 
     case RCV_TIMEOUT:
-        timeout.tv_sec = value/1000000;
-        timeout.tv_usec = value%1000000;//less than rt_period?
-        if (setsockopt(eth->sockfdc,
-                         SOL_SOCKET,
-                         SO_RCVTIMEO,
-                         (char *)&timeout,sizeof(timeout))) {
-              perror("[ETHERNET] setsockopt()");
+      timeout.tv_sec = value / 1000000;
+      timeout.tv_usec = value % 1000000; // less than rt_period?
+      if (setsockopt(eth->sockfdc, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout, sizeof(timeout))) {
+        perror("[ETHERNET] setsockopt()");
+      } else {
+        printf("receive timeout= %u usec\n", (unsigned int)timeout.tv_usec);
+      }
+      for (int i = 0; i < eth->num_fd; i++) {
+        if (setsockopt(eth->sockfdd[i], SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout, sizeof(timeout))) {
+          perror("[ETHERNET] setsockopt()");
         } else {
-              printf( "receive timeout= %u usec\n",(unsigned int)timeout.tv_usec);
+          printf("receive timeout= %u usec\n", (unsigned int)timeout.tv_usec);
         }
-        for (int i=0;i<eth->num_fd;i++) {
-          if (setsockopt(eth->sockfdd[i],
-                         SOL_SOCKET,
-                         SO_RCVTIMEO,
-                         (char *)&timeout,sizeof(timeout))) {
-              perror("[ETHERNET] setsockopt()");
-          } else {
-              printf( "receive timeout= %u usec\n",(unsigned int)timeout.tv_usec);
-          }
-        }
-        break;
+      }
+      break;
 
     case SND_TIMEOUT:
-        timeout.tv_sec = value/1000000000;
-        timeout.tv_usec = value%1000000000;//less than rt_period?
-        if (setsockopt(eth->sockfdc,
-                       SOL_SOCKET,
-                       SO_SNDTIMEO,
-                       (char *)&timeout,sizeof(timeout))) {
-            perror("[ETHERNET] setsockopt()");
+      timeout.tv_sec = value / 1000000000;
+      timeout.tv_usec = value % 1000000000; // less than rt_period?
+      if (setsockopt(eth->sockfdc, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout, sizeof(timeout))) {
+        perror("[ETHERNET] setsockopt()");
+      } else {
+        printf("send timeout= %d,%d sec\n", (int)timeout.tv_sec, (int)timeout.tv_usec);
+      }
+      for (int i = 0; i < eth->num_fd; i++) {
+        if (setsockopt(eth->sockfdd[i], SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout, sizeof(timeout))) {
+          perror("[ETHERNET] setsockopt()");
         } else {
-            printf( "send timeout= %d,%d sec\n",(int)timeout.tv_sec,(int)timeout.tv_usec);
+          printf("send timeout= %d,%d sec\n", (int)timeout.tv_sec, (int)timeout.tv_usec);
         }
-        for (int i=0;i<eth->num_fd;i++) {
-          if (setsockopt(eth->sockfdd[i],
-                         SOL_SOCKET,
-                         SO_SNDTIMEO,
-                         (char *)&timeout,sizeof(timeout))) {
-              perror("[ETHERNET] setsockopt()");
-          } else {
-              printf( "send timeout= %d,%d sec\n",(int)timeout.tv_sec,(int)timeout.tv_usec);
-          }
-        }
-        break;
-
+      }
+      break;
 
     /******************* interface level options  *************************/
     case MTU_SIZE: /* change  MTU of the eth interface */
-        ifr.ifr_addr.sa_family = AF_INET;
-        strncpy(ifr.ifr_name,eth->if_name, sizeof(ifr.ifr_name)-1);
-        ifr.ifr_mtu =value;
-        for (int i=0;i<eth->num_fd;i++) {
-          if (ioctl(eth->sockfdd[i],SIOCSIFMTU,(caddr_t)&ifr) < 0 )
-              perror ("[ETHERNET] Can't set the MTU");
-          else
-              printf("[ETHERNET] %s MTU size has changed to %d\n",eth->if_name,ifr.ifr_mtu);
-        }
-        break;
+      ifr.ifr_addr.sa_family = AF_INET;
+      strncpy(ifr.ifr_name, eth->if_name, sizeof(ifr.ifr_name) - 1);
+      ifr.ifr_mtu = value;
+      for (int i = 0; i < eth->num_fd; i++) {
+        if (ioctl(eth->sockfdd[i], SIOCSIFMTU, (caddr_t)&ifr) < 0)
+          perror("[ETHERNET] Can't set the MTU");
+        else
+          printf("[ETHERNET] %s MTU size has changed to %d\n", eth->if_name, ifr.ifr_mtu);
+      }
+      break;
 
-    case TX_Q_LEN:  /* change TX queue length of eth interface */
-        ifr.ifr_addr.sa_family = AF_INET;
-        strncpy(ifr.ifr_name,eth->if_name, sizeof(ifr.ifr_name)-1);
-        ifr.ifr_qlen =value;
-        for (int i=0;i<eth->num_fd;i++) {
-          if (ioctl(eth->sockfdd[i],SIOCSIFTXQLEN,(caddr_t)&ifr) < 0 )
-              perror ("[ETHERNET] Can't set the txqueuelen");
-          else
-              printf("[ETHERNET] %s txqueuelen size has changed to %d\n",eth->if_name,ifr.ifr_qlen);
-        }
-        break;
+    case TX_Q_LEN: /* change TX queue length of eth interface */
+      ifr.ifr_addr.sa_family = AF_INET;
+      strncpy(ifr.ifr_name, eth->if_name, sizeof(ifr.ifr_name) - 1);
+      ifr.ifr_qlen = value;
+      for (int i = 0; i < eth->num_fd; i++) {
+        if (ioctl(eth->sockfdd[i], SIOCSIFTXQLEN, (caddr_t)&ifr) < 0)
+          perror("[ETHERNET] Can't set the txqueuelen");
+        else
+          printf("[ETHERNET] %s txqueuelen size has changed to %d\n", eth->if_name, ifr.ifr_qlen);
+      }
+      break;
 
     /******************* device level options  *************************/
     case COALESCE_PAR:
-        ret=snprintf(system_cmd,sizeof(system_cmd),"ethtool -C %s rx-usecs %d",eth->if_name,value);
-        if (ret > 0) {
-            ret=system(system_cmd);
-            if (ret == -1) {
-                fprintf (stderr,"[ETHERNET] Can't start shell to execute %s %s",system_cmd, strerror(errno));
-            } else {
-                printf ("[ETHERNET] status of %s is %d\n", system_cmd, WEXITSTATUS(ret));
-            }
-            printf("[ETHERNET] Coalesce parameters %s\n",system_cmd);
+      ret = snprintf(system_cmd, sizeof(system_cmd), "ethtool -C %s rx-usecs %d", eth->if_name, value);
+      if (ret > 0) {
+        ret = system(system_cmd);
+        if (ret == -1) {
+          fprintf(stderr, "[ETHERNET] Can't start shell to execute %s %s", system_cmd, strerror(errno));
         } else {
-            perror("[ETHERNET] Can't set coalesce parameters\n");
+          printf("[ETHERNET] status of %s is %d\n", system_cmd, WEXITSTATUS(ret));
         }
-        break;
+        printf("[ETHERNET] Coalesce parameters %s\n", system_cmd);
+      } else {
+        perror("[ETHERNET] Can't set coalesce parameters\n");
+      }
+      break;
 
     case PAUSE_PAR:
-        if (value==1) ret=snprintf(system_cmd,sizeof(system_cmd),"ethtool -A %s autoneg off rx off tx off",eth->if_name);
-        else if (value==0) ret=snprintf(system_cmd,sizeof(system_cmd),"ethtool -A %s autoneg on rx on tx on",eth->if_name);
-        else break;
-        if (ret > 0) {
-            ret=system(system_cmd);
-            if (ret == -1) {
-                fprintf (stderr,"[ETHERNET] Can't start shell to execute %s %s",system_cmd, strerror(errno));
-            } else {
-                printf ("[ETHERNET] status of %s is %d\n", system_cmd, WEXITSTATUS(ret));
-            }
-            printf("[ETHERNET] Pause parameters %s\n",system_cmd);
-        } else {
-            perror("[ETHERNET] Can't set pause parameters\n");
-        }
+      if (value == 1)
+        ret = snprintf(system_cmd, sizeof(system_cmd), "ethtool -A %s autoneg off rx off tx off", eth->if_name);
+      else if (value == 0)
+        ret = snprintf(system_cmd, sizeof(system_cmd), "ethtool -A %s autoneg on rx on tx on", eth->if_name);
+      else
         break;
+      if (ret > 0) {
+        ret = system(system_cmd);
+        if (ret == -1) {
+          fprintf(stderr, "[ETHERNET] Can't start shell to execute %s %s", system_cmd, strerror(errno));
+        } else {
+          printf("[ETHERNET] status of %s is %d\n", system_cmd, WEXITSTATUS(ret));
+        }
+        printf("[ETHERNET] Pause parameters %s\n", system_cmd);
+      } else {
+        perror("[ETHERNET] Can't set pause parameters\n");
+      }
+      break;
 
     case RING_PAR:
-        ret=snprintf(system_cmd,sizeof(system_cmd),"ethtool -G %s val %d",eth->if_name,value);
-        if (ret > 0) {
-            ret=system(system_cmd);
-            if (ret == -1) {
-                fprintf (stderr,"[ETHERNET] Can't start shell to execute %s %s",system_cmd, strerror(errno));
-            } else {
-                printf ("[ETHERNET] status of %s is %d\n", system_cmd, WEXITSTATUS(ret));
-            }
-            printf("[ETHERNET] Ring parameters %s\n",system_cmd);
-        } else {
-            perror("[ETHERNET] Can't set ring parameters\n");
-        }
-        break;
-    case KERNEL_RCV_BUF_MAX_SIZE:
-      ret=snprintf(system_cmd,sizeof(system_cmd),"sysctl -w net.core.rmem_max=%d;sysctl -w net.core.rmem_default=%d",value,value);
+      ret = snprintf(system_cmd, sizeof(system_cmd), "ethtool -G %s val %d", eth->if_name, value);
       if (ret > 0) {
-	ret=system(system_cmd);
-	if (ret == -1) {
-	  fprintf (stderr,"[ETHERNET] Can't start shell to execute %s %s",system_cmd, strerror(errno));
-	} else {
-	  printf ("[ETHERNET] status of %s is %d\n", system_cmd, WEXITSTATUS(ret));
-	}
-	printf("[ETHERNET] net core rmem %s\n",system_cmd);
+        ret = system(system_cmd);
+        if (ret == -1) {
+          fprintf(stderr, "[ETHERNET] Can't start shell to execute %s %s", system_cmd, strerror(errno));
+        } else {
+          printf("[ETHERNET] status of %s is %d\n", system_cmd, WEXITSTATUS(ret));
+        }
+        printf("[ETHERNET] Ring parameters %s\n", system_cmd);
       } else {
-	perror("[ETHERNET] Can't set net core rmem\n");
+        perror("[ETHERNET] Can't set ring parameters\n");
+      }
+      break;
+    case KERNEL_RCV_BUF_MAX_SIZE:
+      ret = snprintf(system_cmd,
+                     sizeof(system_cmd),
+                     "sysctl -w net.core.rmem_max=%d;sysctl -w net.core.rmem_default=%d",
+                     value,
+                     value);
+      if (ret > 0) {
+        ret = system(system_cmd);
+        if (ret == -1) {
+          fprintf(stderr, "[ETHERNET] Can't start shell to execute %s %s", system_cmd, strerror(errno));
+        } else {
+          printf("[ETHERNET] status of %s is %d\n", system_cmd, WEXITSTATUS(ret));
+        }
+        printf("[ETHERNET] net core rmem %s\n", system_cmd);
+      } else {
+        perror("[ETHERNET] Can't set net core rmem\n");
       }
       break;
     case KERNEL_SND_BUF_MAX_SIZE:
-      ret=snprintf(system_cmd,sizeof(system_cmd),"sysctl -w net.core.wmem_max=%d;sysctl -w net.core.wmem_default=%d;sysctl -w net.core.netdev_max_backlog=5000;sysctl -w net.core.optmem_max=524288;",value,value);
+      ret = snprintf(system_cmd,
+                     sizeof(system_cmd),
+                     "sysctl -w net.core.wmem_max=%d;sysctl -w net.core.wmem_default=%d;sysctl -w "
+                     "net.core.netdev_max_backlog=5000;sysctl -w net.core.optmem_max=524288;",
+                     value,
+                     value);
       if (ret > 0) {
-	ret=system(system_cmd);
-	if (ret == -1) {
-	  fprintf (stderr,"[ETHERNET] Can't start shell to execute %s %s",system_cmd, strerror(errno));
-	} else {
-	  printf ("[ETHERNET] status of %s is %d\n", system_cmd, WEXITSTATUS(ret));
-	}
-	printf("[ETHERNET] net core wmem %s\n",system_cmd);
+        ret = system(system_cmd);
+        if (ret == -1) {
+          fprintf(stderr, "[ETHERNET] Can't start shell to execute %s %s", system_cmd, strerror(errno));
+        } else {
+          printf("[ETHERNET] status of %s is %d\n", system_cmd, WEXITSTATUS(ret));
+        }
+        printf("[ETHERNET] net core wmem %s\n", system_cmd);
       } else {
-	perror("[ETHERNET] Can't set net core wmem\n");
+        perror("[ETHERNET] Can't set net core wmem\n");
       }
       break;
     default:
-        break;
-    }
-    return 0;
+      break;
+  }
+  return 0;
 }
 
 int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg, eth_params_t *eth_params)
 {
-    eth_state_t *eth = (eth_state_t*)malloc(sizeof(eth_state_t));
-    memset(eth, 0, sizeof(eth_state_t));
+  eth_state_t *eth = (eth_state_t *)malloc(sizeof(eth_state_t));
+  memset(eth, 0, sizeof(eth_state_t));
 
-    eth->flags = eth_params->transp_preference;
+  eth->flags = eth_params->transp_preference;
 
-    // load third-party driver
-    if (eth->flags == ETH_UDP_IF5_ECPRI_MODE) load_lib(device,openair0_cfg,eth_params,RAU_REMOTE_THIRDPARTY_RADIO_HEAD);
+  // load third-party driver
+  if (eth->flags == ETH_UDP_IF5_ECPRI_MODE)
+    load_lib(device, openair0_cfg, eth_params, RAU_REMOTE_THIRDPARTY_RADIO_HEAD);
 
+  if (eth_params->if_compress == 0) {
+    eth->compression = NO_COMPRESS;
+  } else if (eth_params->if_compress == 1) {
+    eth->compression = ALAW_COMPRESS;
+  } else {
+    printf("transport_init: Unknown compression scheme %d - default to ALAW", eth_params->if_compress);
+    eth->compression = ALAW_COMPRESS;
+  }
 
-    if (eth_params->if_compress == 0) {
-        eth->compression = NO_COMPRESS;
-    } else if (eth_params->if_compress == 1) {
-        eth->compression = ALAW_COMPRESS;
-    } else {
-        printf("transport_init: Unknown compression scheme %d - default to ALAW", eth_params->if_compress);
-        eth->compression = ALAW_COMPRESS;
-    }
+  eth->num_fd = 1;
 
-    eth->num_fd = 1;
+  printf("[ETHERNET]: Initializing openair0_device_t for %s ...\n", ((device->host_type == RAU_HOST) ? "RAU" : "RRU"));
+  printf("[ETHERNET]: num_fd %d\n", eth->num_fd);
+  device->transp_type = ETHERNET_TP;
+  device->trx_start_func = trx_eth_start;
+  device->trx_get_stats_func = trx_eth_get_stats;
+  device->trx_reset_stats_func = trx_eth_reset_stats;
+  device->trx_end_func = trx_eth_end;
+  device->trx_stop_func = trx_eth_stop;
+  device->trx_set_freq_func = trx_eth_set_freq;
+  device->trx_set_gains_func = trx_eth_set_gains;
+  device->trx_write_init = trx_eth_write_init;
 
-    printf("[ETHERNET]: Initializing openair0_device_t for %s ...\n", ((device->host_type == RAU_HOST) ? "RAU" : "RRU"));
-    printf("[ETHERNET]: num_fd %d\n",eth->num_fd);
-    device->transp_type      = ETHERNET_TP;
-    device->trx_start_func   = trx_eth_start;
-    device->trx_get_stats_func   = trx_eth_get_stats;
-    device->trx_reset_stats_func = trx_eth_reset_stats;
-    device->trx_end_func         = trx_eth_end;
-    device->trx_stop_func        = trx_eth_stop;
-    device->trx_set_freq_func    = trx_eth_set_freq;
-    device->trx_set_gains_func   = trx_eth_set_gains;
-    device->trx_write_init       = trx_eth_write_init;
+  device->trx_read_func2 = NULL;
+  device->trx_read_func = NULL;
+  device->trx_write_func2 = NULL;
+  device->trx_write_func = NULL;
 
-    device->trx_read_func2 = NULL;
-    device->trx_read_func = NULL;
-    device->trx_write_func2 = NULL;
-    device->trx_write_func = NULL;
+  if (eth->flags == ETH_RAW_MODE) {
+    device->trx_write_func = trx_eth_write_raw;
+    device->trx_read_func = trx_eth_read_raw;
+  } else if (eth->flags == ETH_UDP_MODE || eth->flags == ETH_UDP_IF5_ECPRI_MODE) {
+    device->trx_write_func2 = trx_eth_write_udp;
+    device->trx_read_func2 = trx_eth_read_udp;
+    device->trx_ctlsend_func = trx_eth_ctlsend_udp;
+    device->trx_ctlrecv_func = trx_eth_ctlrecv_udp;
+    memset((void *)&device->fhstate, 0, sizeof(device->fhstate));
+    printf("Setting %d RX channels to waiting\n", openair0_cfg->rx_num_channels);
+    for (int i = openair0_cfg->rx_num_channels; i < 8; i++)
+      device->fhstate.r[i] = 1;
+  } else if (eth->flags == ETH_RAW_IF4p5_MODE) {
+    device->trx_write_func = trx_eth_write_raw_IF4p5;
+    device->trx_read_func = trx_eth_read_raw_IF4p5;
+  } else if (eth->flags == ETH_UDP_IF4p5_MODE) {
+    device->trx_write_func = trx_eth_write_udp_IF4p5;
+    device->trx_read_func = trx_eth_read_udp_IF4p5;
+    device->trx_ctlsend_func = trx_eth_ctlsend_udp;
+    device->trx_ctlrecv_func = trx_eth_ctlrecv_udp;
+  } else {
+    // device->trx_write_func   = trx_eth_write_udp_IF4p5;
+    // device->trx_read_func    = trx_eth_read_udp_IF4p5;
+  }
 
-    if  (eth->flags == ETH_RAW_MODE) {
-        device->trx_write_func   = trx_eth_write_raw;
-        device->trx_read_func    = trx_eth_read_raw;
-    } else if (eth->flags == ETH_UDP_MODE || eth->flags == ETH_UDP_IF5_ECPRI_MODE) {
-        device->trx_write_func2   = trx_eth_write_udp;
-        device->trx_read_func2    = trx_eth_read_udp;
-        device->trx_ctlsend_func = trx_eth_ctlsend_udp;
-        device->trx_ctlrecv_func = trx_eth_ctlrecv_udp;
-        memset((void*)&device->fhstate,0,sizeof(device->fhstate));
-        printf("Setting %d RX channels to waiting\n",openair0_cfg->rx_num_channels);
-	for (int i=openair0_cfg->rx_num_channels;i<8;i++) device->fhstate.r[i] = 1;
-    } else if (eth->flags == ETH_RAW_IF4p5_MODE) {
-        device->trx_write_func   = trx_eth_write_raw_IF4p5;
-        device->trx_read_func    = trx_eth_read_raw_IF4p5;
-    } else if (eth->flags == ETH_UDP_IF4p5_MODE) {
-        device->trx_write_func   = trx_eth_write_udp_IF4p5;
-        device->trx_read_func    = trx_eth_read_udp_IF4p5;
-        device->trx_ctlsend_func = trx_eth_ctlsend_udp;
-        device->trx_ctlrecv_func = trx_eth_ctlrecv_udp;
-    } else {
-        //device->trx_write_func   = trx_eth_write_udp_IF4p5;
-        //device->trx_read_func    = trx_eth_read_udp_IF4p5;
-    }
-
-    eth->if_name = eth_params->local_if_name;
-    device->priv = eth;
-    device->openair0_cfg=&openair0_cfg[0];
-    return 0;
+  eth->if_name = eth_params->local_if_name;
+  device->priv = eth;
+  device->openair0_cfg = &openair0_cfg[0];
+  return 0;
 }
-
 
 /**************************************************************************************************************************
  *                                         DEBUGING-RELATED FUNCTIONS                                                     *
  **************************************************************************************************************************/
-void dump_packet(char *title,
-                 unsigned char* pkt,
-                 int bytes,
-                 unsigned int tx_rx_flag)
+void dump_packet(char *title, unsigned char *pkt, int bytes, unsigned int tx_rx_flag)
 {
-    static int numSend = 1;
-    static int numRecv = 1;
-    int num, k;
-    char tmp[48];
-    unsigned short int cksum;
+  static int numSend = 1;
+  static int numRecv = 1;
+  int num, k;
+  char tmp[48];
+  unsigned short int cksum;
 
-    num = (tx_rx_flag)? numSend++:numRecv++;
-    for (k = 0; k < 24; k++) sprintf(tmp+k, "%02X", pkt[k]);
-    cksum = calc_csum((unsigned short *)pkt, bytes>>2);
-    printf("%s-%s (%06d): %s 0x%04X\n", title,(tx_rx_flag)? "TX":"RX", num, tmp, cksum);
+  num = (tx_rx_flag) ? numSend++ : numRecv++;
+  for (k = 0; k < 24; k++)
+    sprintf(tmp + k, "%02X", pkt[k]);
+  cksum = calc_csum((unsigned short *)pkt, bytes >> 2);
+  printf("%s-%s (%06d): %s 0x%04X\n", title, (tx_rx_flag) ? "TX" : "RX", num, tmp, cksum);
 }
 
-
-unsigned short calc_csum (unsigned short *buf,
-                          int nwords)
+unsigned short calc_csum(unsigned short *buf, int nwords)
 {
-    unsigned long sum;
-    for (sum = 0; nwords > 0; nwords--)
-        sum += *buf++;
-    sum = (sum >> 16) + (sum & 0xffff);
-    sum += (sum >> 16);
-    return ~sum;
+  unsigned long sum;
+  for (sum = 0; nwords > 0; nwords--)
+    sum += *buf++;
+  sum = (sum >> 16) + (sum & 0xffff);
+  sum += (sum >> 16);
+  return ~sum;
 }
 
 void dump_dev(openair0_device_t *device)
 {
-    eth_state_t *eth = (eth_state_t*)device->priv;
+  eth_state_t *eth = (eth_state_t *)device->priv;
 
-    printf("Ethernet device configuration:\n");
-    printf("       RB number: %i, sample rate: %lf \n" ,
-           device->openair0_cfg->num_rb_dl, device->openair0_cfg->sample_rate);
-    printf("       RAU configured for %i tx/%i rx channels)\n",
-           device->openair0_cfg->tx_num_channels,device->openair0_cfg->rx_num_channels);
-    printf("       Running flags: %s %s (\n",
-           ((eth->flags & ETH_RAW_MODE)  ? "RAW socket mode - ":""),
-           ((eth->flags & ETH_UDP_MODE)  ? "UDP socket mode - ":""));
-    printf("       Number of iqs dumped when displaying packets: %i\n\n",eth->iqdumpcnt);
-
+  printf("Ethernet device configuration:\n");
+  printf("       RB number: %i, sample rate: %lf \n", device->openair0_cfg->num_rb_dl, device->openair0_cfg->sample_rate);
+  printf("       RAU configured for %i tx/%i rx channels)\n",
+         device->openair0_cfg->tx_num_channels,
+         device->openair0_cfg->rx_num_channels);
+  printf("       Running flags: %s %s (\n",
+         ((eth->flags & ETH_RAW_MODE) ? "RAW socket mode - " : ""),
+         ((eth->flags & ETH_UDP_MODE) ? "UDP socket mode - " : ""));
+  printf("       Number of iqs dumped when displaying packets: %i\n\n", eth->iqdumpcnt);
 }
 
 void inline dump_txcounters(openair0_device_t *device)
 {
-    eth_state_t *eth = (eth_state_t*)device->priv;
-    printf("   Ethernet device interface tx counters:\n");
-    printf("   Sent packets: %llu send errors: %i\n",   (long long unsigned int)eth->tx_count, eth->num_tx_errors);
+  eth_state_t *eth = (eth_state_t *)device->priv;
+  printf("   Ethernet device interface tx counters:\n");
+  printf("   Sent packets: %llu send errors: %i\n", (long long unsigned int)eth->tx_count, eth->num_tx_errors);
 }
 
 void inline dump_rxcounters(openair0_device_t *device)
 {
-    eth_state_t *eth = (eth_state_t*)device->priv;
-    printf("   Ethernet device interface rx counters:\n");
-    printf("   Received packets: %llu missed packets errors: %i\n", (long long unsigned int)eth->rx_count, eth->num_underflows);
+  eth_state_t *eth = (eth_state_t *)device->priv;
+  printf("   Ethernet device interface rx counters:\n");
+  printf("   Received packets: %llu missed packets errors: %i\n", (long long unsigned int)eth->rx_count, eth->num_underflows);
 }
 
 void inline dump_buff(openair0_device_t *device, char *buff, unsigned int tx_rx_flag, int nsamps)
 {
-    char *strptr;
-    eth_state_t *eth = (eth_state_t*)device->priv;
-    /*need to add ts number of iqs in printf need to fix dump iqs call */
-    strptr = (( tx_rx_flag == TX_FLAG) ? "TX" : "RX");
-    printf("\n %s, nsamps=%i \n" ,strptr,nsamps);
+  char *strptr;
+  eth_state_t *eth = (eth_state_t *)device->priv;
+  /*need to add ts number of iqs in printf need to fix dump iqs call */
+  strptr = ((tx_rx_flag == TX_FLAG) ? "TX" : "RX");
+  printf("\n %s, nsamps=%i \n", strptr, nsamps);
 
-    if (tx_rx_flag == 1) {
-        dump_txcounters(device);
-        printf("  First %i iqs of TX buffer\n",eth->iqdumpcnt);
-        dump_iqs(buff,eth->iqdumpcnt);
-    } else {
-        dump_rxcounters(device);
-        printf("  First %i iqs of RX buffer\n",eth->iqdumpcnt);
-        dump_iqs(buff,eth->iqdumpcnt);
-    }
-
+  if (tx_rx_flag == 1) {
+    dump_txcounters(device);
+    printf("  First %i iqs of TX buffer\n", eth->iqdumpcnt);
+    dump_iqs(buff, eth->iqdumpcnt);
+  } else {
+    dump_rxcounters(device);
+    printf("  First %i iqs of RX buffer\n", eth->iqdumpcnt);
+    dump_iqs(buff, eth->iqdumpcnt);
+  }
 }
 
-
-void dump_iqs(char * buff,
-              int iq_cnt)
+void dump_iqs(char *buff, int iq_cnt)
 {
-    int i;
-    for (i=0; i<iq_cnt; i++) {
-        printf("s%02i: Q=%+ij I=%+i%s",i,
-               ((iqoai_t *)(buff))[i].q,
-               ((iqoai_t *)(buff))[i].i,
-               ((i+1)%3 == 0) ? "\n" : "  ");
-    }
+  int i;
+  for (i = 0; i < iq_cnt; i++) {
+    printf("s%02i: Q=%+ij I=%+i%s", i, ((iqoai_t *)(buff))[i].q, ((iqoai_t *)(buff))[i].i, ((i + 1) % 3 == 0) ? "\n" : "  ");
+  }
 }

--- a/radio/ETHERNET/ethernet_lib.c
+++ b/radio/ETHERNET/ethernet_lib.c
@@ -63,36 +63,36 @@ int trx_eth_start(openair0_device_t *device)
                    device->openair0_cfg->txfh_cores[i],
                    OAI_PRIORITY_RT_MAX);
     }
-    device->sampling_rate_ratio_n = 1;
-    device->sampling_rate_ratio_d = 1;
+    eth->sampling_rate_ratio_n = 1;
+    eth->sampling_rate_ratio_d = 1;
     if (device->openair0_cfg->nr_flag == 1) { // This check if RRU knows about NR numerologies
       if (device->openair0_cfg->num_rb_dl <= 162 && device->openair0_cfg->num_rb_dl > 106) {
-        device->sampling_rate_ratio_n = 2;
-        device->txrx_offset = 5500;
+        eth->sampling_rate_ratio_n = 2;
+        eth->txrx_offset = 5500;
       } else if (device->openair0_cfg->num_rb_dl <= 106 && device->openair0_cfg->num_rb_dl > 51) {
-        device->sampling_rate_ratio_d = 3;
-        device->sampling_rate_ratio_n = 4;
-        device->txrx_offset = 3750;
+        eth->sampling_rate_ratio_d = 3;
+        eth->sampling_rate_ratio_n = 4;
+        eth->txrx_offset = 3750;
       } else if (device->openair0_cfg->num_rb_dl == 51) {
-        device->sampling_rate_ratio_n = 1;
-        device->sampling_rate_ratio_d = 1;
-        device->txrx_offset = 7500;
+        eth->sampling_rate_ratio_n = 1;
+        eth->sampling_rate_ratio_d = 1;
+        eth->txrx_offset = 7500;
       } else
         AssertFatal(1 == 0, "num_rb_dl %d not ok with ECPRI\n", device->openair0_cfg->num_rb_dl);
     } else {
       if (device->openair0_cfg->num_rb_dl == 100 || device->openair0_cfg->num_rb_dl == 51) {
-        device->sampling_rate_ratio_d = 1;
-        device->txrx_offset = 7500;
+        eth->sampling_rate_ratio_d = 1;
+        eth->txrx_offset = 7500;
       } else if (device->openair0_cfg->num_rb_dl == 75) {
-        device->sampling_rate_ratio_d = 4;
-        device->sampling_rate_ratio_n = 3;
-        device->txrx_offset = 7500;
+        eth->sampling_rate_ratio_d = 4;
+        eth->sampling_rate_ratio_n = 3;
+        eth->txrx_offset = 7500;
       } else if (device->openair0_cfg->num_rb_dl == 50) {
-        device->sampling_rate_ratio_d = 2;
-        device->txrx_offset = 7500;
+        eth->sampling_rate_ratio_d = 2;
+        eth->txrx_offset = 7500;
       } else if (device->openair0_cfg->num_rb_dl == 25) {
-        device->sampling_rate_ratio_d = 4;
-        device->txrx_offset = 7500;
+        eth->sampling_rate_ratio_d = 4;
+        eth->txrx_offset = 7500;
       } else
         AssertFatal(1 == 0, "num_rb_dl %d not ok with ECPRI\n", device->openair0_cfg->num_rb_dl);
     }

--- a/radio/ETHERNET/ethernet_lib.c
+++ b/radio/ETHERNET/ethernet_lib.c
@@ -492,10 +492,10 @@ int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg, e
     device->trx_read_func2 = trx_eth_read_udp;
     device->trx_ctlsend_func = trx_eth_ctlsend_udp;
     device->trx_ctlrecv_func = trx_eth_ctlrecv_udp;
-    memset((void *)&device->fhstate, 0, sizeof(device->fhstate));
+    memset(&eth->fhstate, 0, sizeof(eth->fhstate));
     printf("Setting %d RX channels to waiting\n", openair0_cfg->rx_num_channels);
     for (int i = openair0_cfg->rx_num_channels; i < 8; i++)
-      device->fhstate.r[i] = 1;
+      eth->fhstate.r[i] = 1;
   } else if (eth->flags == ETH_RAW_IF4p5_MODE) {
     device->trx_write_func = trx_eth_write_raw_IF4p5;
     device->trx_read_func = trx_eth_read_raw_IF4p5;

--- a/radio/ETHERNET/ethernet_lib.h
+++ b/radio/ETHERNET/ethernet_lib.h
@@ -38,6 +38,19 @@ typedef struct {
   notifiedFIFO_t *resp;
 } udp_ctx_t;
 
+typedef struct fhstate_s {
+  openair0_timestamp_t TS[8];
+  openair0_timestamp_t TS0;
+  openair0_timestamp_t olddeltaTS[8];
+  openair0_timestamp_t oldTS[8];
+  openair0_timestamp_t TS_read;
+  int first_read;
+  uint32_t *buff[8];
+  uint32_t buff_size;
+  int r[8];
+  int active;
+} fhstate_t;
+
 /*!\brief opaque ethernet data structure */
 typedef struct {
   
@@ -52,7 +65,7 @@ typedef struct {
   /*!\brief buffer size */ 
   unsigned int buffer_size;
   /*!\brief Fronthaul state */
-  fhstate_t *fhstate;
+  fhstate_t fhstate;
   /*!\brief destination address (control) for UDP socket*/
   struct sockaddr_in dest_addrc;
   /*!\brief local address (control) for UDP socket*/

--- a/radio/ETHERNET/ethernet_lib.h
+++ b/radio/ETHERNET/ethernet_lib.h
@@ -96,6 +96,13 @@ typedef struct {
   /*!\brief number of errors in interface's transmitter */ 
   int num_tx_errors;
 
+  /*!brief numerator of sampling rate ratio*/
+  int sampling_rate_ratio_n;
+  /*!brief denominator of sampling rate ratio*/
+  int sampling_rate_ratio_d;
+  /*!brief the TX/RX timing offset*/
+  int txrx_offset;
+
   /*!\brief current TX timestamp */
   openair0_timestamp_t tx_current_ts;
   /*!\brief socket file desc */

--- a/radio/rfsimulator/stored_node.c
+++ b/radio/rfsimulator/stored_node.c
@@ -4,6 +4,7 @@
 
 
 #include <common/utils/simple_executable.h>
+#include "common_lib.h"
 
 volatile int             oai_exit = 0;
 


### PR DESCRIPTION
This PR has three goals

1. Remove the usage of eth_params in L2/L3 code, and replace with tailored data structures for _IP_ connectivity where necessary
2. Remove many of the includes of `common_lib.h` where possible
3. Slightly clean up `openair0_device` and in particular move fields to `eth_state_t` where appropriate

I wanted to clean up the usage of `eth_params_t` as in [remove-eth_params.patch](https://github.com/user-attachments/files/29466967/remove-eth_params.patch), but this does not work as the AW2S driver indirectly accesses it in ways that I cannot simply move it into eth_params. Probably the rework there is to remove all `third_party` fptrs, make a dedicated struct to store AW2S data in `priv` (not only a pointer to the ORI library), and store eth_params as passed to the initialization function.
