### PR TITLE
fix(PHY): compare NID2 instead of NID1 in rx_sss_nr() coherence check

### DIFF
--- a/openair1/PHY/NR_UE_TRANSPORT/sss_nr.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/sss_nr.c
@@ -217,7 +217,7 @@ sss_detection_result_t rx_sss_nr(nr_sss_params_t *params,
   int Nid1_start = 0;
   int Nid1_end = N_ID_1_NUMBER;
   if (target_Nid_cell != -1) {
-    if (GET_NID1(target_Nid_cell) != pss->nid2) {
+    if (GET_NID2(target_Nid_cell) != pss->nid2) {
       LOG_E(PHY, "calling sss detection with incoherent context %d, %d\n", pss->nid2, target_Nid_cell);
     } else {
       Nid1_start = GET_NID1(target_Nid_cell);


### PR DESCRIPTION
target_Nid_cell was being decomposed with GET_NID1() and compared against pss->nid2 (the detected PSS NID2). Since Nid1 != Nid2 in almost all cases, the coherence check always failed, forcing an exhaustive 336-hypothesis SSS search instead of the intended single-candidate fast path when validating a known neighbor PCI, and spamming LOG_E on every such call.

Closes: #296