### PR TITLE
feat(mocn): add multi-PLMN MOCN support for OAI gNB

### DIFF
--- a/common/utils/telnetsrv/telnetsrv_o1.c
+++ b/common/utils/telnetsrv/telnetsrv_o1.c
@@ -338,7 +338,7 @@ static int set_bwconfig(char *buf, int debug, telnet_printfunc_t prnt)
   mac->common_channels[0].mib = get_new_MIB_NR(scc);
 
   const f1ap_served_cell_info_t *info = &mac->f1_config.setup_req->cell[0].info;
-  nr_mac_configure_sib1(mac, &info->plmn, info->nr_cellid, *info->tac);
+  nr_mac_configure_sib1(mac, info->nr_cellid, *info->tac, info->num_plmn, info->served_plmn_list);
 
   prnt("OK\n");
   return 0;

--- a/common/utils/telnetsrv/telnetsrv_o1.c
+++ b/common/utils/telnetsrv/telnetsrv_o1.c
@@ -156,8 +156,8 @@ static int get_stats(char *buf, int debug, telnet_printfunc_t prnt)
     prnt("      \"" TAC "\": %ld,\n", *cell_info->tac);
     prnt("      \"" MCC "\": \"%03d\",\n", cell_info->plmn.mcc);
     prnt("      \"" MNC "\": \"%0*d\",\n", cell_info->plmn.mnc_digit_length, cell_info->plmn.mnc);
-    prnt("      \"" SD  "\": %d,\n", cell_info->nssai[0].sd);
-    prnt("      \"" SST "\": %d\n", cell_info->nssai[0].sst);
+    prnt("      \"" SD  "\": %d,\n", cell_info->served_plmn_list[0].nssai[0].sd);
+    prnt("      \"" SST "\": %d\n", cell_info->served_plmn_list[0].nssai[0].sst);
     prnt("    },\n");
     prnt("    \"device\": {\n");
     prnt("      \"gnbId\": %d,\n", sr->gNB_DU_id);

--- a/openair2/COMMON/f1ap_messages_types.h
+++ b/openair2/COMMON/f1ap_messages_types.h
@@ -137,9 +137,6 @@ typedef struct f1ap_served_cell_info_s {
   uint16_t nr_pci;
   // 5GS TAC (Optional)
   uint32_t *tac;
-  // Compatibility bridge (removed once O1 migrates): legacy single-PLMN slice list
-  uint16_t num_ssi;
-  nssai_t nssai[MAX_NUM_SLICES];
   // Served PLMN list (each PLMN carries its own TAI Slice Support List, 38.473 §9.3.1.10)
   // For MOCN, num_plmn>=1 and served_plmn_list[0..num_plmn-1] hold all broadcast PLMNs and slices.
   uint16_t num_plmn;

--- a/openair2/COMMON/f1ap_messages_types.h
+++ b/openair2/COMMON/f1ap_messages_types.h
@@ -81,6 +81,9 @@
 /* 9.2.12.3 of 3GPP TS 38.473 V16.21.0*/
 #define MAX_NUM_MEASURE_TRPS 64
 
+/* Maximum number of PLMNs that can be served by a cell */
+#define F1AP_MAX_NB_PLMNS 6
+
 typedef struct f1ap_net_config_t {
   char *CU_f1_ip_address;
   char *DU_f1c_ip_address;
@@ -118,6 +121,14 @@ typedef struct f1ap_tdd_info_s {
   f1ap_transmission_bandwidth_t tbw;
 } f1ap_tdd_info_t;
 
+/* PLMN information including its slice list
+ * Per 38.473 §9.3.1.10, each PLMN can have its own set of slices */
+typedef struct f1ap_served_plmn_info_t {
+  plmn_id_t plmn;
+  uint16_t num_nssai;
+  nssai_t nssai[MAX_NUM_SLICES];
+} f1ap_served_plmn_info_t;
+
 typedef struct f1ap_served_cell_info_s {
   // NR CGI (Mandatory)
   plmn_id_t plmn;
@@ -126,9 +137,13 @@ typedef struct f1ap_served_cell_info_s {
   uint16_t nr_pci;
   // 5GS TAC (Optional)
   uint32_t *tac;
-  // TAI Slice Support List (Optional)
+  // Compatibility bridge (removed once O1 migrates): legacy single-PLMN slice list
   uint16_t num_ssi;
   nssai_t nssai[MAX_NUM_SLICES];
+  // Served PLMN list (each PLMN carries its own TAI Slice Support List, 38.473 §9.3.1.10)
+  // For MOCN, num_plmn>=1 and served_plmn_list[0..num_plmn-1] hold all broadcast PLMNs and slices.
+  uint16_t num_plmn;
+  f1ap_served_plmn_info_t served_plmn_list[F1AP_MAX_NB_PLMNS];
   // NR-Mode-Info (Mandatory)
   f1ap_mode_t mode;
   union {

--- a/openair2/F1AP/lib/f1ap_interface_management.c
+++ b/openair2/F1AP/lib/f1ap_interface_management.c
@@ -465,11 +465,20 @@ static F1AP_Served_Cell_Information_t encode_served_cell_info(const f1ap_served_
     OCTET_STRING_fromBuf(netOrder, ((char *)&tac) + 1, 3);
   }
   // Served PLMNs 1..<maxnoofBPLMNs>
-  asn1cSequenceAdd(scell_info.servedPLMNs.list, F1AP_ServedPLMNs_Item_t, servedPLMN_item);
-  // PLMN Identity (M)
-  MCC_MNC_TO_PLMNID(c->plmn.mcc, c->plmn.mnc, c->plmn.mnc_digit_length, &servedPLMN_item->pLMN_Identity);
-  // NSSAIs (O)
-  servedPLMN_item->iE_Extensions = (struct F1AP_ProtocolExtensionContainer *)write_slice_info(c->num_ssi, c->nssai);
+  // MOCN: emit one ServedPLMNs_Item per broadcast PLMN with its own slice list.
+  // Compat bridge: num_plmn==0 (legacy producer not yet migrated) falls back to the
+  // primary PLMN with its legacy slice list (num_ssi/nssai); removed once O1 migrates.
+  int num_splmn = c->num_plmn > 0 ? c->num_plmn : 1;
+  for (int i = 0; i < num_splmn; i++) {
+    const plmn_id_t *p = (c->num_plmn > 0) ? &c->served_plmn_list[i].plmn : &c->plmn;
+    int ns = (c->num_plmn > 0) ? c->served_plmn_list[i].num_nssai : c->num_ssi;
+    const nssai_t *nssai = (c->num_plmn > 0) ? c->served_plmn_list[i].nssai : c->nssai;
+    asn1cSequenceAdd(scell_info.servedPLMNs.list, F1AP_ServedPLMNs_Item_t, servedPLMN_item);
+    // PLMN Identity (M)
+    MCC_MNC_TO_PLMNID(p->mcc, p->mnc, p->mnc_digit_length, &servedPLMN_item->pLMN_Identity);
+    // NSSAIs (O) — per-PLMN TAI Slice Support List
+    servedPLMN_item->iE_Extensions = (struct F1AP_ProtocolExtensionContainer *)write_slice_info(ns, nssai);
+  }
   // NR-Mode-Info (M)
   F1AP_NR_Mode_Info_t *nR_Mode_Info = &scell_info.nR_Mode_Info;
   if (c->mode == F1AP_MODE_FDD) { // FDD Info
@@ -515,9 +524,23 @@ static bool decode_served_cell_info(const F1AP_Served_Cell_Information_t *in, f1
   BIT_STRING_TO_NR_CELL_IDENTITY(&in->nRCGI.nRCellIdentity, info->nr_cellid);
   // NR PCI (M)
   info->nr_pci = in->nRPCI;
-  // Served PLMNs (>= 1)
-  AssertError(in->servedPLMNs.list.count == 1, return false, "at least and only 1 PLMN must be present");
-  info->num_ssi = read_slice_info(in->servedPLMNs.list.array[0], info->nssai, 16);
+  // Served PLMNs (>= 1) — MOCN: decode all PLMNs into served_plmn_list
+  AssertError(in->servedPLMNs.list.count >= 1, return false, "at least 1 ServedPLMN must be present");
+  AssertError(in->servedPLMNs.list.count <= F1AP_MAX_NB_PLMNS,
+              return false,
+              "ServedPLMN count %d exceeds F1AP_MAX_NB_PLMNS=%d",
+              in->servedPLMNs.list.count,
+              F1AP_MAX_NB_PLMNS);
+  info->num_plmn = in->servedPLMNs.list.count;
+  for (int i = 0; i < in->servedPLMNs.list.count; ++i) {
+    F1AP_ServedPLMNs_Item_t *splmn = in->servedPLMNs.list.array[i];
+    PLMNID_TO_MCC_MNC(&splmn->pLMN_Identity,
+                      info->served_plmn_list[i].plmn.mcc,
+                      info->served_plmn_list[i].plmn.mnc,
+                      info->served_plmn_list[i].plmn.mnc_digit_length);
+    info->served_plmn_list[i].num_nssai =
+        read_slice_info(splmn, info->served_plmn_list[i].nssai, MAX_NUM_SLICES);
+  }
   // FDD Info
   if (in->nR_Mode_Info.present == F1AP_NR_Mode_Info_PR_fDD) {
     info->mode = F1AP_MODE_FDD;
@@ -876,12 +899,17 @@ static f1ap_served_cell_info_t copy_f1ap_served_cell_info(const f1ap_served_cell
     .plmn = src->plmn,
     .nr_cellid = src->nr_cellid,
     .nr_pci = src->nr_pci,
-    .num_ssi = src->num_ssi,
+    .num_ssi = src->num_ssi, // compat bridge
+    .num_plmn = src->num_plmn,
     .mode = src->mode,
   };
 
+  // compat bridge: copy legacy slice list (removed once O1 migrates)
   for (int i = 0; i < src->num_ssi; ++i)
     dst.nssai[i] = src->nssai[i];
+  // Deep-copy per-PLMN slice lists (MOCN: each PLMN may carry its own slice support list)
+  for (int i = 0; i < src->num_plmn; ++i)
+    dst.served_plmn_list[i] = src->served_plmn_list[i];
 
   if (src->mode == F1AP_MODE_TDD)
     dst.tdd = src->tdd;

--- a/openair2/F1AP/lib/f1ap_interface_management.c
+++ b/openair2/F1AP/lib/f1ap_interface_management.c
@@ -466,13 +466,15 @@ static F1AP_Served_Cell_Information_t encode_served_cell_info(const f1ap_served_
   }
   // Served PLMNs 1..<maxnoofBPLMNs>
   // MOCN: emit one ServedPLMNs_Item per broadcast PLMN with its own slice list.
-  // Compat bridge: num_plmn==0 (legacy producer not yet migrated) falls back to the
-  // primary PLMN with its legacy slice list (num_ssi/nssai); removed once O1 migrates.
-  int num_splmn = c->num_plmn > 0 ? c->num_plmn : 1;
-  for (int i = 0; i < num_splmn; i++) {
-    const plmn_id_t *p = (c->num_plmn > 0) ? &c->served_plmn_list[i].plmn : &c->plmn;
-    int ns = (c->num_plmn > 0) ? c->served_plmn_list[i].num_nssai : c->num_ssi;
-    const nssai_t *nssai = (c->num_plmn > 0) ? c->served_plmn_list[i].nssai : c->nssai;
+  // At least one served PLMN is mandatory; guard the fixed-size array.
+  AssertFatal(c->num_plmn > 0 && c->num_plmn <= F1AP_MAX_NB_PLMNS,
+              "num_plmn %d must be in [1, %d]\n",
+              c->num_plmn,
+              F1AP_MAX_NB_PLMNS);
+  for (int i = 0; i < c->num_plmn; i++) {
+    const plmn_id_t *p = &c->served_plmn_list[i].plmn;
+    int ns = c->served_plmn_list[i].num_nssai;
+    const nssai_t *nssai = c->served_plmn_list[i].nssai;
     asn1cSequenceAdd(scell_info.servedPLMNs.list, F1AP_ServedPLMNs_Item_t, servedPLMN_item);
     // PLMN Identity (M)
     MCC_MNC_TO_PLMNID(p->mcc, p->mnc, p->mnc_digit_length, &servedPLMN_item->pLMN_Identity);
@@ -895,18 +897,19 @@ bool decode_f1ap_setup_request(const F1AP_F1AP_PDU_t *pdu, f1ap_setup_req_t *out
 
 static f1ap_served_cell_info_t copy_f1ap_served_cell_info(const f1ap_served_cell_info_t *src)
 {
+  AssertFatal(src->num_plmn > 0 && src->num_plmn <= F1AP_MAX_NB_PLMNS,
+              "num_plmn %d must be in [1, %d]\n",
+              src->num_plmn,
+              F1AP_MAX_NB_PLMNS);
+
   f1ap_served_cell_info_t dst = {
     .plmn = src->plmn,
     .nr_cellid = src->nr_cellid,
     .nr_pci = src->nr_pci,
-    .num_ssi = src->num_ssi, // compat bridge
     .num_plmn = src->num_plmn,
     .mode = src->mode,
   };
 
-  // compat bridge: copy legacy slice list (removed once O1 migrates)
-  for (int i = 0; i < src->num_ssi; ++i)
-    dst.nssai[i] = src->nssai[i];
   // Deep-copy per-PLMN slice lists (MOCN: each PLMN may carry its own slice support list)
   for (int i = 0; i < src->num_plmn; ++i)
     dst.served_plmn_list[i] = src->served_plmn_list[i];

--- a/openair2/F1AP/lib/f1ap_lib_common.c
+++ b/openair2/F1AP/lib/f1ap_lib_common.c
@@ -41,26 +41,17 @@ bool eq_f1ap_cell_info(const f1ap_served_cell_info_t *a, const f1ap_served_cell_
   if (a->tac)
     _EQ_CHECK_INT(*a->tac, *b->tac);
   _EQ_CHECK_INT(a->num_plmn, b->num_plmn);
-  if (a->num_plmn == 0) {
-    // compat bridge: legacy single-PLMN slice comparison (removed once O1 migrates)
-    _EQ_CHECK_INT(a->num_ssi, b->num_ssi);
-    for (int i = 0; i < a->num_ssi; ++i) {
-      _EQ_CHECK_INT(a->nssai[i].sst, b->nssai[i].sst);
-      _EQ_CHECK_INT(a->nssai[i].sd, b->nssai[i].sd);
-    }
-  } else {
-    if (a->num_plmn > F1AP_MAX_NB_PLMNS)
+  if (a->num_plmn > F1AP_MAX_NB_PLMNS)
+    return false;
+  for (int i = 0; i < a->num_plmn; ++i) {
+    if (!eq_f1ap_plmn(&a->served_plmn_list[i].plmn, &b->served_plmn_list[i].plmn))
       return false;
-    for (int i = 0; i < a->num_plmn; ++i) {
-      if (!eq_f1ap_plmn(&a->served_plmn_list[i].plmn, &b->served_plmn_list[i].plmn))
-        return false;
-      _EQ_CHECK_INT(a->served_plmn_list[i].num_nssai, b->served_plmn_list[i].num_nssai);
-      if (a->served_plmn_list[i].num_nssai > MAX_NUM_SLICES)
-        return false;
-      for (int j = 0; j < a->served_plmn_list[i].num_nssai; ++j) {
-        _EQ_CHECK_INT(a->served_plmn_list[i].nssai[j].sst, b->served_plmn_list[i].nssai[j].sst);
-        _EQ_CHECK_INT(a->served_plmn_list[i].nssai[j].sd, b->served_plmn_list[i].nssai[j].sd);
-      }
+    _EQ_CHECK_INT(a->served_plmn_list[i].num_nssai, b->served_plmn_list[i].num_nssai);
+    if (a->served_plmn_list[i].num_nssai > MAX_NUM_SLICES)
+      return false;
+    for (int j = 0; j < a->served_plmn_list[i].num_nssai; ++j) {
+      _EQ_CHECK_INT(a->served_plmn_list[i].nssai[j].sst, b->served_plmn_list[i].nssai[j].sst);
+      _EQ_CHECK_INT(a->served_plmn_list[i].nssai[j].sd, b->served_plmn_list[i].nssai[j].sd);
     }
   }
   _EQ_CHECK_INT(a->mode, b->mode);

--- a/openair2/F1AP/lib/f1ap_lib_common.c
+++ b/openair2/F1AP/lib/f1ap_lib_common.c
@@ -40,10 +40,28 @@ bool eq_f1ap_cell_info(const f1ap_served_cell_info_t *a, const f1ap_served_cell_
     return false;
   if (a->tac)
     _EQ_CHECK_INT(*a->tac, *b->tac);
-  _EQ_CHECK_INT(a->num_ssi, b->num_ssi);
-  for (int i = 0; i < a->num_ssi; ++i) {
-    _EQ_CHECK_INT(a->nssai[i].sst, b->nssai[i].sst);
-    _EQ_CHECK_INT(a->nssai[i].sd, b->nssai[i].sd);
+  _EQ_CHECK_INT(a->num_plmn, b->num_plmn);
+  if (a->num_plmn == 0) {
+    // compat bridge: legacy single-PLMN slice comparison (removed once O1 migrates)
+    _EQ_CHECK_INT(a->num_ssi, b->num_ssi);
+    for (int i = 0; i < a->num_ssi; ++i) {
+      _EQ_CHECK_INT(a->nssai[i].sst, b->nssai[i].sst);
+      _EQ_CHECK_INT(a->nssai[i].sd, b->nssai[i].sd);
+    }
+  } else {
+    if (a->num_plmn > F1AP_MAX_NB_PLMNS)
+      return false;
+    for (int i = 0; i < a->num_plmn; ++i) {
+      if (!eq_f1ap_plmn(&a->served_plmn_list[i].plmn, &b->served_plmn_list[i].plmn))
+        return false;
+      _EQ_CHECK_INT(a->served_plmn_list[i].num_nssai, b->served_plmn_list[i].num_nssai);
+      if (a->served_plmn_list[i].num_nssai > MAX_NUM_SLICES)
+        return false;
+      for (int j = 0; j < a->served_plmn_list[i].num_nssai; ++j) {
+        _EQ_CHECK_INT(a->served_plmn_list[i].nssai[j].sst, b->served_plmn_list[i].nssai[j].sst);
+        _EQ_CHECK_INT(a->served_plmn_list[i].nssai[j].sd, b->served_plmn_list[i].nssai[j].sd);
+      }
+    }
   }
   _EQ_CHECK_INT(a->mode, b->mode);
   if (a->mode == F1AP_MODE_TDD) {

--- a/openair2/F1AP/tests/f1ap_lib_test.c
+++ b/openair2/F1AP/tests/f1ap_lib_test.c
@@ -206,9 +206,19 @@ static void test_f1ap_setup_request(void)
       .plmn.mcc = 1,
       .plmn.mnc = 1,
       .plmn.mnc_digit_length = 3,
-      .num_ssi = 1,
-      .nssai[0].sst = 1,
-      .nssai[0].sd = 1,
+      .num_plmn = 2,
+      .served_plmn_list[0].plmn.mcc = 1,
+      .served_plmn_list[0].plmn.mnc = 1,
+      .served_plmn_list[0].plmn.mnc_digit_length = 3,
+      .served_plmn_list[0].num_nssai = 1,
+      .served_plmn_list[0].nssai[0].sst = 1,
+      .served_plmn_list[0].nssai[0].sd = 1,
+      .served_plmn_list[1].plmn.mcc = 208,
+      .served_plmn_list[1].plmn.mnc = 93,
+      .served_plmn_list[1].plmn.mnc_digit_length = 2,
+      .served_plmn_list[1].num_nssai = 1,
+      .served_plmn_list[1].nssai[0].sst = 2,
+      .served_plmn_list[1].nssai[0].sd = 2,
       .tac = tac,
   };
   // create message
@@ -278,6 +288,7 @@ static void test_f1ap_setup_request(void)
   free_f1ap_setup_request(&cp);
   // free original message
   free_f1ap_setup_request(&orig);
+  printf("%s() successful\n", __func__);
 }
 
 /**
@@ -509,6 +520,11 @@ static void test_f1ap_du_configuration_update(void)
       .plmn.mcc = 1,
       .plmn.mnc = 1,
       .plmn.mnc_digit_length = 3,
+      .num_plmn = 1,
+      .served_plmn_list[0].plmn.mcc = 1,
+      .served_plmn_list[0].plmn.mnc = 1,
+      .served_plmn_list[0].plmn.mnc_digit_length = 3,
+      .served_plmn_list[0].num_nssai = 0,
       .tac = tac,
   };
   char *mtc2_data = "mtc2";
@@ -530,6 +546,11 @@ static void test_f1ap_du_configuration_update(void)
       .plmn.mcc = 2,
       .plmn.mnc = 2,
       .plmn.mnc_digit_length = 2,
+      .num_plmn = 1,
+      .served_plmn_list[0].plmn.mcc = 2,
+      .served_plmn_list[0].plmn.mnc = 2,
+      .served_plmn_list[0].plmn.mnc_digit_length = 2,
+      .served_plmn_list[0].num_nssai = 0,
   };
   /* create message */
   f1ap_gnb_du_configuration_update_t orig = {
@@ -589,6 +610,7 @@ static void test_f1ap_du_configuration_update(void)
   AssertFatal(ret, "eq_f1ap_setup_request(): copied message doesn't match\n");
   free_f1ap_du_configuration_update(&cp);
   free_f1ap_du_configuration_update(&orig);
+  printf("%s() successful\n", __func__);
 }
 
 /**

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -996,11 +996,24 @@ static int read_du_cell_info(bool separate_du,
 
   // PLMN
   plmn_id_t p[PLMN_LIST_MAX_SIZE] = {0};
-  set_plmn_config(p, 0);
-  info->plmn = p[0];
+  uint8_t num_plmn = set_plmn_config(p, 0);
+
+  info->num_plmn = num_plmn;
+  for (int i = 0; i < num_plmn; i++) {
+    // populate served_plmn_list with each broadcast PLMN and its slices
+    info->served_plmn_list[i].plmn = p[i];
+    info->served_plmn_list[i].num_nssai = set_snssai_config(info->served_plmn_list[i].nssai,
+                                                            MAX_NUM_SLICES,
+                                                            0, // gNB index (first gNB)
+                                                            i // PLMN index (current PLMN in loop)
+    );
+  }
+
+  info->plmn = p[0]; // primary PLMN of the NR CGI
   info->nr_cellid = (uint64_t) * (GNBParamList.paramarray[0][GNB_NRCELLID_IDX].u64ptr);
 
-  // SNSSAI
+  // compat bridge: keep populating the legacy slice list (first PLMN) for
+  // consumers not yet migrated (O1/telnet); removed once O1 migrates.
   info->num_ssi = set_snssai_config(info->nssai, MAX_NUM_SLICES, 0, 0);
 
   return 1;

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -1846,8 +1846,7 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg)
     cc->du_SIBs = fill_du_sibs(GNBParamList.paramarray[0]);
 
     if (IS_SA_MODE(get_softmodem_params()))
-      nr_mac_configure_sib1(RC.nrmac[0], &info.plmn, info.nr_cellid, *info.tac);
-
+      nr_mac_configure_sib1(RC.nrmac[0], info.nr_cellid, *info.tac, info.num_plmn, info.served_plmn_list);
     // read F1 Setup information from config and generated MIB/SIB1
     // and store it at MAC for sending later
     NR_BCCH_BCH_Message_t *mib = RC.nrmac[0]->common_channels[0].mib;

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -1012,10 +1012,6 @@ static int read_du_cell_info(bool separate_du,
   info->plmn = p[0]; // primary PLMN of the NR CGI
   info->nr_cellid = (uint64_t) * (GNBParamList.paramarray[0][GNB_NRCELLID_IDX].u64ptr);
 
-  // compat bridge: keep populating the legacy slice list (first PLMN) for
-  // consumers not yet migrated (O1/telnet); removed once O1 migrates.
-  info->num_ssi = set_snssai_config(info->nssai, MAX_NUM_SLICES, 0, 0);
-
   return 1;
 }
 

--- a/openair2/LAYER2/NR_MAC_gNB/config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/config.c
@@ -1224,13 +1224,13 @@ void prepare_du_configuration_update(gNB_MAC_INST *mac,
   mac->mac_rrc.gnb_du_configuration_update(&update);
 }
 
-void nr_mac_configure_sib1(gNB_MAC_INST *nrmac, const plmn_id_t *plmn, uint64_t cellID, int tac)
+void nr_mac_configure_sib1(gNB_MAC_INST *nrmac, uint64_t cellID, int tac, int num_plmn, const f1ap_served_plmn_info_t *served_plmn_list)
 {
   AssertFatal(IS_SA_MODE(get_softmodem_params()), "error: SIB1 only applicable for SA\n");
 
   NR_COMMON_channels_t *cc = &nrmac->common_channels[0];
   NR_ServingCellConfigCommon_t *scc = cc->ServingCellConfigCommon;
-  NR_BCCH_DL_SCH_Message_t *sib1 = get_SIB1_NR(scc, plmn, cellID, tac, &nrmac->radio_config);
+  NR_BCCH_DL_SCH_Message_t *sib1 = get_SIB1_NR(scc, cellID, tac, &nrmac->radio_config, num_plmn, served_plmn_list);
   cc->sib1 = sib1;
   cc->sib1_bcch_length = encode_SIB_NR(sib1, cc->sib1_bcch_pdu, sizeof(cc->sib1_bcch_pdu));
   AssertFatal(cc->sib1_bcch_length > 0, "could not encode SIB1\n");

--- a/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
@@ -38,7 +38,7 @@ void mac_top_destroy_gNB(gNB_MAC_INST *mac);
 void nr_mac_send_f1_setup_req(void);
 int get_ssbidx_from_beam(const gNB_MAC_INST *mac, int beam_idx);
 void nr_mac_config_scc(gNB_MAC_INST *nrmac, NR_ServingCellConfigCommon_t *scc, const nr_mac_config_t *mac_config);
-void nr_mac_configure_sib1(gNB_MAC_INST *nrmac, const plmn_id_t *plmn, uint64_t cellID, int tac);
+void nr_mac_configure_sib1(gNB_MAC_INST *nrmac, uint64_t cellID, int tac, int num_plmn, const f1ap_served_plmn_info_t *served_plmn_list);
 bool nr_mac_configure_other_sib(gNB_MAC_INST *nrmac, int num_cu_sib, const f1ap_sib_msg_t cu_sib[num_cu_sib]);
 bool nr_mac_add_test_ue(gNB_MAC_INST *nrmac, uint32_t rnti, NR_CellGroupConfig_t *CellGroup);
 void nr_mac_prepare_ra_ue(gNB_MAC_INST *nrmac, NR_UE_info_t *UE);

--- a/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
@@ -2779,10 +2779,11 @@ int configure_coreset_for_mux23(const NR_ServingCellConfigCommon_t *scc,
 }
 
 NR_BCCH_DL_SCH_Message_t *get_SIB1_NR(const NR_ServingCellConfigCommon_t *scc,
-                                      const plmn_id_t *plmn,
                                       uint64_t cellID,
                                       int tac,
-                                      const nr_mac_config_t *mac_config)
+                                      const nr_mac_config_t *mac_config,
+                                      int num_plmn,
+                                      const f1ap_served_plmn_info_t *served_plmn_list)
 {
   AssertFatal(cellID < (1l << 36), "cellID must fit within 36 bits, but is %lu\n", cellID);
 
@@ -2806,21 +2807,19 @@ NR_BCCH_DL_SCH_Message_t *get_SIB1_NR(const NR_ServingCellConfigCommon_t *scc,
   sib1->cellSelectionInfo->q_RxLevMin = -65;
 
   // cellAccessRelatedInfo
-  // TODO : Add support for more than one PLMN
-  int num_plmn = 1; // int num_plmn = configuration->num_plmn;
   asn1cSequenceAdd(sib1->cellAccessRelatedInfo.plmn_IdentityInfoList.list, struct NR_PLMN_IdentityInfo, nr_plmn_info);
   for (int i = 0; i < num_plmn; ++i) {
     asn1cSequenceAdd(nr_plmn_info->plmn_IdentityList.list, struct NR_PLMN_Identity, nr_plmn);
     asn1cCalloc(nr_plmn->mcc, mcc);
-    int confMcc = plmn->mcc;
+    int confMcc = served_plmn_list[i].plmn.mcc;
     asn1cSequenceAdd(mcc->list, NR_MCC_MNC_Digit_t, mcc0);
     *mcc0 = (confMcc / 100) % 10;
     asn1cSequenceAdd(mcc->list, NR_MCC_MNC_Digit_t, mcc1);
     *mcc1 = (confMcc / 10) % 10;
     asn1cSequenceAdd(mcc->list, NR_MCC_MNC_Digit_t, mcc2);
     *mcc2 = confMcc % 10;
-    int mnc = plmn->mnc;
-    if (plmn->mnc_digit_length == 3) {
+    int mnc = served_plmn_list[i].plmn.mnc;
+    if (served_plmn_list[i].plmn.mnc_digit_length == 3) {
       asn1cSequenceAdd(nr_plmn->mnc.list, NR_MCC_MNC_Digit_t, mnc0);
       *mnc0 = (mnc / 100) % 10;
     }

--- a/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.h
@@ -62,10 +62,11 @@ int encode_MeasurementTimingConfiguration(const struct NR_MeasurementTimingConfi
 void free_MeasurementTimingConfiguration(struct NR_MeasurementTimingConfiguration *mtc);
 
 NR_BCCH_DL_SCH_Message_t *get_SIB1_NR(const NR_ServingCellConfigCommon_t *scc,
-                                      const plmn_id_t *plmn,
                                       uint64_t cellID,
                                       int tac,
-                                      const nr_mac_config_t *mac_config);
+                                      const nr_mac_config_t *mac_config,
+                                      int num_plmn,
+                                      const f1ap_served_plmn_info_t *served_plmn_list);
 void update_SIB1_NR_SI(NR_BCCH_DL_SCH_Message_t *sib1, int num_sibs, int sibs[num_sibs]);
 int encode_sysinfo_ie(NR_SystemInformation_IEs_t *sysInfo, uint8_t *buf, int len);
 void free_SIB1_NR(NR_BCCH_DL_SCH_Message_t *sib1);

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -582,7 +582,7 @@ static f1ap_ue_context_setup_req_t rrc_fill_f1_ue_context_setup(gNB_RRC_UE_t *ue
   f1ap_ue_context_setup_req_t req = {
       .gNB_CU_ue_id = ue->rrc_ue_id,
       .servCellIndex = RRC_PCELL_INDEX,
-      .plmn = cell->info.plmn,
+      .plmn = ue->serving_plmn,
       .nr_cellid = cell->info.cell_id,
   };
 

--- a/openair2/RRC/NR/rrc_gNB_du.c
+++ b/openair2/RRC/NR/rrc_gNB_du.c
@@ -452,11 +452,25 @@ int get_ssb_arfcn(const struct nr_rrc_cell_container_t *cell)
   return 0;
 }
 
-static bool rrc_gNB_plmn_matches(const gNB_RRC_INST *rrc, const f1ap_served_cell_info_t *info)
+/* Return true if a PLMN is present in the CU/gNB configured PLMN list. */
+static bool rrc_gNB_plmn_matches(const nr_rrc_config_t *conf, const plmn_id_t *p)
 {
-  const nr_rrc_config_t *conf = &rrc->configuration;
-  return conf->num_plmn == 1 // F1 supports only one
-         && conf->plmn[0].mcc == info->plmn.mcc && conf->plmn[0].mnc == info->plmn.mnc;
+  for (int c = 0; c < conf->num_plmn; c++) {
+    if (conf->plmn[c].mcc == p->mcc && conf->plmn[c].mnc == p->mnc
+        && conf->plmn[c].mnc_digit_length == p->mnc_digit_length)
+      return true;
+  }
+  return false;
+}
+
+/* MOCN: accept the cell if at least one DU-advertised PLMN is served by the CU. */
+static bool rrc_gNB_served_plmns_match(const nr_rrc_config_t *conf, const f1ap_served_cell_info_t *info)
+{
+  for (int d = 0; d < info->num_plmn; d++) {
+    if (rrc_gNB_plmn_matches(conf, &info->served_plmn_list[d].plmn))
+      return true;
+  }
+  return false;
 }
 
 static bool extract_sys_info(const f1ap_gnb_du_system_info_t *sys_info, NR_MIB_t **mib, NR_SIB1_t **sib1)
@@ -704,7 +718,7 @@ void rrc_gNB_process_f1_setup_req(f1ap_setup_req_t *req, sctp_assoc_t assoc_id)
   }
   for (int i = 0; i < req->num_cells_available; i++) {
     f1ap_served_cell_info_t *cell_info = &req->cell[i].info;
-    if (!rrc_gNB_plmn_matches(rrc, cell_info)) {
+    if (!rrc_gNB_served_plmns_match(&rrc->configuration, cell_info)) {
       LOG_E(NR_RRC,
             "PLMN mismatch: CU %03d.%0*d, DU %03d%0*d\n",
             rrc->configuration.plmn[0].mcc,
@@ -1022,7 +1036,7 @@ void rrc_gNB_process_f1_du_configuration_update(f1ap_gnb_du_configuration_update
     const f1ap_served_cell_info_t *new_ci = &conf_up->cell_to_modify[0].info;
 
     // verify the new plmn of the cell
-    if (!rrc_gNB_plmn_matches(rrc, new_ci)) {
+    if (!rrc_gNB_served_plmns_match(&rrc->configuration, new_ci)) {
       LOG_W(NR_RRC, "PLMN does not match, ignoring gNB-DU configuration update\n");
       return;
     }

--- a/openair2/RRC/NR_UE/rrc_UE.c
+++ b/openair2/RRC/NR_UE/rrc_UE.c
@@ -473,8 +473,60 @@ static void get_sib19_schedinfo(NR_UE_RRC_SI_INFO *SI_info, NR_SI_SchedulingInfo
   }
 }
 
+/* Convert one SIB1 NR_PLMN_Identity to plmn_id_t. No MCC inheritance: an entry
+ * with omitted/malformed MCC/MNC fails (returns false) and is left as a zeroed,
+ * non-matchable placeholder by the caller to keep 1-based indices aligned. */
+static bool plmn_from_asn1(const NR_PLMN_Identity_t *src, plmn_id_t *dst)
+{
+  if (!src || !dst || !src->mcc || src->mcc->list.count != 3)
+    return false;
+  if (src->mnc.list.count != 2 && src->mnc.list.count != 3)
+    return false;
+  for (int i = 0; i < 3; i++)
+    if (!src->mcc->list.array[i])
+      return false;
+  for (int i = 0; i < src->mnc.list.count; i++)
+    if (!src->mnc.list.array[i])
+      return false;
+  dst->mcc = (*src->mcc->list.array[0]) * 100 + (*src->mcc->list.array[1]) * 10 + (*src->mcc->list.array[2]);
+  dst->mnc_digit_length = src->mnc.list.count;
+  dst->mnc = (src->mnc.list.count == 3)
+                 ? (*src->mnc.list.array[0]) * 100 + (*src->mnc.list.array[1]) * 10 + (*src->mnc.list.array[2])
+                 : (*src->mnc.list.array[0]) * 10 + (*src->mnc.list.array[1]);
+  return true;
+}
+
 static void nr_rrc_process_sib1(NR_UE_RRC_INST_t *rrc, NR_UE_RRC_SI_INFO *SI_info, NR_SIB1_t *sib1)
 {
+  /* PLMN selection (MOCN): build the broadcast PLMN list from SIB1 (only the
+   * outer PLMN-IdentityInfo block currently emitted by get_SIB1_NR is used),
+   * keeping 1-based positions, and let NAS pick the entry matching the UE IMSI. */
+  {
+    plmn_id_t plmns[PLMN_LIST_MAX_SIZE] = {0};
+    int num_plmns = 0;
+    const NR_PLMN_IdentityInfoList_t *info_list = &sib1->cellAccessRelatedInfo.plmn_IdentityInfoList;
+    if (info_list->list.array && info_list->list.count > 0) {
+      const NR_PLMN_IdentityInfo_t *plmn_info = info_list->list.array[0];
+      const int count = (plmn_info && plmn_info->plmn_IdentityList.list.array) ? plmn_info->plmn_IdentityList.list.count : 0;
+      if (count > 0 && count <= PLMN_LIST_MAX_SIZE) {
+        num_plmns = count;
+        for (int j = 0; j < num_plmns; j++)
+          plmn_from_asn1(plmn_info->plmn_IdentityList.list.array[j], &plmns[j]); /* failure: zeroed placeholder, index kept */
+      } else if (count > PLMN_LIST_MAX_SIZE) {
+        LOG_W(NR_RRC, "SIB1 broadcasts %d PLMNs, cannot handle (max %d)\n", count, PLMN_LIST_MAX_SIZE);
+      }
+    }
+
+    long selected = 1;
+    nr_ue_nas_t *nas = get_ue_nas_info(rrc->ue_id);
+    if (nas_get_selected_plmn(nas, plmns, num_plmns, &selected)) {
+      rrc->selected_plmn_identity = selected;
+    } else {
+      rrc->selected_plmn_identity = 1; /* fallback to first PLMN */
+      LOG_W(NR_RRC, "No PLMN matched UE IMSI; falling back to selected_plmn_identity=1\n");
+    }
+  }
+
   if(g_log->log_component[NR_RRC].level >= OAILOG_DEBUG)
     xer_fprint(stdout, &asn_DEF_NR_SIB1, (const void *) sib1);
   RRCLOG_A("SIB1 decoded\n");

--- a/openair3/NAS/NR_UE/5GS/tests/nas_lib_test.c
+++ b/openair3/NAS/NR_UE/5GS/tests/nas_lib_test.c
@@ -390,6 +390,118 @@ static void test_auth_reject(void)
   AssertFatal(eq_auth_reject(&orig, &dec), "test_auth_reject() failed: original and decoded messages do not match\n");
 }
 
+/**
+ * @brief Test NAS PLMN selection (nas_get_selected_plmn): IMSI vs SIB1 PLMN list
+ */
+static void test_nas_get_selected_plmn(void)
+{
+  uicc_t uicc = {0};
+  nr_ue_nas_t nas = {0};
+  nas.uicc = &uicc;
+  long sel;
+  const long SENTINEL = -999;
+
+  const plmn_id_t p20893_2 = {.mcc = 208, .mnc = 93, .mnc_digit_length = 2};
+  const plmn_id_t p20894_2 = {.mcc = 208, .mnc = 94, .mnc_digit_length = 2};
+  const plmn_id_t p208093_3 = {.mcc = 208, .mnc = 93, .mnc_digit_length = 3}; /* MNC 093 */
+  const plmn_id_t p310260_3 = {.mcc = 310, .mnc = 260, .mnc_digit_length = 3};
+  const plmn_id_t zero = {0}; /* placeholder */
+
+  /* 1. 2-digit MNC hit -> index 1 */
+  uicc.imsiStr = "208930000000003"; uicc.nmc_size = 2;
+  plmn_id_t t1[] = {p20893_2};
+  sel = SENTINEL; AssertFatal(nas_get_selected_plmn(&nas, t1, 1, &sel) && sel == 1, "case 1 (2-digit hit)\n");
+
+  /* 2. 3-digit MNC hit -> index 1 */
+  uicc.imsiStr = "310260000000000"; uicc.nmc_size = 3;
+  plmn_id_t t2[] = {p310260_3};
+  sel = SENTINEL; AssertFatal(nas_get_selected_plmn(&nas, t2, 1, &sel) && sel == 1, "case 2 (3-digit hit)\n");
+
+  /* 3. leading-zero MNC 093 (3-digit) -> index 1 */
+  uicc.imsiStr = "208093000000000"; uicc.nmc_size = 3;
+  plmn_id_t t3[] = {p208093_3};
+  sel = SENTINEL; AssertFatal(nas_get_selected_plmn(&nas, t3, 1, &sel) && sel == 1, "case 3 (MNC 093)\n");
+
+  /* 4. same MCC, different MNC -> no match */
+  uicc.imsiStr = "208930000000003"; uicc.nmc_size = 2;
+  plmn_id_t t4[] = {p20894_2};
+  sel = SENTINEL; AssertFatal(!nas_get_selected_plmn(&nas, t4, 1, &sel) && sel == SENTINEL, "case 4 (diff MNC)\n");
+
+  /* 5. different MCC, same MNC -> no match */
+  plmn_id_t t5[] = {{.mcc = 310, .mnc = 93, .mnc_digit_length = 2}};
+  sel = SENTINEL; AssertFatal(!nas_get_selected_plmn(&nas, t5, 1, &sel) && sel == SENTINEL, "case 5 (diff MCC)\n");
+
+  /* 6. same MNC value, different mnc_digit_length -> no match (093 vs 93) */
+  uicc.imsiStr = "208930000000003"; uicc.nmc_size = 2;
+  plmn_id_t t6[] = {p208093_3};
+  sel = SENTINEL; AssertFatal(!nas_get_selected_plmn(&nas, t6, 1, &sel) && sel == SENTINEL, "case 6 (digit length differs)\n");
+
+  /* 7/8/9. first/second/third entry hit -> 1/2/3 */
+  uicc.imsiStr = "208930000000003"; uicc.nmc_size = 2;
+  plmn_id_t t789[] = {p20893_2, p20894_2, {.mcc = 208, .mnc = 95, .mnc_digit_length = 2}};
+  sel = SENTINEL; AssertFatal(nas_get_selected_plmn(&nas, t789, 3, &sel) && sel == 1, "case 7 (first -> 1)\n");
+  uicc.imsiStr = "208940000000000";
+  sel = SENTINEL; AssertFatal(nas_get_selected_plmn(&nas, t789, 3, &sel) && sel == 2, "case 8 (second -> 2)\n");
+  uicc.imsiStr = "208950000000000";
+  sel = SENTINEL; AssertFatal(nas_get_selected_plmn(&nas, t789, 3, &sel) && sel == 3, "case 9 (third -> 3)\n");
+
+  /* 10. middle zero placeholder, later hit keeps original 1-based index (3) */
+  uicc.imsiStr = "208950000000000"; uicc.nmc_size = 2;
+  plmn_id_t t10[] = {p20893_2, zero, {.mcc = 208, .mnc = 95, .mnc_digit_length = 2}};
+  sel = SENTINEL; AssertFatal(nas_get_selected_plmn(&nas, t10, 3, &sel) && sel == 3, "case 10 (placeholder keeps index)\n");
+
+  /* 11. all placeholders -> false */
+  plmn_id_t t11[] = {zero, zero, zero};
+  sel = SENTINEL; AssertFatal(!nas_get_selected_plmn(&nas, t11, 3, &sel) && sel == SENTINEL, "case 11 (all placeholder)\n");
+
+  /* 12/13. no match -> false, output sentinel unchanged */
+  uicc.imsiStr = "999990000000000"; uicc.nmc_size = 2;
+  sel = SENTINEL; AssertFatal(!nas_get_selected_plmn(&nas, t789, 3, &sel) && sel == SENTINEL, "case 12/13 (no match, sentinel kept)\n");
+
+  /* 14. IMSI too short -> false */
+  uicc.imsiStr = "208"; uicc.nmc_size = 2;
+  sel = SENTINEL; AssertFatal(!nas_get_selected_plmn(&nas, t1, 1, &sel) && sel == SENTINEL, "case 14 (IMSI too short)\n");
+
+  /* 15. MNC length not 2 or 3 -> false */
+  uicc.imsiStr = "208930000000003"; uicc.nmc_size = 4;
+  sel = SENTINEL; AssertFatal(!nas_get_selected_plmn(&nas, t1, 1, &sel) && sel == SENTINEL, "case 15 (bad nmc_size)\n");
+
+  /* 16/17/18. null nas / null plmns / null output -> false */
+  uicc.imsiStr = "208930000000003"; uicc.nmc_size = 2;
+  AssertFatal(!nas_get_selected_plmn(NULL, t1, 1, &sel), "case 16 (null nas)\n");
+  AssertFatal(!nas_get_selected_plmn(&nas, NULL, 1, &sel), "case 17 (null plmns)\n");
+  AssertFatal(!nas_get_selected_plmn(&nas, t1, 1, NULL), "case 18 (null out)\n");
+
+  /* 18b/18c. null uicc / null imsiStr -> false, output unchanged */
+  nr_ue_nas_t nas_no_uicc = {0};
+  sel = SENTINEL; AssertFatal(!nas_get_selected_plmn(&nas_no_uicc, t1, 1, &sel) && sel == SENTINEL, "case 18b (null uicc)\n");
+  uicc_t uicc_no_imsi = {0};
+  nr_ue_nas_t nas_no_imsi = {0};
+  nas_no_imsi.uicc = &uicc_no_imsi;
+  sel = SENTINEL; AssertFatal(!nas_get_selected_plmn(&nas_no_imsi, t1, 1, &sel) && sel == SENTINEL, "case 18c (null imsiStr)\n");
+
+  /* 19. num_plmns == 0 -> false */
+  sel = SENTINEL; AssertFatal(!nas_get_selected_plmn(&nas, t1, 0, &sel) && sel == SENTINEL, "case 19 (num_plmns 0)\n");
+
+  /* 20. no scan beyond num_plmns: match sits at index 1 but num_plmns limits to 1 -> false */
+  uicc.imsiStr = "208940000000000"; uicc.nmc_size = 2;
+  sel = SENTINEL; AssertFatal(!nas_get_selected_plmn(&nas, t789, 1, &sel) && sel == SENTINEL, "case 20 (no over-scan)\n");
+
+  /* 21. capacity (independent of PLMN_LIST_MAX_SIZE value): only the last entry
+   * matches -> index max; num_plmns > capacity -> false, output unchanged. */
+  plmn_id_t full[PLMN_LIST_MAX_SIZE];
+  for (int i = 0; i < PLMN_LIST_MAX_SIZE; i++)
+    full[i] = p20894_2; /* all non-matching */
+  full[PLMN_LIST_MAX_SIZE - 1] = p20893_2; /* only last matches */
+  uicc.imsiStr = "208930000000003"; uicc.nmc_size = 2;
+  sel = SENTINEL;
+  AssertFatal(nas_get_selected_plmn(&nas, full, PLMN_LIST_MAX_SIZE, &sel) && sel == PLMN_LIST_MAX_SIZE, "case 21a (== capacity)\n");
+  sel = SENTINEL;
+  AssertFatal(!nas_get_selected_plmn(&nas, full, PLMN_LIST_MAX_SIZE + 1, &sel) && sel == SENTINEL, "case 21b (> capacity)\n");
+
+  LOG_A(NAS, "test_nas_get_selected_plmn() passed\n");
+}
+
 int main()
 {
   // Initialize logging system
@@ -405,5 +517,6 @@ int main()
   test_auth_failure();
   test_auth_reject();
   test_security_mode_reject();
+  test_nas_get_selected_plmn();
   return 0;
 }

--- a/openair3/NAS/NR_UE/CMakeLists.txt
+++ b/openair3/NAS/NR_UE/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_subdirectory(5GS)
 
-add_library(nr_nas STATIC nr_nas_msg.c)
+add_library(nr_nas STATIC nr_nas_msg.c nas_plmn_select.c)
 
 target_link_libraries(nr_nas PUBLIC asn1_lte_rrc_hdrs asn1_nr_rrc_hdrs)
 target_link_libraries(nr_nas PUBLIC

--- a/openair3/NAS/NR_UE/nas_plmn_select.c
+++ b/openair3/NAS/NR_UE/nas_plmn_select.c
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+/* PLMN selection helper kept in its own translation unit so unit tests can link
+ * it without dragging the ITTI/task dependencies of nr_nas_msg.c. */
+
+#include <string.h>
+#include "nr_nas_msg.h"
+
+bool nas_get_selected_plmn(const nr_ue_nas_t *nas, const plmn_id_t *plmns, int num_plmns, long *selected_plmn_identity)
+{
+  if (!nas || !nas->uicc || !nas->uicc->imsiStr || !plmns || !selected_plmn_identity)
+    return false;
+  if (num_plmns <= 0 || num_plmns > PLMN_LIST_MAX_SIZE)
+    return false;
+  const char *imsi = nas->uicc->imsiStr;
+  const int mnc_len = nas->uicc->nmc_size; /* 2 or 3 */
+  if ((mnc_len != 2 && mnc_len != 3) || strlen(imsi) < (size_t)(3 + mnc_len))
+    return false;
+  const uint16_t ue_mcc = (imsi[0] - '0') * 100 + (imsi[1] - '0') * 10 + (imsi[2] - '0');
+  const uint16_t ue_mnc = (mnc_len == 3) ? (imsi[3] - '0') * 100 + (imsi[4] - '0') * 10 + (imsi[5] - '0')
+                                         : (imsi[3] - '0') * 10 + (imsi[4] - '0');
+  for (int k = 0; k < num_plmns; k++) {
+    if (plmns[k].mnc_digit_length == mnc_len && plmns[k].mcc == ue_mcc && plmns[k].mnc == ue_mnc) {
+      *selected_plmn_identity = k + 1; /* 1-based per TS 38.331 */
+      return true;
+    }
+  }
+  return false;
+}

--- a/openair3/NAS/NR_UE/nr_nas_msg.h
+++ b/openair3/NAS/NR_UE/nr_nas_msg.h
@@ -80,6 +80,9 @@ typedef struct {
 } nr_ue_nas_t;
 
 nr_ue_nas_t *get_ue_nas_info(module_id_t module_id);
+/* @brief Return true and write the 1-based selectedPLMN-Identity (TS 38.331) of the
+ * plmns[] entry matching the UE IMSI (MCC/MNC from UICC); false (output untouched) if none. */
+bool nas_get_selected_plmn(const nr_ue_nas_t *nas, const plmn_id_t *plmns, int num_plmns, long *selected_plmn_identity);
 void generateRegistrationRequest(as_nas_info_t *initialNasMsg, nr_ue_nas_t *nas, bool is_security_mode);
 void generateServiceRequest(as_nas_info_t *initialNasMsg, nr_ue_nas_t *nas);
 void *nas_nrue_task(void *args_p);

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.fr1.106PRB.usrpb210.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.fr1.106PRB.usrpb210.conf
@@ -13,7 +13,10 @@ gNBs =
 
     // Tracking area code, 0x0000 and 0xfffe are reserved values
     tracking_area_code  =  1;
-    plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+    plmn_list = (
+      { mcc = 208; mnc = 93; mnc_length = 2; snssaiList = ({ sst = 1; sd = 0x010203; }) },
+      { mcc = 208; mnc = 94; mnc_length = 2; snssaiList = ({ sst = 1; sd = 0x010204; }) }
+    );
 
     nr_cellid = 12345678L;
 
@@ -157,13 +160,12 @@ gNBs =
 
 
     ////////// AMF parameters:
-    amf_ip_address = ({ ipv4 = "192.168.70.132"; });
-
+    amf_ip_address = ({ ipv4 = "128.105.145.14"; }, { ipv4 = "128.105.145.12"; });
 
     NETWORK_INTERFACES :
     {
-        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.70.129/24";
-        GNB_IPV4_ADDRESS_FOR_NGU                 = "192.168.70.129/24";
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "128.105.145.13/22";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "10.10.3.1/24";
         GNB_PORT_FOR_S1U                         = 2152; # Spec 2152
     };
 


### PR DESCRIPTION
## Summary

This PR fills in the missing NR gNB-side support needed to run an end-to-end 5G MOCN setup in OAI.

The main goal is to allow one OAI gNB to advertise multiple PLMNs in SIB1 and let each UE select the appropriate PLMN based on its IMSI. The base OAI/Duranta code already has selected-PLMN-aware NGAP/AMF routing support. This PR wires up the missing NR gNB-side multi-PLMN broadcast/configuration and UE-selection path so that the selected PLMN can be used to route each UE to the Core serving that PLMN.

In other words, this PR completes the key NR gNB-side path needed for a working 5G MOCN deployment in OAI. The changes were ported onto the latest Duranta/OAI weekly `develop` branch `2026.w27` and validated end-to-end with two independent L25GC+ cores (a free5GC-derived 5G Core).

## Main changes

### F1AP served-cell information

- Extend served-cell information to carry per-PLMN slice information.
- Add served PLMN structures for multiple PLMNs.
- Update F1AP encode/decode/copy/equal helpers.
- Update the corresponding F1AP unit test.

### gNB config and SIB1 broadcasting

- Parse all configured `plmn_list` entries and their `snssaiList`.
- Propagate the served PLMN list into the MAC/RRC SIB1 configuration path.
- Remove the previous hard-coded single-PLMN assumption so SIB1 can advertise multiple PLMNs.

### CU/DU PLMN validation

- Replace the legacy single-PLMN CU/DU check with a MOCN-aware validation.
- The DU/cell is accepted only if every DU-advertised PLMN is present in the CU/gNB configured PLMN list.
- This preserves meaningful validation for misconfigured non-MOCN cases while allowing a CU to support more PLMNs than a given DU/cell advertises.

### nrUE PLMN selection

- Let nrUE walk the SIB1 `plmn-IdentityInfoList`.
- Match PLMN entries against the UE IMSI MCC/MNC.
- Set `selected_plmn_identity` according to the matched PLMN.

### RRC / selected PLMN propagation

- Carry the UE-selected serving PLMN through the NR gNB UE context path.
- The existing selected-PLMN-aware NGAP/AMF routing support in the base code can then route UE signalling to the AMF/Core serving the selected PLMN.
- This PR therefore provides the missing multi-PLMN broadcast/configuration and UE-selection pieces needed to exercise that routing end-to-end in a 5G MOCN setup.

### O1 / telnet exporter adaptation

- Update the O1/telnet exporter to read slice information from the new served-PLMN list layout after the F1AP served-cell structure change.

### Reference configs

- Include the gNB/UE/UE2 configuration used for the two-core validation setup.
- These config changes are mainly provided as a reproducibility reference, so reviewers can see exactly how the setup was run.
- If maintainers prefer not to modify default configs, these can be moved to example files or described only in the PR body.

## Validation

This PR was built and validated on the latest Duranta/OAI weekly `develop` branch `2026.w27` using a two-core L25GC+ testbed.

L25GC+ is a free5GC-derived 5G Core with UPF-side optimizations. In this validation setup, two independent L25GC+ cores were used to emulate two operators / two core networks.

Test topology:

- `node0`: OAI gNB and two OAI nrUE instances.
  - Both nrUE instances run on the same OAI node as the gNB.
  - The UEs are separated using the OAI multi-UE namespace setup.
- `node1`: L25GC+ Core1 / PLMN `20893` / UPF1.
- `node2`: L25GC+ Core2 / PLMN `20894` / UPF2.
- `node3`: DN1 for Core1.
- `node4`: DN2 for Core2.

Validation results:

- The gNB establishes NGAP/SCTP connections with both Core1 AMF and Core2 AMF.
- UE1 selects PLMN `20893` based on its IMSI.
- UE1 attaches through Core1, obtains a Core1-assigned IP address, and reaches DN1 through Core1 UPF/GTP-U.
- UE2 selects PLMN `20894` based on its IMSI.
- UE2 attaches through Core2, obtains a Core2-assigned IP address, and reaches DN2 through Core2 UPF/GTP-U.
- UE1 → DN1 ping succeeds.
- UE2 → DN2 ping succeeds.
- UE1 → DN1 and UE2 → DN2 simultaneous iperf3 tests succeed.

Screenshots / figures included in this PR:

1. Testbed topology showing node0–node4, PLMN/Core mapping, UE namespaces, and DN paths.
2. Concurrent UE1/UE2 ping tests.
3. Concurrent UE1/UE2 iperf3 tests.
4. Two-AMF NGAP setup success.

<img width="1348" height="713" alt="image" src="https://github.com/user-attachments/assets/86530e7c-c52e-4be5-b3a0-b00a74630b3d" />
<img width="1924" height="874" alt="853223007d33cec70ec9672e977fd9d1" src="https://github.com/user-attachments/assets/65b80828-a5c6-4027-8234-aedb9e3e97fa" />
<img width="2370" height="1544" alt="89cd3d7f31ed38a2fb1afca023c7e927" src="https://github.com/user-attachments/assets/9b18a014-6cda-415f-aa08-ff96c8b09239" />
<img width="1716" height="1538" alt="b3963feb0d3c35900ab5907f7f60c2e0" src="https://github.com/user-attachments/assets/1dcf935a-0614-496e-86f2-b5ddcb0cc1f7" />


