### PR TITLE
Update the OAI UE config parameters check range with the standard SST and SD values

### DIFF
--- a/openair3/UICC/pdu_session.c
+++ b/openair3/UICC/pdu_session.c
@@ -34,8 +34,8 @@
               3 /*PDU_SESSION_TYPE_IPV4V6*/,         \
               5 /*PDU_SESSION_TYPE_ETHER*/},         \
              4}},                                    \
-    {.s2 = {config_check_intrange, {1, 4}}},         \
-    {.s2 = {config_check_intrange, {1, 0xffffff}}},  \
+    {.s2 = {config_check_intrange, {0, 127}}},       \
+    {.s2 = {config_check_intrange, {0, 0xffffff}}},  \
     {.s4 = {config_check_dnn}},                      \
 }
 // clang-format on


### PR DESCRIPTION
This PR updates the SST and SD authorized range provided for OAI UE UICC configuration check as per the S-NSSAI as defined in TS 24.501 Sec. 9.11.2.8 and TS 23.003 Sec. 28.4.2.
The standard SST range is from 0 to 127 (while 128 to 255 are reserved for operator-specific purposes) and 
standard SD range is from 0x000000 to 0xFFFFFF.

Thanks to IOS-MCN, IISc for providing the IOS-MCN-CORE setup to test the ue-nas-simulator.