### PR TITLE
Improve PUSCH delay estimates for TA update

### DIFF
--- a/common/utils/nr/nr_common.h
+++ b/common/utils/nr/nr_common.h
@@ -173,6 +173,8 @@ typedef struct frame_structure_s {
 typedef struct {
   /// Time shift in number of samples estimated based on DMRS-PDSCH/PUSCH
   int est_delay;
+  /// True when est_delay is based on a clear enough channel impulse response peak
+  bool valid;
   /// Max position in OFDM symbol related to time shift estimation based on DMRS-PDSCH/PUSCH
   int delay_max_pos;
   /// Max value related to time shift estimation based on DMRS-PDSCH/PUSCH

--- a/openair1/PHY/NR_ESTIMATION/nr_ul_channel_estimation.c
+++ b/openair1/PHY/NR_ESTIMATION/nr_ul_channel_estimation.c
@@ -614,10 +614,8 @@ int nr_pusch_channel_estimation(PHY_VARS_gNB *gNB,
     nest_count += nest_count_arr[aarx];
   }
   // get the maximum delay
-  *delay = delay_arr[0];
-  for (int aarx = 1; aarx < nb_antennas_rx; aarx++) {
-    if ((delay_arr[aarx].valid && !delay->valid)
-        || (delay_arr[aarx].valid == delay->valid && delay_arr[aarx].est_delay >= delay->est_delay)) {
+  for (int aarx = 0; aarx < nb_antennas_rx; aarx++) {
+    if (delay_arr[aarx].valid && delay_arr[aarx].delay_max_val > delay->delay_max_val) {
       *delay = delay_arr[aarx];
     }
   }

--- a/openair1/PHY/NR_ESTIMATION/nr_ul_channel_estimation.c
+++ b/openair1/PHY/NR_ESTIMATION/nr_ul_channel_estimation.c
@@ -616,7 +616,8 @@ int nr_pusch_channel_estimation(PHY_VARS_gNB *gNB,
   // get the maximum delay
   *delay = delay_arr[0];
   for (int aarx = 1; aarx < nb_antennas_rx; aarx++) {
-    if (delay_arr[aarx].est_delay >= delay->est_delay) {
+    if ((delay_arr[aarx].valid && !delay->valid)
+        || (delay_arr[aarx].valid == delay->valid && delay_arr[aarx].est_delay >= delay->est_delay)) {
       *delay = delay_arr[aarx];
     }
   }

--- a/openair1/PHY/nr_phy_common/src/nr_phy_common.c
+++ b/openair1/PHY/nr_phy_common/src/nr_phy_common.c
@@ -370,7 +370,8 @@ void nr_est_delay(int ofdm_symbol_size, const c16_t *ls_est, c16_t *ch_estimates
   // estimated delay, and causing the delay compensation to worsen the result instead of improving it. After analyzing several
   // peaks, and doing many tests, a PEAK_DETECT_THRESHOLD = 15 is an adequate value, to apply delay compensation only when there is
   // clearly a peak
-  delay->est_delay = mean_val > 0 && max_val / mean_val > PEAK_DETECT_THRESHOLD ? max_pos - sync_pos : 0;
+  delay->valid = mean_val > 0 && max_val / mean_val > PEAK_DETECT_THRESHOLD;
+  delay->est_delay = delay->valid ? max_pos - sync_pos : 0;
 }
 
 unsigned int nr_get_tx_amp(int power_dBm, int power_max_dBm, int total_nb_rb, int nb_rb)

--- a/openair1/SCHED_NR/phy_procedures_nr_gNB.c
+++ b/openair1/SCHED_NR/phy_procedures_nr_gNB.c
@@ -429,37 +429,42 @@ static void nr_fill_indication(const PHY_VARS_gNB *gNB,
 {
   // Get estimated timing advance for MAC
   const int sync_pos = pusch->delay.est_delay;
+  int timing_advance_update = 0xffff;
 
   // scale the 16 factor in N_TA calculation in 38.213 section 4.2 according to the used FFT size
   uint16_t bw_scaling = 16 * gNB->frame_parms.ofdm_symbol_size / 2048;
 
-  // do some integer rounding to improve TA accuracy
-  int sync_pos_rounded;
-  if (sync_pos > 0)
-    sync_pos_rounded = sync_pos + (bw_scaling / 2) - 1;
-  else
-    sync_pos_rounded = sync_pos - (bw_scaling / 2) + 1;
   if (stats)
     stats->ulsch_stats.sync_pos = sync_pos;
 
-  int timing_advance_update = sync_pos_rounded / bw_scaling;
+  if (pusch->delay.valid) {
+    // do some integer rounding to improve TA accuracy
+    int sync_pos_rounded;
+    if (sync_pos > 0)
+      sync_pos_rounded = sync_pos + (bw_scaling / 2) - 1;
+    else
+      sync_pos_rounded = sync_pos - (bw_scaling / 2) + 1;
 
-  // put timing advance command in 0..63 range
-  timing_advance_update += 31;
-  timing_advance_update = max(timing_advance_update, 0);
-  timing_advance_update = min(timing_advance_update, 63);
+    timing_advance_update = sync_pos_rounded / bw_scaling;
+
+    // put timing advance command in 0..63 range
+    timing_advance_update += 31;
+    timing_advance_update = max(timing_advance_update, 0);
+    timing_advance_update = min(timing_advance_update, 63);
+  }
 
   // estimate UL_CQI for MAC
   int SNRtimes10 = dB_fixed_x10(pusch->ulsch_power_tot) - dB_fixed_x10(pusch->ulsch_noise_power_tot);
 
   LOG_D(PHY,
-        "%d.%d: Estimated SNR for PUSCH is = %f dB (ulsch_power %f, noise %f) delay %d\n",
+        "%d.%d: Estimated SNR for PUSCH is = %f dB (ulsch_power %f, noise %f) delay %d%s\n",
         frame,
         slot_rx,
         SNRtimes10 / 10.0,
         dB_fixed_x10(pusch->ulsch_power_tot) / 10.0,
         dB_fixed_x10(pusch->ulsch_noise_power_tot) / 10.0,
-        sync_pos);
+        sync_pos,
+        pusch->delay.valid ? "" : " (invalid)");
 
   int cqi;
   if      (SNRtimes10 < -640) cqi=0;


### PR DESCRIPTION
This PR prevents invalid PUSCH delay measurements from triggering timing-advance updates.
Tracks whether the channel impulse response has a sufficiently clear peak for a reliable delay estimate.
Reports 0xffff instead of a timing-advance command when the delay estimate is invalid.
Marks invalid estimates in PHY debug logs.
For multiple receive antennas, selects the valid delay estimate with the strongest channel impulse response peak instead of the numerically largest delay.
This avoids erroneous timing-advance adjustments under noisy or weak-signal conditions.

Closes: #208 