### PR TITLE
Improvements to decoding in PBCH

### DIFF
--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -77,6 +77,7 @@ static bool nr_pbch_detection(const UE_nr_rxtx_proc_t *proc,
     // computing channel estimation for selected best ssb
     int16_t pbch_e_rx[NR_POLAR_PBCH_E];
 
+    uint8_t log2_maxh = 0;
     for (int i = pbch_initial_symbol; i < pbch_initial_symbol + 3; i++) {
       __attribute__((aligned(32))) c16_t dl_ch_estimates[nb_ant][estimateSz];
       for (int aarx = 0; aarx < nb_ant; aarx++) {
@@ -106,7 +107,8 @@ static bool nr_pbch_detection(const UE_nr_rxtx_proc_t *proc,
                            ssb_start_subcarrier,
                            rxdataF[i],
                            dl_ch_estimates,
-                           pbch_e_rx);
+                           pbch_e_rx,
+                           &log2_maxh);
     }
 
     if (0

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_pbch.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_pbch.c
@@ -284,7 +284,8 @@ void nr_generate_pbch_llr(const PHY_VARS_NR_UE *ue,
                           const int ssb_start_subcarrier,
                           const c16_t rxdataF[frame_parms->nb_antennas_rx][frame_parms->ofdm_symbol_size],
                           const c16_t dl_ch_estimates[frame_parms->nb_antennas_rx][frame_parms->ofdm_symbol_size],
-                          int16_t pbch_e_rx[NR_POLAR_PBCH_E])
+                          int16_t pbch_e_rx[NR_POLAR_PBCH_E],
+                          uint8_t *log2_maxh)
 {
   const int symbol_offset = nr_get_ssb_start_symbol(frame_parms, i_ssb) % (NR_SYMBOLS_PER_SLOT);
   const int nb_re = (symbolSSB == 2) ? 72 : 180;
@@ -307,23 +308,22 @@ void nr_generate_pbch_llr(const PHY_VARS_NR_UE *ue,
   LOG_I(PHY, "[PHY] PBCH starting channel_level\n");
 #endif
 
-  double log2_maxh = 0;
-  uint32_t max_h = 0;
   if (symbolSSB == 1) {
     int avg[frame_parms->nb_antennas_rx];
     nr_channel_level(0, PBCH_MAX_RE_PER_SYMBOL, dl_ch_estimates_ext, frame_parms->nb_antennas_rx, 1, avg, nb_re);
-    max_h = avg[0];
+    uint32_t max_h = avg[0];
     for (int i = 1; i < frame_parms->nb_antennas_rx; i++)
       max_h = cmax(avg[i], max_h);
-    log2_maxh = 3 + (log2_approx(max_h) / 2);
-  }
+    *log2_maxh = 3 + (log2_approx(max_h) / 2);
 
 #ifdef DEBUG_PBCH
-  LOG_I(PHY, "[PHY] PBCH log2_maxh = %f (%d)\n", log2_maxh, max_h);
+    LOG_I(PHY, "[PHY] PBCH log2_maxh = %f (%d)\n", log2_maxh, max_h);
 #endif
+  }
+
   __attribute__((aligned(32))) struct complex16 rxdataF_comp[frame_parms->nb_antennas_rx][PBCH_MAX_RE_PER_SYMBOL];
   nr_pbch_channel_compensation(rxdataF_ext, dl_ch_estimates_ext, nb_re, rxdataF_comp, frame_parms,
-                               log2_maxh); // log2_maxh+I0_shift
+                               *log2_maxh); // log2_maxh+I0_shift
 
   /*if (frame_parms->nb_antennas_rx > 1)
     pbch_detection_mrc(frame_parms,

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_pbch.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_pbch.c
@@ -192,25 +192,19 @@ void nr_pbch_channel_compensation(const struct complex16 rxdataF_ext[][PBCH_MAX_
   }
 }
 
-void nr_pbch_detection_mrc(NR_DL_FRAME_PARMS *frame_parms,
-                           int **rxdataF_comp,
-                           uint8_t symbol) {
-  uint8_t symbol_mod;
-  int i, nb_rb = 6;
-  simde__m128i *rxdataF_comp128_0, *rxdataF_comp128_1;
-  symbol_mod = (symbol>=(7-frame_parms->Ncp)) ? symbol-(7-frame_parms->Ncp) : symbol;
+static void nr_pbch_detection_mrc(struct complex16 rxdataF_comp[][PBCH_MAX_RE_PER_SYMBOL], uint8_t nb_antennas_rx, int nb_re)
+{
+  if (nb_antennas_rx == 1)
+    return;
 
-  if (frame_parms->nb_antennas_rx > 1) {
-    rxdataF_comp128_0 = (simde__m128i *)&rxdataF_comp[0][symbol_mod * 6 * 12];
-    rxdataF_comp128_1 = (simde__m128i *)&rxdataF_comp[1][symbol_mod * 6 * 12];
+  simde__m128i *rxdataF_comp128_0 = (simde__m128i *)rxdataF_comp[0];
 
-    // MRC on each re of rb, both on MF output and magnitude (for 16QAM/64QAM llr computation)
-    for (i = 0; i < nb_rb * 3; i++) {
-      rxdataF_comp128_0[i] =
-          simde_mm_adds_epi16(simde_mm_srai_epi16(rxdataF_comp128_0[i], 1), simde_mm_srai_epi16(rxdataF_comp128_1[i], 1));
+  for (int a = 1; a < nb_antennas_rx; a++) {
+    simde__m128i *rxdataF_comp128_a = (simde__m128i *)rxdataF_comp[a];
+    for (int i = 0; i < nb_re / 4; i++) {
+      rxdataF_comp128_0[i] = simde_mm_adds_epi16(rxdataF_comp128_0[i], rxdataF_comp128_a[i]);
     }
   }
-
 }
 
 void nr_pbch_unscrambling(int16_t *demod_pbch_e,
@@ -325,10 +319,7 @@ void nr_generate_pbch_llr(const PHY_VARS_NR_UE *ue,
   nr_pbch_channel_compensation(rxdataF_ext, dl_ch_estimates_ext, nb_re, rxdataF_comp, frame_parms,
                                *log2_maxh); // log2_maxh+I0_shift
 
-  /*if (frame_parms->nb_antennas_rx > 1)
-    pbch_detection_mrc(frame_parms,
-                        rxdataF_comp,
-                        symbol);*/
+  nr_pbch_detection_mrc(rxdataF_comp, frame_parms->nb_antennas_rx, nb_re);
 
   /*
       if (mimo_mode == ALAMOUTI) {

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
@@ -320,7 +320,8 @@ void nr_generate_pbch_llr(const PHY_VARS_NR_UE *ue,
                           const int ssb_start_subcarrier,
                           const c16_t rxdataF[frame_parms->nb_antennas_rx][frame_parms->ofdm_symbol_size],
                           const c16_t dl_ch_estimates[frame_parms->nb_antennas_rx][frame_parms->ofdm_symbol_size],
-                          int16_t pbch_e_rx[NR_POLAR_PBCH_E]);
+                          int16_t pbch_e_rx[NR_POLAR_PBCH_E],
+                          uint8_t *log2_maxh);
 int nr_pbch_decode(PHY_VARS_NR_UE *ue,
                    const NR_DL_FRAME_PARMS *frame_parms,
                    const UE_nr_rxtx_proc_t *proc,

--- a/openair1/PHY/NR_UE_TRANSPORT/pss_nr.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/pss_nr.c
@@ -233,18 +233,18 @@ pss_detection_result_t pss_search_time_nr(const pss_search_t *p)
 #endif
   }
 
-  LOG_D(PHY,
-        "[UE] nr_synchro_time: Sync source (nid2) = %d, Peak found at pos %d, val = %ld (%d dB power over signal avg %d dB), ffo "
-        "%lf\n",
-        pss_source,
-        peak_position,
-        peak_value,
-        dB_fixed64(peak_value),
-        dB_fixed64(avg[pss_source]),
-        ffo_est);
-
   if (peak_value == 0 || peak_value < 5 * avg[pss_source])
     return (pss_detection_result_t){.success = false};
+
+  LOG_D(PHY,
+      "[UE] nr_synchro_time: Sync source (nid2) = %d, Peak found at pos %d, val = %ld (%d dB power over signal avg %d dB), ffo "
+      "%lf\n",
+      pss_source,
+      peak_position,
+      peak_value,
+      dB_fixed64(peak_value),
+      dB_fixed64(avg[pss_source]),
+      ffo_est);
 
 #ifdef DBG_PSS_NR
   static int debug_cnt = 0;

--- a/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
+++ b/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
@@ -892,14 +892,14 @@ int get_ssb_index_in_symbol(const PHY_VARS_NR_UE *ue, const int symbIdxInFrame, 
 /* Description: Generates PBCH LLRs from frequency domain signal for one OFDM symbol.
                 Generates PBCH time domain channel response.
    Returns    : SSB index if symbol contains SSB. Else returns -1. */
-int nr_process_pbch_symbol(
-    PHY_VARS_NR_UE *ue,
-    const UE_nr_rxtx_proc_t *proc,
-    const int symbol,
-    const int ssbIndexIn,
-    c16_t dl_ch_estimates_time[ue->frame_parms.nb_antennas_rx][ue->frame_parms.ofdm_symbol_size],
-    c16_t *dl_ch_estimates_symbol,
-    int16_t pbch_e_rx[NR_POLAR_PBCH_E])
+int nr_process_pbch_symbol(PHY_VARS_NR_UE *ue,
+                           const UE_nr_rxtx_proc_t *proc,
+                           const int symbol,
+                           const int ssbIndexIn,
+                           c16_t dl_ch_estimates_time[ue->frame_parms.nb_antennas_rx][ue->frame_parms.ofdm_symbol_size],
+                           c16_t *dl_ch_estimates_symbol,
+                           int16_t pbch_e_rx[NR_POLAR_PBCH_E],
+                           uint8_t *log2_maxh)
 {
   NR_DL_FRAME_PARMS *fp = &ue->frame_parms;
   const int symbIdxInFrame = symbol + NR_SYMBOLS_PER_SLOT * proc->nr_slot_rx;
@@ -956,7 +956,17 @@ int nr_process_pbch_symbol(
     memcpy(dl_ch_estimates_symbol, dl_ch_estimates[0], sizeof(*dl_ch_estimates_symbol) * NR_PBCH_NUM_RB * NR_NB_SC_PER_RB);
 
   const int symbIdxInSSB = relPbchSymb + 1;
-  nr_generate_pbch_llr(ue, proc, fp, symbIdxInSSB, ssbIndex, nid, ssb_start_subcarrier, rxdataF, dl_ch_estimates, pbch_e_rx);
+  nr_generate_pbch_llr(ue,
+                       proc,
+                       fp,
+                       symbIdxInSSB,
+                       ssbIndex,
+                       nid,
+                       ssb_start_subcarrier,
+                       rxdataF,
+                       dl_ch_estimates,
+                       pbch_e_rx,
+                       log2_maxh);
   // Do measurements on middle symbol of PBCH block
   if (relPbchSymb == 1) {
     nr_ue_ssb_rsrp_measurements(ue, ssbIndex, proc, rxdataF);
@@ -977,7 +987,8 @@ static int pbch_process(PHY_VARS_NR_UE *UE,
                         c16_t pbch_ch_est_sym1[NR_PBCH_NUM_RB * NR_NB_SC_PER_RB],
                         c16_t pbch_ch_est_time[UE->frame_parms.nb_antennas_rx][UE->frame_parms.ofdm_symbol_size],
                         int16_t pbch_e_rx[NR_POLAR_PBCH_E],
-                        int *pbchSymbCnt)
+                        int *pbchSymbCnt,
+                        uint8_t *log2_maxh)
 {
   int sampleShift = INT_MAX;
 
@@ -990,7 +1001,7 @@ static int pbch_process(PHY_VARS_NR_UE *UE,
   else if (*pbchSymbCnt == 2)
     cur_pbch_est = pbch_ch_est_sym3;
 
-  *ssbIndex = nr_process_pbch_symbol(UE, proc, symbol, *ssbIndex, pbch_ch_est_time, cur_pbch_est, pbch_e_rx);
+  *ssbIndex = nr_process_pbch_symbol(UE, proc, symbol, *ssbIndex, pbch_ch_est_time, cur_pbch_est, pbch_e_rx, log2_maxh);
   // If valid PBCH symbol, increment symbol count.
   if (*ssbIndex > -1)
     (*pbchSymbCnt)++;
@@ -1057,10 +1068,11 @@ int pbch_processing(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, nr_phy_da
     c16_t pbch_ch_est_sym1[NR_PBCH_NUM_RB * NR_NB_SC_PER_RB];
 
     int ssbIndex = -1;
+    uint8_t log2_maxh = 0;
     // TODO: Remove loopover symbols when symbol based receiver is fully integrated.
     for (int symbol = 0; symbol < fp->symbols_per_slot; symbol++) {
       const int pbch_sampleShift =
-          pbch_process(ue, proc, symbol, &ssbIndex, pbch_ch_est_sym1, pbch_ch_est_time, pbch_e_rx, &pbchSymbCnt);
+          pbch_process(ue, proc, symbol, &ssbIndex, pbch_ch_est_sym1, pbch_ch_est_time, pbch_e_rx, &pbchSymbCnt, &log2_maxh);
       // To prevent overwrite estimated shift by consecutive symbol calls
       sampleShift = (sampleShift == INT_MAX) ? pbch_sampleShift : sampleShift;
     }

--- a/openair1/SIMULATION/NR_PHY/pbchsim.c
+++ b/openair1/SIMULATION/NR_PHY/pbchsim.c
@@ -665,6 +665,7 @@ int main(int argc, char **argv)
         proc.nr_slot_rx = ssb_slot;
         proc.gNB_id = 0;
         int16_t pbch_e_rx[NR_POLAR_PBCH_E];
+        uint8_t log2_maxh = 0;
         for (int i = UE->symbol_offset + 1; i < UE->symbol_offset + 4; i++) {
           nr_slot_fep(UE,
                       frame_parms,
@@ -702,7 +703,8 @@ int main(int argc, char **argv)
                                frame_parms->ssb_start_subcarrier,
                                rxdataF_symb,
                                dl_ch_estimates,
-                               pbch_e_rx);
+                               pbch_e_rx,
+                               &log2_maxh);
         }
         fapiPbch_t result;
         int ret_ssb_idx;


### PR DESCRIPTION
In the develop branch, there is a `log2_maxh` that is only applied to the first symbol in the PBCH, while for the other symbols, a shift of `log2_maxh = 0` is applied.

This PR solves this bug and applies `log2_maxh` to all symbols.

Due to the previous fix, we no longer run the risk of saturation if we apply an MRC, and therefore a commit was added to apply an MRC to the PBCHs received from multiple antennas, thus improving PBCH decoding. Currently in develop, only the PBCH received on antenna 0 was being used.