### PR TITLE
Add Debian 13 support

### DIFF
--- a/cmake_targets/build_oai
+++ b/cmake_targets/build_oai
@@ -25,7 +25,7 @@ BUILD_TOOL_OPT="-j$(nproc)"
 function print_help() {
   echo_info "
 This script compiles OpenAirInterface Software, and can install dependencies
-for a number of distributions (Ubuntu 22-24, Fedora, RHEL9).
+for a number of distributions (Ubuntu 22-26, Debian 11-13, Fedora, RHEL9).
 Options:
 --arch-native
    Passes -march=native to the compiler.

--- a/cmake_targets/tools/build_helper
+++ b/cmake_targets/tools/build_helper
@@ -410,7 +410,9 @@ check_install_oai_software() {
     fi
     $SUDO $INSTALLER update -y
   if [[ "$OS_BASEDISTRO" == "debian" ]]; then
-    $SUDO apt install -y software-properties-common
+    if [[ "$(get_distribution_release)" != "debian13" ]]; then
+      $SUDO apt install -y software-properties-common
+    fi
     case "$(get_distribution_release)" in
          "debian11" | "debian12" | "debian13" )
             specific_packages="libz-dev"

--- a/cmake_targets/tools/build_helper
+++ b/cmake_targets/tools/build_helper
@@ -88,6 +88,7 @@ check_supported_distribution() {
         "ubuntu22.04") return 0 ;;
         "debian11")    return 0 ;;
         "debian12")    return 0 ;;
+        "debian13")    return 0 ;;
         "fedora43")    return 0 ;;
         "fedora44")    return 0 ;;
         "rhel9.0")     return 0 ;;
@@ -189,6 +190,12 @@ install_usrp_uhd_driver_from_source(){
 
 check_install_usrp_uhd_driver(){
     if [[ "$OS_BASEDISTRO" == "debian" ]]; then
+        if [[ "$(get_distribution_release)" == "debian13" ]] && [[ ! -v BUILD_UHD_FROM_SOURCE ]]; then
+            $SUDO apt-get update
+            $SUDO apt-get install -y libuhd-dev uhd-host
+            return
+        fi
+
         boost_libs_ubuntu="libboost-chrono-dev libboost-date-time-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libboost-test-dev libboost-regex-dev"
         #first we remove old installation
         $SUDO apt-get remove uhd* libuhd* -y || true
@@ -358,12 +365,14 @@ check_install_soapy () {
 check_install_additional_tools (){
   $SUDO $INSTALLER update -y
   local optional_packages=""
+  local pcre_package="libpcre3-dev"
   if [[ "$OS_BASEDISTRO" == "debian" ]]; then
     case "$(get_distribution_release)" in
-        "ubuntu22.04" | "debian11" | "debian12" )
+        "ubuntu22.04" | "debian11" | "debian12" | "debian13" )
             optional_packages="python3 python3-pip python3-dev python3-scipy python3-matplotlib python3-pyroute2 universal-ctags"
             ;;
     esac
+    [[ "$(get_distribution_release)" == "debian13" ]] && pcre_package="libpcre2-dev"
     PACKAGE_LIST="\
         doxygen \
         libgnutls28-dev \
@@ -374,7 +383,7 @@ check_install_additional_tools (){
         libforms-bin \
         libforms-dev \
         libxft-dev \
-        libpcre3-dev \
+        $pcre_package \
         libssh-dev \
         libxml2-dev"
   elif [[ "$OS_DISTRO" == "rhel" ]] || [[ "$OS_DISTRO" == "centos" ]] || [[ "$OS_DISTRO" == "rocky" ]] ||  [[ "$OS_DISTRO" == "fedora" ]]; then
@@ -403,7 +412,7 @@ check_install_oai_software() {
   if [[ "$OS_BASEDISTRO" == "debian" ]]; then
     $SUDO apt install -y software-properties-common
     case "$(get_distribution_release)" in
-         "debian11" | "debian12" )
+         "debian11" | "debian12" | "debian13" )
             specific_packages="libz-dev"
             ;;
     esac

--- a/cmake_targets/tools/build_helper
+++ b/cmake_targets/tools/build_helper
@@ -382,6 +382,7 @@ check_install_additional_tools (){
         iperf3 \
         libforms-bin \
         libforms-dev \
+        libglfw3-dev \
         libxft-dev \
         $pcre_package \
         libssh-dev \

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -176,7 +176,7 @@ install elsewhere, using one of these two methods:
 cmake .. -GNinja -DASN1C_EXEC=/opt/asn1c/bin/asn1c
 ```
 
-### Installing UHD from source
+### Installing UHD
 
 Previously for Ubuntu distributions, when installing the pre-requisites, most of the packages are installed from PPA.
 
@@ -186,9 +186,11 @@ Now, when installing the pre-requisites, especially the `UHD` driver, you can no
 
 - For `fedora`-based OS, it was already the case all the time. But now you can specify which version to install.
 - For `ubuntu` OS, you can still install from the Ettus PPA or select a version to install from source.
-  * In case of PPA installation, you do nothing special, the script will install the latest version available on the PPA.
+  * In case of PPA installation, you do nothing special; the script installs the distribution-specific UHD version from the PPA.
     - `./build_oai -I -w USRP`
-  * In case of a installation from source, you do as followed:
+- For Debian 13, `build_oai` installs the distribution-provided `libuhd-dev` and `uhd-host` packages by default.
+  - `./build_oai -I -w USRP`
+- To install UHD from source on Ubuntu or Debian 13, set the following environment variables:
 
 ```bash
 export BUILD_UHD_FROM_SOURCE=True


### PR DESCRIPTION
- Add Debian 13 to the supported distributions.
- Skip "software-properties-common" on Debian 13 since it isn't available in the normal Trixie repositories.
- Select "libpcre2-dev" for Debian 13 optional dependencies instead of libpcre3-dev.
- Add "libglfw3-dev" to the Debian-family optional package list so that --build-lib imscope can run.
- Verified on Raspberry Pi Compute Module 5 running Debian GNU/Linux 13.5 (Trixie) on AArch64 with:
./build_oai -I --install-optional-packages
./build_oai -w USRP --ninja -P --nrUE --UE --gNB --eNB --build-lib "telnetsrv enbscope uescope nrscope oai_iqplayer imscope imscope_record" -C