### PR TITLE
Add compression support for O-RU

### DIFF
--- a/executables/main_nr_ru.c
+++ b/executables/main_nr_ru.c
@@ -221,13 +221,14 @@ int main(int argc, char **argv)
   ret = ru->rfdevice.trx_start_func(&ru->rfdevice);
   AssertFatal(ret == 0, "RU %u: trx_start_func() ret %d: cannot start rfdevice\n", ru->idx, ret);
 
-  threadCreate(&oru.north_read_thread, oru_north_read_thread, (void *)&oru, "north_read_thread", -1, OAI_PRIORITY_RT_MAX);
-  threadCreate(&oru.south_read_thread, oru_south_read_thread, (void *)&oru, "south_read_thread", -1, OAI_PRIORITY_RT_MAX);
-  usleep(1000);
-  oru_fh_start(oru.fronthaul);
-
   // Signal handler
   signal(SIGINT, sig_handler);
+
+  ret = oru_fh_start(oru.fronthaul);
+  AssertFatal(ret == 0, "Cannot start O-RU fronthaul\n");
+
+  threadCreate(&oru.south_read_thread, oru_south_read_thread, (void *)&oru, "south_read_thread", -1, OAI_PRIORITY_RT_MAX);
+  threadCreate(&oru.north_read_thread, oru_north_read_thread, (void *)&oru, "north_read_thread", -1, OAI_PRIORITY_RT_MAX);
 
   while (oai_exit == 0) {
     oru_fh_print_stats(oru.fronthaul);

--- a/executables/nr-oru.c
+++ b/executables/nr-oru.c
@@ -73,6 +73,8 @@
 #define CONFIG_STRING_T2A_UP "T2a_up"
 #define CONFIG_STRING_T2A_CP "T2a_cp"
 #define CONFIG_STRING_PRACH_EAXC_OFFSET "prach_eaxc_offset"
+#define CONFIG_STRING_PRACH_KBAR "prach_kbar"
+#define CONFIG_STRING_COMP_TYPE         "comp_type"
 
 #define HLP_DPDK_DEVICES "DPDK devices to use for the O-RU."
 #define HLP_RX_CORE "The CPU core to be used to deploy dpdk RX worker for O-RU."
@@ -80,6 +82,14 @@
 #define HLP_DU_MAC_ADDRESSES "DU MAC addreses, used to prepare Ethernet headers."
 #define HLP_MTU "MTU for RX and TX."
 #define HLP_PRACH_EAXC_OFFSET "PRACH eAxC offset."
+#define HLP_PRACH_KBAR "PRACH kbar offset."
+#define HLP_COMP_TYPE         "DL U-plane compression method: none, bfp, blkscale, or ulaw."
+
+#define COMP_TYPE_CHECK                                                               \
+  &(checkedparam_t)                                                                   \
+  {                                                                                   \
+    .s3a = { config_checkstr_assign_integer, {"none", "bfp", "blkscale", "ulaw"}, {0, 1, 2, 3}, 4 } \
+  }
 
 // clang-format off
 #define CMDLINE_PARAMS_DESC_ORU_FH \
@@ -91,7 +101,9 @@
   {CONFIG_STRING_MTU,                        HLP_MTU,               0,                      .iptr=NULL,       .defintval=9600,              TYPE_INT,          0}, \
   {CONFIG_STRING_T2A_UP,                     "",                    0,                      .iptr=NULL,       .defintarrayval=NULL,         TYPE_INTARRAY,     0}, \
   {CONFIG_STRING_T2A_CP,                     "",                    0,                      .iptr=NULL,       .defintarrayval=NULL,         TYPE_INTARRAY,     0}, \
-  {CONFIG_STRING_PRACH_EAXC_OFFSET,          HLP_PRACH_EAXC_OFFSET, 0,                      .iptr=NULL,       .defintval=0,                 TYPE_INT,          0}  \
+  {CONFIG_STRING_PRACH_EAXC_OFFSET,          HLP_PRACH_EAXC_OFFSET, 0,                      .u8ptr=NULL,      .defuintval=0,                TYPE_UINT8,        0}, \
+  {CONFIG_STRING_PRACH_KBAR,                 HLP_PRACH_KBAR,        0,                      .uptr=NULL,       .defuintval=4,                TYPE_UINT,         0}, \
+  {CONFIG_STRING_COMP_TYPE,                  HLP_COMP_TYPE,         0,                      .strptr=NULL,     .defstrval="none",           TYPE_STRING,       0, COMP_TYPE_CHECK}  \
 }
 // clang-format on
 
@@ -232,12 +244,15 @@ int get_oru_options(ORU_t *oru)
     fh_cfg->du_mac_addrs[i] = gpd(fh_param, nump, CONFIG_STRING_DU_MAC_ADDRESSES)->strlistptr[i];
     AssertFatal(strlen(fh_cfg->du_mac_addrs[i]) == 17, "Invalid MAC address\n");
   }
-  fh_cfg->enable_compression = false;
+  int comp_type_idx = config_paramidx_fromname(fh_param, nump, CONFIG_STRING_COMP_TYPE);
+  AssertFatal(comp_type_idx >= 0, "Index for %s config option not found!\n", CONFIG_STRING_COMP_TYPE);
+  fh_cfg->comp_type = (fh_comp_method_t)config_get_processedint(config_get_if(), &fh_param[comp_type_idx]);
   fh_cfg->rx_core = *gpd(fh_param, nump, CONFIG_STRING_RX_CORE)->iptr;
   fh_cfg->mtu = *gpd(fh_param, nump, CONFIG_STRING_MTU)->iptr;
   fh_cfg->num_prbs = oru->bw_tx[0];
   fh_cfg->numerology = oru->numerology;
-  fh_cfg->prach_eaxc_offset = *gpd(fh_param, nump, CONFIG_STRING_PRACH_EAXC_OFFSET)->iptr;
+  fh_cfg->prach_eaxc_offset = *gpd(fh_param, nump, CONFIG_STRING_PRACH_EAXC_OFFSET)->u8ptr;
+  fh_cfg->prach_kbar = *gpd(fh_param, nump, CONFIG_STRING_PRACH_KBAR)->uptr;
 
   AssertFatal(gpd(fh_param, nump, CONFIG_STRING_T2A_UP)->numelt == 2, "Two parameters required for %s\n", CONFIG_STRING_T2A_UP);
   fh_cfg->T2a_up_min_uS = gpd(fh_param, nump, CONFIG_STRING_T2A_UP)->iptr[0];

--- a/fronthaul/oru/CMakeLists.txt
+++ b/fronthaul/oru/CMakeLists.txt
@@ -5,9 +5,13 @@ target_include_directories(oru_io PUBLIC ./)
 target_link_libraries(oru_io PUBLIC fh_core ${dpdk_LIBRARIES})
 target_include_directories(oru_io PRIVATE ${dpdk_INCLUDE_DIRS})
 
+add_library(fh_compression fh_compression.c)
+target_include_directories(fh_compression PUBLIC ./)
+target_link_libraries(fh_compression PRIVATE UTIL)
+
 add_library(oru_packet_processor oru_packet_processor.c)
 target_include_directories(oru_packet_processor PUBLIC ./)
-target_link_libraries(oru_packet_processor PUBLIC ${dpdk_LIBRARIES} PRIVATE xran_pkt UTIL)
+target_link_libraries(oru_packet_processor PUBLIC ${dpdk_LIBRARIES} PRIVATE xran_pkt UTIL fh_compression)
 
 add_library(oru_fh oru_fh.c)
 target_include_directories(oru_fh PUBLIC ./)

--- a/fronthaul/oru/fh_compression.c
+++ b/fronthaul/oru/fh_compression.c
@@ -1,0 +1,230 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include "fh_compression.h"
+#include "assertions.h"
+#include <limits.h>
+#include <string.h>
+
+/* ---- bit-stream helpers ---- */
+
+static void pack_bits(uint8_t *stream, int offset, int32_t val, int width)
+{
+  uint32_t bits = (uint32_t)(val & ((1u << width) - 1));
+  for (int i = 0; i < width; i++) {
+    int bit_offset = offset + i;
+    int pos = bit_offset >> 3;
+    int shift = 7 - (bit_offset & 7);
+    stream[pos] |= (uint8_t)(((bits >> (width - 1 - i)) & 1u) << shift);
+  }
+}
+
+static int32_t unpack_bits(const uint8_t *stream, int offset, int width)
+{
+  uint32_t bits = 0;
+  for (int i = 0; i < width; i++) {
+    int bit_offset = offset + i;
+    int pos = bit_offset >> 3;
+    int shift = 7 - (bit_offset & 7);
+    bits = (bits << 1) | ((stream[pos] >> shift) & 1u);
+  }
+  uint32_t sign = 1u << (width - 1);
+  return (bits & sign) ? (int32_t)(bits | ~((1u << width) - 1)) : (int32_t)bits;
+}
+
+/* ---- BFP ---- */
+
+static uint16_t saturating_abs16(int16_t v)
+{
+  if (v == INT16_MIN)
+    return INT16_MAX;
+  return (uint16_t)(v < 0 ? -v : v);
+}
+
+static int leading_zero_count16(uint16_t v)
+{
+  int count = 0;
+  for (int bit = 15; bit >= 0; bit--) {
+    if (v & (1u << bit))
+      break;
+    count++;
+  }
+  return count;
+}
+
+static void bfp_compress_prb(const int16_t *src, int8_t *dst, int iq_bits)
+{
+  uint16_t max_abs = 1;
+  for (int i = 0; i < FH_VALS_PER_PRB; i++) {
+    uint16_t v = saturating_abs16(src[i]);
+    if (v > max_abs)
+      max_abs = v;
+  }
+  int exponent = 16 - iq_bits + 1 - leading_zero_count16(max_abs);
+  if (exponent < 0)
+    exponent = 0;
+  dst[0] = (int8_t)exponent;
+  uint8_t *out = (uint8_t *)(dst + 1);
+  memset(out, 0, 3 * iq_bits);
+  for (int i = 0; i < FH_VALS_PER_PRB; i++)
+    pack_bits(out, i * iq_bits, src[i] >> exponent, iq_bits);
+}
+
+static void bfp_decompress_prb(const int8_t *src, int16_t *dst, int iq_bits)
+{
+  int exponent = (int)(uint8_t)src[0];
+  const uint8_t *in = (const uint8_t *)(src + 1);
+  for (int i = 0; i < FH_VALS_PER_PRB; i++)
+    dst[i] = (int16_t)(unpack_bits(in, i * iq_bits, iq_bits) << exponent);
+}
+
+/* ---- BLKSCALE ---- */
+
+static void blkscale_compress_prb(const int16_t *src, int8_t *dst, int iq_bits)
+{
+  int32_t max_abs = 1;
+  for (int i = 0; i < FH_VALS_PER_PRB; i++) {
+    int32_t v = src[i] < 0 ? -(int32_t)src[i] : (int32_t)src[i];
+    if (v > max_abs)
+      max_abs = v;
+  }
+  int bit_width = 32 - __builtin_clz((uint32_t)max_abs);
+  int shift = bit_width - (iq_bits - 1);
+  if (shift < 0)
+    shift = 0;
+  dst[0] = (int8_t)shift;
+  uint8_t *out = (uint8_t *)(dst + 1);
+  memset(out, 0, 3 * iq_bits);
+  const int32_t clip_max = (1 << (iq_bits - 1)) - 1;
+  const int32_t clip_min = -(1 << (iq_bits - 1));
+  for (int i = 0; i < FH_VALS_PER_PRB; i++) {
+    int32_t val = src[i] >> shift;
+    if (val > clip_max)
+      val = clip_max;
+    else if (val < clip_min)
+      val = clip_min;
+    pack_bits(out, i * iq_bits, val, iq_bits);
+  }
+}
+
+static void blkscale_decompress_prb(const int8_t *src, int16_t *dst, int iq_bits)
+{
+  int shift = (int)(uint8_t)src[0];
+  const uint8_t *in = (const uint8_t *)(src + 1);
+  for (int i = 0; i < FH_VALS_PER_PRB; i++)
+    dst[i] = (int16_t)(unpack_bits(in, i * iq_bits, iq_bits) << shift);
+}
+
+/* ---- ULAW ---- */
+
+/* G.711 mu-law constants (ITU-T G.711) */
+#define ULAW_BIAS      33    /* additive bias before segmentation */
+#define ULAW_CLIP      32734 /* saturation level: INT16_MAX - ULAW_BIAS */
+#define ULAW_NORM      127   /* segment normalization factor */
+#define ULAW_SEG_MASK  0x07  /* 3-bit segment index */
+
+static int16_t ulaw_encode(int16_t s, int iq_bits)
+{
+  int sign = s < 0 ? -1 : 1;
+  int x = s < 0 ? -(int)s : (int)s;
+  x = x > ULAW_CLIP ? ULAW_CLIP : x;
+  x += ULAW_BIAS;
+  int seg = 0;
+  for (int t = x >> 5; t > 1 && seg < 7; t >>= 1)
+    seg++;
+  int code = (((x >> (seg + 1)) & 0x0F) | (seg << 4)) ^ 0x7F;
+  int peak = (1 << (iq_bits - 1)) - 1;
+  return (int16_t)(sign * (code * peak / ULAW_NORM));
+}
+
+static int16_t ulaw_decode(int16_t s, int iq_bits)
+{
+  int sign = s < 0 ? -1 : 1;
+  int x = s < 0 ? -(int)s : (int)s;
+  int peak = (1 << (iq_bits - 1)) - 1;
+  if (peak == 0)
+    return 0;
+  int code = x * ULAW_NORM / peak;
+  code ^= 0x7F;
+  int seg = (code >> 4) & ULAW_SEG_MASK;
+  int decoded = (((code & 0x0F) << 1) | 1) << (seg + 2);
+  decoded -= ULAW_BIAS;
+  if (decoded < 0)
+    decoded = 0;
+  return (int16_t)(sign * decoded);
+}
+
+static void ulaw_compress_prb(const int16_t *src, int8_t *dst, int iq_bits)
+{
+  dst[0] = 0;
+  uint8_t *out = (uint8_t *)(dst + 1);
+  memset(out, 0, 3 * iq_bits);
+  for (int i = 0; i < FH_VALS_PER_PRB; i++)
+    pack_bits(out, i * iq_bits, ulaw_encode(src[i], iq_bits), iq_bits);
+}
+
+static void ulaw_decompress_prb(const int8_t *src, int16_t *dst, int iq_bits)
+{
+  const uint8_t *in = (const uint8_t *)(src + 1);
+  for (int i = 0; i < FH_VALS_PER_PRB; i++)
+    dst[i] = ulaw_decode((int16_t)unpack_bits(in, i * iq_bits, iq_bits), iq_bits);
+}
+
+/* ---- public API ---- */
+
+void fh_compress_prbs(fh_comp_method_t method, int iq_bits, int n_prb, const int16_t *src, int8_t *dst)
+{
+  AssertFatal(method != FH_COMP_NONE, "fh_compress_prbs called with FH_COMP_NONE\n");
+  AssertFatal(iq_bits >= 1 && iq_bits <= 16, "iq_bits %d out of range [1..16]\n", iq_bits);
+  const int src_stride = FH_VALS_PER_PRB;
+  const int dst_stride = FH_COMP_PRB_BYTES(iq_bits);
+  for (int p = 0; p < n_prb; p++) {
+    switch (method) {
+      case FH_COMP_BFP:
+        bfp_compress_prb(src + p * src_stride, dst + p * dst_stride, iq_bits);
+        break;
+      case FH_COMP_BLKSCALE:
+        blkscale_compress_prb(src + p * src_stride, dst + p * dst_stride, iq_bits);
+        break;
+      case FH_COMP_ULAW:
+        ulaw_compress_prb(src + p * src_stride, dst + p * dst_stride, iq_bits);
+        break;
+      default:
+        AssertFatal(0, "Unsupported compression method %d\n", method);
+    }
+  }
+}
+
+void fh_decompress_prbs(fh_comp_method_t method, int iq_bits, int n_prb, const int8_t *src, int16_t *dst)
+{
+  AssertFatal(method != FH_COMP_NONE, "fh_decompress_prbs called with FH_COMP_NONE\n");
+  AssertFatal(iq_bits >= 1 && iq_bits <= 16, "iq_bits %d out of range [1..16]\n", iq_bits);
+  const int src_stride = FH_COMP_PRB_BYTES(iq_bits);
+  const int dst_stride = FH_VALS_PER_PRB;
+  for (int p = 0; p < n_prb; p++) {
+    switch (method) {
+      case FH_COMP_BFP:
+        bfp_decompress_prb(src + p * src_stride, dst + p * dst_stride, iq_bits);
+        break;
+      case FH_COMP_BLKSCALE:
+        blkscale_decompress_prb(src + p * src_stride, dst + p * dst_stride, iq_bits);
+        break;
+      case FH_COMP_ULAW:
+        ulaw_decompress_prb(src + p * src_stride, dst + p * dst_stride, iq_bits);
+        break;
+      default:
+        AssertFatal(0, "Unsupported compression method %d\n", method);
+    }
+  }
+}
+
+void fh_compress_prach(fh_comp_method_t method, int iq_bits, int kbar, const int16_t *src, int8_t *dst)
+{
+  const int total_vals = FH_PRACH_NUM_PRBS * FH_VALS_PER_PRB;
+  int16_t padded[FH_PRACH_NUM_PRBS * FH_VALS_PER_PRB];
+  AssertFatal(kbar >= 0 && kbar + FH_PRACH_NUM_SUBCARRIERS * 2 <= total_vals, "PRACH kbar %d out of range\n", kbar);
+  memset(padded, 0, total_vals * sizeof(int16_t));
+  memcpy(padded + kbar, src, FH_PRACH_NUM_SUBCARRIERS * 2 * sizeof(int16_t));
+  fh_compress_prbs(method, iq_bits, FH_PRACH_NUM_PRBS, padded, dst);
+}

--- a/fronthaul/oru/fh_compression.h
+++ b/fronthaul/oru/fh_compression.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  FH_COMP_NONE     = 0,
+  FH_COMP_BFP      = 1,
+  FH_COMP_BLKSCALE = 2,
+  FH_COMP_ULAW     = 3,
+} fh_comp_method_t;
+
+#define FH_COMP_NUM_METHODS 4
+
+/* Compressed byte budget per PRB: 1 header byte + 3 × iq_bits packed sample bytes.
+ * Applies to BFP, BLKSCALE, and ULAW. Typical iq_bits values: 8, 9, 12, 14. */
+#define FH_COMP_PRB_BYTES(iq_bits) (1 + 3 * (iq_bits))
+
+/* PRACH carries FH_PRACH_NUM_SUBCARRIERS subcarriers, zero-padded to FH_PRACH_NUM_PRBS before compression. */
+#define FH_PRACH_NUM_SUBCARRIERS 139
+#define FH_PRACH_NUM_PRBS 12
+#define FH_SC_PER_PRB     12
+#define FH_VALS_PER_PRB   (2 * FH_SC_PER_PRB)
+
+void fh_compress_prbs(fh_comp_method_t method, int iq_bits, int n_prb, const int16_t *src, int8_t *dst);
+void fh_decompress_prbs(fh_comp_method_t method, int iq_bits, int n_prb, const int8_t *src, int16_t *dst);
+void fh_compress_prach(fh_comp_method_t method, int iq_bits, int kbar, const int16_t *src, int8_t *dst);
+
+#ifdef __cplusplus
+}
+#endif

--- a/fronthaul/oru/oru_fh.c
+++ b/fronthaul/oru/oru_fh.c
@@ -68,7 +68,8 @@ static void timer_cb(uint64_t s_abs, void *user_data)
 
 void *oru_fh_init(oru_fh_config_t *cfg)
 {
-  AssertFatal(cfg->enable_compression == false, "IQ compression not supported\n");
+  AssertFatal(cfg->comp_type < FH_COMP_NUM_METHODS,
+              "comp_type %d out of range [0..%d]\n", cfg->comp_type, FH_COMP_NUM_METHODS - 1);
 
   char *argv[64];
   int argc = 0;
@@ -206,7 +207,9 @@ void *oru_fh_init(oru_fh_config_t *cfg)
                                                (send_func_t)oru_io_send_uplane,
                                                &fh->io,
                                                cfg->mtu,
-                                               cfg->prach_eaxc_offset);
+                                               cfg->prach_eaxc_offset,
+                                               cfg->comp_type,
+                                               cfg->prach_kbar);
 
   return fh;
 }

--- a/fronthaul/oru/oru_fh.h
+++ b/fronthaul/oru/oru_fh.h
@@ -7,6 +7,7 @@
 
 #include "oru_io.h"
 #include <stdint.h>
+#include "fh_compression.h"
 #include "oru_packet_processor.h"
 
 typedef struct {
@@ -25,8 +26,7 @@ typedef struct {
 } oru_fh_tdd_pattern_t;
 
 typedef struct {
-  // Compression configuration
-  bool enable_compression;
+  fh_comp_method_t comp_type;
   int numerology;
   uint16_t num_prbs;
   // MTU configuration
@@ -44,6 +44,7 @@ typedef struct {
   uint32_t T2a_cp_max_uS;
   oru_fh_tdd_pattern_t tdd_pattern;
   int prach_eaxc_offset;
+  int prach_kbar;
 } oru_fh_config_t;
 
 /**

--- a/fronthaul/oru/oru_packet_processor.c
+++ b/fronthaul/oru/oru_packet_processor.c
@@ -43,6 +43,7 @@
 #define MAX_RX_FRAGMENTS 4
 #define MAX_MBUFS_PER_SYMBOL 64
 #define MAX_SLOTS_PER_FRAME 160
+#define XRAN_IQ_BITS_UNCOMPRESSED 16 /* xRAN table 7.7.1.1-1: udIqWidth=0 means 16-bit samples */
 
 typedef struct {
   struct {
@@ -59,6 +60,8 @@ typedef struct {
   int expected_iq;
   int received_iq;
   uint64_t absolute_symbol;
+  fh_comp_method_t comp_method;
+  uint8_t iq_width;
 } dl_symbol_job_t;
 
 typedef struct {
@@ -69,6 +72,8 @@ typedef struct {
   int num_prb;
   int start_prb;
   int filter_id;
+  fh_comp_method_t comp_method;
+  uint8_t iq_width;
 } prach_job_t;
 typedef struct {
   _Atomic(uint64_t) dl_tdd_mismatch;
@@ -105,6 +110,7 @@ typedef struct {
   uint32_t T2a_max_up_dl_sym_diff;
   struct xran_eaxcid_config eaxcid_config;
   int prach_eaxc_offset;
+  int prach_kbar;
   int numerology;
   int num_prb;
   oru_packet_processor_stats_t stats;
@@ -117,6 +123,7 @@ typedef struct {
   void *io_controller;
   _Atomic(uint8_t) pusch_seq_id[MAX_ANTENNAS];
   size_t mtu;
+  fh_comp_method_t dl_comp_method;
 } oru_packet_processor_context_t;
 
 static inline void set_bit(uint8_t *bits, uint64_t bit)
@@ -153,7 +160,9 @@ void *init_packet_processor(int numerology,
                             send_func_t send_func,
                             void *io_controller,
                             size_t mtu,
-                            int prach_eaxc_offset)
+                            int prach_eaxc_offset,
+                            fh_comp_method_t dl_comp_method,
+                            int prach_kbar)
 {
   oru_packet_processor_context_t *ctx = calloc(1, sizeof(*ctx));
   ctx->alloc_func = alloc_func;
@@ -164,6 +173,11 @@ void *init_packet_processor(int numerology,
   ctx->numerology = numerology;
   ctx->mtu = mtu;
   ctx->prach_eaxc_offset = prach_eaxc_offset;
+  AssertFatal(prach_kbar >= 0 && prach_kbar + FH_PRACH_NUM_SUBCARRIERS * 2 <= FH_PRACH_NUM_PRBS * FH_VALS_PER_PRB,
+              "PRACH kbar %d out of range\n",
+              prach_kbar);
+  ctx->prach_kbar = prach_kbar;
+  ctx->dl_comp_method = dl_comp_method;
   uint32_t slots_per_subframe = 1 << numerology;
   uint32_t symbol_duration_uS = 1000 / slots_per_subframe / NR_SYMBOLS_PER_SLOT;
   ctx->T2a_min_cp_sym_diff = T2a_cp_min_uS / symbol_duration_uS;
@@ -314,7 +328,7 @@ void handle_uplane_packet(void *context, void *pkt)
   uint16_t sym_inc;
   uint16_t rb;
   uint16_t sect_id;
-  int expect_comp = 0;
+  const bool has_comp_hdr = ctx->dl_comp_method != FH_COMP_NONE;
   uint8_t staticComp = 0;
   uint8_t compMeth = 0;
   uint8_t iqWidth = 0;
@@ -334,12 +348,17 @@ void handle_uplane_packet(void *context, void *pkt)
                                     &sym_inc,
                                     &rb,
                                     &sect_id,
-                                    expect_comp,
+                                    has_comp_hdr,
                                     staticComp,
                                     &compMeth,
                                     &iqWidth);
   if (ret == 0) {
     LOG_W(HW, "Error reading packet\n");
+    rte_pktmbuf_free(pkt);
+    return;
+  }
+  if (has_comp_hdr && compMeth >= FH_COMP_NUM_METHODS) {
+    LOG_W(HW, "U-plane packet: invalid compression method %u, dropping\n", compMeth);
     rte_pktmbuf_free(pkt);
     return;
   }
@@ -362,7 +381,6 @@ void handle_uplane_packet(void *context, void *pkt)
         compMeth,
         iqWidth);
 
-  AssertFatal(compMeth == 0, "Compression not supported\n");
   int mu = ctx->numerology;
   int slots_per_subframe = 1 << mu;
   int num_symbols_per_frame = NR_NUMBER_OF_SUBFRAMES_PER_FRAME * slots_per_subframe * NR_SYMBOLS_PER_SLOT;
@@ -417,6 +435,8 @@ void handle_uplane_packet(void *context, void *pkt)
     rte_pktmbuf_free(pkt);
   }
   job->received_iq += num_prbu == 0 ? ctx->num_prb : num_prbu;
+  job->comp_method = (fh_comp_method_t)compMeth;
+  job->iq_width = iqWidth == 0 ? XRAN_IQ_BITS_UNCOMPRESSED : iqWidth;
   if (job->expected_iq == job->received_iq) {
     try_push_symbol_job(ctx, target_absolute_symbol);
   }
@@ -470,6 +490,8 @@ static void handle_dl_cplane_packet(oru_packet_processor_context_t *ctx,
       job->absolute_symbol = target_absolute_symbol + i;
       job->expected_iq = 0;
       job->received_iq = 0;
+      job->comp_method = FH_COMP_NONE;
+      job->iq_width = 16;
       for (int j = 0; j < MAX_ANTENNAS; j++) {
         job->per_antenna[j].cplane_received = false;
         job->per_antenna[j].num_rx_fragments = 0;
@@ -492,6 +514,8 @@ static void handle_dl_cplane_packet(oru_packet_processor_context_t *ctx,
     }
     job->per_antenna[ant_id].section_id = section->hdr.u1.common.sectionId;
     job->expected_iq += section->hdr.u1.common.numPrbc == 0 ? ctx->num_prb : section->hdr.u1.common.numPrbc;
+    job->comp_method = (fh_comp_method_t)hdr->udComp.udCompMeth;
+    job->iq_width = hdr->udComp.udIqWidth == 0 ? XRAN_IQ_BITS_UNCOMPRESSED : hdr->udComp.udIqWidth;
   }
 }
 
@@ -534,7 +558,7 @@ static void handle_ul_cplane_packet(oru_packet_processor_context_t *ctx,
     memset(ul_job, 0, sizeof(*ul_job));
     ul_job->response_payload.section_id = section->hdr.u1.common.sectionId;
     ul_job->response_payload.comp_method = hdr->udComp.udCompMeth;
-    ul_job->response_payload.iq_width = hdr->udComp.udIqWidth == 0 ? 16 : hdr->udComp.udIqWidth;
+    ul_job->response_payload.iq_width = hdr->udComp.udIqWidth == 0 ? XRAN_IQ_BITS_UNCOMPRESSED : hdr->udComp.udIqWidth;
     uint64_t absolute_gps_symbol = target_absolute_symbol;
     ul_job->hyper_frame = absolute_gps_symbol / (1024 * (10 * (1 << ctx->numerology) * 14));
     ul_job->frame = (absolute_gps_symbol / (10 * (1 << ctx->numerology) * 14)) % 1024;
@@ -617,6 +641,8 @@ void handle_prach_cplane_packet(oru_packet_processor_context_t *ctx,
   job->num_prb = section->hdr.u1.common.numPrbc == 0 ? ctx->num_prb : section->hdr.u1.common.numPrbc;
   job->start_prb = section->hdr.u1.common.startPrbc;
   job->filter_id = hdr->cmnhdr.field.filterIndex;
+  job->comp_method = (fh_comp_method_t)hdr->udComp.udCompMeth;
+  job->iq_width = hdr->udComp.udIqWidth == 0 ? XRAN_IQ_BITS_UNCOMPRESSED : hdr->udComp.udIqWidth;
   RATELIMIT(PRACH_ERR_LOG_RATELIMIT, {
     LOG_A(HW,
           "PRACH JOB added slot_in_frame %d, aarx %d target_absolute_symbol %lu\n",
@@ -826,12 +852,18 @@ void get_packet_processor_stats(void *context, oru_packet_processor_stats_t *out
   }
 }
 
-static void unpack_iq(c16_t *txdataF, void *iqdata, int start_prb, int num_prb)
+static void unpack_iq(c16_t *txdataF, const uint8_t *iqdata, int start_prb, int num_prb,
+                      fh_comp_method_t comp_method, uint8_t iq_width)
 {
-  uint16_t *source = (uint16_t *)iqdata;
-  uint16_t *destination = (uint16_t *)&txdataF[start_prb * NR_NB_SC_PER_RB];
-  for (int j = 0; j < num_prb * NR_NB_SC_PER_RB * 2; j++) {
-    destination[j] = rte_bswap16(source[j]);
+  if (comp_method != FH_COMP_NONE) {
+    fh_decompress_prbs(comp_method, iq_width, num_prb,
+                       (const int8_t *)iqdata,
+                       (int16_t *)&txdataF[start_prb * NR_NB_SC_PER_RB]);
+  } else {
+    const uint16_t *source = (const uint16_t *)iqdata;
+    uint16_t *destination = (uint16_t *)&txdataF[start_prb * NR_NB_SC_PER_RB];
+    for (int j = 0; j < num_prb * NR_NB_SC_PER_RB * 2; j++)
+      destination[j] = rte_bswap16(source[j]);
   }
 }
 
@@ -864,7 +896,9 @@ void read_dl_iq(void *context, uint32_t **txdataF, int nb_tx, uint64_t *hyper_fr
       unpack_iq((c16_t *)txdataF[aatx],
                 job->per_antenna[aatx].rx_fragments[k].iq_data,
                 job->per_antenna[aatx].rx_fragments[k].start_prbc,
-                job->per_antenna[aatx].rx_fragments[k].num_prbc);
+                job->per_antenna[aatx].rx_fragments[k].num_prbc,
+                job->comp_method,
+                job->iq_width);
       if (job->per_antenna[aatx].rx_fragments[k].mbuf) {
         rte_pktmbuf_free(job->per_antenna[aatx].rx_fragments[k].mbuf);
       }
@@ -991,7 +1025,9 @@ void write_ul_iq(void *context, uint32_t *rxdataF, int symbol, const ul_job_t *j
   if (use_comp) {
     overhead += sizeof(struct data_section_compression_hdr);
   }
-  int max_prb_per_packet = (int)((ctx->mtu - overhead) / (NR_NB_SC_PER_RB * sizeof(int32_t)));
+  const size_t prb_bytes = use_comp ? (size_t)FH_COMP_PRB_BYTES(job->response_payload.iq_width)
+                                    : (size_t)(NR_NB_SC_PER_RB * sizeof(int32_t));
+  int max_prb_per_packet = (int)((ctx->mtu - overhead) / prb_bytes);
 
   while (rbs_sent < total_ul_rbs) {
     int num_ul_rbs = total_ul_rbs - rbs_sent;
@@ -1010,7 +1046,8 @@ void write_ul_iq(void *context, uint32_t *rxdataF, int symbol, const ul_job_t *j
       header_length += sizeof(struct data_section_compression_hdr);
     }
     const uint num_sc = num_ul_rbs * NR_NB_SC_PER_RB;
-    size_t data_len = sizeof(int32_t) * num_sc;
+    size_t data_len = use_comp ? (size_t)FH_COMP_PRB_BYTES(job->response_payload.iq_width) * num_ul_rbs
+                               : (size_t)sizeof(int32_t) * num_sc;
 
     char *buf = rte_pktmbuf_append(pkt, (uint16_t)(header_length + data_len));
     if (buf == NULL) {
@@ -1036,21 +1073,29 @@ void write_ul_iq(void *context, uint32_t *rxdataF, int symbol, const ul_job_t *j
     struct data_section_hdr *data_section_header = (struct data_section_hdr *)(radio_app_header + 1);
     fill_data_section_header(data_section_header, num_ul_rbs, start_prb_base + rbs_sent, section_id);
 
-    void *iq_data_start;
+    uint8_t *iq_data_start;
     if (use_comp) {
       struct data_section_compression_hdr *compression_header = (struct data_section_compression_hdr *)(data_section_header + 1);
       compression_header->ud_comp_hdr.ud_comp_meth = job->response_payload.comp_method;
       compression_header->ud_comp_hdr.ud_iq_width = XRAN_CONVERT_IQWIDTH(job->response_payload.iq_width);
       compression_header->rsrvd = 0;
-      iq_data_start = (void *)(compression_header + 1);
+      iq_data_start = (uint8_t *)(compression_header + 1);
     } else {
-      iq_data_start = (void *)(data_section_header + 1);
+      iq_data_start = (uint8_t *)(data_section_header + 1);
     }
 
-    uint16_t *src = (uint16_t *)&rxdataF[(start_prb_base + rbs_sent) * NR_NB_SC_PER_RB];
-    uint16_t *dst = (uint16_t *)iq_data_start;
-    for (int i = 0; i < num_sc * 2; i++) {
-      *dst++ = rte_cpu_to_be_16(*src++);
+    const int16_t *src = (const int16_t *)&rxdataF[(start_prb_base + rbs_sent) * NR_NB_SC_PER_RB];
+    if (use_comp) {
+      fh_compress_prbs((fh_comp_method_t)job->response_payload.comp_method,
+                       job->response_payload.iq_width,
+                       num_ul_rbs,
+                       src,
+                       (int8_t *)iq_data_start);
+    } else {
+      const uint16_t *raw = (const uint16_t *)src;
+      uint16_t *dst = (uint16_t *)iq_data_start;
+      for (int i = 0; i < num_sc * 2; i++)
+        dst[i] = rte_cpu_to_be_16(raw[i]);
     }
     rbs_sent += num_ul_rbs;
   }
@@ -1131,9 +1176,13 @@ void write_prach_iq(void *context, uint32_t **txdataF, int nb_rx, int frame, int
       continue;
     }
 
+    const bool prach_compressed = job->comp_method != FH_COMP_NONE;
     size_t header_length = sizeof(struct xran_ecpri_hdr) + sizeof(struct radio_app_common_hdr) + sizeof(struct data_section_hdr);
+    if (prach_compressed)
+      header_length += sizeof(struct data_section_compression_hdr);
     const uint prach_length = 139;
-    size_t data_len = sizeof(int32_t) * prach_length;
+    size_t data_len = prach_compressed ? (size_t)FH_COMP_PRB_BYTES(job->iq_width) * FH_PRACH_NUM_PRBS
+                                       : (size_t)(prach_length + ctx->prach_kbar) * 2 * sizeof(uint16_t);
 
     char *buf = rte_pktmbuf_append(pkt, (uint16_t)(header_length + data_len));
     if (buf == NULL) {
@@ -1164,11 +1213,22 @@ void write_prach_iq(void *context, uint32_t **txdataF, int nb_rx, int frame, int
     struct data_section_hdr *data_section_header = (struct data_section_hdr *)(radio_app_header + 1);
     fill_data_section_header(data_section_header, num_ul_rbs, start_prb, section_id);
 
-    void *iq_data_start = (void *)(data_section_header + 1);
-    uint16_t *src = (uint16_t *)txdataF[aarx];
-    uint16_t *dst = (uint16_t *)iq_data_start;
-    for (int i = 0; i < prach_length * 2; i++) {
-      *dst++ = rte_cpu_to_be_16(*src++);
+    uint8_t *iq_data_start;
+    if (prach_compressed) {
+      struct data_section_compression_hdr *comp_hdr =
+          (struct data_section_compression_hdr *)(data_section_header + 1);
+      comp_hdr->ud_comp_hdr.ud_comp_meth = job->comp_method;
+      comp_hdr->ud_comp_hdr.ud_iq_width = XRAN_CONVERT_IQWIDTH(job->iq_width);
+      comp_hdr->rsrvd = 0;
+      iq_data_start = (uint8_t *)(comp_hdr + 1);
+      fh_compress_prach(job->comp_method, job->iq_width, ctx->prach_kbar, (const int16_t *)txdataF[aarx], (int8_t *)iq_data_start);
+    } else {
+      iq_data_start = (uint8_t *)(data_section_header + 1);
+      const uint16_t *raw = (const uint16_t *)txdataF[aarx];
+      uint16_t *dst = (uint16_t *)iq_data_start;
+      memset(dst, 0, (prach_length + ctx->prach_kbar) * 2 * sizeof(uint16_t));
+      for (int i = 0; i < prach_length * 2; i++)
+        dst[ctx->prach_kbar + i] = rte_cpu_to_be_16(raw[i]);
     }
   }
 

--- a/fronthaul/oru/oru_packet_processor.h
+++ b/fronthaul/oru/oru_packet_processor.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "fh_compression.h"
 #include <stdint.h>
 #include <stddef.h>
 
@@ -95,7 +96,9 @@ void *init_packet_processor(int numerology,
                             void (*send_mbufs)(void *io_controller, struct rte_mbuf **mbufs, uint32_t num_mbufs),
                             void *io_controller,
                             size_t mtu,
-                            int prach_eaxc_offset);
+                            int prach_eaxc_offset,
+                            fh_comp_method_t dl_comp_method,
+                            int prach_kbar);
 void write_ul_iq(void *context, uint32_t *rxdataF, int symbol, const ul_job_t *job);
 void write_prach_iq(void *context, uint32_t **txdataF, int nb_rx, int frame, int slot_in_frame, int symbol);
 void cleanup_packet_processor(void *context);

--- a/fronthaul/oru/tests/CMakeLists.txt
+++ b/fronthaul/oru/tests/CMakeLists.txt
@@ -10,11 +10,17 @@ add_test(NAME test_oru_io COMMAND test_oru_io ${DPDK_TEST_ARGS} "--file-prefix=t
 set_property(TEST test_oru_io PROPERTY LABELS fronthaul)
 
 add_executable(test_oru_packet_processor test_oru_packet_processor.c)
-target_link_libraries(test_oru_packet_processor PRIVATE oru_packet_processor log_headers ${dpdk_LIBRARIES})
+target_link_libraries(test_oru_packet_processor PRIVATE oru_packet_processor fh_compression log_headers ${dpdk_LIBRARIES})
 target_include_directories(test_oru_packet_processor PRIVATE ${dpdk_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/../../xran_pkt)
 add_dependencies(tests test_oru_packet_processor)
 add_test(NAME test_oru_packet_processor COMMAND test_oru_packet_processor ${DPDK_TEST_ARGS} "--file-prefix=test_oru_packet_processor" "--vdev=net_null0" "--vdev=net_null1")
 set_property(TEST test_oru_packet_processor PROPERTY LABELS fronthaul)
+
+add_executable(test_fh_compression test_fh_compression.c)
+target_link_libraries(test_fh_compression PRIVATE fh_compression)
+add_dependencies(tests test_fh_compression)
+add_test(NAME test_fh_compression COMMAND test_fh_compression)
+set_property(TEST test_fh_compression PROPERTY LABELS fronthaul)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PCAP REQUIRED libpcap)

--- a/fronthaul/oru/tests/test_fh_compression.c
+++ b/fronthaul/oru/tests/test_fh_compression.c
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include "fh_compression.h"
+
+void exit_function(const char *file, const char *function, const int line, const char *s, const int assertflag)
+{
+  fprintf(stderr, "Error at %s:%s:%d - %s\n", file, function, line, s ? s : "None");
+  exit(1);
+}
+
+static void test_bfp_roundtrip(void)
+{
+  printf("Testing BFP compress/decompress round-trip...\n");
+  const int n_prb = 1;
+  const int iq_bits = 9;
+  int16_t src[FH_VALS_PER_PRB];
+  for (int i = 0; i < FH_VALS_PER_PRB; i += 2) {
+    src[i] = 100;
+    src[i + 1] = -200;
+  }
+  int8_t compressed[FH_COMP_PRB_BYTES(iq_bits)];
+  memset(compressed, 0, sizeof(compressed));
+  int16_t recovered[FH_VALS_PER_PRB];
+
+  fh_compress_prbs(FH_COMP_BFP, iq_bits, n_prb, src, compressed);
+  /* I=100, Q=-200: max_abs=200, lzc=8, exponent=16-9+1-8=0 -> exact round-trip */
+  assert((uint8_t)compressed[0] == 0);
+  fh_decompress_prbs(FH_COMP_BFP, iq_bits, n_prb, compressed, recovered);
+
+  for (int i = 0; i < FH_VALS_PER_PRB; i++)
+    assert(recovered[i] == src[i]);
+  printf("BFP round-trip passed!\n");
+}
+
+static void test_bfp_known_vector(void)
+{
+  printf("Testing BFP decompression of hand-constructed vector...\n");
+  /* For iq_bits=8, packed values land on byte boundaries so the compressed
+   * bytes can be written by hand without bit-arithmetic.
+   * exponent=0, I=4 (0x04), Q=-4 (0xFC) for all 12 subcarriers. */
+  const int iq_bits = 8;
+  const int n_prb = 1;
+  int8_t known[FH_COMP_PRB_BYTES(iq_bits)]; /* 1 + 3*8 = 25 bytes */
+  memset(known, 0, sizeof(known));
+  known[0] = 0; /* exponent */
+  for (int i = 0; i < FH_VALS_PER_PRB; i += 2) {
+    known[1 + i] = 0x04;          /* I = 4 */
+    known[1 + i + 1] = (int8_t)0xFC; /* Q = -4 in 8-bit two's complement */
+  }
+  int16_t recovered[FH_VALS_PER_PRB];
+  fh_decompress_prbs(FH_COMP_BFP, iq_bits, n_prb, known, recovered);
+  for (int i = 0; i < FH_VALS_PER_PRB; i += 2) {
+    assert(recovered[i] == 4);
+    assert(recovered[i + 1] == -4);
+  }
+  printf("BFP known-vector check passed!\n");
+}
+
+int main(void)
+{
+  test_bfp_roundtrip();
+  test_bfp_known_vector();
+  printf("All compression tests passed!\n");
+  return 0;
+}

--- a/fronthaul/oru/tests/test_oru_packet_processor.c
+++ b/fronthaul/oru/tests/test_oru_packet_processor.c
@@ -13,7 +13,9 @@
 #include <rte_ether.h>
 #include <rte_byteorder.h>
 #include "xran_pkt_api.h"
+#include "xran_pkt_up.h"
 #include "oru_packet_processor.h"
+#include "fh_compression.h"
 
 #include "log.h"
 #include "common/config/config_userapi.h"
@@ -37,6 +39,13 @@ struct xran_eaxcid_config g_eaxcid_config = {.mask_cuPortId = 0xF000,
                                              .bit_ruPortId = 0};
 
 struct rte_mempool *mp = NULL;
+
+#define TEST_PRACH_KBAR 4
+
+static int16_t g_ul_known_src[20 * FH_VALS_PER_PRB];
+static int16_t g_ul_recovered_iq[20 * FH_VALS_PER_PRB];
+static const int g_ul_test_num_prb = 20;
+static const int g_ul_test_iq_width = 9;
 
 void setup_dpdk(int argc, char **argv)
 {
@@ -69,7 +78,24 @@ void test_send_mbuf(void *io_controller, struct rte_mbuf **mbufs, uint32_t num_m
 void test_init_cleanup()
 {
   printf("Testing init and cleanup...\n");
-  void *ctx = init_packet_processor(1, 273, 200, 400, 100, 300, 2, 2, 0, 0, 5, test_alloc_mbuf, test_send_mbuf, NULL, 1500, 0);
+  void *ctx = init_packet_processor(1,
+                                    273,
+                                    200,
+                                    400,
+                                    100,
+                                    300,
+                                    2,
+                                    2,
+                                    0,
+                                    0,
+                                    5,
+                                    test_alloc_mbuf,
+                                    test_send_mbuf,
+                                    NULL,
+                                    1500,
+                                    0,
+                                    FH_COMP_NONE,
+                                    0);
   assert(ctx != NULL);
   oru_packet_processor_stats_t stats;
   get_packet_processor_stats(ctx, &stats);
@@ -82,7 +108,24 @@ void test_init_cleanup()
 void test_cplane_timing_errors()
 {
   printf("Testing C-Plane timing errors...\n");
-  void *ctx = init_packet_processor(1, 273, 200, 400, 100, 300, 2, 2, 0, 0, 5, test_alloc_mbuf, test_send_mbuf, NULL, 1500, 0);
+  void *ctx = init_packet_processor(1,
+                                    273,
+                                    200,
+                                    400,
+                                    100,
+                                    300,
+                                    2,
+                                    2,
+                                    0,
+                                    0,
+                                    5,
+                                    test_alloc_mbuf,
+                                    test_send_mbuf,
+                                    NULL,
+                                    1500,
+                                    0,
+                                    FH_COMP_NONE,
+                                    0);
   assert(ctx != NULL);
 
   // Set current symbol
@@ -142,7 +185,24 @@ void test_cplane_uplane_match()
   int slots_per_subframe = 1 << mu;
   // T2a_cp ranges: 200 to 400 us (approx 5 to 11 symbols)
   // T2a_up ranges: 100 to 300 us (approx 2 to 8 symbols)
-  void *ctx = init_packet_processor(mu, 273, 200, 400, 100, 300, 2, 2, 0, 0, 5, test_alloc_mbuf, test_send_mbuf, NULL, 1500, 0);
+  void *ctx = init_packet_processor(mu,
+                                    273,
+                                    200,
+                                    400,
+                                    100,
+                                    300,
+                                    2,
+                                    2,
+                                    0,
+                                    0,
+                                    5,
+                                    test_alloc_mbuf,
+                                    test_send_mbuf,
+                                    NULL,
+                                    1500,
+                                    0,
+                                    FH_COMP_NONE,
+                                    0);
   assert(ctx != NULL);
 
   uint64_t current_sym = 1000;
@@ -256,7 +316,24 @@ void test_frame_wrap_around()
   printf("Testing frame wrap around...\n");
   int mu = 1; // 30kHz
   int slots_per_subframe = 1 << mu;
-  void *ctx = init_packet_processor(mu, 273, 200, 400, 100, 300, 2, 2, 0, 0, 5, test_alloc_mbuf, test_send_mbuf, NULL, 1500, 0);
+  void *ctx = init_packet_processor(mu,
+                                    273,
+                                    200,
+                                    400,
+                                    100,
+                                    300,
+                                    2,
+                                    2,
+                                    0,
+                                    0,
+                                    5,
+                                    test_alloc_mbuf,
+                                    test_send_mbuf,
+                                    NULL,
+                                    1500,
+                                    0,
+                                    FH_COMP_NONE,
+                                    0);
   assert(ctx != NULL);
 
   // Total symbols = 5 slots * 14 = 70.
@@ -360,7 +437,24 @@ void test_cplane_14_symbols()
 {
   printf("Testing 1 C-plane message for 14 symbols...\n");
   int mu = 1; // 30kHz
-  void *ctx = init_packet_processor(mu, 273, 200, 400, 100, 300, 5, 0, 0, 0, 5, test_alloc_mbuf, test_send_mbuf, NULL, 1500, 0);
+  void *ctx = init_packet_processor(mu,
+                                    273,
+                                    200,
+                                    400,
+                                    100,
+                                    300,
+                                    5,
+                                    0,
+                                    0,
+                                    0,
+                                    5,
+                                    test_alloc_mbuf,
+                                    test_send_mbuf,
+                                    NULL,
+                                    1500,
+                                    0,
+                                    FH_COMP_NONE,
+                                    0);
   assert(ctx != NULL);
 
   uint64_t current_sym = 1000;
@@ -479,7 +573,24 @@ void test_other_bw_4ant_prb_offset()
   printf("Testing other bandwidth, 4 antennas, and PRB offset...\n");
   int mu = 1; // 30kHz
   int num_prb = 106; // Different bandwidth
-  void *ctx = init_packet_processor(mu, num_prb, 200, 400, 100, 300, 4, 4, 0, 0, 5, test_alloc_mbuf, test_send_mbuf, NULL, 1500, 0);
+  void *ctx = init_packet_processor(mu,
+                                    num_prb,
+                                    200,
+                                    400,
+                                    100,
+                                    300,
+                                    4,
+                                    4,
+                                    0,
+                                    0,
+                                    5,
+                                    test_alloc_mbuf,
+                                    test_send_mbuf,
+                                    NULL,
+                                    1500,
+                                    0,
+                                    FH_COMP_NONE,
+                                    0);
   assert(ctx != NULL);
 
   uint64_t current_sym = 1000;
@@ -644,8 +755,12 @@ void test_send_mbuf_prach(void *io_controller, struct rte_mbuf **mbufs, uint32_t
     // In this test, we expect exactly 20 PRBs in the header
     assert(sent_sec->fields.num_prbu == (uint8_t)XRAN_CONVERT_NUMPRBC(20));
     assert(sent_sec->fields.start_prbu == 0);
-    // size includes 14 bytes ethernet header. Data length is exactly 139 SCs (139 * 4 bytes).
-    assert(size == expected_header_len + 139 * 4 + 14);
+    // size includes 14 bytes ethernet header.
+    assert(size == expected_header_len + (139 + TEST_PRACH_KBAR) * 4 + 14);
+    uint16_t *payload = (uint16_t *)(sent_sec + 1);
+    for (int j = 0; j < TEST_PRACH_KBAR; j++)
+      assert(payload[j] == 0);
+    assert(rte_be_to_cpu_16(payload[TEST_PRACH_KBAR]) == 1);
 
     rte_pktmbuf_free(mbuf);
   }
@@ -732,14 +847,58 @@ void test_send_mbuf_prb_offset(void *io_controller, struct rte_mbuf **mbufs, uin
   }
 }
 
+void test_send_mbuf_ul_bfp(void *io_controller, struct rte_mbuf **mbufs, uint32_t num_mbufs)
+{
+  for (uint32_t i = 0; i < num_mbufs; i++) {
+    struct rte_mbuf *mbuf = mbufs[i];
+    g_packets_sent++;
+
+    struct xran_ecpri_hdr *sent_ecpri = rte_pktmbuf_mtod(mbuf, struct xran_ecpri_hdr *);
+    struct radio_app_common_hdr *sent_app = (struct radio_app_common_hdr *)(sent_ecpri + 1);
+    struct data_section_hdr *sent_sec = (struct data_section_hdr *)(sent_app + 1);
+    sent_sec->fields.all_bits = rte_be_to_cpu_32(sent_sec->fields.all_bits);
+
+    struct data_section_compression_hdr *sent_comp = (struct data_section_compression_hdr *)(sent_sec + 1);
+    assert(sent_comp->ud_comp_hdr.ud_comp_meth == FH_COMP_BFP);
+    assert(sent_comp->ud_comp_hdr.ud_iq_width == (uint8_t)XRAN_CONVERT_IQWIDTH(g_ul_test_iq_width));
+
+    int num_prb = sent_sec->fields.num_prbu == 0 ? 273 : (int)sent_sec->fields.num_prbu;
+    size_t header_len = sizeof(struct xran_ecpri_hdr) + sizeof(struct radio_app_common_hdr)
+                        + sizeof(struct data_section_hdr) + sizeof(struct data_section_compression_hdr);
+    size_t payload_len = rte_pktmbuf_pkt_len(mbuf) - header_len;
+    assert(payload_len == (size_t)FH_COMP_PRB_BYTES(g_ul_test_iq_width) * num_prb);
+
+    const int8_t *payload = (const int8_t *)(sent_comp + 1);
+    fh_decompress_prbs(FH_COMP_BFP, g_ul_test_iq_width, num_prb, payload, g_ul_recovered_iq);
+
+    rte_pktmbuf_free(mbuf);
+  }
+}
+
 void test_uplink_basic()
 {
   printf("Testing basic uplink...\n");
   int mu = 1;
   int num_prb = 100;
   g_packets_sent = 0;
-  void *ctx =
-      init_packet_processor(mu, num_prb, 200, 400, 100, 300, 2, 2, 0, 0, 5, test_alloc_mbuf, test_send_mbuf_no_frag, NULL, 1500, 0);
+  void *ctx = init_packet_processor(mu,
+                                    num_prb,
+                                    200,
+                                    400,
+                                    100,
+                                    300,
+                                    2,
+                                    2,
+                                    0,
+                                    0,
+                                    5,
+                                    test_alloc_mbuf,
+                                    test_send_mbuf_no_frag,
+                                    NULL,
+                                    1500,
+                                    0,
+                                    FH_COMP_NONE,
+                                    0);
   assert(ctx != NULL);
 
   // Pattern: 5 slots, 2 DL, 2 UL. Symbols 0-27 DL, 42-69 UL.
@@ -814,8 +973,24 @@ void test_uplink_fragmentation()
   int mu = 1;
   int num_prb = 100;
   g_packets_sent = 0;
-  void *ctx =
-      init_packet_processor(mu, num_prb, 200, 400, 100, 300, 2, 2, 0, 0, 5, test_alloc_mbuf, test_send_mbuf_frag, NULL, 1500, 0);
+  void *ctx = init_packet_processor(mu,
+                                    num_prb,
+                                    200,
+                                    400,
+                                    100,
+                                    300,
+                                    2,
+                                    2,
+                                    0,
+                                    0,
+                                    5,
+                                    test_alloc_mbuf,
+                                    test_send_mbuf_frag,
+                                    NULL,
+                                    1500,
+                                    0,
+                                    FH_COMP_NONE,
+                                    0);
   assert(ctx != NULL);
 
   // Pattern: 5 slots, 2 DL, 2 UL. Symbols 0-27 DL, 42-69 UL.
@@ -906,6 +1081,8 @@ void test_uplink_large_mtu()
                                     test_send_mbuf_large_mtu,
                                     NULL,
                                     9600,
+                                    0,
+                                    FH_COMP_NONE,
                                     0);
   assert(ctx != NULL);
 
@@ -996,6 +1173,8 @@ void test_uplink_prb_offset()
                                     test_send_mbuf_prb_offset,
                                     NULL,
                                     1500,
+                                    0,
+                                    FH_COMP_NONE,
                                     0);
   assert(ctx != NULL);
 
@@ -1086,7 +1265,9 @@ void test_prach_generation()
                                     test_send_mbuf_prach,
                                     NULL,
                                     1500,
-                                    prach_eaxc_offset);
+                                    prach_eaxc_offset,
+                                    FH_COMP_NONE,
+                                    TEST_PRACH_KBAR);
   assert(ctx != NULL);
 
   // Pattern: 5 slots, 2 DL, 2 UL. Symbols 0-27 DL, 42-69 UL.
@@ -1136,6 +1317,9 @@ void test_prach_generation()
   uint32_t *txdataF[1];
   uint32_t iq_input[100 * 12];
   memset(iq_input, 0, sizeof(iq_input));
+  uint16_t *iq_raw = (uint16_t *)iq_input;
+  for (int i = 0; i < 139 * 2; i++)
+    iq_raw[i] = i + 1;
   txdataF[0] = iq_input;
 
   for (int i = 0; i < 4; i++) {
@@ -1158,7 +1342,24 @@ void test_hyper_frame_calculation()
   printf("Testing hyper-frame calculation...\n");
   int mu = 1; // 30kHz
   int slots_per_subframe = 1 << mu;
-  void *ctx = init_packet_processor(mu, 273, 200, 400, 100, 300, 2, 2, 0, 0, 5, test_alloc_mbuf, test_send_mbuf, NULL, 1500, 0);
+  void *ctx = init_packet_processor(mu,
+                                    273,
+                                    200,
+                                    400,
+                                    100,
+                                    300,
+                                    2,
+                                    2,
+                                    0,
+                                    0,
+                                    5,
+                                    test_alloc_mbuf,
+                                    test_send_mbuf,
+                                    NULL,
+                                    1500,
+                                    0,
+                                    FH_COMP_NONE,
+                                    0);
   assert(ctx != NULL);
 
   int num_symbols_per_frame = 10 * slots_per_subframe * 14; // 280
@@ -1249,6 +1450,206 @@ void test_hyper_frame_calculation()
   printf("Hyper-frame calculation test passed!\n");
 }
 
+void test_dl_bfp_decompression(void)
+{
+  printf("Testing DL BFP decompression...\n");
+  int mu = 1;
+  int slots_per_subframe = 1 << mu;
+  const int n_prb = 1;
+  const int iq_bits = 9;
+
+  int16_t src_iq[FH_VALS_PER_PRB];
+  for (int i = 0; i < FH_VALS_PER_PRB; i += 2) {
+    src_iq[i] = 100;
+    src_iq[i + 1] = -200;
+  }
+  int8_t pre_compressed[FH_COMP_PRB_BYTES(iq_bits)];
+  fh_compress_prbs(FH_COMP_BFP, iq_bits, n_prb, src_iq, pre_compressed);
+
+  void *ctx = init_packet_processor(mu, 273, 200, 400, 100, 300,
+                                    2, 2, 0, 0, 5,
+                                    test_alloc_mbuf, test_send_mbuf,
+                                    NULL, 1500, 0,
+                                    FH_COMP_BFP, 0);
+  assert(ctx != NULL);
+
+  uint64_t current_sym = 1000;
+  handle_absolute_symbol_tick(ctx, current_sym);
+  uint64_t target_sym = current_sym + 7;
+
+  int num_symbols_per_frame = 10 * slots_per_subframe * 14;
+  int slot_in_frame = (target_sym % num_symbols_per_frame) / 14;
+
+  // DL C-plane
+  struct rte_mbuf *c_mbuf = rte_pktmbuf_alloc(mp);
+  struct xran_ecpri_hdr *ecpri = (struct xran_ecpri_hdr *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_ecpri_hdr));
+  ecpri->ecpri_xtc_id = xran_compose_cid(&g_eaxcid_config, 0, 0, 0, 0);
+  struct xran_cp_radioapp_section1_header *apphdr =
+      (struct xran_cp_radioapp_section1_header *)rte_pktmbuf_append(c_mbuf, sizeof(*apphdr));
+  memset(apphdr, 0, sizeof(*apphdr));
+  apphdr->cmnhdr.field.dataDirection = XRAN_DIR_DL;
+  apphdr->cmnhdr.field.payloadVer = XRAN_PAYLOAD_VER;
+  apphdr->cmnhdr.field.frameId = (target_sym / num_symbols_per_frame) % 256;
+  apphdr->cmnhdr.field.subframeId = slot_in_frame / slots_per_subframe;
+  apphdr->cmnhdr.field.slotId = slot_in_frame % slots_per_subframe;
+  apphdr->cmnhdr.field.startSymbolId = target_sym % 14;
+  apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
+  apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
+  struct xran_cp_radioapp_section1 *sec =
+      (struct xran_cp_radioapp_section1 *)rte_pktmbuf_append(c_mbuf, sizeof(*sec));
+  memset(sec, 0, sizeof(*sec));
+  sec->hdr.u.s1.numSymbol = 1;
+  sec->hdr.u1.common.numPrbc = n_prb;
+  *((uint64_t *)sec) = rte_be_to_cpu_64(*((uint64_t *)sec));
+  handle_cplane_packet(ctx, c_mbuf);
+
+  current_sym += 3;
+  handle_absolute_symbol_tick(ctx, current_sym);
+
+  // DL U-plane with BFP compression header + pre-compressed payload
+  struct rte_mbuf *u_mbuf = rte_pktmbuf_alloc(mp);
+  struct xran_ecpri_hdr *u_ecpri = (struct xran_ecpri_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct xran_ecpri_hdr));
+  u_ecpri->ecpri_xtc_id = xran_compose_cid(&g_eaxcid_config, 0, 0, 0, 0);
+  struct radio_app_common_hdr *u_app =
+      (struct radio_app_common_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct radio_app_common_hdr));
+  u_app->frame_id = (target_sym / num_symbols_per_frame) % 256;
+  u_app->sf_slot_sym.subframe_id = slot_in_frame / slots_per_subframe;
+  u_app->sf_slot_sym.slot_id = slot_in_frame % slots_per_subframe;
+  u_app->sf_slot_sym.symb_id = target_sym % 14;
+  u_app->sf_slot_sym.value = rte_cpu_to_be_16(u_app->sf_slot_sym.value);
+  struct data_section_hdr *u_data = (struct data_section_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct data_section_hdr));
+  u_data->fields.num_prbu = n_prb;
+  u_data->fields.start_prbu = 0;
+  u_data->fields.sect_id = 0;
+  u_data->fields.all_bits = rte_cpu_to_be_32(u_data->fields.all_bits);
+  struct data_section_compression_hdr *comp_hdr =
+      (struct data_section_compression_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct data_section_compression_hdr));
+  memset(comp_hdr, 0, sizeof(*comp_hdr));
+  comp_hdr->ud_comp_hdr.ud_comp_meth = FH_COMP_BFP;
+  comp_hdr->ud_comp_hdr.ud_iq_width = XRAN_CONVERT_IQWIDTH(iq_bits);
+  int8_t *payload = (int8_t *)rte_pktmbuf_append(u_mbuf, FH_COMP_PRB_BYTES(iq_bits) * n_prb);
+  assert(payload != NULL);
+  memcpy(payload, pre_compressed, FH_COMP_PRB_BYTES(iq_bits) * n_prb);
+
+  handle_uplane_packet(ctx, u_mbuf);
+
+  oru_packet_processor_stats_t stats;
+  get_packet_processor_stats(ctx, &stats);
+  assert(stats.uplane_err_early == 0);
+  assert(stats.uplane_err_late == 0);
+
+  current_sym += 10;
+  handle_absolute_symbol_tick(ctx, current_sym);
+
+  uint32_t *txdataF[4] = {0};
+  uint32_t output_iq[273 * 12] = {0};
+  txdataF[0] = output_iq;
+
+  int frame, slot, symbol;
+  uint64_t hyper_frame;
+  do {
+    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol);
+  } while (!(frame == (int)((target_sym / num_symbols_per_frame) % 1024) && symbol == (int)(target_sym % 14)));
+
+  // I=100, Q=-200 with exponent=0: exact round-trip through BFP
+  int16_t *recovered = (int16_t *)output_iq;
+  for (int i = 0; i < n_prb * FH_VALS_PER_PRB; i++)
+    assert(recovered[i] == src_iq[i]);
+
+  cleanup_packet_processor(ctx);
+  printf("DL BFP decompression passed!\n");
+}
+
+void test_ul_bfp_compression(void)
+{
+  printf("Testing UL BFP compression...\n");
+  int mu = 1;
+  int slots_per_subframe = 1 << mu;
+  const int iq_bits = 9;
+
+  // I=100, Q=-200: exponent=0 means exact round-trip after compress/decompress
+  for (int i = 0; i < g_ul_test_num_prb * FH_VALS_PER_PRB; i += 2) {
+    g_ul_known_src[i] = 100;
+    g_ul_known_src[i + 1] = -200;
+  }
+  memset(g_ul_recovered_iq, 0, sizeof(g_ul_recovered_iq));
+
+  g_packets_sent = 0;
+  void *ctx = init_packet_processor(mu, 100, 200, 400, 100, 300,
+                                    2, 2, 0, 0, 5,
+                                    test_alloc_mbuf, test_send_mbuf_ul_bfp,
+                                    NULL, 1500, 0,
+                                    FH_COMP_NONE,
+                                    0);
+  assert(ctx != NULL);
+
+  uint64_t current_sym = 47; // 47 % 70 = 47 (UL)
+  handle_absolute_symbol_tick(ctx, current_sym);
+
+  uint64_t target_sym = current_sym + 5; // 52 % 70 = 52 (UL)
+  int num_symbols_per_frame = 10 * slots_per_subframe * 14;
+  int frameId = (target_sym / num_symbols_per_frame) % 256;
+  int slot_in_frame = (target_sym % num_symbols_per_frame) / 14;
+  int subframeId = slot_in_frame / slots_per_subframe;
+  int slotId = slot_in_frame % slots_per_subframe;
+  int startSymbolId = target_sym % 14;
+
+  // UL C-plane with BFP compression fields
+  struct rte_mbuf *c_mbuf = rte_pktmbuf_alloc(mp);
+  struct xran_ecpri_hdr *ecpri = (struct xran_ecpri_hdr *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_ecpri_hdr));
+  ecpri->ecpri_xtc_id = xran_compose_cid(&g_eaxcid_config, 0, 0, 0, 0);
+  struct xran_cp_radioapp_section1_header *apphdr =
+      (struct xran_cp_radioapp_section1_header *)rte_pktmbuf_append(c_mbuf, sizeof(*apphdr));
+  memset(apphdr, 0, sizeof(*apphdr));
+  apphdr->cmnhdr.field.dataDirection = XRAN_DIR_UL;
+  apphdr->cmnhdr.field.payloadVer = XRAN_PAYLOAD_VER;
+  apphdr->cmnhdr.field.frameId = frameId;
+  apphdr->cmnhdr.field.subframeId = subframeId;
+  apphdr->cmnhdr.field.slotId = slotId;
+  apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+  apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
+  apphdr->udComp.udCompMeth = FH_COMP_BFP;
+  apphdr->udComp.udIqWidth = XRAN_CONVERT_IQWIDTH(iq_bits);
+  apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
+  struct xran_cp_radioapp_section1 *sec =
+      (struct xran_cp_radioapp_section1 *)rte_pktmbuf_append(c_mbuf, sizeof(*sec));
+  memset(sec, 0, sizeof(*sec));
+  sec->hdr.u.s1.numSymbol = 1;
+  sec->hdr.u1.common.numPrbc = g_ul_test_num_prb;
+  sec->hdr.u1.common.startPrbc = 0;
+  sec->hdr.u1.common.sectionId = 99;
+  *((uint64_t *)sec) = rte_be_to_cpu_64(*((uint64_t *)sec));
+  handle_cplane_packet(ctx, c_mbuf);
+
+  // Poll UL job and verify compression params propagated from C-plane
+  ul_job_t job;
+  int poll_ret = poll_ul_job(ctx, &job);
+  assert(poll_ret == 0);
+  assert(job.num_prb == g_ul_test_num_prb);
+  assert(job.response_payload.comp_method == FH_COMP_BFP);
+  assert(job.response_payload.iq_width == XRAN_CONVERT_IQWIDTH(iq_bits));
+
+  // Build iq_input in OAI format: each uint32 = I(low16) | Q(high16)
+  uint32_t iq_input[100 * 12];
+  memset(iq_input, 0, sizeof(iq_input));
+  for (int i = 0; i < g_ul_test_num_prb * 12; i++) {
+    uint16_t I = (uint16_t)g_ul_known_src[i * 2];
+    uint16_t Q = (uint16_t)g_ul_known_src[i * 2 + 1];
+    iq_input[i] = (uint32_t)I | ((uint32_t)Q << 16);
+  }
+
+  write_ul_iq(ctx, iq_input, startSymbolId, &job);
+
+  assert(g_packets_sent == 1);
+
+  // Verify: decompressed IQ in stub matches original (exponent=0 -> exact)
+  for (int i = 0; i < g_ul_test_num_prb * FH_VALS_PER_PRB; i++)
+    assert(g_ul_recovered_iq[i] == g_ul_known_src[i]);
+
+  cleanup_packet_processor(ctx);
+  printf("UL BFP compression passed!\n");
+}
+
 int main(int argc, char **argv)
 {
   setup_dpdk(argc, argv);
@@ -1276,6 +1677,10 @@ int main(int argc, char **argv)
   test_prach_generation();
   usleep(10000);
   test_hyper_frame_calculation();
+  usleep(10000);
+  test_dl_bfp_decompression();
+  usleep(10000);
+  test_ul_bfp_compression();
   usleep(10000);
 
   printf("All tests passed!\n");

--- a/fronthaul/oru/tests/test_oru_pcap.c
+++ b/fronthaul/oru/tests/test_oru_pcap.c
@@ -118,7 +118,9 @@ int main(int argc, char *argv[])
                                     test_send_mbuf,
                                     NULL,
                                     mtu,
-                                    prach_eaxc_offset);
+                                    prach_eaxc_offset,
+                                    FH_COMP_NONE,
+                                    0);
   assert(ctx != NULL);
 
   char errbuf[PCAP_ERRBUF_SIZE];

--- a/fronthaul/xran_pkt/xran_pkt_api.c
+++ b/fronthaul/xran_pkt/xran_pkt_api.c
@@ -98,7 +98,7 @@ int32_t xran_extract_iq_samples(struct rte_mbuf *mbuf,
       return 0;
     *compMeth = compr_hdr->ud_comp_hdr.ud_comp_meth;
     *iqWidth = compr_hdr->ud_comp_hdr.ud_iq_width;
-    *iq_data_start = rte_pktmbuf_mtod(mbuf, void *);
+    *iq_data_start = (void *)rte_pktmbuf_adj(mbuf, sizeof(*compr_hdr));
   } else {
     *iq_data_start = (void *)rte_pktmbuf_adj(mbuf, sizeof(*data_hdr));
   }

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.106prb.fhi72.1x1-oru.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.106prb.fhi72.1x1-oru.conf
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+Active_gNBs = ( "gNB-OAI");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    =  0xe00;
+    gNB_name  =  "gNB-OAI";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  1;
+    plmn_list = ({ mcc = 208; mnc = 99; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345678L;
+
+    ////////// Physical parameters:
+
+    pdsch_AntennaPorts_N1 = 1;
+    maxMIMO_layers        = 1;
+    min_rxtxtime = 6;
+
+    servingCellConfigCommon = (
+    {
+ #spCellConfigCommon
+
+      physCellId                                                    = 0;
+     # n_TimingAdvanceOffset                                         = 0;
+#  downlinkConfigCommon
+    #frequencyInfoDL
+      # center frequency = 4049.76 MHz
+      # selected SSB frequency = 4049.76 MHz
+      absoluteFrequencySSB                                          = 669984;
+      dl_frequencyBand                                              = 77;
+      # frequency point A = 4030.68 MHz
+      dl_absoluteFrequencyPointA                                    = 668712;
+      #scs-SpecificCarrierList
+        dl_offstToCarrier                                           = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing                                        = 1;
+        dl_carrierBandwidth                                         = 106;
+     #initialDownlinkBWP
+      #genericParameters
+       initialDLBWPlocationAndBandwidth                             = 28875; #38.101-1 Table 5.3.2-1
+       #
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing                               = 1;
+      #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero                          = 11;
+        initialDLBWPsearchSpaceZero                                 = 0;
+
+  #uplinkConfigCommon
+     #frequencyInfoUL
+      ul_frequencyBand                                              = 77;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 106;
+      pMax                                                          = 23;
+     #initialUplinkBWP
+      #genericParameters
+        initialULBWPlocationAndBandwidth                            = 28875;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+        #rach-ConfigGeneric
+          prach_ConfigurationIndex                                  = 157;
+#prach_msg1_FDM
+#0 = one, 1=two, 2=four, 3=eight
+          prach_msg1_FDM                                            = 0;
+          prach_msg1_FrequencyStart                                 = 0;
+          zeroCorrelationZoneConfig                                 = 0;
+          preambleReceivedTargetPower                               = -100;
+#preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+          preambleTransMax                                          = 7;
+#powerRampingStep
+# 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep                                            = 2;
+#ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+#1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+#one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 15;
+#ra_ContentionResolutionTimer
+#(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer                                = 7;
+        rsrp_ThresholdSSB                                           = 19;
+#prach-RootSequenceIndex_PR
+#1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR                                  = 2;
+        prach_RootSequenceIndex                                     = 1;
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        #
+        msg1_SubcarrierSpacing                                      = 1,
+# restrictedSetConfig
+# 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig                                         = 0,
+
+# this is the offset between the last PRACH preamble power and the Msg3 PUSCH, 2 times the field value in dB
+        msg3_DeltaPreamble                                          = 2;
+        p0_NominalWithGrant                                         = -100;
+
+# pucch-ConfigCommon setup :
+# pucchGroupHopping
+# 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping                                           = 0;
+        hoppingId                                                   = 0;
+        p0_nominal                                                  = -96;
+
+      ssb_PositionsInBurst_Bitmap                                   = 0x1;
+
+# ssb_periodicityServingCell
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+# dmrs_TypeA_position
+# 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+  #tdd-UL-DL-ConfigurationCommon
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 5;
+      nrofDownlinkSlots                                             = 3;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 1;
+      nrofUplinkSymbols                                             = 4;
+
+  ssPBCH_BlockPower                                                 = 0;
+  }
+
+  );
+
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+    ////////// AMF parameters:
+    amf_ip_address = ({ ipv4 = "192.168.101.132"; });
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.101.140";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "192.168.101.140";
+        GNB_PORT_FOR_NGU                         = 2152; # Spec 2152
+    };
+  }
+);
+
+MACRLCs = (
+{
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 200;
+  pucch_TargetSNRx10          = 200;
+  pusch_FailureThres          = 100;
+}
+);
+
+L1s = (
+{
+  num_cc = 1;
+  tr_n_preference = "local_mac";
+  prach_dtx_threshold = 110;
+  pucch0_dtx_threshold = 80;
+  pusch_dtx_threshold = -100;
+ # thread_pool_size = 8;
+  tx_amp_backoff_dB = 36;
+  L1_rx_thread_core = -1;
+  L1_tx_thread_core = -1;
+  phase_compensation = 0; # needs to match O-RU configuration
+}
+);
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 1;
+  nb_rx          = 1;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  sl_ahead       = 5;
+  tr_preference  = "raw_if4p5"; # important: activate FHI7.2
+  do_precoding   = 0; # needs to match O-RU configuration
+}
+);
+
+security = {
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms = ( "nea0" );
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms = ( "nia2", "nia0" );
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};
+
+fhi_72 = {
+  dpdk_devices = ("0000:05:02.2", "0000:05:02.3"); # one VF can be used as well
+  dpdk_iova_mode = "VA";
+  system_core = 7;
+  io_core = 8;
+  worker_cores = (9);
+  ru_addr = ("00:11:22:33:64:66", "00:11:22:33:64:67");
+  mtu = 9600;
+  fh_config = ({
+    T1a_cp_dl = (285, 470);
+    T1a_cp_ul = (285, 429);
+    T1a_up = (300, 450);
+    Ta4 = (900, 950);
+    ru_config = {
+      comp_hdr_type = "dynamic";
+      iq_width = 9;
+      iq_width_prach = 9;
+    };
+    prach_config = {
+      kbar = 4;
+    };
+  });
+};

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.sa.band77.106prb.fhi72.1x1-oru.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.sa.band77.106prb.fhi72.1x1-oru.conf
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+ORUs = (
+{
+  tx_bw = [106];
+  rx_bw = [106];
+  carrier_tx = [4049760];
+  carrier_rx = [4049760];
+  prach_config_index = 157;
+  prach_msg1_start = 0;
+  tdd_period = 5;
+  num_dl_slots = 3;
+  num_dl_symbols = 6;
+  num_ul_slots = 1;
+  num_ul_symbols = 4;
+  numerology = 1;
+  fronthaul = {
+    dpdk_devices = ("0000:05:02.0", "0000:05:02.1"); # one VF can be used as well
+    rx_core = 25;
+    du_mac_addr = ("00:11:22:33:64:68", "00:11:22:33:64:69");
+    mtu = 9216;
+    T2a_up = (300, 1200);
+    T2a_cp = (285, 1200);
+    prach_eaxc_offset = 1;
+    prach_kbar = 4;
+    extra_eal_args = ("--file-prefix", "ru");
+    comp_type = "bfp";  # options: "none", "bfp", "blkscale", "ulaw"
+  }
+});
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 1;
+  nb_rx          = 1;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  sl_ahead       = 5;
+  tr_preference  = "raw_if4p5"; # important: activate FHI7.2
+  do_precoding   = 0; # needs to match O-RU configuration
+  # PRACH configuration
+  num_tp_cores = 4;
+  tp_cores = [-1,-1,-1,-1];
+});
+
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+};


### PR DESCRIPTION
This PR adds IQ compression support to the native O-RU fronthaul. The O-RU can now compress UL IQ samples before sending them to the O-DU and decompress DL IQ samples received from the O-DU. It supports Block Floating Point, block scaling, and µ-law compression.

The PR also fixes an O-RU startup deadlock that occurred under restricted CPU affinity (when using taskset). The issue was caused by the north and south read threads starting before the DPDK RX loop and blocking while waiting for fronthaul events. The fix starts the RX loop first and creates the application threads afterward.