### PR TITLE
NR RRC: use serving cell band for UE capability enquiry

### DIFF
--- a/openair2/RRC/NR/MESSAGES/asn1_msg.c
+++ b/openair2/RRC/NR/MESSAGES/asn1_msg.c
@@ -413,7 +413,7 @@ int do_NR_SecurityModeCommand(uint8_t *const buffer,
   return((enc_rval.encoded+7)/8);
 }
 
-int do_NR_SA_UECapabilityEnquiry(uint8_t *const buffer, const uint8_t Transaction_id)
+int do_NR_SA_UECapabilityEnquiry(uint8_t *const buffer, const uint8_t Transaction_id, const int band)
 {
   NR_UE_CapabilityRequestFilterNR_t *sa_band_filter;
   NR_FreqBandList_t *sa_band_list;
@@ -436,7 +436,7 @@ int do_NR_SA_UECapabilityEnquiry(uint8_t *const buffer, const uint8_t Transactio
   ue_capabilityrat_request->rat_Type = NR_RAT_Type_nr;
 
   sa_band_infoNR = (NR_FreqBandInformationNR_t*)calloc(1,sizeof(NR_FreqBandInformationNR_t));
-  sa_band_infoNR->bandNR = 78;
+  sa_band_infoNR->bandNR = band;
   sa_band_info = (NR_FreqBandInformation_t*)calloc(1,sizeof(NR_FreqBandInformation_t));
   sa_band_info->present = NR_FreqBandInformation_PR_bandInformationNR;
   sa_band_info->choice.bandInformationNR = sa_band_infoNR;

--- a/openair2/RRC/NR/MESSAGES/asn1_msg.h
+++ b/openair2/RRC/NR/MESSAGES/asn1_msg.h
@@ -88,7 +88,7 @@ int do_NR_SecurityModeCommand(uint8_t *const buffer,
                               const uint8_t cipheringAlgorithm,
                               NR_IntegrityProtAlgorithm_t integrityProtAlgorithm);
 
-int do_NR_SA_UECapabilityEnquiry(uint8_t *const buffer, const uint8_t Transaction_id);
+int do_NR_SA_UECapabilityEnquiry(uint8_t *const buffer, const uint8_t Transaction_id, const int band);
 
 int do_NR_RRCRelease(uint8_t *buffer, size_t buffer_size, uint8_t Transaction_id);
 

--- a/openair2/RRC/NR/MESSAGES/tests/test_asn1_msg.cpp
+++ b/openair2/RRC/NR/MESSAGES/tests/test_asn1_msg.cpp
@@ -83,7 +83,7 @@ TEST(nr_asn1, rrc_reject)
 TEST(nr_asn1, sa_capability_enquiry)
 {
   unsigned char buf[1000];
-  EXPECT_GT(do_NR_SA_UECapabilityEnquiry(buf, 0), 0);
+  EXPECT_GT(do_NR_SA_UECapabilityEnquiry(buf, 0, 78), 0);
 }
 
 TEST(nr_asn1, rrc_reconfiguration_complete_for_nsa)

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -2139,8 +2139,13 @@ static void rrc_gNB_generate_UECapabilityEnquiry(gNB_RRC_INST *rrc, gNB_RRC_UE_t
   T(T_ENB_RRC_UE_CAPABILITY_ENQUIRY, T_INT(rrc->module_id), T_INT(0), T_INT(0), T_INT(ue->rrc_ue_id));
   uint8_t xid = rrc_gNB_get_next_transaction_identifier(rrc->module_id);
   ue->xids[xid] = RRC_UECAPABILITY_ENQUIRY;
-  int size = do_NR_SA_UECapabilityEnquiry(buffer, xid);
-  LOG_I(NR_RRC, "UE %d: Logical Channel DL-DCCH, Generate NR UECapabilityEnquiry (bytes %d, xid %d)\n", ue->rrc_ue_id, size, xid);
+  nr_rrc_cell_container_t *pcell = rrc_get_pcell_for_ue(rrc, ue);
+  DevAssert(pcell != NULL);
+  const int band = pcell->info.mode == NR_MODE_TDD ? pcell->info.tdd.dlul.band : pcell->info.fdd.dl.band;
+
+  int size = do_NR_SA_UECapabilityEnquiry(buffer, xid, band);
+  LOG_I(NR_RRC, "UE %d: Logical Channel DL-DCCH, Generate NR UECapabilityEnquiry for band %d (bytes %d, xid %d)\n", 
+    ue->rrc_ue_id, band, size, xid);
 
   AssertFatal(!NODE_IS_DU(rrc->node_type), "illegal node type DU!\n");
 


### PR DESCRIPTION
Pass the configured primary cell band into do_NR_SA_UECapabilityEnquiry() instead of hardcoding band 78. Derive the band for both TDD and FDD cells, log it, and update the ASN.1 test call.