### PR TITLE
ITTI: cleanup memset after alloc, adopt calloc_or_fail

### DIFF
--- a/common/utils/ocp_itti/intertask_interface.cpp
+++ b/common/utils/ocp_itti/intertask_interface.cpp
@@ -11,6 +11,7 @@
 extern "C" {
 #include <intertask_interface.h>
 #include <common/utils/system.h>
+#include <common/utils/utils.h>
 #include "executables/softmodem-common.h"
 
 typedef struct timer_elm_s {
@@ -40,11 +41,11 @@ typedef struct timer_elm_s {
   static int nb_queues=0;
   static pthread_mutex_t lock_nb_queues;
 
-  void *itti_malloc(task_id_t origin_task_id, task_id_t destination_task_id, ssize_t size) {
-    void *ptr = NULL;
-    AssertFatal ((ptr=calloc (size, 1)) != NULL, "Memory allocation of %zu bytes failed (%d -> %d)!\n",
-                 size, origin_task_id, destination_task_id);
-    return ptr;
+  void *itti_malloc(task_id_t origin_task_id, task_id_t destination_task_id, ssize_t size)
+  {
+    UNUSED(origin_task_id);
+    UNUSED(destination_task_id);
+    return calloc_or_fail(1, size);
   }
 
   int itti_free(task_id_t task_id, void *ptr) {

--- a/openair2/RRC/NR/rrc_gNB_NGAP.c
+++ b/openair2/RRC/NR/rrc_gNB_NGAP.c
@@ -216,7 +216,6 @@ void rrc_gNB_send_NGAP_NAS_FIRST_REQ(gNB_RRC_INST *rrc, gNB_RRC_UE_t *UE, NR_RRC
 {
   MessageDef *message_p = itti_alloc_new_message(TASK_RRC_GNB, rrc->module_id, NGAP_NAS_FIRST_REQ);
   ngap_nas_first_req_t *req = &NGAP_NAS_FIRST_REQ(message_p);
-  memset(req, 0, sizeof(*req));
 
   // RAN UE NGAP ID
   req->gNB_ue_ngap_id = UE->rrc_ue_id;
@@ -654,7 +653,6 @@ void rrc_gNB_send_NGAP_INITIAL_CONTEXT_SETUP_FAIL(uint32_t gnb, const ngap_cause
 {
   MessageDef *msg_p = itti_alloc_new_message(TASK_RRC_GNB, 0, NGAP_INITIAL_CONTEXT_SETUP_FAIL);
   ngap_initial_context_setup_fail_t *fail = &NGAP_INITIAL_CONTEXT_SETUP_FAIL(msg_p);
-  memset(fail, 0, sizeof(*fail));
   fail->gNB_ue_ngap_id = gnb;
   fail->cause = causeP;
   itti_send_msg_to_task(TASK_NGAP, 0, msg_p);
@@ -1417,7 +1415,6 @@ void rrc_gNB_send_NGAP_UE_CONTEXT_RELEASE_REQ(const module_id_t gnb_mod_idP,
     const gNB_RRC_UE_t *UE = &ue_context_pP->ue_context;
     MessageDef *msg = itti_alloc_new_message(TASK_RRC_GNB, 0, NGAP_UE_CONTEXT_RELEASE_REQ);
     ngap_ue_release_req_t *req = &NGAP_UE_CONTEXT_RELEASE_REQ(msg);
-    memset(req, 0, sizeof(*req));
     req->gNB_ue_ngap_id = UE->rrc_ue_id;
     req->cause.type = causeP.type;
     req->cause.value = causeP.value;
@@ -1769,7 +1766,6 @@ void rrc_gNB_send_NGAP_UE_CAPABILITIES_IND(gNB_RRC_INST *rrc, gNB_RRC_UE_t *UE, 
     MessageDef *msg_p;
     msg_p = itti_alloc_new_message (TASK_RRC_GNB, rrc->module_id, NGAP_UE_CAPABILITIES_IND);
     ngap_ue_cap_info_ind_t *ind = &NGAP_UE_CAPABILITIES_IND(msg_p);
-    memset(ind, 0, sizeof(*ind));
     ind->gNB_ue_ngap_id = UE->rrc_ue_id;
     ind->ue_radio_cap.len = encoded;
     ind->ue_radio_cap.buf = buf2;
@@ -1783,7 +1779,6 @@ void rrc_gNB_send_NGAP_HANDOVER_REQUEST_ACKNOWLEDGE(gNB_RRC_INST *rrc, gNB_RRC_U
 
   MessageDef *msg_p = itti_alloc_new_message(TASK_RRC_GNB, 0, NGAP_HANDOVER_REQUEST_ACKNOWLEDGE);
   ngap_handover_request_ack_t *msg = &NGAP_HANDOVER_REQUEST_ACKNOWLEDGE(msg_p);
-  memset(msg, 0, sizeof(*msg));
 
   // RAN UE NGAP ID
   msg->gNB_ue_ngap_id = UE->rrc_ue_id;
@@ -1830,7 +1825,6 @@ void rrc_gNB_send_NGAP_HANDOVER_NOTIFY(gNB_RRC_INST *rrc, gNB_RRC_UE_t *UE)
   }
   MessageDef *msg_p = itti_alloc_new_message(TASK_RRC_GNB, 0, NGAP_HANDOVER_NOTIFY);
   ngap_handover_notify_t *ho_notify = &NGAP_HANDOVER_NOTIFY(msg_p);
-  memset(ho_notify, 0, sizeof(*ho_notify));
 
   ho_notify->gNB_ue_ngap_id = UE->rrc_ue_id;
   ho_notify->amf_ue_ngap_id = UE->amf_ue_ngap_id;
@@ -1858,7 +1852,6 @@ void rrc_gNB_send_NGAP_HANDOVER_CANCEL(int module_id, gNB_RRC_UE_t *UE, ngap_cau
 
   MessageDef *msg_p = itti_alloc_new_message(TASK_RRC_GNB, 0, NGAP_HANDOVER_CANCEL);
   ngap_handover_cancel_t *ho_cancel = &NGAP_HANDOVER_CANCEL(msg_p);
-  memset(ho_cancel, 0, sizeof(*ho_cancel));
 
   /* Mandatory IEs (38.413 §9.2.3.11) */
   ho_cancel->gNB_ue_ngap_id = UE->rrc_ue_id;
@@ -1900,7 +1893,6 @@ void rrc_gNB_send_NGAP_PDUSESSION_RELEASE_RESPONSE(gNB_RRC_INST *rrc, gNB_RRC_UE
   MessageDef   *msg_p;
   msg_p = itti_alloc_new_message (TASK_RRC_GNB, rrc->module_id, NGAP_PDUSESSION_RELEASE_RESPONSE);
   ngap_pdusession_release_resp_t *resp = &NGAP_PDUSESSION_RELEASE_RESPONSE(msg_p);
-  memset(resp, 0, sizeof(*resp));
   resp->gNB_ue_ngap_id = UE->rrc_ue_id;
 
   FOR_EACH_SEQ_ARR(rrc_pdu_session_param_t *, session, &UE->pduSessions) {

--- a/openair3/NGAP/ngap_gNB_handlers.c
+++ b/openair3/NGAP/ngap_gNB_handlers.c
@@ -700,7 +700,6 @@ static int ngap_gNB_handle_handover_request(sctp_assoc_t assoc_id, uint32_t stre
 
   MessageDef *message_p = itti_alloc_new_message(TASK_NGAP, 0, NGAP_HANDOVER_REQUEST);
   ngap_handover_request_t *msg = &NGAP_HANDOVER_REQUEST(message_p);
-  memset(msg, 0, sizeof(*msg));
 
   if (decode_ng_handover_request(msg, pdu) < 0) {
     NGAP_ERROR("Failed to decode NG Handover Request\n");
@@ -771,7 +770,6 @@ static int ngap_gNB_handle_initial_context_request(sctp_assoc_t assoc_id, uint32
   
   MessageDef *message_p = itti_alloc_new_message(TASK_NGAP, 0, NGAP_INITIAL_CONTEXT_SETUP_REQ);
   ngap_initial_context_setup_req_t * msg=&NGAP_INITIAL_CONTEXT_SETUP_REQ(message_p);
-  memset(msg, 0, sizeof(*msg));
   msg->gNB_ue_ngap_id = ue_desc_p->gNB_ue_ngap_id;
   msg->amf_ue_ngap_id = ue_desc_p->amf_ue_ngap_id;
   /* id-UEAggregateMaximumBitRate */
@@ -958,7 +956,6 @@ static int ngap_gNB_handle_pdusession_setup_request(sctp_assoc_t assoc_id, uint3
 
   MessageDef * message_p = itti_alloc_new_message(TASK_NGAP, 0, NGAP_PDUSESSION_SETUP_REQ);
   ngap_pdusession_setup_req_t * msg=&NGAP_PDUSESSION_SETUP_REQ(message_p);
-  memset(msg, 0, sizeof(*msg));
   msg->gNB_ue_ngap_id = ue_desc_p->gNB_ue_ngap_id;
   msg->amf_ue_ngap_id = ue_desc_p->amf_ue_ngap_id;
 
@@ -1015,7 +1012,6 @@ static int ngap_gNB_handle_handover_command(sctp_assoc_t assoc_id, uint32_t stre
 
   MessageDef *message_p = itti_alloc_new_message(TASK_NGAP, 0, NGAP_HANDOVER_COMMAND);
   ngap_handover_command_t *msg = &NGAP_HANDOVER_COMMAND(message_p);
-  memset(msg, 0, sizeof(*msg));
   if (decode_ng_handover_command(msg, pdu) < 0) {
     NGAP_ERROR("Failed to decode NG Handover Command");
     free_ng_handover_command(msg);
@@ -1322,7 +1318,6 @@ static int ngap_gNB_handle_pdusession_modify_request(sctp_assoc_t assoc_id, uint
               (uint64_t)ue_desc_p->amf_ue_ngap_id, amf_ue_ngap_id);
     MessageDef *message_p = itti_alloc_new_message (TASK_RRC_GNB, 0, NGAP_PDUSESSION_MODIFY_RESP);
     ngap_pdusession_modify_resp_t* msg=&NGAP_PDUSESSION_MODIFY_RESP(message_p);
-    memset(msg, 0, sizeof(*msg));
     msg->gNB_ue_ngap_id = gnb_ue_ngap_id;
     for (int nb_of_pdusessions_failed = 0; nb_of_pdusessions_failed < ie->value.choice.PDUSessionResourceModifyListModReq.list.count; nb_of_pdusessions_failed++) {
         NGAP_PDUSessionResourceModifyItemModReq_t *item_p;
@@ -1340,7 +1335,6 @@ static int ngap_gNB_handle_pdusession_modify_request(sctp_assoc_t assoc_id, uint
 
   MessageDef *message_p = itti_alloc_new_message(TASK_NGAP, 0, NGAP_PDUSESSION_MODIFY_REQ);
   ngap_pdusession_modify_req_t * msg=&NGAP_PDUSESSION_MODIFY_REQ(message_p);
-  memset(msg, 0, sizeof(*msg));
   msg->amf_ue_ngap_id  = amf_ue_ngap_id;
   msg->gNB_ue_ngap_id = gnb_ue_ngap_id;
 
@@ -1425,7 +1419,6 @@ static int ngap_gNB_handle_pdusession_release_command(sctp_assoc_t assoc_id, uin
              assoc_id, gnb_ue_ngap_id, amf_ue_ngap_id);
   MessageDef * message_p = itti_alloc_new_message(TASK_NGAP, 0, NGAP_PDUSESSION_RELEASE_COMMAND);
   ngap_pdusession_release_command_t * msg=&NGAP_PDUSESSION_RELEASE_COMMAND(message_p);
-  memset(msg, 0, sizeof(*msg));
 
   msg->gNB_ue_ngap_id = gnb_ue_ngap_id;
   msg->amf_ue_ngap_id = amf_ue_ngap_id;
@@ -1508,7 +1501,6 @@ static int ngap_gNB_handle_dl_ran_status_transfer(sctp_assoc_t assoc_id, uint32_
 
   MessageDef *message_p = itti_alloc_new_message(TASK_NGAP, 0, NGAP_DL_RAN_STATUS_TRANSFER);
   ngap_ran_status_transfer_t *msg = &NGAP_DL_RAN_STATUS_TRANSFER(message_p);
-  memset(msg, 0, sizeof(*msg));
 
   msg->amf_ue_ngap_id = amf_ue_ngap_id;
   msg->gnb_ue_ngap_id = gnb_ue_ngap_id;


### PR DESCRIPTION
In NGAP/RRC memset calls after itti_alloc_new_message are redundant since memory is already zero-initialized by itti_alloc_new_message via calloc().

Also, in itti_malloc, manual calloc + AssertFatal  is replaced by calloc_or_fail, which provides better error messages and calls abort().