### PR TITLE
NR UE: add assert for reserved bits per symbol not multiple of Qm

### DIFF
--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -882,6 +882,10 @@ static void map_overlapped_ack(uci_on_pusch_bit_type_t *template,
     const int32_t num_ack_remaining = G_ack - ack_bits_marked;
     if (num_ack_remaining <= 0)
       continue;
+    AssertFatal(num_reserved_bits_on_sym % Qm == 0,
+                "reserved bits on symbol (%u) not a multiple of Qm (%d)\n",
+                num_reserved_bits_on_sym,
+                Qm);
     const uint32_t num_reserved_re = num_reserved_bits_on_sym / Qm;
     const uint32_t num_ack_re_remaining = num_ack_remaining / Qm;
     const uint32_t d_factor_re = get_d_factor_re(num_ack_re_remaining, num_reserved_re);


### PR DESCRIPTION
`map_overlapped_ack()` divides `num_reserved_bits_on_sym` by `Qm` to get the number of reserved REs. Add assertion to catch cases where the reserved bit count is not a multiple of `Qm`, which would indicate a bug in the upstream UCI-on-PUSCH mapping.
This is a follow-up of comment [here](https://github.com/duranta-project/openairinterface5g/pull/221#issuecomment-4808696683)