### PR TITLE
Allocate multiple UEs in one slot (DL/UL)

### DIFF
--- a/nfapi/open-nFAPI/nfapi/public_inc/nfapi_nr_interface_scf.h
+++ b/nfapi/open-nFAPI/nfapi/public_inc/nfapi_nr_interface_scf.h
@@ -822,7 +822,7 @@ typedef struct {
 //table 3-37 
 
 #define DCI_PAYLOAD_BYTE_LEN 8 // 12 ? TS38.212 sec 7.3.1
-#define MAX_DCI_CORESET 8
+#define MAX_DCI_CORESET 12
 
 typedef struct {
   // The RNTI used for identifying the UE when receiving the PDU Value: 1 -> 65535.

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch.c
@@ -886,11 +886,9 @@ void nr_dlsch_preprocessor(gNB_MAC_INST *mac, post_process_pdsch_t *pp_pdsch)
   for (int i = 0; i < num_beams; i++)
     n_rb_sched[i] = bw;
 
-  int average_agg_level = 4; // TODO find a better estimation
-  int max_sched_ues = bw / (average_agg_level * NR_NB_REG_PER_CCE);
-
   // FAPI cannot handle more than MAX_DCI_CORESET DCIs
-  max_sched_ues = min(max_sched_ues, MAX_DCI_CORESET);
+  static_assert(4 < MAX_DCI_CORESET, "cannot have more concurrent UEs than MAX_DCI_CORESET\n");
+  int max_sched_ues = 4;
 
   nr_dl_schedule(mac, pp_pdsch, UE_info->connected_ue_list, max_sched_ues, num_beams, n_rb_sched);
 }

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch_default_policies.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch_default_policies.c
@@ -239,18 +239,26 @@ int nr_dl_proportional_fair(const nr_dl_sched_params_t *params, nr_dl_candidate_
     COMMIT_ALLOC(params, cand, rbStart, min_rbSize, cand->sched_pdsch.mcs, n_scheduled);
   }
 
-  /* Phase 3: New data UEs — PF priority order, largest free block */
-  for (int j = 0; j < n_active; j++) {
+  /* BW is the same across all beams, just use beam 0 */
+  int max_rbSize = params->n_rb_avail[0];
+  DevAssert(max_rbSize >= min_rbSize);
+  int n_remain_ue = params->max_num_ue - n_scheduled;
+  // share RBs fairly between remaining allocatable UEs
+  int n_rb_per_ue = max(min_rbSize, max_rbSize / n_remain_ue);
+
+  /* Phase 3: New data UEs — PF priority order, count number of RBs required,
+   * store number of excess RBs for UEs. Check two additional UEs in case the
+   * first ones cannot be allocated (DCI alloc fail). This is only necessary
+   * because we use type-1 allocation, if we used type-0, we could fix the UEs,
+   * then iteratively give RBs as needed. */
+  uint16_t rbs_ue[MAX_MOBILES_PER_GNB] = {0};
+  int excess_total_rbs = max_rbSize;
+  for (int j = 0, n = 0; j < n_active && n < n_remain_ue + 2; j++) {
     nr_dl_candidate_t *cand = order[j];
     if (cand->is_retx || cand->pending_bytes == 0)
       continue;
 
-    int rbStart;
-    uint16_t *vrb_map = params->vrb_map[cand->alloc_beam_idx];
-    int max_rbSize = find_largest_free_block(vrb_map, cand->alloc_slbitmap, cand->bwp_start, cand->bwp_size, &rbStart);
-    if (max_rbSize < min_rbSize)
-      continue;
-
+    // calculate the number of RBs that UE would like to have
     int mcs = cand->sched_pdsch.mcs;
     uint8_t Qm = nr_get_Qm_dl(mcs, cand->mcs_table);
     uint16_t R = nr_get_code_rate_dl(mcs, cand->mcs_table);
@@ -260,7 +268,6 @@ int nr_dl_proportional_fair(const nr_dl_sched_params_t *params, nr_dl_candidate_
                                               cand->sched_pdsch.nrOfLayers);
     const int oh = 3 * 4 + (cand->UE->UE_sched_ctrl.ta_apply ? 2 : 0);
     uint32_t tbs;
-    uint16_t rbSize;
     nr_find_nb_rb(Qm,
                   R,
                   1,
@@ -271,8 +278,38 @@ int nr_dl_proportional_fair(const nr_dl_sched_params_t *params, nr_dl_candidate_
                   min_rbSize,
                   max_rbSize,
                   &tbs,
-                  &rbSize);
+                  &rbs_ue[j]);
+    if (n < n_remain_ue) {
+      // for the first n_remain_ue UEs: account number of RBs
+      // so excess RBs not used by some UEs could be given to others
+      excess_total_rbs -= min(rbs_ue[j], n_rb_per_ue);
+      excess_total_rbs = max(excess_total_rbs, 0);
+    }
+    n++;
+  }
 
+  /* allocate up to all UEs checked above */
+  for (int j = 0; j < n_active; j++) {
+    nr_dl_candidate_t *cand = order[j];
+    if (cand->is_retx || cand->pending_bytes == 0 || rbs_ue[j] == 0)
+      continue;
+
+    // give every UE its chunk of data. If total_rbs indicates excess RBs, give
+    // additionally as appropriate.
+    int rb_req = min(rbs_ue[j], n_rb_per_ue);
+    int excess_req = max(rbs_ue[j] - rb_req, 0);
+    if (excess_total_rbs > 0 && excess_req > 0) {
+      int excess_ack = min(excess_total_rbs, excess_req);
+      rb_req += excess_ack;
+      excess_total_rbs -= excess_ack;
+      DevAssert(excess_total_rbs >= 0);
+    }
+    int rbStart, rbSize;
+    uint16_t *vrb_map = params->vrb_map[cand->alloc_beam_idx];
+    if (!get_rb_alloc(min_rbSize, rb_req, cand->bwp_start, cand->bwp_size, vrb_map, cand->alloc_slbitmap, &rbStart, &rbSize))
+      continue;
+
+    int mcs = cand->sched_pdsch.mcs;
     COMMIT_ALLOC(params, cand, rbStart, rbSize, mcs, n_scheduled);
   }
 

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -938,6 +938,7 @@ nfapi_nr_dl_dci_pdu_t *prepare_dci_pdu(nfapi_nr_dl_tti_pdcch_pdu_rel15_t *pdcch_
                                        int beam_index,
                                        int rnti)
 {
+  DevAssert(pdcch_pdu->numDlDci < MAX_DCI_CORESET);
   nfapi_nr_dl_dci_pdu_t *dci_pdu = &pdcch_pdu->dci_pdu[pdcch_pdu->numDlDci];
   dci_pdu->RNTI = rnti;
   dci_pdu->AggregationLevel = aggregation_level;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -2501,11 +2501,9 @@ void nr_ulsch_preprocessor(gNB_MAC_INST *nr_mac, post_process_pusch_t *pp_pusch)
   int num_beams = nr_mac->beam_info.beam_allocation ? nr_mac->beam_info.beams_per_period : 1;
   int bw = scc->uplinkConfigCommon->frequencyInfoUL->scs_SpecificCarrierList.list.array[0]->carrierBandwidth;
 
-  int average_agg_level = 4; // TODO find a better estimation
-  int max_dci = bw / (average_agg_level * NR_NB_REG_PER_CCE);
-
   // FAPI cannot handle more than MAX_DCI_CORESET DCIs
-  max_dci = min(max_dci, MAX_DCI_CORESET);
+  static_assert(4 < MAX_DCI_CORESET, "cannot have more concurrent UEs than MAX_DCI_CORESET\n");
+  int max_dci = 4;
 
   fsn_t current = {frame, slot, *scc->ssbSubcarrierSpacing};
   fsn_t min_next = fsn_add_delta(current, min_rxtx);

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch_default_policies.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch_default_policies.c
@@ -270,37 +270,34 @@ int nr_ul_proportional_fair(const nr_ul_sched_params_t *params, nr_ul_candidate_
     COMMIT_UL_ALLOC(params, cand, rbStart, min_rb, cand->sched_pusch.mcs, n_scheduled);
   }
 
-  /* Phase 3: New data UEs — PF priority order, largest free block */
-  for (int j = 0; j < n_active; j++) {
+  /* BW is the same across all beams, just use beam 0 */
+  int max_rbSize = params->n_rb_avail[0];
+  DevAssert(max_rbSize >= min_rb);
+  int n_remain_ue = params->max_num_ue - n_scheduled;
+  // share RBs fairly between remaining allocatable UEs
+  int n_rb_per_ue = max(min_rb, max_rbSize / n_remain_ue);
+
+  /* Phase 3: New data UEs — PF priority order, count number of RBs required,
+   * store number of excess RBs. Check two additional UEs in case the first
+   * ones cannot be allocated (DCI alloc fail). This is only necessary because
+   * we use type-1 allocate; if we used type-0, we could fix the UEs, then give
+   * iteratively the RBs as needed*/
+  uint16_t rbs_ue[MAX_MOBILES_PER_GNB] = {0};
+  int excess_total_rbs = max_rbSize;
+  for (int j = 0, n = 0; j < n_active && n < n_remain_ue + 2; j++) {
     nr_ul_candidate_t *cand = order[j];
     if (cand->is_retx || cand->sched_inactive)
       continue;
 
-    int block_start;
-    uint16_t *vrb_map = params->vrb_map_UL[cand->alloc_beam_idx];
-    int block_len = find_largest_free_block(vrb_map, cand->alloc_slbitmap, cand->bwp_start, cand->bwp_size, &block_start);
-    if (block_len < min_rb)
-      continue;
-
-    uint16_t rbSize = block_len;
-    uint8_t mcs = cand->sched_pusch.mcs;
-
-    if (cand->pcmax != 0 || cand->ph != 0) {
-      nr_ul_phr_advice_t advice;
-      if (!nr_ul_check_phr(params, cand, rbSize, mcs, &advice)) {
-        rbSize = advice.max_mcs_min_rb.rbSize;
-        mcs = advice.max_mcs_min_rb.mcs;
-      }
-    }
-
+    // calculate the number of RBs that UE would like to have. Power limitation
+    // is later
     NR_UE_UL_BWP_t *current_BWP = &cand->UE->current_UL_BWP;
     NR_pusch_dmrs_t dmrs_info =
         get_ul_dmrs_params(params->scc, current_BWP, &cand->sched_pusch.tda_info, cand->sched_pusch.nrOfLayers);
     uint16_t Rt;
     uint8_t Qt;
-    update_ul_ue_R_Qm(mcs, current_BWP->mcs_table, current_BWP->pusch_Config, &Rt, &Qt);
+    update_ul_ue_R_Qm(cand->sched_pusch.mcs, current_BWP->mcs_table, current_BWP->pusch_Config, &Rt, &Qt);
     uint32_t tb_size;
-    uint16_t final_rbSize;
     nr_find_nb_rb(Qt,
                   Rt,
                   current_BWP->transform_precoding,
@@ -309,11 +306,55 @@ int nr_ul_proportional_fair(const nr_ul_sched_params_t *params, nr_ul_candidate_
                   dmrs_info.N_PRB_DMRS * dmrs_info.num_dmrs_symb,
                   cand->pending_bytes,
                   min_rb,
-                  rbSize,
+                  max_rbSize,
                   &tb_size,
-                  &final_rbSize);
+                  &rbs_ue[j]);
+    if (n < n_remain_ue) {
+      // for the first n_remain_ue UEs: account number of RBs
+      // so excess RBs not used by some UEs could be given to others
+      excess_total_rbs -= min(rbs_ue[j], n_rb_per_ue);
+      excess_total_rbs = max(excess_total_rbs, 0);
+    }
+    n++;
+  }
 
-    COMMIT_UL_ALLOC(params, cand, block_start, final_rbSize, mcs, n_scheduled);
+  /* allocate up to all UEs checked above */
+  for (int j = 0; j < n_active; j++) {
+    nr_ul_candidate_t *cand = order[j];
+    if (cand->is_retx || cand->sched_inactive || rbs_ue[j] == 0)
+      continue;
+
+    // give every UE its chunk of data. If total_rbs indicates excess RBs, give
+    // additionally as appropriate.
+    int rb_req = min(rbs_ue[j], n_rb_per_ue);
+    int excess_req = max(rbs_ue[j] - rb_req, 0);
+    uint8_t mcs = cand->sched_pusch.mcs;
+    // check if power is enough for rb_req + excess_req if actually received a
+    // PHR (PCmax > 0, otherwise nothing is scheduled)
+    nr_ul_phr_advice_t advice;
+    if (cand->pcmax != 0 && !nr_ul_check_phr(params, cand, rb_req + excess_req, mcs, &advice)) {
+      int lim_rb = advice.max_mcs_min_rb.rbSize;
+      if (lim_rb > rb_req) {
+        // enough for rb_req, but not excess_req
+        excess_req = lim_rb - rb_req;
+      } else {
+        // not enough for rb_req
+        excess_req = 0;
+        rb_req = lim_rb;
+      }
+      mcs = advice.max_mcs_min_rb.mcs;
+    }
+    if (excess_total_rbs > 0 && excess_req > 0) {
+      int excess_ack = min(excess_total_rbs, excess_req);
+      rb_req += excess_ack;
+      excess_total_rbs -= excess_ack;
+      DevAssert(excess_total_rbs >= 0);
+    }
+    int rbStart, rbSize;
+    uint16_t *vrb_map = params->vrb_map_UL[cand->alloc_beam_idx];
+    if (!get_rb_alloc(min_rb, rb_req, cand->bwp_start, cand->bwp_size, vrb_map, cand->alloc_slbitmap, &rbStart, &rbSize))
+      continue;
+    COMMIT_UL_ALLOC(params, cand, rbStart, rbSize, mcs, n_scheduled);
   }
 
   return n_scheduled;


### PR DESCRIPTION
This PR allows to schedule multiple UEs in one slot via a 2-pass loop. Since we still use type-1 RB allocation, we use start+length. Thus, once an allocation is made, it is non-trivial to change it if another UE has been allocated, because it would be necessary to change the allocation of multiple UEs retroactively. Thus, the two-pass algorithm

1. calculates the amount of RBs relevant for each UE, storing the number of requested RBs
2. makes allocations while accounting for excess RBs (excess RBs are given to the first UE(s) to preserve the PF property)

TODO
- [x] DL done, check CI
- [x] UL TBD

Further, the number of DCIs in DL/UL is capped to 4 to prevent excessive computation times, as shown in nrdlbench. Also, increase the number of DCIs per slot to 12 (from 8, which might be reached with 4 DL/4 UL UEs) and add asserts.