### PR TITLE
CI: Collect amariue logs, update eNB configs

### DIFF
--- a/ci-scripts/Jenkinsfile-GitHub-Container
+++ b/ci-scripts/Jenkinsfile-GitHub-Container
@@ -48,7 +48,6 @@ def nsaTDDB200Status = ''
 def saTDDB200Status = ''
 def phytestLDPCoffloadStatus = ''
 def saAW2SStatus = ''
-def cn5gCOTSUESanityCheck = ''
 def saAERIALStatus = ''
 def saMultiAntennaStatus = ''
 def saFHI72Status = ''
@@ -708,29 +707,6 @@ pipeline {
               script {
                 currentBuild.result = 'FAILURE'
                 failingStages += saAW2SStatus
-              }
-            }
-          }
-        }
-        stage ("Sanity-Check OAI-CN5G") {
-          when { expression {do5Gtest} }
-          steps {
-            script {
-              triggerCN5GDownstreamJob ('OAI-CN5G-COTS-UE-Test')
-            }
-          }
-          post {
-            always {
-              script {
-                // Using a unique variable name for each test stage to avoid overwriting on a global variable
-                // due to parallel-time concurrency
-                cn5gCOTSUESanityCheck = finalizeDownstreamJob('OAI-CN5G-COTS-UE-Test')
-              }
-            }
-            failure {
-              script {
-                currentBuild.result = 'FAILURE'
-                failingStages += cn5gCOTSUESanityCheck
               }
             }
           }

--- a/ci-scripts/as_ue/multi-00105-100.cfg
+++ b/ci-scripts/as_ue/multi-00105-100.cfg
@@ -7,7 +7,7 @@
 #define N_ANTENNA_UL 1
 #define TDD 1
 
-log_options: "all.level=debug,all.max_size=0,nas.level=debug,nas.max_size=1,rrc.level=debug,rrc.max_size=1",
+log_options: "all.level=info,all.max_size=0,nas.level=debug,nas.max_size=1,rrc.level=debug,rrc.max_size=1",
 log_filename: "/tmp/ue.log",
 
 /* Enable remote API and Web interface */

--- a/ci-scripts/as_ue/multi-00105-40.cfg
+++ b/ci-scripts/as_ue/multi-00105-40.cfg
@@ -7,7 +7,7 @@
 #define N_ANTENNA_UL 1
 #define TDD 1
 
-log_options: "all.level=debug,all.max_size=0,nas.level=debug,nas.max_size=1,rrc.level=debug,rrc.max_size=1",
+log_options: "all.level=info,all.max_size=0,nas.level=debug,nas.max_size=1,rrc.level=debug,rrc.max_size=1",
 log_filename: "/tmp/ue.log",
 
 /* Enable remote API and Web interface */

--- a/ci-scripts/ci_infra.yaml
+++ b/ci-scripts/ci_infra.yaml
@@ -217,11 +217,19 @@ amarisoft_00105_40MHz:
   InitScript: /root/lteue-linux-2025-03-15/lteue /root/oaicicd/ran_sa_fhi72_mplane_40MHz/multi-00105-40.cfg &
   TermScript: /root/lteue-linux-2025-03-15/ws.js -t 10 127.0.0.1:9002 '{"message":"quit"}' || killall -KILL lteue-avx2
   NetworkScript: ip netns exec ue1 ip a show dev pdn0
+  Tracing:
+    Start: '' # nothing to be done
+    Stop: '' # nothing to be done
+    Collect: 'cp /tmp/ue.log %%log_dir%%'
 amarisoft_00105_100MHz:
   Host: amariue
   InitScript: /root/lteue-linux-2025-03-15/lteue /root/oaicicd/ran_sa_fhi72_mplane_100MHz/multi-00105-100.cfg &
   TermScript: /root/lteue-linux-2025-03-15/ws.js -t 10 127.0.0.1:9002 '{"message":"quit"}' || killall -KILL lteue-avx2
   NetworkScript: ip netns exec ue1 ip a show dev pdn0
+  Tracing:
+    Start: '' # nothing to be done
+    Stop: '' # nothing to be done
+    Collect: 'cp /tmp/ue.log %%log_dir%%'
 amarisoft_ue_1:
   Host: amariue
   AttachScript: /root/lteue-linux-2025-03-15/ws.js 127.0.0.1:9002 '{"message":"power_on","ue_id":1}'

--- a/ci-scripts/conf_files/enb.band40.100prb.usrpb200.tm1-defaultscheduler.conf
+++ b/ci-scripts/conf_files/enb.band40.100prb.usrpb200.tm1-defaultscheduler.conf
@@ -184,7 +184,8 @@ L1s = (
     	{
 	num_cc = 1;
 	tr_n_preference = "local_mac";
-        }  
+	prach_dtx_threshold = 200;
+	}
 );
 
 RUs = (

--- a/ci-scripts/conf_files/enb.band40.25prb.usrpb200.conf
+++ b/ci-scripts/conf_files/enb.band40.25prb.usrpb200.conf
@@ -184,7 +184,8 @@ L1s = (
     	{
 	num_cc = 1;
 	tr_n_preference = "local_mac";
-        }  
+	prach_dtx_threshold = 200;
+	}
 );
 
 RUs = (

--- a/ci-scripts/conf_files/enb.band7.100prb.usrpb200.tm1.conf
+++ b/ci-scripts/conf_files/enb.band7.100prb.usrpb200.tm1.conf
@@ -216,6 +216,7 @@ L1s =
   {
     num_cc = 1;
     tr_n_preference = "local_mac";
+    prach_dtx_threshold = 200;
   }
 );
 

--- a/ci-scripts/conf_files/enb.band7.25prb.usrpb200.tm1-norrc.conf
+++ b/ci-scripts/conf_files/enb.band7.25prb.usrpb200.tm1-norrc.conf
@@ -216,6 +216,7 @@ L1s =
   {
     num_cc = 1;
     tr_n_preference = "local_mac";
+    prach_dtx_threshold = 200;
   }
 );
 

--- a/ci-scripts/conf_files/enb.band7.25prb.usrpb200.tm1.conf
+++ b/ci-scripts/conf_files/enb.band7.25prb.usrpb200.tm1.conf
@@ -216,6 +216,7 @@ L1s =
   {
     num_cc = 1;
     tr_n_preference = "local_mac";
+    prach_dtx_threshold = 200;
   }
 );
 

--- a/ci-scripts/conf_files/enb.band7.50prb.usrpb200.tm1.conf
+++ b/ci-scripts/conf_files/enb.band7.50prb.usrpb200.tm1.conf
@@ -216,6 +216,7 @@ L1s =
   {
     num_cc = 1;
     tr_n_preference = "local_mac";
+    prach_dtx_threshold = 200;
   }
 );
 


### PR DESCRIPTION
CI runs:
- :white_check_mark: https://jenkins-oai.eurecom.fr/job/RAN-LTE-TDD-LTEBOX-Container/3278/ - Test successful with prach_dtx_threshold set to 20 dB. The eNB log size was reduced to less than 100 kB, and consistent RA attempts are no longer observed.
- :grey_question: https://jenkins-oai.eurecom.fr/job/RAN-SA-FHI72-MPLANE-CN5G/543/

TODO: 
- [x] check amariue log options - what do we need to collect? --> level changed to info
```
log_options: "all.level=debug,all.max_size=0,nas.level=debug,nas.max_size=1,rrc.level=debug,rrc.max_size=1",
log_filename: "/tmp/ue.log",
```
- [x] check RAN-LTE-FDD-LTEBOX-Container if consistent RA attempts also present
- [x] remove OAI-CN5G-COTS-UE-Test from parent pipeline