### PR TITLE
ci: Speedup fhi72 dockerfiles

### DIFF
--- a/docker/Dockerfile.build.fhi72.native_arm.ubuntu
+++ b/docker/Dockerfile.build.fhi72.native_arm.ubuntu
@@ -27,7 +27,6 @@ RUN apt-get update && \
 
 RUN rm -Rf /oai-ran
 WORKDIR /oai-ran
-COPY . .
 
 ## Download and build DPDK
 RUN wget --no-verbose http://fast.dpdk.org/rel/dpdk-24.11.4.tar.xz && \
@@ -53,6 +52,8 @@ RUN git clone https://git.gitlab.arm.com/networking/ral.git /opt/ral && \
     cmake -GNinja -DBUILD_SHARED_LIBS=On /opt/ral/ && \
     ninja && \
     ninja install
+
+COPY . .
 
 FROM ran-base AS ran-build-fhi72
 ## Build and install OAI

--- a/docker/Dockerfile.build.fhi72.rhel9
+++ b/docker/Dockerfile.build.fhi72.rhel9
@@ -12,7 +12,6 @@ ENV TZ=Europe
 
 RUN rm -Rf /oai-ran
 WORKDIR /oai-ran
-COPY . .
 
 ARG xran_VERSION=11.1.1
 
@@ -30,6 +29,8 @@ RUN git clone https://github.com/openairinterface/o-du-phy.git /opt/phy && \
     git checkout $xran_VERSION &&\
     cd /opt/phy/fhi_lib/lib && \
     WIRELESS_SDK_TOOLCHAIN=gcc RTE_SDK=/oai-ran/dpdk-stable-24.11.4/ XRAN_DIR=/opt/phy/fhi_lib make XRAN_LIB_SO=1
+
+COPY . .
 
 FROM ran-base AS ran-build-fhi72
 ARG E2AP_VERSION=E2AP_V3

--- a/docker/Dockerfile.build.fhi72.t2.ubuntu
+++ b/docker/Dockerfile.build.fhi72.t2.ubuntu
@@ -27,7 +27,7 @@ RUN apt-get update && \
 
 RUN rm -Rf /oai-ran
 WORKDIR /oai-ran
-COPY . .
+
 ## Copy T2 patch
 COPY ./$T2_PATCH /opt/.
 ## Download and build DPDK
@@ -45,6 +45,8 @@ RUN git clone https://github.com/openairinterface/o-du-phy.git /opt/phy && \
     git checkout $xran_VERSION &&\
     cd /opt/phy/fhi_lib/lib && \
     WIRELESS_SDK_TOOLCHAIN=gcc RTE_SDK=/oai-ran/dpdk-$DPDK_VERSION/ XRAN_DIR=/opt/phy/fhi_lib make XRAN_LIB_SO=1
+
+COPY . .
 
 FROM ran-base AS ran-build-fhi72-t2
 ## Build and install OAI

--- a/docker/Dockerfile.build.fhi72.ubuntu
+++ b/docker/Dockerfile.build.fhi72.ubuntu
@@ -32,7 +32,6 @@ RUN apt-get update && \
 
 RUN rm -Rf /oai-ran
 WORKDIR /oai-ran
-COPY . .
 
 RUN git clone https://github.com/CESNET/libyang.git && \
     cd libyang && \
@@ -80,6 +79,8 @@ RUN git clone https://github.com/openairinterface/o-du-phy.git /opt/phy && \
     git checkout $xran_VERSION &&\
     cd /opt/phy/fhi_lib/lib && \
     WIRELESS_SDK_TOOLCHAIN=gcc RTE_SDK=/oai-ran/dpdk-stable-24.11.4/ XRAN_DIR=/opt/phy/fhi_lib make XRAN_LIB_SO=1
+
+COPY . .
 
 FROM ran-base AS ran-build-fhi72
 ## Build and install OAI


### PR DESCRIPTION
Move COPY . . down in 7.2 dockerfiles. This layer doesn't cache well due to changes in docker context, moving it down allows docker builder to cache other layers that are not affected by the context.