### PR TITLE
ci: Speedup unit test dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ common/utils/T/T_IDs.h
 common/utils/T/T_messages.txt.h
 common/utils/T/genids
 common/utils/T/genids.o
+build/

--- a/ci-scripts/docker/Dockerfile.unittest.ubuntu
+++ b/ci-scripts/docker/Dockerfile.unittest.ubuntu
@@ -10,8 +10,7 @@
 FROM ran-base:develop AS ran-tests
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get upgrade --yes && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
         libgtest-dev \
         libyaml-cpp-dev \
         libzmq3-dev \
@@ -26,7 +25,9 @@ WORKDIR /oai-ran
 COPY . .
 
 WORKDIR /oai-ran/build
-RUN cmake .. -GNinja \
+RUN --mount=type=cache,target=/root/.cache/ccache/ \
+    --mount=type=cache,target=/root/.cache/cpm/ \
+    cmake .. -GNinja \
       -DENABLE_TESTS=ON -DOAI_ZMQ=ON -DCMAKE_BUILD_TYPE=Debug \
       -DSANITIZE_ADDRESS=True -DOAI_VRTSIM_TAPS_CLIENT=ON -DOAI_RU_FRONTHAUL=ON \
     && \


### PR DESCRIPTION
Use docker cache, reduce the number of installed apt packages and reduce compilation scope.