### PR TITLE
Fix PSS correlation peak value and average value on the OAI UE logs

### DIFF
--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -332,6 +332,8 @@ static void nr_scan_ssb(void *arg)
       continue;
     }
 
+    ssbInfo->pssCorrAvgPower = search_params.pss_res.avg;
+    ssbInfo->pssCorrPeakPower = search_params.pss_res.peak;
     ssbInfo->ssbOffset = search_params.pss_res.pos - search_params.nb_prefix_samples;
     ssbInfo->nidCell = search_params.sss_res.nid_cell;
 


### PR DESCRIPTION
These metrics are very helpful to properly adjust the USRP gains on the OAI UE. There was a regression in the code, this commit just gets it showing properly again.

Current *develop*:
```
[NR_PHY] Starting sync detection
[PHY]    [UE thread Synch] Running Initial Synch 
[NR_PHY] Starting cell search with center freq: 3619200000, bandwidth: 106. Scanning for 1 number of GSCN.
[NR_PHY] Scanning GSCN: 0, with SSB offset: 516, SSB Freq: 0.000000
[PHY]    Initial sync: pbch decoded sucessfully, ssb index 0
[PHY]    pbch rx ok. rsrp:51 dB/RE, adjust_rxgain:-1 dB
[NR_PHY] Cell Detected with GSCN: 0, SSB SC offset: 516, SSB Ref: 0.000000, PSS Corr peak: 0 dB, PSS Corr Average: 0
```

This PR:
```
[PHY]    SSB position provided
[NR_PHY] Starting sync detection
[PHY]    [UE thread Synch] Running Initial Synch 
[NR_PHY] Starting cell search with center freq: 3619200000, bandwidth: 106. Scanning for 1 number of GSCN.
[NR_PHY] Scanning GSCN: 0, with SSB offset: 516, SSB Freq: 0.000000
[PHY]    Initial sync: pbch decoded sucessfully, ssb index 0
[PHY]    pbch rx ok. rsrp:51 dB/RE, adjust_rxgain:-1 dB
[NR_PHY] Cell Detected with GSCN: 0, SSB SC offset: 516, SSB Ref: 0.000000, PSS Corr peak: 99 dB, PSS Corr Average: 61
```