### PR TITLE
fix(phy): Fix an uninitialized variable bug in dot_product

### DIFF
--- a/openair1/PHY/TOOLS/cdot_prod.c
+++ b/openair1/PHY/TOOLS/cdot_prod.c
@@ -17,7 +17,7 @@
 c32_t dot_product(const c16_t *x, const c16_t *y, const uint32_t N, const int output_shift)
 {
 
-  c32_t ret;
+  c32_t ret = {0, 0};
 
   const c16_t *end = x + N;
 


### PR DESCRIPTION
This was only present on non x86 systems.