### PR TITLE
Handle invalid input in nr_get_E

### DIFF
--- a/openair1/PHY/NR_TRANSPORT/nr_dlsch_coding.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_dlsch_coding.c
@@ -235,9 +235,11 @@ int nr_dlsch_encoding(PHY_VARS_gNB *gNB,
 
     for (int r = 0; r < TB_parameters->C; r++) {
       nrLDPC_segment_encoding_parameters_t *segment_parameters = &TB_parameters->segments[r];
+      int E = nr_get_E(TB_parameters->G, TB_parameters->C, TB_parameters->Qm, rel15->nrOfLayers, r);
+      if (E < 0)
+        return -1;
       segment_parameters->c = dlsch->c[r];
-      segment_parameters->E = nr_get_E(TB_parameters->G, TB_parameters->C, TB_parameters->Qm, rel15->nrOfLayers, r);
-
+      segment_parameters->E = E;
       reset_meas(&segment_parameters->ts_interleave);
       reset_meas(&segment_parameters->ts_rate_match);
       reset_meas(&segment_parameters->ts_ldpc_encode);

--- a/openair1/PHY/NR_TRANSPORT/nr_tbs_tools.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_tbs_tools.c
@@ -19,13 +19,15 @@ nr_get_G(uint16_t nb_rb, uint16_t nb_symb_sch, uint8_t nb_re_dmrs, uint16_t leng
   return (G);
 }
 
-uint32_t nr_get_E(uint32_t G, uint8_t C, uint8_t Qm, uint8_t Nl, uint8_t r)
+int nr_get_E(uint32_t G, uint8_t C, uint8_t Qm, uint8_t Nl, uint8_t r)
 {
+  if (Nl <= 0 || Qm <= 0) {
+    LOG_E(PHY, "Invalid input parameter in nr_get_E: Qm %d Nl %d\n", Qm, Nl);
+    return -1;
+  }
+
   uint32_t E;
   uint8_t Cprime = C; // assume CBGTI not present
-
-  AssertFatal(Nl > 0, "Nl is 0\n");
-  AssertFatal(Qm > 0, "Qm is 0\n");
   if (r <= Cprime - ((G / (Nl * Qm)) % Cprime) - 1)
     E = Nl * Qm * (G / (Nl * Qm * Cprime));
   else

--- a/openair1/PHY/NR_TRANSPORT/nr_transport_common_proto.h
+++ b/openair1/PHY/NR_TRANSPORT/nr_transport_common_proto.h
@@ -35,7 +35,7 @@ uint32_t nr_get_G(uint16_t nb_rb,
                   uint8_t Qm,
                   uint8_t Nl);
 
-uint32_t nr_get_E(uint32_t G, uint8_t C, uint8_t Qm, uint8_t Nl, uint8_t r);
+int nr_get_E(uint32_t G, uint8_t C, uint8_t Qm, uint8_t Nl, uint8_t r);
 
 void compute_nr_prach_seq(uint8_t short_sequence, uint8_t num_sequences, uint8_t rootSequenceIndex, c16_t X_u[64][839]);
 

--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch_decoding.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch_decoding.c
@@ -226,11 +226,13 @@ int nr_ulsch_decoding(PHY_VARS_gNB *phy_vars_gNB,
     }
 
     nrLDPC_TB_decoding_parameters_t *TB_parameters = &TBs[pusch_id];
-
+    int E = nr_get_E(TB_parameters->G, TB_parameters->C, TB_parameters->Qm, TB_parameters->nb_layers, 0);
+    if (E < 0)
+      return -1;
     TB_parameters->llr = ulsch_llr;
     TB_parameters->d = harq_process->d;
     TB_parameters->c = harq_process->c;
-    TB_parameters->E = nr_get_E(TB_parameters->G, TB_parameters->C, TB_parameters->Qm, TB_parameters->nb_layers, 0);
+    TB_parameters->E = E;
     TB_parameters->first_rE2 = TB_parameters->C;
     TB_parameters->E2 = TB_parameters->E;
     TB_parameters->R = nr_get_R_ldpc_decoder(TB_parameters->rv_index,

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_decoding.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_decoding.c
@@ -147,9 +147,12 @@ void nr_dlsch_decoding(PHY_VARS_NR_UE *phy_vars_ue,
         TB_parameters.C,
         TB_parameters.Qm,
         TB_parameters.llr);
+  int E = nr_get_E(TB_parameters.G, TB_parameters.C, TB_parameters.Qm, TB_parameters.nb_layers, 0);
+  if (E < 0)
+    return;
   TB_parameters.c = harq_process->c;
   TB_parameters.d = harq_process->d;
-  TB_parameters.E = nr_get_E(TB_parameters.G, TB_parameters.C, TB_parameters.Qm, TB_parameters.nb_layers, 0);
+  TB_parameters.E = E;
   TB_parameters.E2 = TB_parameters.E;
   TB_parameters.first_rE2 = TB_parameters.C;
   for (int r = 1; r < TB_parameters.C; r++) {

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_coding.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_coding.c
@@ -156,17 +156,14 @@ int nr_ulsch_encoding(PHY_VARS_NR_UE *ue,
 
     for (int r = 0; r < TB_parameters->C; r++) {
       nrLDPC_segment_encoding_parameters_t *segment_parameters = &TB_parameters->segments[r];
+      int E = nr_get_E(TB_parameters->G, TB_parameters->C, TB_parameters->Qm, TB_parameters->nb_layers, r);
+      if (E < 0)
+         return -1;
       segment_parameters->c = harq_process->c[r];
-      segment_parameters->E = nr_get_E(TB_parameters->G,
-                                            TB_parameters->C,
-                                            TB_parameters->Qm,
-                                            TB_parameters->nb_layers,
-                                            r);
-
+      segment_parameters->E = E;
       reset_meas(&segment_parameters->ts_interleave);
       reset_meas(&segment_parameters->ts_rate_match);
       reset_meas(&segment_parameters->ts_ldpc_encode);
-
     } // TB_parameters->C
   } // pusch_id
 


### PR DESCRIPTION
This PR prevents the function nr_get_E to crash with an assertion for invalid input by handling the scenario with an error code