### PR TITLE
Simplifications for xran builds

### DIFF
--- a/cmake_targets/tools/MODULES/Findxran.cmake
+++ b/cmake_targets/tools/MODULES/Findxran.cmake
@@ -6,7 +6,7 @@
 # Finds the xran library. Note that the library number is as follows:
 # - oran_e_maintenance_release_v1.5 -> 5.1.6
 # - oran_f_release_v1.3 -> 6.1.4
-# - oran_k_release_v1.2 -> 11.1.2
+# - oran_k_release_v1.3 -> 11.1.3
 #
 # Required options
 # ^^^^^^^^^^^^^^^^

--- a/doc/ORAN_FHI7.2_Tutorial.md
+++ b/doc/ORAN_FHI7.2_Tutorial.md
@@ -421,15 +421,14 @@ git apply ~/openairinterface5g/cmake_targets/tools/oran_fhi_integration_patches/
 ```bash
 git clone https://github.com/openairinterface/o-du-phy.git ~/phy
 cd ~/phy
-git checkout 11.1.2 # the tag points to the `main` branch which has all patches applied that are relevant for OAI integration; the tag matches the value of cmake variable `K_VERSION`
+git checkout 11.1.3 # the tag points to the `main` branch which has all patches applied that are relevant for OAI integration; the tag matches the value of cmake variable `K_VERSION`
 ```
 or use `xran_DOWNLOAD` option when compiling OAI gNB.
 
 Compile the fronthaul interface library by calling `make` and the option
 `XRAN_LIB_SO=1` to have it build a shared object. Note that we provide two
 environment variables `RTE_SDK` for the path to the source tree of DPDK, and
-`XRAN_DIR` to set the path to the fronthaul library. For building for a Arm
-target, set as well the environment variable `TARGET=armv8`.
+`XRAN_DIR` to set the path to the fronthaul library.
 
 **Note**: you need at least gcc-11 and g++-11.
 

--- a/docker/Dockerfile.build.fhi72.native_arm.ubuntu
+++ b/docker/Dockerfile.build.fhi72.native_arm.ubuntu
@@ -9,7 +9,7 @@
 
 FROM ran-base:latest AS ran-base
 
-ARG xran_VERSION=11.1.2
+ARG xran_VERSION=11.1.3
 ARG E2AP_VERSION=E2AP_V3
 ARG KPM_VERSION=KPM_V3_00
 ENV DEBIAN_FRONTEND=noninteractive
@@ -42,7 +42,7 @@ RUN git clone https://github.com/openairinterface/o-du-phy.git /opt/phy && \
     cd /opt/phy && \
     git checkout $xran_VERSION &&\
     cd /opt/phy/fhi_lib/lib && \
-    TARGET=armv8 WIRELESS_SDK_TOOLCHAIN=gcc RTE_SDK=/oai-ran/dpdk-stable-24.11.4/ XRAN_DIR=/opt/phy/fhi_lib make XRAN_LIB_SO=1
+    WIRELESS_SDK_TOOLCHAIN=gcc RTE_SDK=/oai-ran/dpdk-stable-24.11.4/ XRAN_DIR=/opt/phy/fhi_lib make XRAN_LIB_SO=1
 
 ## Build Arm RAN Acceleration Library
 RUN git clone https://git.gitlab.arm.com/networking/ral.git /opt/ral && \

--- a/docker/Dockerfile.build.fhi72.rhel9
+++ b/docker/Dockerfile.build.fhi72.rhel9
@@ -14,7 +14,7 @@ RUN rm -Rf /oai-ran
 WORKDIR /oai-ran
 COPY . .
 
-ARG xran_VERSION=11.1.2
+ARG xran_VERSION=11.1.3
 
 ## Download and build DPDK
 RUN wget --no-verbose http://fast.dpdk.org/rel/dpdk-24.11.4.tar.xz && \

--- a/docker/Dockerfile.build.fhi72.t2.ubuntu
+++ b/docker/Dockerfile.build.fhi72.t2.ubuntu
@@ -9,7 +9,7 @@
 
 FROM ran-base:latest AS ran-base
 
-ARG xran_VERSION=11.1.2
+ARG xran_VERSION=11.1.3
 ARG DPDK_VERSION=22.11
 ARG T2_PATCH=AMD-T2-SDFEC_25-03-1.patch
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile.build.fhi72.ubuntu
+++ b/docker/Dockerfile.build.fhi72.ubuntu
@@ -9,7 +9,7 @@
 
 FROM ran-base:latest AS ran-base
 
-ARG xran_VERSION=11.1.2
+ARG xran_VERSION=11.1.3
 ARG E2AP_VERSION=E2AP_V3
 ARG KPM_VERSION=KPM_V3_00
 ENV DEBIAN_FRONTEND=noninteractive

--- a/radio/fhi_72/CMakeLists.txt
+++ b/radio/fhi_72/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(oran_fhlib_5g MODULE
 set(F_VERSION 6.1.9)
 set(K_VERSION 11.1.2)
 
-add_boolean_option(xran_DOWNLOAD OFF "Download and build xran library" OFF)
+add_boolean_option(xran_DOWNLOAD ON "Download and build xran library if not found in xran_LOCATION" OFF)
 
 find_package(xran)
 if(xran_FOUND)

--- a/radio/fhi_72/CMakeLists.txt
+++ b/radio/fhi_72/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(oran_fhlib_5g MODULE
 )
 
 set(F_VERSION 6.1.9)
-set(K_VERSION 11.1.2)
+set(K_VERSION 11.1.3)
 
 add_boolean_option(xran_DOWNLOAD ON "Download and build xran library if not found in xran_LOCATION" OFF)
 


### PR DESCRIPTION
- make xran_DOWNLOAD=ON default - skips an extra argument in `cmake` command
- Automatically detect aarch64 and select correct target for external xran build