### PR TITLE
fix(fhi_72): Avoid crashing on late PRACH packets

### DIFF
--- a/common/utils/utils.h
+++ b/common/utils/utils.h
@@ -75,6 +75,15 @@ extern "C" {
     }                    \
   } while (0)
 
+#define RATELIMIT(n, block)                                                               \
+  do {                                                                                    \
+    static _Atomic unsigned long counter = 0;                                             \
+    unsigned long current = atomic_fetch_add_explicit(&counter, 1, memory_order_relaxed); \
+    if (current % (n) == 0) {                                                             \
+      block                                                                               \
+    }                                                                                     \
+  } while (0)
+
 static inline void *malloc16_clear( size_t size ) {
   void *ptr = memalign(64, size + 64);
   DevAssert(ptr);

--- a/fronthaul/oru/oru_packet_processor.c
+++ b/fronthaul/oru/oru_packet_processor.c
@@ -21,15 +21,6 @@
 
 #define PRACH_ERR_LOG_RATELIMIT 10000
 
-#define RATELIMIT(n, block)                                                               \
-  do {                                                                                    \
-    static _Atomic unsigned long counter = 0;                                             \
-    unsigned long current = atomic_fetch_add_explicit(&counter, 1, memory_order_relaxed); \
-    if (current % (n) == 0) {                                                             \
-      block                                                                               \
-    }                                                                                     \
-  } while (0)
-
 #define DL_JOB_RING_SIZE 128
 #define UL_JOB_RING_SIZE 128
 #define MAX_CONCURRENT_DL_JOBS (DL_JOB_RING_SIZE - 1)

--- a/radio/fhi_72/oaioran.c
+++ b/radio/fhi_72/oaioran.c
@@ -287,8 +287,13 @@ void oai_xran_fh_rx_prach_callback(void *pCallbackTag, xran_status_t status
             struct xran_prb_map *pRbMap = (struct xran_prb_map *)bufs->prachdstdecomp[ant_id][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
             AssertFatal(pRbMap != NULL, "(%d:%d:%d)pRbMapPrach == NULL. Aborting.\n", cc_id, tti % XRAN_N_FE_BUF_LEN, ant_id);
             for (uint32_t sym_id = 0; sym_id < XRAN_NUM_OF_SYMBOL_PER_SLOT; sym_id++) {
-              AssertFatal(pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt <= 1, "PRACH segmentation is not supported\n");
-              info->nRxPkt[cc_id][ant_id][sym_id] = pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt;
+              if (pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt > 1)
+              {
+                RATELIMIT(1000, {
+                  LOG_E(HW, "PRACH segmentation or late PRACH packet: tti %u sym %u: nRxPkt = %u\n", tti, sym_id, pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt);
+                });
+              }
+              info->nRxPkt[cc_id][ant_id][sym_id] = min(pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt, 1);
               pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt = 0;
             }
           }


### PR DESCRIPTION
Late PRACH packets from O-RU can cause xran to accumulate them into the same ring buffer entry. Remove the AssertFatal and replace with a rate-limited LOG_E.