### PR TITLE
fix(ci): fetch PR head so fork branches are checked for pre-ci-checks

### DIFF
--- a/ci-scripts/pre-ci-check.sh
+++ b/ci-scripts/pre-ci-check.sh
@@ -52,6 +52,12 @@ while getopts ":s:t:h" opt; do
     esac
 done
 
+# For fork PRs the head commit is often not in the workspace; fetch it so the
+# rev-list ranges below resolve and forks are checked like in-repo branches.
+if ! git rev-parse --verify --quiet "${SOURCE_BRANCH}^{commit}" >/dev/null; then
+    git fetch --no-tags --quiet origin "$SOURCE_BRANCH" || true
+fi
+
 # ----------------------------
 # Merged commits
 # ----------------------------


### PR DESCRIPTION
Using the head commit of PR #304 (a fork PR), on the `develop` branch.

The commit is not in the workspace, so the check aborts yet still reports success:

```
  $ bash ci-scripts/pre-ci-check.sh -s a26852621cf0f8c89f5e3697d96a685bff0c95ef -t origin/develop
  SHA recognized in a26852621cf0f8c89f5e3697d96a685bff0c95ef, using "" as branch name
  fatal: Invalid revision range origin/develop..a26852621cf0f8c89f5e3697d96a685bff0c95ef
  fatal: Invalid revision range origin/develop..a26852621cf0f8c89f5e3697d96a685bff0c95ef
  All commits are signed off using 'git commit -s'.
```

Confirming the PR head commit is absent locally, while a develop commit resolves fine:

```
  $ git rev-parse --verify --quiet "a26852621cf0f8c89f5e3697d96a685bff0c95ef^{commit}"
                                          # (no output -> commit missing)
```
```
  $ git rev-parse --verify --quiet "70508ebaf52f2aae420566d380c6537f2efb9f0c^{commit}"
  70508ebaf52f2aae420566d380c6537f2efb9f0c
```

Once the commit is fetched, the range resolves and the check runs for real:

```
  $ git fetch --no-tags --quiet origin a26852621cf0f8c89f5e3697d96a685bff0c95ef

  $ bash ci-scripts/pre-ci-check.sh -s a26852621cf0f8c89f5e3697d96a685bff0c95ef -t origin/develop
  SHA recognized in a26852621cf0f8c89f5e3697d96a685bff0c95ef, using "" as branch name
  All commits are signed off using 'git commit -s'.
```

Tests:

- Unsigned commits: https://github.com/duranta-project/openairinterface5g/pull/307#issuecomment-4991591931
- Merge commits: https://github.com/duranta-project/openairinterface5g/pull/307#issuecomment-4991748211