### PR TITLE
Cleanup `RU_t` for NR and LTE

### DIFF
--- a/executables/lte-ru.c
+++ b/executables/lte-ru.c
@@ -2364,13 +2364,11 @@ void set_function_spec_param(RU_t *ru) {
         ru->feptx_prec            = NULL;                   // nothing (this is a time-domain signal)
         ru->start_if              = start_if;               // need to start the if interface for if5
         ru->ifdevice.host_type    = RRU_HOST;
-        ru->rfdevice.host_type    = RRU_HOST;
-        ru->ifdevice.eth_params   = &ru->eth_params;
         reset_meas(&ru->rx_fhaul);
         reset_meas(&ru->tx_fhaul);
         reset_meas(&ru->compression);
         reset_meas(&ru->transport);
-        ret = openair0_transport_load(&ru->ifdevice,&ru->openair0_cfg,&ru->eth_params);
+        ret = openair0_transport_load(&ru->ifdevice,&ru->openair0_cfg);
         LOG_I(PHY,"NGFI_RRU_IF5: openair0_transport_init returns %d for ru_id %d\n", ret, ru->idx);
 
         if (ret<0) {
@@ -2387,13 +2385,11 @@ void set_function_spec_param(RU_t *ru) {
         ru->feptx_prec            = NULL;
         ru->start_if              = start_if;                 // need to start the if interface for if4p5
         ru->ifdevice.host_type    = RRU_HOST;
-        ru->rfdevice.host_type    = RRU_HOST;
-        ru->ifdevice.eth_params   = &ru->eth_params;
         reset_meas(&ru->rx_fhaul);
         reset_meas(&ru->tx_fhaul);
         reset_meas(&ru->compression);
         reset_meas(&ru->transport);
-        ret = openair0_transport_load(&ru->ifdevice,&ru->openair0_cfg,&ru->eth_params);
+        ret = openair0_transport_load(&ru->ifdevice,&ru->openair0_cfg);
         LOG_I(PHY,"NGFI_RRU_if4p5 : openair0_transport_init returns %d for ru_id %d\n", ret, ru->idx);
 
         if (ret<0) {
@@ -2445,13 +2441,12 @@ void set_function_spec_param(RU_t *ru) {
         ru->fh_south_out         = fh_if5_south_out;    // synchronous IF5 transmission
         ru->fh_south_asynch_in   = NULL;                // no asynchronous UL
       }
-      ru->start_rf               = ru->eth_params.transp_preference == ETH_UDP_IF5_ECPRI_MODE ? start_streaming : NULL;
+      ru->start_rf               = ru->ifdevice.eth_params.transp_preference == ETH_UDP_IF5_ECPRI_MODE ? start_streaming : NULL;
       ru->stop_rf                = NULL;
       ru->start_if               = start_if;             // need to start if interface for IF5
       ru->ifdevice.host_type     = RAU_HOST;
-      ru->ifdevice.eth_params    = &ru->eth_params;
       ru->ifdevice.configure_rru = configure_ru;
-      ret = openair0_transport_load(&ru->ifdevice,&ru->openair0_cfg,&ru->eth_params);
+      ret = openair0_transport_load(&ru->ifdevice,&ru->openair0_cfg);
       LOG_I(PHY,"REMOTE_IF5: openair0_transport_init returns %d for ru_id %d\n", ret, ru->idx);
 
       if (ret<0) {
@@ -2475,9 +2470,8 @@ void set_function_spec_param(RU_t *ru) {
       ru->stop_rf                = NULL;
       ru->start_if               = start_if;            // need to start if interface for IF4p5
       ru->ifdevice.host_type     = RAU_HOST;
-      ru->ifdevice.eth_params    = &ru->eth_params;
       ru->ifdevice.configure_rru = configure_ru;
-      ret = openair0_transport_load(&ru->ifdevice, &ru->openair0_cfg, &ru->eth_params);
+      ret = openair0_transport_load(&ru->ifdevice, &ru->openair0_cfg);
       LOG_I(PHY,"REMOTE IF4p5: openair0_transport_init returns %d for ru_id %d\n", ret, ru->idx);
 
       if (ret<0) {
@@ -2828,42 +2822,42 @@ RU_t **RCconfig_RU(int nb_RU,int nb_L1_inst,PHY_VARS_eNB ***eNB,uint64_t *ru_mas
           ru[j]->state                           = RU_RUN;
           printf("Setting function for RU %d to eNodeB_3GPP\n",j);
         } else {
-          ru[j]->eth_params.local_if_name            = strdup(*(RUParamList.paramarray[j][RU_LOCAL_IF_NAME_IDX].strptr));
-          ru[j]->eth_params.my_addr                  = strdup(*(RUParamList.paramarray[j][RU_LOCAL_ADDRESS_IDX].strptr));
-          ru[j]->eth_params.remote_addr              = strdup(*(RUParamList.paramarray[j][RU_REMOTE_ADDRESS_IDX].strptr));
-          ru[j]->eth_params.my_portd                 = *(RUParamList.paramarray[j][RU_LOCAL_PORTD_IDX].uptr);
-          ru[j]->eth_params.remote_portd             = *(RUParamList.paramarray[j][RU_REMOTE_PORTD_IDX].uptr);
+          ru[j]->ifdevice.eth_params.local_if_name            = strdup(*(RUParamList.paramarray[j][RU_LOCAL_IF_NAME_IDX].strptr));
+          ru[j]->ifdevice.eth_params.my_addr                  = strdup(*(RUParamList.paramarray[j][RU_LOCAL_ADDRESS_IDX].strptr));
+          ru[j]->ifdevice.eth_params.remote_addr              = strdup(*(RUParamList.paramarray[j][RU_REMOTE_ADDRESS_IDX].strptr));
+          ru[j]->ifdevice.eth_params.my_portd                 = *(RUParamList.paramarray[j][RU_LOCAL_PORTD_IDX].uptr);
+          ru[j]->ifdevice.eth_params.remote_portd             = *(RUParamList.paramarray[j][RU_REMOTE_PORTD_IDX].uptr);
 
           // Check if control port set
           if  (!(config_isparamset(RUParamList.paramarray[j],RU_REMOTE_PORTC_IDX)) ) {
             LOG_I(PHY,"Removing control port for RU %d\n",j);
             ru[j]->has_ctrl_prt            = 0;
           } else {
-            ru[j]->eth_params.my_portc                 = *(RUParamList.paramarray[j][RU_LOCAL_PORTC_IDX].uptr);
-            ru[j]->eth_params.remote_portc             = *(RUParamList.paramarray[j][RU_REMOTE_PORTC_IDX].uptr);
-            LOG_I(PHY," Control port %u \n",ru[j]->eth_params.my_portc);
+            ru[j]->ifdevice.eth_params.my_portc                 = *(RUParamList.paramarray[j][RU_LOCAL_PORTC_IDX].uptr);
+            ru[j]->ifdevice.eth_params.remote_portc             = *(RUParamList.paramarray[j][RU_REMOTE_PORTC_IDX].uptr);
+            LOG_I(PHY," Control port %u \n",ru[j]->ifdevice.eth_params.my_portc);
           }
 
           if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "udp") == 0) {
             ru[j]->if_south                        = LOCAL_RF;
             ru[j]->function                        = NGFI_RRU_IF5;
-            ru[j]->eth_params.transp_preference    = ETH_UDP_MODE;
+            ru[j]->ifdevice.eth_params.transp_preference    = ETH_UDP_MODE;
             LOG_I(PHY,"Setting function for RU %d to NGFI_RRU_IF5 (udp)\n",j);
           } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "raw") == 0) {
             ru[j]->if_south                        = LOCAL_RF;
             ru[j]->function                        = NGFI_RRU_IF5;
-            ru[j]->eth_params.transp_preference    = ETH_RAW_MODE;
+            ru[j]->ifdevice.eth_params.transp_preference    = ETH_RAW_MODE;
             LOG_I(PHY,"Setting function for RU %d to NGFI_RRU_IF5 (raw)\n",j);
           } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "udp_if4p5") == 0) {
             ru[j]->if_south                        = LOCAL_RF;
             ru[j]->function                        = NGFI_RRU_IF4p5;
-            ru[j]->eth_params.transp_preference    = ETH_UDP_IF4p5_MODE;
+            ru[j]->ifdevice.eth_params.transp_preference    = ETH_UDP_IF4p5_MODE;
             ru[j]->has_ctrl_prt                   =1;
             LOG_I(PHY,"Setting function for RU %d to NGFI_RRU_IF4p5 (udp)\n",j);
           } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "raw_if4p5") == 0) {
             ru[j]->if_south                        = LOCAL_RF;
             ru[j]->function                        = NGFI_RRU_IF4p5;
-            ru[j]->eth_params.transp_preference    = ETH_RAW_IF4p5_MODE;
+            ru[j]->ifdevice.eth_params.transp_preference    = ETH_RAW_IF4p5_MODE;
             ru[j]->has_ctrl_prt                   =1;
             LOG_I(PHY,"Setting function for RU %d to NGFI_RRU_IF4p5 (raw)\n",j);
           }
@@ -2879,35 +2873,35 @@ RU_t **RCconfig_RU(int nb_RU,int nb_L1_inst,PHY_VARS_eNB ***eNB,uint64_t *ru_mas
       } //strcmp(local_rf, "yes") == 0
       else {
         LOG_I(PHY,"RU %d: Transport %s\n",j,*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr));
-        ru[j]->eth_params.local_if_name      = strdup(*(RUParamList.paramarray[j][RU_LOCAL_IF_NAME_IDX].strptr));
-        ru[j]->eth_params.my_addr            = strdup(*(RUParamList.paramarray[j][RU_LOCAL_ADDRESS_IDX].strptr));
-        ru[j]->eth_params.remote_addr        = strdup(*(RUParamList.paramarray[j][RU_REMOTE_ADDRESS_IDX].strptr));
-        ru[j]->eth_params.my_portc           = *(RUParamList.paramarray[j][RU_LOCAL_PORTC_IDX].uptr);
-        ru[j]->eth_params.remote_portc       = *(RUParamList.paramarray[j][RU_REMOTE_PORTC_IDX].uptr);
-        ru[j]->eth_params.my_portd           = *(RUParamList.paramarray[j][RU_LOCAL_PORTD_IDX].uptr);
-        ru[j]->eth_params.remote_portd       = *(RUParamList.paramarray[j][RU_REMOTE_PORTD_IDX].uptr);
+        ru[j]->ifdevice.eth_params.local_if_name      = strdup(*(RUParamList.paramarray[j][RU_LOCAL_IF_NAME_IDX].strptr));
+        ru[j]->ifdevice.eth_params.my_addr            = strdup(*(RUParamList.paramarray[j][RU_LOCAL_ADDRESS_IDX].strptr));
+        ru[j]->ifdevice.eth_params.remote_addr        = strdup(*(RUParamList.paramarray[j][RU_REMOTE_ADDRESS_IDX].strptr));
+        ru[j]->ifdevice.eth_params.my_portc           = *(RUParamList.paramarray[j][RU_LOCAL_PORTC_IDX].uptr);
+        ru[j]->ifdevice.eth_params.remote_portc       = *(RUParamList.paramarray[j][RU_REMOTE_PORTC_IDX].uptr);
+        ru[j]->ifdevice.eth_params.my_portd           = *(RUParamList.paramarray[j][RU_LOCAL_PORTD_IDX].uptr);
+        ru[j]->ifdevice.eth_params.remote_portd       = *(RUParamList.paramarray[j][RU_REMOTE_PORTD_IDX].uptr);
       
         if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "udp") == 0) {
 	  ru[j]->if_south                     = REMOTE_IF5;
 	  ru[j]->function                     = NGFI_RAU_IF5;
-	  ru[j]->eth_params.transp_preference = ETH_UDP_MODE;
+	  ru[j]->ifdevice.eth_params.transp_preference = ETH_UDP_MODE;
         } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "udp_ecpri_if5") == 0) {
 	  ru[j]->if_south                     = REMOTE_IF5;
 	  ru[j]->function                     = NGFI_RAU_IF5;
-	  ru[j]->eth_params.transp_preference = ETH_UDP_IF5_ECPRI_MODE;
+	  ru[j]->ifdevice.eth_params.transp_preference = ETH_UDP_IF5_ECPRI_MODE;
         } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "raw") == 0) {
 	  ru[j]->if_south                     = REMOTE_IF5;
 	  ru[j]->function                     = NGFI_RAU_IF5;
-	  ru[j]->eth_params.transp_preference = ETH_RAW_MODE;
+	  ru[j]->ifdevice.eth_params.transp_preference = ETH_RAW_MODE;
         } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "udp_if4p5") == 0) {
 	  ru[j]->if_south                     = REMOTE_IF4p5;
 	  ru[j]->function                     = NGFI_RAU_IF4p5;
-  	  ru[j]->eth_params.transp_preference = ETH_UDP_IF4p5_MODE;
+    ru[j]->ifdevice.eth_params.transp_preference = ETH_UDP_IF4p5_MODE;
 	  ru[j]->has_ctrl_prt                 = 1;
         } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "raw_if4p5") == 0) {
 	  ru[j]->if_south                     = REMOTE_IF4p5;
 	  ru[j]->function                     = NGFI_RAU_IF4p5;
-	  ru[j]->eth_params.transp_preference = ETH_RAW_IF4p5_MODE;
+	  ru[j]->ifdevice.eth_params.transp_preference = ETH_RAW_IF4p5_MODE;
 	  ru[j]->has_ctrl_prt                 = 1;
 	
           if (strcmp(*(RUParamList.paramarray[j][RU_IS_SLAVE_IDX].strptr), "yes") == 0) ru[j]->is_slave=1;

--- a/executables/lte-ru.c
+++ b/executables/lte-ru.c
@@ -2356,7 +2356,6 @@ void set_function_spec_param(RU_t *ru) {
     case LOCAL_RF:   // this is an RU with integrated RF (RRU, eNB)
       if (ru->function ==  NGFI_RRU_IF5) {                 // IF5 RRU
         ru->do_prach              = 0;                      // no prach processing in RU
-        ru->fh_north_in           = NULL;                   // no shynchronous incoming fronthaul from north
         ru->fh_north_out          = fh_if5_north_out;       // need only to do send_IF5  reception
         ru->fh_south_out          = tx_rf;                  // send output to RF
         ru->fh_north_asynch_in    = fh_if5_north_asynch_in; // TX packets come asynchronously
@@ -2380,7 +2379,6 @@ void set_function_spec_param(RU_t *ru) {
         }
       } else if (ru->function == NGFI_RRU_IF4p5) {
         ru->do_prach              = 1;                        // do part of prach processing in RU
-        ru->fh_north_in           = NULL;                     // no synchronous incoming fronthaul from north
         ru->fh_north_out          = fh_if4p5_north_out;       // send_IF4p5 on reception
         ru->fh_south_out          = tx_rf;                    // send output to RF
         ru->fh_north_asynch_in    = fh_if4p5_north_asynch_in; // TX packets come asynchronously
@@ -2409,7 +2407,6 @@ void set_function_spec_param(RU_t *ru) {
         ru->feprx                = (get_thread_worker_conf() == WORKER_DISABLE) ? fep_full : ru_fep_full_2thread;                // RX DFTs
         ru->feptx_ofdm           = (get_thread_worker_conf() == WORKER_DISABLE) ? feptx_ofdm : feptx_ofdm_2thread;              // this is fep with idft and precoding
         ru->feptx_prec           = feptx_prec;              // this is fep with idft and precoding
-        ru->fh_north_in          = NULL;                    // no incoming fronthaul from north
         ru->fh_north_out         = NULL;                    // no outgoing fronthaul to north
         ru->start_if             = NULL;                    // no if interface
         ru->rfdevice.host_type   = RAU_HOST;

--- a/executables/main_ru.c
+++ b/executables/main_ru.c
@@ -216,41 +216,41 @@ int main ( int argc, char **argv )
     if ( !(config_isparamset(RUParamList.paramarray[j],RU_LOCAL_IF_NAME_IDX)) ) {
       AssertFatal(1==0,"IF_NAME is required\n");
     } else {
-      ru->eth_params.local_if_name            = strdup(*(RUParamList.paramarray[j][RU_LOCAL_IF_NAME_IDX].strptr));
-      ru->eth_params.my_addr                  = strdup(*(RUParamList.paramarray[j][RU_LOCAL_ADDRESS_IDX].strptr));
-      ru->eth_params.remote_addr              = strdup(*(RUParamList.paramarray[j][RU_REMOTE_ADDRESS_IDX].strptr));
-      ru->eth_params.my_portd                 = *(RUParamList.paramarray[j][RU_LOCAL_PORTD_IDX].uptr);
-      ru->eth_params.remote_portd             = *(RUParamList.paramarray[j][RU_REMOTE_PORTD_IDX].uptr);
+      ru->ifdevice.eth_params.local_if_name            = strdup(*(RUParamList.paramarray[j][RU_LOCAL_IF_NAME_IDX].strptr));
+      ru->ifdevice.eth_params.my_addr                  = strdup(*(RUParamList.paramarray[j][RU_LOCAL_ADDRESS_IDX].strptr));
+      ru->ifdevice.eth_params.remote_addr              = strdup(*(RUParamList.paramarray[j][RU_REMOTE_ADDRESS_IDX].strptr));
+      ru->ifdevice.eth_params.my_portd                 = *(RUParamList.paramarray[j][RU_LOCAL_PORTD_IDX].uptr);
+      ru->ifdevice.eth_params.remote_portd             = *(RUParamList.paramarray[j][RU_REMOTE_PORTD_IDX].uptr);
 
       // Check if control port set
       if  (!(config_isparamset(RUParamList.paramarray[j],RU_REMOTE_PORTC_IDX)) ) {
 	printf("Removing control port for RU %d\n",j);
 	ru->has_ctrl_prt            = 0;
       } else {
-	ru->eth_params.my_portc                 = *(RUParamList.paramarray[j][RU_LOCAL_PORTC_IDX].uptr);
-	ru->eth_params.remote_portc             = *(RUParamList.paramarray[j][RU_REMOTE_PORTC_IDX].uptr);
-	printf(" Control port %u \n",ru->eth_params.my_portc);
+	ru->ifdevice.eth_params.my_portc                 = *(RUParamList.paramarray[j][RU_LOCAL_PORTC_IDX].uptr);
+	ru->ifdevice.eth_params.remote_portc             = *(RUParamList.paramarray[j][RU_REMOTE_PORTC_IDX].uptr);
+	printf(" Control port %u \n",ru->ifdevice.eth_params.my_portc);
       }
 
       if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "udp") == 0) {
 	ru->if_south                        = LOCAL_RF;
 	ru->function                        = NGFI_RRU_IF5;
-	ru->eth_params.transp_preference    = ETH_UDP_MODE;
+	ru->ifdevice.eth_params.transp_preference    = ETH_UDP_MODE;
 	printf("Setting function for RU %d to NGFI_RRU_IF5 (udp)\n",j);
       } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "raw") == 0) {
 	ru->if_south                        = LOCAL_RF;
 	ru->function                        = NGFI_RRU_IF5;
-	ru->eth_params.transp_preference    = ETH_RAW_MODE;
+	ru->ifdevice.eth_params.transp_preference    = ETH_RAW_MODE;
 	printf("Setting function for RU %d to NGFI_RRU_IF5 (raw)\n",j);
       } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "udp_if4p5") == 0) {
 	ru->if_south                        = LOCAL_RF;
 	ru->function                        = NGFI_RRU_IF4p5;
-	ru->eth_params.transp_preference    = ETH_UDP_IF4p5_MODE;
+	ru->ifdevice.eth_params.transp_preference    = ETH_UDP_IF4p5_MODE;
 	printf("Setting function for RU %d to NGFI_RRU_IF4p5 (udp)\n",j);
       } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "raw_if4p5") == 0) {
 	ru->if_south                        = LOCAL_RF;
 	ru->function                        = NGFI_RRU_IF4p5;
-	ru->eth_params.transp_preference    = ETH_RAW_IF4p5_MODE;
+	ru->ifdevice.eth_params.transp_preference    = ETH_RAW_IF4p5_MODE;
 	printf("Setting function for RU %d to NGFI_RRU_IF4p5 (raw)\n",j);
       }
 
@@ -275,30 +275,30 @@ int main ( int argc, char **argv )
   } //strcmp(local_rf, "yes") == 0
   else {
     printf("RU %d: Transport %s\n",j,*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr));
-    ru->eth_params.local_if_name      = strdup(*(RUParamList.paramarray[j][RU_LOCAL_IF_NAME_IDX].strptr));
-    ru->eth_params.my_addr            = strdup(*(RUParamList.paramarray[j][RU_LOCAL_ADDRESS_IDX].strptr));
-    ru->eth_params.remote_addr        = strdup(*(RUParamList.paramarray[j][RU_REMOTE_ADDRESS_IDX].strptr));
-    ru->eth_params.my_portc           = *(RUParamList.paramarray[j][RU_LOCAL_PORTC_IDX].uptr);
-    ru->eth_params.remote_portc       = *(RUParamList.paramarray[j][RU_REMOTE_PORTC_IDX].uptr);
-    ru->eth_params.my_portd           = *(RUParamList.paramarray[j][RU_LOCAL_PORTD_IDX].uptr);
-    ru->eth_params.remote_portd       = *(RUParamList.paramarray[j][RU_REMOTE_PORTD_IDX].uptr);
+    ru->ifdevice.eth_params.local_if_name      = strdup(*(RUParamList.paramarray[j][RU_LOCAL_IF_NAME_IDX].strptr));
+    ru->ifdevice.eth_params.my_addr            = strdup(*(RUParamList.paramarray[j][RU_LOCAL_ADDRESS_IDX].strptr));
+    ru->ifdevice.eth_params.remote_addr        = strdup(*(RUParamList.paramarray[j][RU_REMOTE_ADDRESS_IDX].strptr));
+    ru->ifdevice.eth_params.my_portc           = *(RUParamList.paramarray[j][RU_LOCAL_PORTC_IDX].uptr);
+    ru->ifdevice.eth_params.remote_portc       = *(RUParamList.paramarray[j][RU_REMOTE_PORTC_IDX].uptr);
+    ru->ifdevice.eth_params.my_portd           = *(RUParamList.paramarray[j][RU_LOCAL_PORTD_IDX].uptr);
+    ru->ifdevice.eth_params.remote_portd       = *(RUParamList.paramarray[j][RU_REMOTE_PORTD_IDX].uptr);
 
     if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "udp") == 0) {
       ru->if_south                     = REMOTE_IF5;
       ru->function                     = NGFI_RAU_IF5;
-      ru->eth_params.transp_preference = ETH_UDP_MODE;
+      ru->ifdevice.eth_params.transp_preference = ETH_UDP_MODE;
     } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "raw") == 0) {
       ru->if_south                     = REMOTE_IF5;
       ru->function                     = NGFI_RAU_IF5;
-      ru->eth_params.transp_preference = ETH_RAW_MODE;
+      ru->ifdevice.eth_params.transp_preference = ETH_RAW_MODE;
     } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "udp_if4p5") == 0) {
       ru->if_south                     = REMOTE_IF4p5;
       ru->function                     = NGFI_RAU_IF4p5;
-      ru->eth_params.transp_preference = ETH_UDP_IF4p5_MODE;
+      ru->ifdevice.eth_params.transp_preference = ETH_UDP_IF4p5_MODE;
     } else if (strcmp(*(RUParamList.paramarray[j][RU_TRANSPORT_PREFERENCE_IDX].strptr), "raw_if4p5") == 0) {
       ru->if_south                     = REMOTE_IF4p5;
       ru->function                     = NGFI_RAU_IF4p5;
-      ru->eth_params.transp_preference = ETH_RAW_IF4p5_MODE;
+      ru->ifdevice.eth_params.transp_preference = ETH_RAW_IF4p5_MODE;
     }
 
     if (strcmp(*(RUParamList.paramarray[j][RU_IS_SLAVE_IDX].strptr), "yes") == 0) ru->is_slave=1;

--- a/executables/nr-gnb.c
+++ b/executables/nr-gnb.c
@@ -249,9 +249,6 @@ static size_t dump_L1_meas_stats(PHY_VARS_gNB *gNB, RU_t *ru, char *output, size
     output += print_meas_log(&ru->txdataF_copy_stats, "txdataF_copy", NULL, NULL, output, end - output);
   }
 
-  if (ru->fh_north_asynch_in)
-    output += print_meas_log(&ru->rx_fhaul,"rx_fhaul",NULL,NULL, output, end - output);
-
   output += print_meas_log(&ru->tx_fhaul,"tx_fhaul",NULL,NULL, output, end - output);
 
   return output - begin;

--- a/executables/nr-gnb.c
+++ b/executables/nr-gnb.c
@@ -254,10 +254,6 @@ static size_t dump_L1_meas_stats(PHY_VARS_gNB *gNB, RU_t *ru, char *output, size
 
   output += print_meas_log(&ru->tx_fhaul,"tx_fhaul",NULL,NULL, output, end - output);
 
-  if (ru->fh_north_out) {
-    output += print_meas_log(&ru->compression,"compression",NULL,NULL, output, end - output);
-    output += print_meas_log(&ru->transport,"transport",NULL,NULL, output, end - output);
-  }
   return output - begin;
 }
 

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -910,7 +910,6 @@ void set_function_spec_param(RU_t *ru)
       ru->feptx_ofdm = nr_feptx_tp; // need to do transmit Precoding + IDFTs
       ru->fh_south_in = fh_if5_south_in; // synchronous IF5 reception
       ru->fh_south_out = fh_if5_south_out; // synchronous IF5 transmission
-      ru->fh_south_asynch_in = NULL; // no asynchronous UL
       ru->start_rf = ru->eth_params.transp_preference == ETH_UDP_IF5_ECPRI_MODE ? start_streaming : NULL;
       ru->stop_rf = NULL;
       ru->start_write_thread = NULL;
@@ -925,7 +924,6 @@ void set_function_spec_param(RU_t *ru)
       ru->feptx_ofdm = NULL; // no OFDM mod
       ru->fh_south_in = NULL;
       ru->fh_south_out = NULL;
-      ru->fh_south_asynch_in = NULL;
       ru->fh_north_asynch_in = NULL;
       ru->start_rf = NULL; // no local RF
       ru->stop_rf = NULL;

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -556,10 +556,10 @@ void ru_tx_func(void *param)
     ru->feptx_prec(ru,frame_tx,slot_tx);
 
   // do OFDM with/without TX front-end processing  if needed
-  if (ru->fh_north_asynch_in == NULL && ru->feptx_ofdm)
+  if (ru->feptx_ofdm)
     ru->feptx_ofdm(ru, frame_tx, slot_tx);
 
-  if (ru->fh_north_asynch_in == NULL && ru->fh_south_out)
+  if (ru->fh_south_out)
     ru->fh_south_out(ru, frame_tx, slot_tx, info->timestamp_tx);
 }
 
@@ -924,7 +924,6 @@ void set_function_spec_param(RU_t *ru)
       ru->feptx_ofdm = NULL; // no OFDM mod
       ru->fh_south_in = NULL;
       ru->fh_south_out = NULL;
-      ru->fh_north_asynch_in = NULL;
       ru->start_rf = NULL; // no local RF
       ru->stop_rf = NULL;
       ru->start_write_thread = NULL;

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -841,12 +841,6 @@ int start_write_thread(RU_t *ru) {
   return ru->rfdevice.trx_write_init(&ru->rfdevice);
 }
 
-void init_RU_proc(RU_t *ru)
-{
-  ru->proc = (RU_proc_t){.ru = ru, .first_rx = 1, .first_tx = 1};
-  LOG_I(PHY, "Initialized RU proc %d (%s,%s),\n", ru->idx, NB_functions[ru->function], NB_timing[ru->if_timing]);
-}
-
 void start_RU_proc(RU_t *ru)
 {
   threadCreate(&ru->proc.pthread_FH, ru_thread, (void *)ru, "ru_thread", ru->ru_thread_core, OAI_PRIORITY_RT_MAX);
@@ -985,8 +979,12 @@ void init_NR_RU(configmodule_interface_t *cfg, char *rf_config_file)
         }
       }
     }
+
     set_function_spec_param(ru);
-    init_RU_proc(ru);
+
+    // init RU_proc -> needed for timing alignment
+    ru->proc = (RU_proc_t){.ru = ru, .first_rx = 1, .first_tx = 1};
+
     if (ru->if_south != REMOTE_IF4p5) {
       int threadCnt = ru->num_tpcores;
       if (threadCnt < 2)
@@ -1043,7 +1041,6 @@ static void NRRCconfig_RU(configmodule_interface_t *cfg)
     ru->idx = j;
     ru->nr_frame_parms = calloc(1, sizeof(*ru->nr_frame_parms));
     ru->frame_parms = calloc(1, sizeof(*ru->frame_parms));
-    ru->if_timing = synch_to_ext_device;
     paramdef_t *param = RUParamList.paramarray[j];
     if (RC.nb_nr_L1_inst > 0)
       ru->num_gNB = param[RU_ENB_LIST_IDX].numelt;

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -841,12 +841,6 @@ int start_write_thread(RU_t *ru) {
   return ru->rfdevice.trx_write_init(&ru->rfdevice);
 }
 
-void start_RU_proc(RU_t *ru)
-{
-  threadCreate(&ru->proc.pthread_FH, ru_thread, (void *)ru, "ru_thread", ru->ru_thread_core, OAI_PRIORITY_RT_MAX);
-}
-
-
 void kill_NR_RU_proc(int inst) {
   RU_t *ru = RC.ru[inst];
   RU_proc_t *proc = &ru->proc;
@@ -1012,7 +1006,7 @@ void init_NR_RU(configmodule_interface_t *cfg, char *rf_config_file)
 void start_NR_RU()
 {
   RU_t *ru = RC.ru[0];
-  start_RU_proc(ru);
+  threadCreate(&ru->proc.pthread_FH, ru_thread, ru, "ru_thread", ru->ru_thread_core, OAI_PRIORITY_RT_MAX);
 }
 
 void stop_RU(int nb_ru) {
@@ -1040,7 +1034,6 @@ static void NRRCconfig_RU(configmodule_interface_t *cfg)
     RU_t *ru = RC.ru[j] = calloc(1, sizeof(*RC.ru[j]));
     ru->idx = j;
     ru->nr_frame_parms = calloc(1, sizeof(*ru->nr_frame_parms));
-    ru->frame_parms = calloc(1, sizeof(*ru->frame_parms));
     paramdef_t *param = RUParamList.paramarray[j];
     if (RC.nb_nr_L1_inst > 0)
       ru->num_gNB = param[RU_ENB_LIST_IDX].numelt;
@@ -1126,7 +1119,7 @@ static void NRRCconfig_RU(configmodule_interface_t *cfg)
       ru->max_pdschReferenceSignalPower = *param[RU_MAX_RS_EPRE_IDX].uptr;
       ru->max_rxgain = *param[RU_MAX_RXGAIN_IDX].uptr;
       ru->sf_extension = *param[RU_SF_EXTENSION_IDX].uptr;
-    } else { // strcmp(local_rf, "yes") == 0
+    } else {
       char *str = *param[RU_TRANSPORT_PREFERENCE_IDX].strptr;
       LOG_D(PHY, "RU %d: Transport %s\n", j, str);
       ru->ifdevice.eth_params.local_if_name = strdup(*param[RU_LOCAL_IF_NAME_IDX].strptr);
@@ -1153,7 +1146,7 @@ static void NRRCconfig_RU(configmodule_interface_t *cfg)
         ru->if_south = REMOTE_IF4p5;
         ru->function = NGFI_RAU_IF4p5;
       }
-    } /* strcmp(local_rf, "yes") != 0 */
+    }
 
     ru->nb_tx = *param[RU_NB_TX_IDX].uptr;
     ru->nb_rx = *param[RU_NB_RX_IDX].uptr;

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -897,7 +897,6 @@ void set_function_spec_param(RU_t *ru)
       ru->feprx = nr_fep_tp; // this is frequency-shift + DFTs
       ru->feptx_ofdm = nr_feptx_tp; // this is fep with idft and precoding
       ru->feptx_prec = NULL;
-      ru->fh_north_in = NULL; // no incoming fronthaul from north
       ru->fh_north_out = NULL; // no outgoing fronthaul to north
       ru->nr_start_if = NULL; // no if interface
       ru->rfdevice.host_type = RAU_HOST;

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -894,7 +894,6 @@ void set_function_spec_param(RU_t *ru)
     case LOCAL_RF:   // this is an RU with integrated RF (RRU, gNB)
       reset_meas(&ru->rx_fhaul);
       AssertFatal(ru->function == gNodeB_3GPP, "ru->function %d not supported for LOCAL_RF\n", ru->function);
-      ru->do_prach = 0; // no prach processing in RU
       ru->feprx = nr_fep_tp; // this is frequency-shift + DFTs
       ru->feptx_ofdm = nr_feptx_tp; // this is fep with idft and precoding
       ru->feptx_prec = NULL;
@@ -910,7 +909,6 @@ void set_function_spec_param(RU_t *ru)
       break;
 
     case REMOTE_IF5: // the remote unit is IF5 RRU
-      ru->do_prach = 0;
       ru->txfh_in_fep = 0;
       ru->feprx = nr_fep_tp; // this is frequency-shift + DFTs
       ru->feptx_prec = NULL; // need to do transmit Precoding + IDFTs
@@ -927,7 +925,6 @@ void set_function_spec_param(RU_t *ru)
       break;
 
     case REMOTE_IF4p5:
-      ru->do_prach = 0;
       ru->feprx = NULL; // DFTs
       ru->feptx_prec = nr_feptx_prec; // Precoding operation
       ru->feptx_ofdm = NULL; // no OFDM mod

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -896,7 +896,6 @@ void set_function_spec_param(RU_t *ru)
       ru->feptx_ofdm = nr_feptx_tp; // this is fep with idft and precoding
       ru->feptx_prec = NULL;
       ru->nr_start_if = NULL; // no if interface
-      ru->rfdevice.host_type = RAU_HOST;
       ru->fh_south_in = rx_rf; // local synchronous RF RX
       ru->fh_south_out = tx_rf; // local synchronous RF TX
       ru->start_rf = start_rf; // need to start the local RF interface
@@ -914,8 +913,6 @@ void set_function_spec_param(RU_t *ru)
       ru->stop_rf = NULL;
       ru->start_write_thread = NULL;
       ru->nr_start_if = nr_start_if; // need to start if interface for IF5
-      ru->ifdevice.host_type = RAU_HOST;
-      ru->ifdevice.eth_params = &ru->eth_params;
       break;
 
     case REMOTE_IF4p5:
@@ -928,8 +925,6 @@ void set_function_spec_param(RU_t *ru)
       ru->stop_rf = NULL;
       ru->start_write_thread = NULL;
       ru->nr_start_if = nr_start_if; // need to start if interface for IF4p5
-      ru->ifdevice.host_type = RAU_HOST;
-      ru->ifdevice.eth_params = &ru->eth_params;
       break;
 
     default:
@@ -1160,7 +1155,6 @@ static void NRRCconfig_RU(configmodule_interface_t *cfg)
       } else if (strcmp(str, "raw_if4p5") == 0) {
         ru->if_south = REMOTE_IF4p5;
         ru->function = NGFI_RAU_IF4p5;
-        ru->eth_params.transp_preference = ETH_RAW_IF4p5_MODE;
       }
     } /* strcmp(local_rf, "yes") != 0 */
 

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -909,12 +909,11 @@ void set_function_spec_param(RU_t *ru)
       break;
 
     case REMOTE_IF5: // the remote unit is IF5 RRU
-      ru->txfh_in_fep = 0;
       ru->feprx = nr_fep_tp; // this is frequency-shift + DFTs
       ru->feptx_prec = NULL; // need to do transmit Precoding + IDFTs
       ru->feptx_ofdm = nr_feptx_tp; // need to do transmit Precoding + IDFTs
       ru->fh_south_in = fh_if5_south_in; // synchronous IF5 reception
-      ru->fh_south_out = (ru->txfh_in_fep > 0) ? NULL : fh_if5_south_out; // synchronous IF5 transmission
+      ru->fh_south_out = fh_if5_south_out; // synchronous IF5 transmission
       ru->fh_south_asynch_in = NULL; // no asynchronous UL
       ru->start_rf = ru->eth_params.transp_preference == ETH_UDP_IF5_ECPRI_MODE ? start_streaming : NULL;
       ru->stop_rf = NULL;

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -561,8 +561,6 @@ void ru_tx_func(void *param)
 
   if (ru->fh_north_asynch_in == NULL && ru->fh_south_out)
     ru->fh_south_out(ru, frame_tx, slot_tx, info->timestamp_tx);
-  if (ru->fh_north_out)
-    ru->fh_north_out(ru);
 }
 
 /* @brief wait for the next RX TTI to be free
@@ -897,7 +895,6 @@ void set_function_spec_param(RU_t *ru)
       ru->feprx = nr_fep_tp; // this is frequency-shift + DFTs
       ru->feptx_ofdm = nr_feptx_tp; // this is fep with idft and precoding
       ru->feptx_prec = NULL;
-      ru->fh_north_out = NULL; // no outgoing fronthaul to north
       ru->nr_start_if = NULL; // no if interface
       ru->rfdevice.host_type = RAU_HOST;
       ru->fh_south_in = rx_rf; // local synchronous RF RX
@@ -929,7 +926,6 @@ void set_function_spec_param(RU_t *ru)
       ru->fh_south_in = NULL;
       ru->fh_south_out = NULL;
       ru->fh_south_asynch_in = NULL;
-      ru->fh_north_out = NULL;
       ru->fh_north_asynch_in = NULL;
       ru->start_rf = NULL; // no local RF
       ru->stop_rf = NULL;

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -635,7 +635,7 @@ void *ru_thread(void *param)
   // Start IF device if any
   if (ru->nr_start_if) {
     LOG_I(PHY, "starting transport\n");
-    ret = openair0_transport_load(&ru->ifdevice, &ru->openair0_cfg, &ru->eth_params);
+    ret = openair0_transport_load(&ru->ifdevice, &ru->openair0_cfg);
     AssertFatal(ret == 0, "RU %u: openair0_transport_init() ret %d: cannot initialize transport protocol\n", ru->idx, ret);
 
     if (ru->ifdevice.get_internal_parameter) {
@@ -909,7 +909,7 @@ void set_function_spec_param(RU_t *ru)
       ru->feptx_ofdm = nr_feptx_tp; // need to do transmit Precoding + IDFTs
       ru->fh_south_in = fh_if5_south_in; // synchronous IF5 reception
       ru->fh_south_out = fh_if5_south_out; // synchronous IF5 transmission
-      ru->start_rf = ru->eth_params.transp_preference == ETH_UDP_IF5_ECPRI_MODE ? start_streaming : NULL;
+      ru->start_rf = ru->ifdevice.eth_params.transp_preference == ETH_UDP_IF5_ECPRI_MODE ? start_streaming : NULL;
       ru->stop_rf = NULL;
       ru->start_write_thread = NULL;
       ru->nr_start_if = nr_start_if; // need to start if interface for IF5
@@ -1132,26 +1132,26 @@ static void NRRCconfig_RU(configmodule_interface_t *cfg)
     } else { // strcmp(local_rf, "yes") == 0
       char *str = *param[RU_TRANSPORT_PREFERENCE_IDX].strptr;
       LOG_D(PHY, "RU %d: Transport %s\n", j, str);
-      ru->eth_params.local_if_name = strdup(*param[RU_LOCAL_IF_NAME_IDX].strptr);
-      ru->eth_params.my_addr = strdup(*param[RU_LOCAL_ADDRESS_IDX].strptr);
-      ru->eth_params.remote_addr = strdup(*param[RU_REMOTE_ADDRESS_IDX].strptr);
-      ru->eth_params.my_portc = *param[RU_LOCAL_PORTC_IDX].uptr;
-      ru->eth_params.remote_portc = *param[RU_REMOTE_PORTC_IDX].uptr;
-      ru->eth_params.my_portd = *param[RU_LOCAL_PORTD_IDX].uptr;
-      ru->eth_params.remote_portd = *param[RU_REMOTE_PORTD_IDX].uptr;
+      ru->ifdevice.eth_params.local_if_name = strdup(*param[RU_LOCAL_IF_NAME_IDX].strptr);
+      ru->ifdevice.eth_params.my_addr = strdup(*param[RU_LOCAL_ADDRESS_IDX].strptr);
+      ru->ifdevice.eth_params.remote_addr = strdup(*param[RU_REMOTE_ADDRESS_IDX].strptr);
+      ru->ifdevice.eth_params.my_portc = *param[RU_LOCAL_PORTC_IDX].uptr;
+      ru->ifdevice.eth_params.remote_portc = *param[RU_REMOTE_PORTC_IDX].uptr;
+      ru->ifdevice.eth_params.my_portd = *param[RU_LOCAL_PORTD_IDX].uptr;
+      ru->ifdevice.eth_params.remote_portd = *param[RU_REMOTE_PORTD_IDX].uptr;
 
       if (strcmp(str, "udp") == 0) {
         ru->if_south = REMOTE_IF5;
         ru->function = NGFI_RAU_IF5;
-        ru->eth_params.transp_preference = ETH_UDP_MODE;
+        ru->ifdevice.eth_params.transp_preference = ETH_UDP_MODE;
       } else if (strcmp(str, "udp_ecpri_if5") == 0) {
         ru->if_south = REMOTE_IF5;
         ru->function = NGFI_RAU_IF5;
-        ru->eth_params.transp_preference = ETH_UDP_IF5_ECPRI_MODE;
+        ru->ifdevice.eth_params.transp_preference = ETH_UDP_IF5_ECPRI_MODE;
       } else if (strcmp(str, "raw") == 0) {
         ru->if_south = REMOTE_IF5;
         ru->function = NGFI_RAU_IF5;
-        ru->eth_params.transp_preference = ETH_RAW_MODE;
+        ru->ifdevice.eth_params.transp_preference = ETH_RAW_MODE;
       } else if (strcmp(str, "raw_if4p5") == 0) {
         ru->if_south = REMOTE_IF4p5;
         ru->function = NGFI_RAU_IF4p5;

--- a/executables/nr-softmodem.h
+++ b/executables/nr-softmodem.h
@@ -54,7 +54,6 @@ extern void stop_gNB(int);
 
 // In nr-ru.c
 extern void init_NR_RU(configmodule_interface_t *cfg, char *);
-extern void init_RU_proc(RU_t *ru);
 extern void start_NR_RU(void);
 extern void stop_RU(int nb_ru);
 extern void kill_NR_RU_proc(int inst);

--- a/openair1/PHY/TOOLS/calibration_test.c
+++ b/openair1/PHY/TOOLS/calibration_test.c
@@ -103,8 +103,6 @@ int main(int argc, char **argv) {
     .host_type=MIN_HOST_TYPE,
     /* !brief RF frontend parameters set by application */
     .openair0_cfg=NULL, //set by device_init
-    /* !brief ETH params set by application */
-    .eth_params=NULL,
     //! record player data, definition in record_player.h
     .recplay_state=NULL,
     /*!brief Can be used by driver to hold internal structure*/

--- a/openair1/PHY/defs_RU.h
+++ b/openair1/PHY/defs_RU.h
@@ -397,8 +397,6 @@ typedef struct RU_t_s {
   node_timing_t if_timing;
   /// function
   node_function_t function;
-  /// Ethernet parameters for fronthaul interface
-  eth_params_t eth_params;
   /// numerology index
   int numerology;
   /// flag to indicate the RU is in sync with a master reference

--- a/openair1/PHY/defs_RU.h
+++ b/openair1/PHY/defs_RU.h
@@ -485,8 +485,6 @@ typedef struct RU_t_s {
   /// function pointer to synchronous TX fronthaul function
   void (*fh_south_out)(struct RU_t_s *ru, int frame_tx, int tti_tx, uint64_t timestamp_tx);
   /// function pointer to synchronous RX fronthaul function (RRU)
-  void (*fh_north_in)(struct RU_t_s *ru, int *frame, int *subframe);
-  /// function pointer to synchronous RX fronthaul function (RRU)
   void (*fh_north_out)(struct RU_t_s *ru);
   /// function pointer to asynchronous fronthaul interface
   void (*fh_north_asynch_in)(struct RU_t_s *ru, int *frame, int *subframe);

--- a/openair1/PHY/defs_RU.h
+++ b/openair1/PHY/defs_RU.h
@@ -449,8 +449,6 @@ typedef struct RU_t_s {
   int sf_ahead;
   /// TX processing advance in slots (for NR)
   int sl_ahead;
-  /// flag to indicate TX FH is embedded in TX FEP
-  int txfh_in_fep;
   /// flag to indicate half-slot parallelization
   int half_slot_parallelization;
   /// FAPI confiuration

--- a/radio/AW2SORI/oaiori.c
+++ b/radio/AW2SORI/oaiori.c
@@ -888,6 +888,8 @@ int aw2s_oriinit(openair0_device_t *device)
 int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg, eth_params_t *eth_params)
 {
   printf("Initializing AW2S (%p,%p,%p)\n",aw2s_oriinit,aw2s_oricleanup,aw2s_startstreaming); 
+  device->host_type = RAU_HOST;
+  device->eth_params = eth_params;
   device->thirdparty_init           = aw2s_oriinit;
   device->thirdparty_cleanup        = aw2s_oricleanup;
   device->thirdparty_startstreaming = aw2s_startstreaming;

--- a/radio/AW2SORI/oaiori.c
+++ b/radio/AW2SORI/oaiori.c
@@ -426,8 +426,6 @@ int aw2s_oriinit(openair0_device_t *device)
   uint32_t 		numObjects;
   uint32_t		i;
 
-  eth_params_t *eth_params = device->eth_params;
-
   openair0_config_t *openair0_cfg = device->openair0_cfg;
 
   
@@ -449,8 +447,8 @@ int aw2s_oriinit(openair0_device_t *device)
   ori->indicationCallback = cb;
 	
   /* Connect... */
-  printf("Trying to connect to AW2S device on %s : %d\n",eth_params->remote_addr, eth_params->remote_portc);
-  result = ORI_Connect(ori, eth_params->remote_addr, eth_params->remote_portc, 3000, 0);
+  printf("Trying to connect to AW2S device on %s : %d\n", device->eth_params.remote_addr, device->eth_params.remote_portc);
+  result = ORI_Connect(ori, device->eth_params.remote_addr, device->eth_params.remote_portc, 3000, 0);
   if(result != ORI_Result_SUCCESS)
     {
       printf("ORI_Connect failed with error: %s\n", ORI_Result_Print(result));
@@ -786,11 +784,11 @@ int aw2s_oriinit(openair0_device_t *device)
   ORI_Result_e linkParamResult[3];
 
   ORI_Object_s *link= ORI_FindObject(ori, ORI_ObjectType_ORILink, 0, NULL);
-  linkParams.ORILink.AWS_remoteUdpPort = eth_params->my_portd;
+  linkParams.ORILink.AWS_remoteUdpPort = device->eth_params.my_portd;
 
 
-  if (get_mac_addr(eth_params->local_if_name,linkParams.ORILink.AWS_remoteMAC) < 0) return(-1);
-  inet_pton(AF_INET,eth_params->my_addr,(struct in_addr*)linkParams.ORILink.AWS_remoteIP);
+  if (get_mac_addr(device->eth_params.local_if_name,linkParams.ORILink.AWS_remoteMAC) < 0) return(-1);
+  inet_pton(AF_INET,device->eth_params.my_addr,(struct in_addr*)linkParams.ORILink.AWS_remoteIP);
   result = ORI_ObjectParamModify(ori,link,linkParams,linkParamList,3,linkParamResult,&RE_result);
   if(result != ORI_Result_SUCCESS)
     {
@@ -885,11 +883,10 @@ int aw2s_oriinit(openair0_device_t *device)
   return 0;
 }
 
-int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg, eth_params_t *eth_params)
+int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg)
 {
   printf("Initializing AW2S (%p,%p,%p)\n",aw2s_oriinit,aw2s_oricleanup,aw2s_startstreaming); 
   device->host_type = RAU_HOST;
-  device->eth_params = eth_params;
   device->thirdparty_init           = aw2s_oriinit;
   device->thirdparty_cleanup        = aw2s_oricleanup;
   device->thirdparty_startstreaming = aw2s_startstreaming;

--- a/radio/COMMON/common_lib.c
+++ b/radio/COMMON/common_lib.c
@@ -64,10 +64,10 @@ int set_transport(openair0_device_t *device)
   }
 }
 
-typedef int (*devfunc_t)(openair0_device_t *, openair0_config_t *, eth_params_t *);
+typedef int (*devfunc_t)(openair0_device_t *, openair0_config_t *);
 
 /* look for the interface library and load it */
-int load_lib(openair0_device_t *device, openair0_config_t *openair0_cfg, eth_params_t *cfg, uint8_t flag)
+int load_lib(openair0_device_t *device, openair0_config_t *openair0_cfg, uint8_t flag)
 {
   loader_shlibfunc_t shlib_fdesc[1];
   int ret=0;
@@ -111,13 +111,13 @@ int load_lib(openair0_device_t *device, openair0_config_t *openair0_cfg, eth_par
   AssertFatal( (ret >= 0),
   	           "Library %s couldn't be loaded\n",devname);
 
-  return ((devfunc_t)shlib_fdesc[0].fptr)(device,openair0_cfg,cfg);
+  return ((devfunc_t)shlib_fdesc[0].fptr)(device,openair0_cfg);
 }
 
 int openair0_device_load(openair0_device_t *device, openair0_config_t *openair0_cfg)
 {
   int rc=0;
-  rc=load_lib(device, openair0_cfg, NULL,RAU_LOCAL_RADIO_HEAD );
+  rc=load_lib(device, openair0_cfg, RAU_LOCAL_RADIO_HEAD);
 
   if ( rc >= 0) {
     if ( set_device(device) < 0) {
@@ -132,10 +132,10 @@ int openair0_device_load(openair0_device_t *device, openair0_config_t *openair0_
   return rc;
 }
 
-int openair0_transport_load(openair0_device_t *device, openair0_config_t *openair0_cfg, eth_params_t *eth_params)
+int openair0_transport_load(openair0_device_t *device, openair0_config_t *openair0_cfg)
 {
   int rc;
-  rc=load_lib(device, openair0_cfg, eth_params, RAU_REMOTE_RADIO_HEAD);
+  rc=load_lib(device, openair0_cfg, RAU_REMOTE_RADIO_HEAD);
 
   if ( rc >= 0) {
     if ( set_transport(device) < 0) {

--- a/radio/COMMON/common_lib.h
+++ b/radio/COMMON/common_lib.h
@@ -360,7 +360,7 @@ struct openair0_device {
   bool firstTS_initialized;
 
   /* !brief ETH params set by application */
-  eth_params_t *eth_params;
+  eth_params_t eth_params;
   //! record player data, definition in record_player.h
   recplay_state_t *recplay_state;
   /*!brief Can be used by driver to hold internal structure*/
@@ -637,7 +637,7 @@ const char *get_devname(int devtype);
 /*! \brief Initialize openair RF target. It returns 0 if OK */
 int openair0_device_load(openair0_device_t *device, openair0_config_t *openair0_cfg);
 /*! \brief Initialize transport protocol . It returns 0 if OK */
-int openair0_transport_load(openair0_device_t *device, openair0_config_t *openair0_cfg, eth_params_t *eth_params);
+int openair0_transport_load(openair0_device_t *device, openair0_config_t *openair0_cfg);
 
 /*! \brief Set RX frequencies
  * \param device the hardware to use

--- a/radio/ETHERNET/eth_raw.c
+++ b/radio/ETHERNET/eth_raw.c
@@ -37,13 +37,13 @@ int eth_socket_init_raw(openair0_device_t *device)
   int sock_proto=0;  
  
   if (device->host_type == RRU_HOST ) {  /* RRU doesn't know remote MAC(will be retrieved from first packet send from RAU) and remote port(don't care) */
-    local_mac = device->eth_params->my_addr; 
+    local_mac = device->eth_params.my_addr;
     remote_mac = malloc(ETH_ALEN);
     memset((void*)remote_mac,0,ETH_ALEN);
     printf("[%s] local MAC addr (user) %s remote MAC addr (user) %s\n","RRU", local_mac,remote_mac);    
   } else {
-    local_mac = device->eth_params->my_addr;
-    remote_mac = device->eth_params->remote_addr;
+    local_mac = device->eth_params.my_addr;
+    remote_mac = device->eth_params.remote_addr;
     printf("[%s] local MAC addr (user) %s remote MAC addr (user) %s\n","RAU", local_mac,remote_mac);    
   }
    
@@ -77,7 +77,7 @@ int eth_socket_init_raw(openair0_device_t *device)
   eth->local_addrd_ll.sll_family   = AF_PACKET;
   eth->local_addrd_ll.sll_ifindex  = eth->if_index.ifr_ifindex;
   /* hear traffic from specific protocol*/
-  eth->local_addrd_ll.sll_protocol = htons((short)device->eth_params->my_portd);
+  eth->local_addrd_ll.sll_protocol = htons((short)device->eth_params.my_portd);
 
   eth->local_addrd_ll.sll_halen    = ETH_ALEN;
   eth->local_addrd_ll.sll_pkttype  = PACKET_OTHERHOST;
@@ -92,8 +92,8 @@ int eth_socket_init_raw(openair0_device_t *device)
  /* Construct the Ethernet header */ 
  ether_aton_r(local_mac, (struct ether_addr *)(&(eth->ehd.ether_shost)));
  ether_aton_r(remote_mac, (struct ether_addr *)(&(eth->ehd.ether_dhost)));
- eth->ehc.ether_type = htons((short)device->eth_params->my_portc);
- eth->ehd.ether_type = htons((short)device->eth_params->my_portd);
+ eth->ehc.ether_type = htons((short)device->eth_params.my_portc);
+ eth->ehd.ether_type = htons((short)device->eth_params.my_portd);
   
  printf("[%s] binding to hardware address %x:%x:%x:%x:%x:%x\n",((device->host_type == RAU_HOST) ? "RAU": "RRU"),eth->ehd.ether_shost[0],eth->ehd.ether_shost[1],eth->ehd.ether_shost[2],eth->ehd.ether_shost[3],eth->ehd.ether_shost[4],eth->ehd.ether_shost[5]);
  

--- a/radio/ETHERNET/eth_udp.c
+++ b/radio/ETHERNET/eth_udp.c
@@ -37,7 +37,6 @@ uint16_t pck_seq_num_prev=0;
 int eth_socket_init_udp(openair0_device_t *device)
 {
   eth_state_t *eth = (eth_state_t*)device->priv;
-  eth_params_t *eth_params = device->eth_params;
  
   char str_local[INET_ADDRSTRLEN];
   char str_remote[INET_ADDRSTRLEN];
@@ -51,22 +50,22 @@ int eth_socket_init_udp(openair0_device_t *device)
   const char str[2][4] = {"RRU\0","RAU\0"};
   int hostind = 0;
 
-  local_ip     = eth_params->my_addr;   
-  local_portc  = eth_params->my_portc;
-  local_portd  = eth_params->my_portd;
+  local_ip     = device->eth_params.my_addr;
+  local_portc  = device->eth_params.my_portc;
+  local_portd  = device->eth_params.my_portd;
   
 
   if (device->host_type == RRU_HOST ) {
 
     remote_ipc   = "0.0.0.0";   
-    remote_ipd   = eth_params->remote_addr;   
+    remote_ipd   = device->eth_params.remote_addr;
     remote_portc =  0;   
-    remote_portd =  eth_params->remote_portd;;   
+    remote_portd =  device->eth_params.remote_portd;;
     printf("[%s] local ip addr %s portc %d portd %d\n", "RRU", local_ip, local_portc, local_portd);    
   } else { 
-    remote_ipc   = eth_params->remote_addr;   
+    remote_ipc   = device->eth_params.remote_addr;
     remote_ipd   = "0.0.0.0";   
-    remote_portc = eth_params->remote_portc;   
+    remote_portc = device->eth_params.remote_portc;
     remote_portd = 0;
     hostind      = 1;
     printf("[%s] local ip addr %s portc %d portd %d\n","RAU", local_ip, local_portc, local_portd);    

--- a/radio/ETHERNET/ethernet_lib.c
+++ b/radio/ETHERNET/ethernet_lib.c
@@ -28,7 +28,7 @@ int num_devices_eth = 0;
 struct sockaddr_in dest_addr[MAX_INST];
 int dest_addr_len[MAX_INST];
 
-int load_lib(openair0_device_t *device, openair0_config_t *openair0_cfg, eth_params_t *cfg, uint8_t flag);
+int load_lib(openair0_device_t *device, openair0_config_t *openair0_cfg, uint8_t flag);
 
 int trx_eth_start(openair0_device_t *device)
 {
@@ -445,23 +445,23 @@ int ethernet_tune(openair0_device_t *device, unsigned int option, int value)
   return 0;
 }
 
-int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg, eth_params_t *eth_params)
+int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg)
 {
   eth_state_t *eth = (eth_state_t *)malloc(sizeof(eth_state_t));
   memset(eth, 0, sizeof(eth_state_t));
 
-  eth->flags = eth_params->transp_preference;
+  eth->flags = device->eth_params.transp_preference;
 
   // load third-party driver
   if (eth->flags == ETH_UDP_IF5_ECPRI_MODE)
-    load_lib(device, openair0_cfg, eth_params, RAU_REMOTE_THIRDPARTY_RADIO_HEAD);
+    load_lib(device, openair0_cfg, RAU_REMOTE_THIRDPARTY_RADIO_HEAD);
 
-  if (eth_params->if_compress == 0) {
+  if (device->eth_params.if_compress == 0) {
     eth->compression = NO_COMPRESS;
-  } else if (eth_params->if_compress == 1) {
+  } else if (device->eth_params.if_compress == 1) {
     eth->compression = ALAW_COMPRESS;
   } else {
-    printf("transport_init: Unknown compression scheme %d - default to ALAW", eth_params->if_compress);
+    printf("transport_init: Unknown compression scheme %d - default to ALAW", device->eth_params.if_compress);
     eth->compression = ALAW_COMPRESS;
   }
 
@@ -509,7 +509,7 @@ int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg, e
     // device->trx_read_func    = trx_eth_read_udp_IF4p5;
   }
 
-  eth->if_name = eth_params->local_if_name;
+  eth->if_name = device->eth_params.local_if_name;
   device->priv = eth;
   device->openair0_cfg = &openair0_cfg[0];
   return 0;

--- a/radio/USRP/usrp_lib.cpp
+++ b/radio/USRP/usrp_lib.cpp
@@ -1056,6 +1056,7 @@ extern "C" {
       return 0;
     }
 
+    device->host_type = RAU_HOST;
     device->openair0_cfg = openair0_cfg;
     device->trx_start_func = trx_usrp_start;
     device->trx_get_stats_func = trx_usrp_get_stats;

--- a/radio/fhi_72/oran.h
+++ b/radio/fhi_72/oran.h
@@ -11,6 +11,6 @@ void oran_fh_if4p5_south_out(RU_t *ru, int frame, int slot, uint64_t timestamp);
 
 void oran_fh_if4p5_south_in(RU_t *ru, int *frame, int *slot);
 
-int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg, eth_params_t *eth_params);
+int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg);
 
 #endif /* _ORAN_H_ */

--- a/radio/fhi_72/oran_isolate.c
+++ b/radio/fhi_72/oran_isolate.c
@@ -310,6 +310,7 @@ __attribute__((__visibility__("default"))) int transport_init(openair0_device_t 
   eth->nCC = fh_config->nCC;
   eth->num_ports = fh_init.xran_ports;
 
+  device->host_type = RAU_HOST;
   device->transp_type = ETHERNET_TP;
   device->trx_start_func = trx_oran_start;
   device->trx_get_stats_func = trx_oran_get_stats;

--- a/radio/fhi_72/oran_isolate.c
+++ b/radio/fhi_72/oran_isolate.c
@@ -227,8 +227,7 @@ void *get_internal_parameter(char *name)
 }
 
 __attribute__((__visibility__("default"))) int transport_init(openair0_device_t *device,
-                                                              openair0_config_t *openair0_cfg,
-                                                              eth_params_t *eth_params)
+                                                              openair0_config_t *openair0_cfg)
 {
   oran_eth_state_t *eth = calloc_or_fail(1, sizeof(*eth));
 

--- a/radio/fhi_72/oran_isolate.c
+++ b/radio/fhi_72/oran_isolate.c
@@ -87,7 +87,9 @@ void trx_oran_end(openair0_device_t *device)
   printf("ORAN: %s\n", __FUNCTION__);
   oran_eth_state_t *s = device->priv;
   xran_shutdown(s->oran_priv);
-  xran_close(s->oran_priv);
+  for (int32_t port_id = 0; port_id < s->num_ports; port_id++) {
+    xran_close(((void **)s->oran_priv)[port_id]);
+  }
   xran_cleanup();
   xran_mem_mgr_leak_detector_destroy();
 }

--- a/radio/fhi_72/oran_isolate.c
+++ b/radio/fhi_72/oran_isolate.c
@@ -27,9 +27,6 @@
 #endif
 
 typedef struct {
-  eth_state_t e;
-  rru_config_msg_type_t last_msg;
-  int capabilities_sent;
   void *oran_priv;
   void *mplane_priv;
   uint32_t nCC;
@@ -120,18 +117,6 @@ int trx_oran_stop(openair0_device_t *device)
   return (0);
 }
 
-int trx_oran_set_freq(openair0_device_t *device, openair0_config_t *openair0_cfg)
-{
-  printf("ORAN: %s\n", __FUNCTION__);
-  return (0);
-}
-
-int trx_oran_set_gains(openair0_device_t *device, openair0_config_t *openair0_cfg)
-{
-  printf("ORAN: %s\n", __FUNCTION__);
-  return (0);
-}
-
 int trx_oran_get_stats(openair0_device_t *device)
 {
   uint64_t total_time, used_time;
@@ -141,104 +126,6 @@ int trx_oran_get_stats(openair0_device_t *device)
     LOG_I(HW, "xran_get_time_stats(): total thread time %ld, total time essential tasks %ld, num cores used %d\n", total_time, used_time, num_core_used);
   printf("ORAN: %s\n", __FUNCTION__);
   return (0);
-}
-
-int trx_oran_reset_stats(openair0_device_t *device)
-{
-  printf("ORAN: %s\n", __FUNCTION__);
-  return (0);
-}
-
-int ethernet_tune(openair0_device_t *device, unsigned int option, int value)
-{
-  printf("ORAN: %s\n", __FUNCTION__);
-  return 0;
-}
-
-int trx_oran_write_raw(openair0_device_t *device, openair0_timestamp_t timestamp, void **buff, int nsamps, int cc, int flags)
-{
-  printf("ORAN: %s\n", __FUNCTION__);
-  return 0;
-}
-
-int trx_oran_read_raw(openair0_device_t *device, openair0_timestamp_t *timestamp, void **buff, int nsamps, int cc)
-{
-  printf("ORAN: %s\n", __FUNCTION__);
-  return 0;
-}
-
-char *msg_type(int t)
-{
-  static char *s[12] = {
-      "RAU_tick",
-      "RRU_capabilities",
-      "RRU_config",
-      "RRU_config_ok",
-      "RRU_start",
-      "RRU_stop",
-      "RRU_sync_ok",
-      "RRU_frame_resynch",
-      "RRU_MSG_max_num",
-      "RRU_check_sync",
-      "RRU_config_update",
-      "RRU_config_update_ok",
-  };
-
-  if (t < 0 || t > 11)
-    return "UNKNOWN";
-  return s[t];
-}
-
-int trx_oran_ctlsend(openair0_device_t *device, void *msg, ssize_t msg_len)
-{
-  RRU_CONFIG_msg_t *rru_config_msg = msg;
-  oran_eth_state_t *s = device->priv;
-
-  printf("ORAN: %s\n", __FUNCTION__);
-
-  printf("    rru_config_msg->type %d [%s]\n", rru_config_msg->type, msg_type(rru_config_msg->type));
-
-  s->last_msg = rru_config_msg->type;
-
-  return msg_len;
-}
-
-int trx_oran_ctlrecv(openair0_device_t *device, void *msg, ssize_t msg_len)
-{
-  RRU_CONFIG_msg_t *rru_config_msg = msg;
-  oran_eth_state_t *s = device->priv;
-
-  printf("ORAN: %s\n", __FUNCTION__);
-
-  if (s->last_msg == RAU_tick && s->capabilities_sent == 0) {
-    printf("ORAN ctrlrcv RRU_tick received and send capabilities hard coded\n");
-    RRU_capabilities_t *cap;
-    rru_config_msg->type = RRU_capabilities;
-    rru_config_msg->len = sizeof(RRU_CONFIG_msg_t) - MAX_RRU_CONFIG_SIZE + sizeof(RRU_capabilities_t);
-    // Fill RRU capabilities (see openair1/PHY/defs_RU.h)
-    // For now they are hard coded - try to retreive the params from openari device
-
-    cap = (RRU_capabilities_t *)&rru_config_msg->msg[0];
-    cap->FH_fmt = OAI_IF4p5_only;
-    cap->num_bands = 1;
-    cap->band_list[0] = 78;
-    // cap->num_concurrent_bands             = 1; component carriers
-    cap->nb_rx[0] = 1; // device->openair0_cfg->rx_num_channels;
-    cap->nb_tx[0] = 1; // device->openair0_cfg->tx_num_channels;
-    cap->max_pdschReferenceSignalPower[0] = -27;
-    cap->max_rxgain[0] = 90;
-    cap->N_RB_DL[0] = 106;
-    cap->N_RB_UL[0] = 106;
-
-    s->capabilities_sent = 1;
-
-    return rru_config_msg->len;
-  }
-  if (s->last_msg == RRU_config) {
-    printf("Oran RRU_config\n");
-    rru_config_msg->type = RRU_config_ok;
-  }
-  return 0;
 }
 
 void oran_fh_if4p5_south_in(RU_t *ru, int *frame, int *slot)
@@ -420,25 +307,14 @@ __attribute__((__visibility__("default"))) int transport_init(openair0_device_t 
   initNotifiedFIFO(&oran_sync_fifo);
   initNotifiedFIFO(&oran_sync_fifo_prach);
 
-  eth->e.flags = ETH_RAW_IF4p5_MODE;
-  eth->e.compression = NO_COMPRESS;
-  eth->e.if_name = eth_params->local_if_name;
-  eth->last_msg = (rru_config_msg_type_t)-1;
   eth->nCC = fh_config->nCC;
   eth->num_ports = fh_init.xran_ports;
 
   device->transp_type = ETHERNET_TP;
   device->trx_start_func = trx_oran_start;
   device->trx_get_stats_func = trx_oran_get_stats;
-  device->trx_reset_stats_func = trx_oran_reset_stats;
   device->trx_end_func = trx_oran_end;
   device->trx_stop_func = trx_oran_stop;
-  device->trx_set_freq_func = trx_oran_set_freq;
-  device->trx_set_gains_func = trx_oran_set_gains;
-  device->trx_write_func = trx_oran_write_raw;
-  device->trx_read_func = trx_oran_read_raw;
-  device->trx_ctlsend_func = trx_oran_ctlsend;
-  device->trx_ctlrecv_func = trx_oran_ctlrecv;
   device->get_internal_parameter = get_internal_parameter;
   device->priv = eth;
   device->openair0_cfg = &openair0_cfg[0];

--- a/radio/rfsimulator/simulator.cpp
+++ b/radio/rfsimulator/simulator.cpp
@@ -1627,6 +1627,7 @@ extern "C" __attribute__((__visibility__("default"))) int device_init(openair0_d
   }
   /* let's pretend to be a b2x0 */
   device->type = RFSIMULATOR;
+  device->host_type = RAU_HOST;
   openair0_cfg->rx_gain[0] = 0;
   device->openair0_cfg = openair0_cfg;
   device->priv = rfsimulator;


### PR DESCRIPTION
For both LTE and NR, removes:
- `txfh_in_fep`
- `fh_north_in`
- `eth_params_t` -> initialized directly via `ifdevice`

For NR, removes:
- `do_prach`
- `fh_north_out`
- `fh_south_asynch_in`
- `fh_north_asynch_in`

Removes useless time-domain functions pointers for split 7.2.