### PR TITLE
Timing Advance Correction and CBRA RAPID Handling

### DIFF
--- a/openair1/PHY/NR_TRANSPORT/nr_prach.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_prach.c
@@ -602,17 +602,16 @@ rx_prach_out_t rx_nr_prach(const prach_item_t *in, int occasion)
     for (int i = 0; i < NCS2; i++) {
       const int peak_bin = preamble_shift2 + i;
       const int levdB = dB_fixed_times10(prach_ifft[peak_bin]);
-      if (levdB > out.max_preamble_energy || (levdB == out.max_preamble_energy && out.max_preamble_delay > i)) {
+      if (levdB > out.max_preamble_energy || (levdB == out.max_preamble_energy && out.max_preamble_delay_raw > i)) {
         LOG_D(NR_PHY_RACH, "preamble_index %d, delay %d en %d dB > %d dB\n", preamble_index, i, levdB, out.max_preamble_energy);
         out.max_preamble_energy = levdB;
         out.max_preamble_delay_raw = i;
-        out.max_preamble_delay = i; // Note: This has to be normalized to the 30.72 Ms/s sampling rate
         out.max_preamble = preamble_index;
       }
     }
   } // preamble_index
 
-  // The conversion from *max_preamble_delay from TA value is done here.
+  // The conversion from raw PRACH delay to TA value is done here.
   // It is normalized to the 30.72 Ms/s, considering the numerology, N_RB and the sampling rate
   // See table 6.3.3.1 -1 and -2 in 38211.
 
@@ -627,14 +626,18 @@ rx_prach_out_t rx_nr_prach(const prach_item_t *in, int occasion)
   // Format >3: 2048/2^mu samples @ 30.72 Ms/s, 2048/2^mu * 4 samples @ 122.88 Ms/s
   // By solving:
   // max_preamble_delay * ( (2048/2^mu*(fs/30.72M)) / 256 ) / fs = TA * 16 * 64 / 2^mu * Tc
-  int mu = in->numerology_index;
+  const uint32_t raw_delay = out.max_preamble_delay_raw;
+  const int mu = in->numerology_index;
   if (in->prach_sequence_length == 0) {
+    const uint32_t mu_scale = 1U << mu;
+
     if (prach_fmt == 0 || prach_fmt == 1 || prach_fmt == 2)
-      out.max_preamble_delay *= 3 * (1 << mu) / 2;
+      out.max_preamble_delay = (raw_delay * 3U * mu_scale + 1U) / 2U;
     else if (prach_fmt == 3)
-      out.max_preamble_delay *= 3 * (1 << mu) / 8;
-  } else
-    out.max_preamble_delay /= 2;
+      out.max_preamble_delay = (raw_delay * 3U * mu_scale + 4U) / 8U;
+  } else {
+    out.max_preamble_delay = (raw_delay + 1U) / 2U;
+  }
 
   stop_meas(in->rx_prach);
   return out;

--- a/openair1/PHY/NR_TRANSPORT/nr_prach.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_prach.c
@@ -600,11 +600,12 @@ rx_prach_out_t rx_nr_prach(const prach_item_t *in, int occasion)
     int preamble_shift2 = preamble_shift == 0 ? 0 : (preamble_shift << log2_ifft_size) / N_ZC;
 
     for (int i = 0; i < NCS2; i++) {
-      int lev = prach_ifft[preamble_shift2 + i];
-      int levdB = dB_fixed_times10(lev);
+      const int peak_bin = preamble_shift2 + i;
+      const int levdB = dB_fixed_times10(prach_ifft[peak_bin]);
       if (levdB > out.max_preamble_energy || (levdB == out.max_preamble_energy && out.max_preamble_delay > i)) {
         LOG_D(NR_PHY_RACH, "preamble_index %d, delay %d en %d dB > %d dB\n", preamble_index, i, levdB, out.max_preamble_energy);
         out.max_preamble_energy = levdB;
+        out.max_preamble_delay_raw = i;
         out.max_preamble_delay = i; // Note: This has to be normalized to the 30.72 Ms/s sampling rate
         out.max_preamble = preamble_index;
       }

--- a/openair1/PHY/NR_TRANSPORT/nr_transport_proto.h
+++ b/openair1/PHY/NR_TRANSPORT/nr_transport_proto.h
@@ -123,6 +123,7 @@ typedef struct rx_prach_out {
   uint16_t max_preamble;
   uint16_t max_preamble_energy;
   uint16_t max_preamble_delay;
+  uint16_t max_preamble_delay_raw; // raw PRACH correlation-bin delay before TA normalization
 } rx_prach_out_t;
 rx_prach_out_t rx_nr_prach(const prach_item_t *, int occasion);
 

--- a/openair1/PHY/defs_nr_UE.h
+++ b/openair1/PHY/defs_nr_UE.h
@@ -395,6 +395,7 @@ typedef struct PHY_VARS_NR_UE_s {
   int ta_frame;
   int ta_slot;
   int ta_command;
+  bool ta_command_is_rar; /// Pending TA command originated from a Random Access Response
 
   /// Flag to initialize averaging of PHY measurements
   int init_averaging;

--- a/openair1/SCHED_NR/nr_prach_procedures.c
+++ b/openair1/SCHED_NR/nr_prach_procedures.c
@@ -37,22 +37,41 @@ void L1_nr_prach_procedures(PHY_VARS_gNB *gNB, prach_item_t *prach_id, nfapi_nr_
     // given wrt to start of the 15kHz slot or 60kHz slot. Here we work slot based, so this function is anyway only called in slots
     // where there is PRACH. Its up to the MAC to schedule another PRACH PDU in the case there are there N_RA_slot \in {0,1}.
     rx_prach_out_t res = rx_nr_prach(prach_id, prach_oc);
+    const bool prach_noise_ready = gNB->prach_energy_counter == NUM_PRACH_RX_FOR_NOISE_ESTIMATE;
+    const bool prach_above_threshold = res.max_preamble_energy > gNB->measurements.prach_I0 + gNB->prach_thres;
+    const bool prach_ind_has_space = rach_ind->number_of_pdus < MAX_NUM_NR_RX_RACH_PDUS;
+    const bool prach_accepted = prach_noise_ready && prach_above_threshold && prach_ind_has_space;
     LOG_D(NR_PHY,
-          "[RAPROC] Frame %d, slot %d, occasion %d (prachStartSymbol %d) : Most likely preamble %d, energy %d.%d dB delay %d "
-          "(prach_energy counter %d)\n",
+          "[RAPROC] %d.%d occasion %d symbol %u format %u sequence-length %d N_ZC %d PRACH-SCS %d UL-mu %d NCS %u "
+          "RAPID %u energy %d.%d dB I0 %d.%d dB threshold %d.%d dB raw-delay %u TA %u "
+          "noise %d/%d noise-ready %d threshold-pass %d indication-space %d accepted %d\n",
           frame,
           slot,
           prach_oc,
           prachStartSymbol,
+          prach_pdu->prach_format,
+          prach_id->prach_sequence_length,
+          prach_id->prach_sequence_length == 0 ? 839 : 139,
+          prach_id->mu,
+          prach_id->numerology_index,
+          prach_pdu->num_cs,
           res.max_preamble,
           res.max_preamble_energy / 10,
           res.max_preamble_energy % 10,
+          gNB->measurements.prach_I0 / 10,
+          gNB->measurements.prach_I0 % 10,
+          gNB->prach_thres / 10,
+          gNB->prach_thres % 10,
+          res.max_preamble_delay_raw,
           res.max_preamble_delay,
-          gNB->prach_energy_counter);
+          gNB->prach_energy_counter,
+          NUM_PRACH_RX_FOR_NOISE_ESTIMATE,
+          prach_noise_ready,
+          prach_above_threshold,
+          prach_ind_has_space,
+          prach_accepted);
 
-    if ((gNB->prach_energy_counter == NUM_PRACH_RX_FOR_NOISE_ESTIMATE)
-        && (res.max_preamble_energy > gNB->measurements.prach_I0 + gNB->prach_thres)
-        && (rach_ind->number_of_pdus < MAX_NUM_NR_RX_RACH_PDUS)) {
+    if (prach_accepted) {
       LOG_A(NR_PHY,
             "[RAPROC] %d.%d Initiating RA procedure with preamble %d, energy %d.%d dB (I0 %d, thres %d), delay %d start symbol "
             "%u freq index %u\n",

--- a/openair1/SCHED_NR_UE/fapi_nr_ue_l1.c
+++ b/openair1/SCHED_NR_UE/fapi_nr_ue_l1.c
@@ -108,7 +108,7 @@ static void configure_ta_command(PHY_VARS_NR_UE *ue, fapi_nr_ta_command_pdu *ta_
   if (ta_command_pdu->is_rar) {
     ue->ta_slot = ta_command_pdu->ta_slot;
     ue->ta_frame = ta_command_pdu->ta_frame;
-    ue->ta_command = ta_command_pdu->ta_command + 31; // To use TA adjustment algo in ue_ta_procedures()
+    ue->ta_command = ta_command_pdu->ta_command;
   } else {
     ue->ta_slot = (ta_command_pdu->ta_slot + ul_tx_timing_adjustment) % slots_per_frame;
     if (ta_command_pdu->ta_slot + ul_tx_timing_adjustment > slots_per_frame)
@@ -117,14 +117,15 @@ static void configure_ta_command(PHY_VARS_NR_UE *ue, fapi_nr_ta_command_pdu *ta_
       ue->ta_frame = ta_command_pdu->ta_frame;
     ue->ta_command = ta_command_pdu->ta_command;
   }
+  ue->ta_command_is_rar = ta_command_pdu->is_rar;
 
   LOG_D(PHY,
-        "[UE %d] TA command received in %d.%d: %s command %u, apply in %d.%d (application-delay %d slots)\n",
+        "[UE %d] TA command received in %d.%d: %s command %d, apply in %d.%d (application-delay %d slots)\n",
         ue->Mod_id,
         ta_command_pdu->ta_frame,
         ta_command_pdu->ta_slot,
-        ta_command_pdu->is_rar ? "absolute RAR" : "relative MAC CE",
-        ta_command_pdu->ta_command,
+        ta_command_pdu->is_rar ? "RAR" : "relative MAC CE",
+        ue->ta_command,
         ue->ta_frame,
         ue->ta_slot,
         ta_command_pdu->is_rar ? 0 : ul_tx_timing_adjustment);

--- a/openair1/SCHED_NR_UE/fapi_nr_ue_l1.c
+++ b/openair1/SCHED_NR_UE/fapi_nr_ue_l1.c
@@ -119,8 +119,15 @@ static void configure_ta_command(PHY_VARS_NR_UE *ue, fapi_nr_ta_command_pdu *ta_
   }
 
   LOG_D(PHY,
-        "TA command received in %d.%d Starting UL time alignment procedures. TA update will be applied at frame %d slot %d\n",
-        ta_command_pdu->ta_frame, ta_command_pdu->ta_slot, ue->ta_frame, ue->ta_slot);
+        "[UE %d] TA command received in %d.%d: %s command %u, apply in %d.%d (application-delay %d slots)\n",
+        ue->Mod_id,
+        ta_command_pdu->ta_frame,
+        ta_command_pdu->ta_slot,
+        ta_command_pdu->is_rar ? "absolute RAR" : "relative MAC CE",
+        ta_command_pdu->ta_command,
+        ue->ta_frame,
+        ue->ta_slot,
+        ta_command_pdu->is_rar ? 0 : ul_tx_timing_adjustment);
 }
 
 static void nr_ue_scheduled_response_dl(NR_UE_MAC_INST_t *mac,

--- a/openair1/SCHED_NR_UE/fapi_nr_ue_l1.c
+++ b/openair1/SCHED_NR_UE/fapi_nr_ue_l1.c
@@ -110,11 +110,9 @@ static void configure_ta_command(PHY_VARS_NR_UE *ue, fapi_nr_ta_command_pdu *ta_
     ue->ta_frame = ta_command_pdu->ta_frame;
     ue->ta_command = ta_command_pdu->ta_command;
   } else {
-    ue->ta_slot = (ta_command_pdu->ta_slot + ul_tx_timing_adjustment) % slots_per_frame;
-    if (ta_command_pdu->ta_slot + ul_tx_timing_adjustment > slots_per_frame)
-      ue->ta_frame = (ta_command_pdu->ta_frame + 1) % 1024;
-    else
-      ue->ta_frame = ta_command_pdu->ta_frame;
+    const int target_slot = ta_command_pdu->ta_slot + ul_tx_timing_adjustment;
+    ue->ta_slot = target_slot % slots_per_frame;
+    ue->ta_frame = (ta_command_pdu->ta_frame + target_slot / slots_per_frame) % 1024;
     ue->ta_command = ta_command_pdu->ta_command;
   }
   ue->ta_command_is_rar = ta_command_pdu->is_rar;

--- a/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
+++ b/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
@@ -190,15 +190,24 @@ void ue_ta_procedures(PHY_VARS_NR_UE *ue, int slot_tx, int frame_tx)
     // = 16 * ofdm_symbol_size / 2048
     uint16_t bw_scaling = 16 * ofdm_symbol_size / 2048;
 
-    ue->timing_advance += (ue->ta_command - 31) * bw_scaling;
+    const int timing_advance_before = ue->timing_advance;
+    const int ta_delta_units = ue->ta_command - 31;
+    const int ta_delta_samples = ta_delta_units * bw_scaling;
+    ue->timing_advance += ta_delta_samples;
 
     LOG_D(PHY,
-          "[UE %d] [%d.%d] Got timing advance command %u from MAC, new value is %d\n",
+          "[UE %d] %d.%d applied TA command %u: delta-TA-units %d, samples-per-unit %u, delta-samples %d, "
+          "timing-advance %d -> %d samples (N_TA_offset %d)\n",
           ue->Mod_id,
           frame_tx,
           slot_tx,
           ue->ta_command,
-          ue->timing_advance);
+          ta_delta_units,
+          bw_scaling,
+          ta_delta_samples,
+          timing_advance_before,
+          ue->timing_advance,
+          ue->N_TA_offset);
 
     ue->ta_frame = -1;
     ue->ta_slot = -1;

--- a/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
+++ b/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
@@ -191,26 +191,40 @@ void ue_ta_procedures(PHY_VARS_NR_UE *ue, int slot_tx, int frame_tx)
     uint16_t bw_scaling = 16 * ofdm_symbol_size / 2048;
 
     const int timing_advance_before = ue->timing_advance;
-    const int ta_delta_units = ue->ta_command - 31;
-    const int ta_delta_samples = ta_delta_units * bw_scaling;
-    ue->timing_advance += ta_delta_samples;
+    const bool ta_command_is_rar = ue->ta_command_is_rar;
+    const int ta_units = ta_command_is_rar ? ue->ta_command : ue->ta_command - 31;
+    const int ta_samples = ta_units * bw_scaling;
+
+    if (ta_command_is_rar && timing_advance_before != 0)
+      LOG_W(PHY,
+            "[UE %d] %d.%d applying RAR TA command %d to non-zero timing advance %d samples; "
+            "timing advance should have been reset before PRACH\n",
+            ue->Mod_id,
+            frame_tx,
+            slot_tx,
+            ue->ta_command,
+            timing_advance_before);
+
+    ue->timing_advance += ta_samples;
 
     LOG_D(PHY,
-          "[UE %d] %d.%d applied TA command %u: delta-TA-units %d, samples-per-unit %u, delta-samples %d, "
+          "[UE %d] %d.%d applied %s command %d: TA-units %d, samples-per-unit %u, command-samples %d, "
           "timing-advance %d -> %d samples (N_TA_offset %d)\n",
           ue->Mod_id,
           frame_tx,
           slot_tx,
+          ta_command_is_rar ? "RAR" : "relative MAC CE",
           ue->ta_command,
-          ta_delta_units,
+          ta_units,
           bw_scaling,
-          ta_delta_samples,
+          ta_samples,
           timing_advance_before,
           ue->timing_advance,
           ue->N_TA_offset);
 
     ue->ta_frame = -1;
     ue->ta_slot = -1;
+    ue->ta_command_is_rar = false;
   }
 }
 

--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
@@ -5095,6 +5095,49 @@ uint32_t compute_PDU_length(uint32_t num_TLV, uint32_t total_length)
   return pdu_length;
 }
 
+ssb_ro_preambles_t get_ssb_ro_preambles_4step(struct NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB *config)
+{
+  ssb_ro_preambles_t ret = {0};
+  switch (config->present) {
+    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_oneEighth:
+      ret.ssb_per_ro = 0.125;
+      ret.preambles_per_ssb = (config->choice.oneEighth + 1) << 2;
+      break;
+    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_oneFourth:
+      ret.ssb_per_ro = 0.25;
+      ret.preambles_per_ssb = (config->choice.oneFourth + 1) << 2;
+      break;
+    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_oneHalf:
+      ret.ssb_per_ro = 0.5;
+      ret.preambles_per_ssb = (config->choice.oneHalf + 1) << 2;
+      break;
+    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_one:
+      ret.ssb_per_ro = 1;
+      ret.preambles_per_ssb = (config->choice.one + 1) << 2;
+      break;
+    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_two:
+      ret.ssb_per_ro = 2;
+      ret.preambles_per_ssb = (config->choice.two + 1) << 2;
+      break;
+    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_four:
+      ret.ssb_per_ro = 4;
+      ret.preambles_per_ssb = config->choice.four;
+      break;
+    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_eight:
+      ret.ssb_per_ro = 8;
+      ret.preambles_per_ssb = config->choice.eight;
+      break;
+    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_sixteen:
+      ret.ssb_per_ro = 16;
+      ret.preambles_per_ssb = config->choice.sixteen;
+      break;
+    default:
+      AssertFatal(false, "Invalid ssb_perRACH_OccasionAndCB_PreamblesPerSSB\n");
+  }
+  LOG_D(NR_MAC, "SSB per RO %f preambles per SSB %d\n", ret.ssb_per_ro, ret.preambles_per_ssb);
+  return ret;
+}
+
 // RA-RNTI computation (associated to PRACH occasion in which the RA Preamble is transmitted)
 // - this does not apply to contention-free RA Preamble for beam failure recovery request
 // - getting star_symb, SFN_nbr from table 6.3.3.2-3 (TDD and FR1 scenario)

--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.h
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.h
@@ -156,6 +156,11 @@ typedef struct {
   uint16_t bwpSize;
 } bwp_info_t;
 
+typedef struct {
+  float ssb_per_ro;
+  int preambles_per_ssb;
+} ssb_ro_preambles_t;
+
 uint32_t get_Y(const NR_SearchSpace_t *ss, int slot, rnti_t rnti);
 
 uint8_t get_BG(uint32_t A, uint16_t R);
@@ -249,6 +254,7 @@ uint8_t compute_nr_root_seq(NR_RACH_ConfigCommon_t *rach_config,
                             uint8_t nb_preambles,
                             uint8_t unpaired,
                             frequency_range_t);
+ssb_ro_preambles_t get_ssb_ro_preambles_4step(struct NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB *config);
 
 int ul_ant_bits(NR_DMRS_UplinkConfig_t *NR_DMRS_UplinkConfig, long transformPrecoder);
 

--- a/openair2/LAYER2/NR_MAC_UE/mac_defs.h
+++ b/openair2/LAYER2/NR_MAC_UE/mac_defs.h
@@ -282,11 +282,6 @@ typedef struct {
 } NR_PRACH_RESOURCES_t;
 
 typedef struct {
-  float ssb_per_ro;
-  int preambles_per_ssb;
-} ssb_ro_preambles_t;
-
-typedef struct {
   bool active;
   uint32_t preamble_index;
   uint32_t ssb_index;

--- a/openair2/LAYER2/NR_MAC_UE/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_UE/mac_proto.h
@@ -347,6 +347,5 @@ int sl_nr_ue_slot_select(const sl_nr_phy_config_request_t *cfg, int nr_slot, uin
 void nr_ue_sidelink_scheduler(nr_sidelink_indication_t *sl_ind, NR_UE_MAC_INST_t *mac);
 
 NR_SearchSpace_t *get_common_search_space(const NR_UE_MAC_INST_t *mac, const NR_SearchSpaceId_t ss_id);
-ssb_ro_preambles_t get_ssb_ro_preambles_4step(struct NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB *config);
 void update_pdcch_config(NR_UE_MAC_INST_t *mac);
 #endif

--- a/openair2/LAYER2/NR_MAC_UE/nr_ra_procedures.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ra_procedures.c
@@ -166,49 +166,6 @@ static void select_preamble_group(NR_UE_MAC_INST_t *mac)
   // else if Msg3 is being retransmitted, we keep what used in first transmission of Msg3
 }
 
-ssb_ro_preambles_t get_ssb_ro_preambles_4step(struct NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB *config)
-{
-  ssb_ro_preambles_t ret = {0};
-  switch (config->present) {
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_oneEighth:
-      ret.ssb_per_ro = 0.125;
-      ret.preambles_per_ssb = (config->choice.oneEighth + 1) << 2;
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_oneFourth:
-      ret.ssb_per_ro = 0.25;
-      ret.preambles_per_ssb = (config->choice.oneFourth + 1) << 2;
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_oneHalf:
-      ret.ssb_per_ro = 0.5;
-      ret.preambles_per_ssb = (config->choice.oneHalf + 1) << 2;
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_one:
-      ret.ssb_per_ro = 1;
-      ret.preambles_per_ssb = (config->choice.one + 1) << 2;
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_two:
-      ret.ssb_per_ro = 2;
-      ret.preambles_per_ssb = (config->choice.two + 1) << 2;
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_four:
-      ret.ssb_per_ro = 4;
-      ret.preambles_per_ssb = config->choice.four;
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_eight:
-      ret.ssb_per_ro = 8;
-      ret.preambles_per_ssb = config->choice.eight;
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_sixteen:
-      ret.ssb_per_ro = 16;
-      ret.preambles_per_ssb = config->choice.sixteen;
-      break;
-    default:
-      AssertFatal(false, "Invalid ssb_perRACH_OccasionAndCB_PreamblesPerSSB\n");
-  }
-  LOG_D(NR_MAC, "SSB per RO %f preambles per SSB %d\n", ret.ssb_per_ro, ret.preambles_per_ssb);
-  return ret;
-}
-
 static ssb_ro_preambles_t get_ssb_ro_preambles_2step(struct NR_RACH_ConfigCommonTwoStepRA_r16__msgA_SSB_PerRACH_OccasionAndCB_PreamblesPerSSB_r16 *config)
 {
   ssb_ro_preambles_t ret = {0};

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
@@ -3265,13 +3265,27 @@ static void handle_rar_reception(NR_UE_MAC_INST_t *mac, NR_MAC_RAR *rar, frame_t
   int ret = nr_ue_pusch_scheduler(mac, 1, frame, slot, &frame_tx, &slot_tx, tda_info.k2 + ntn_ue_koffset);
 
   // TA command
+  const int ta = rar->TA2 + (rar->TA1 << 5);
+  const bool ta_timer_active = nr_timer_is_active(&mac->time_alignment_timer);
   // if the timeAlignmentTimer associated with this TAG is not running
-  if (!nr_timer_is_active(&mac->time_alignment_timer)) {
-    const int ta = rar->TA2 + (rar->TA1 << 5);
+  if (!ta_timer_active)
     set_time_alignment(mac, ta, rar_ta, frame_tx, slot_tx);
-    LOG_W(MAC, "received TA command %d\n", 31 + ta);
-  }
   // else ignore the received Timing Advance Command
+  LOG_D(NR_MAC,
+        "[UE %d] RAR %d.%d RAPID %u absolute TA %d Msg3 %d.%d k2 %ld NTN K-offset %d "
+        "Msg3-scheduled %d timeAlignmentTimer %s TA-action %s\n",
+        mac->ue_id,
+        frame,
+        slot,
+        ra->ra_PreambleIndex,
+        ta,
+        frame_tx,
+        slot_tx,
+        tda_info.k2,
+        ntn_ue_koffset,
+        ret != -1,
+        ta_timer_active ? "active" : "inactive",
+        ta_timer_active ? "ignored" : "applied");
 
 #ifdef DEBUG_RAR
   LOG_I(NR_MAC, "rarh->E = 0x%x\n", rarh->E);

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_RA.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_RA.c
@@ -23,7 +23,57 @@
 
 #include <executables/softmodem-common.h>
 
-static const float ssb_per_rach_occasion[8] = {0.125, 0.25, 0.5, 1, 2, 4, 8};
+typedef struct {
+  bool checked; // Validator covers this RA case.
+  bool valid; // RAPID accepted, or case unchecked.
+  uint16_t num_valid_rapids; // Number of accepted consecutive RAPIDs.
+  const char *reason; // Static unchecked-case reason.
+} nr_rapid_check_t;
+
+static nr_rapid_check_t check_rapid_for_prach_occasion(nr_cell_sched_t *cell, uint16_t preamble_index)
+{
+  nr_rapid_check_t check = {
+      .checked = false,
+      .valid = true,
+      .num_valid_rapids = 0,
+      .reason = "unchecked",
+  };
+
+  NR_COMMON_channels_t *cc = &cell->common_channels;
+  NR_ServingCellConfigCommon_t *scc = cc->ServingCellConfigCommon;
+  NR_BWP_UplinkCommon_t *initialUplinkBWP = scc->uplinkConfigCommon->initialUplinkBWP;
+
+  if (initialUplinkBWP->ext1 && initialUplinkBWP->ext1->msgA_ConfigCommon_r16) {
+    check.reason = "msgA_not_checked";
+    return check;
+  }
+
+  NR_RACH_ConfigCommon_t *rach_ConfigCommon = initialUplinkBWP->rach_ConfigCommon->choice.setup;
+  ssb_ro_preambles_t ssb_ro = get_ssb_ro_preambles_4step(rach_ConfigCommon->ssb_perRACH_OccasionAndCB_PreamblesPerSSB);
+
+  /*
+   * First implementation validates the non-shared RO case. For shared ROs,
+   * preserve existing behavior until SSB/RO-specific RAPID partitioning is added.
+   */
+  if (ssb_ro.ssb_per_ro > 1) {
+    check.reason = "shared_ro_not_checked";
+    return check;
+  }
+
+  if (ssb_ro.preambles_per_ssb <= 0) {
+    check.reason = "invalid_cb_preambles";
+    return check;
+  }
+
+  const uint16_t total_ra_preambles =
+      rach_ConfigCommon->totalNumberOfRA_Preambles ? *rach_ConfigCommon->totalNumberOfRA_Preambles : MAX_NUM_NR_PRACH_PREAMBLES;
+  const uint16_t num_valid_rapids = min(ssb_ro.preambles_per_ssb, (int)total_ra_preambles);
+
+  check.checked = true;
+  check.num_valid_rapids = num_valid_rapids;
+  check.valid = preamble_index < num_valid_rapids;
+  return check;
+}
 
 static int16_t ssb_index_from_prach(nr_cell_sched_t *cell,
                                     frame_t frameP,
@@ -42,8 +92,9 @@ static int16_t ssb_index_from_prach(nr_cell_sched_t *cell,
   uint8_t total_RApreambles = MAX_NUM_NR_PRACH_PREAMBLES;
   if (rach_ConfigCommon->totalNumberOfRA_Preambles != NULL)
     total_RApreambles = *rach_ConfigCommon->totalNumberOfRA_Preambles;
-  
-  float  num_ssb_per_RO = ssb_per_rach_occasion[cfg->prach_config.ssb_per_rach.value];	
+
+  ssb_ro_preambles_t ssb_ro = get_ssb_ro_preambles_4step(rach_ConfigCommon->ssb_perRACH_OccasionAndCB_PreamblesPerSSB);
+  float num_ssb_per_RO = ssb_ro.ssb_per_ro;
   uint16_t start_symbol_index = 0;
   uint8_t temp_start_symbol = 0;
   uint16_t RA_sfn_index = -1;
@@ -110,43 +161,14 @@ void find_SSB_and_RO_available(nr_cell_sched_t *cell)
   uint16_t unused_RA_occasion, repetition = 0;
   uint8_t num_active_ssb = 0;
 
-  struct NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB *ssb_perRACH_OccasionAndCB_PreamblesPerSSB = rach_ConfigCommon->ssb_perRACH_OccasionAndCB_PreamblesPerSSB;
-
-  switch (ssb_perRACH_OccasionAndCB_PreamblesPerSSB->present) {
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_oneEighth:
-      cc->cb_preambles_per_ssb = 4 * (ssb_perRACH_OccasionAndCB_PreamblesPerSSB->choice.oneEighth + 1);
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_oneFourth:
-      cc->cb_preambles_per_ssb = 4 * (ssb_perRACH_OccasionAndCB_PreamblesPerSSB->choice.oneFourth + 1);
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_oneHalf:
-      cc->cb_preambles_per_ssb = 4 * (ssb_perRACH_OccasionAndCB_PreamblesPerSSB->choice.oneHalf + 1);
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_one:
-      cc->cb_preambles_per_ssb = 4 * (ssb_perRACH_OccasionAndCB_PreamblesPerSSB->choice.one + 1);
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_two:
-      cc->cb_preambles_per_ssb = 4 * (ssb_perRACH_OccasionAndCB_PreamblesPerSSB->choice.two + 1);
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_four:
-      cc->cb_preambles_per_ssb = ssb_perRACH_OccasionAndCB_PreamblesPerSSB->choice.four;
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_eight:
-      cc->cb_preambles_per_ssb = ssb_perRACH_OccasionAndCB_PreamblesPerSSB->choice.eight;
-      break;
-    case NR_RACH_ConfigCommon__ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR_sixteen:
-      cc->cb_preambles_per_ssb = ssb_perRACH_OccasionAndCB_PreamblesPerSSB->choice.sixteen;
-      break;
-    default:
-      AssertFatal(1 == 0, "Unsupported ssb_perRACH_config %d\n", ssb_perRACH_OccasionAndCB_PreamblesPerSSB->present);
-      break;
-  }
+  ssb_ro_preambles_t ssb_ro = get_ssb_ro_preambles_4step(rach_ConfigCommon->ssb_perRACH_OccasionAndCB_PreamblesPerSSB);
+  cc->cb_preambles_per_ssb = ssb_ro.preambles_per_ssb;
 
   // prach is scheduled according to configuration index and tables 6.3.3.2.2 to 6.3.3.2.4
   frequency_range_t freq_range = get_freq_range_from_arfcn(scc->downlinkConfigCommon->frequencyInfoDL->absoluteFrequencyPointA);
   nr_prach_info_t prach_info =  get_nr_prach_occasion_info_from_index(config_index, freq_range, cc->frame_type);
 
-  float num_ssb_per_RO = ssb_per_rach_occasion[cfg->prach_config.ssb_per_rach.value];	
+  float num_ssb_per_RO = ssb_ro.ssb_per_ro;
   uint8_t fdm = cfg->prach_config.num_prach_fd_occasions.value;
   uint64_t L_ssb = (((uint64_t) cfg->ssb_table.ssb_mask_list[0].ssb_mask.value) << 32) | cfg->ssb_table.ssb_mask_list[1].ssb_mask.value;
   cc->total_prach_occasions_per_config_period = prach_info.N_RA_sfn * prach_info.N_t_slot * prach_info.N_RA_slot * fdm;
@@ -362,6 +384,8 @@ void schedule_nr_prach(gNB_MAC_INST *gNB, nr_cell_sched_t *cell, frame_t frameP,
       NR_beam_alloc_t beam = {0};
       uint32_t N_t_slot = cc->prach_info.N_t_slot;
       uint32_t start_symb = cc->prach_info.start_symbol;
+      const float num_ssb_per_RO =
+          get_ssb_ro_preambles_4step(rach_ConfigCommon->ssb_perRACH_OccasionAndCB_PreamblesPerSSB).ssb_per_ro;
       for (int fdm_index = 0; fdm_index < fdm; fdm_index++) { // one structure per frequency domain occasion
         AssertFatal(UL_tti_req->n_pdus < sizeofArray(UL_tti_req->pdus_list), "Invalid UL_tti_req->n_pdus %d\n", UL_tti_req->n_pdus);
         nfapi_nr_ul_tti_request_number_of_pdus_t *newpdu = UL_tti_req->pdus_list + UL_tti_req->n_pdus;
@@ -381,7 +405,6 @@ void schedule_nr_prach(gNB_MAC_INST *gNB, nr_cell_sched_t *cell, frame_t frameP,
             continue;
 
           num_td_occ++;
-          float num_ssb_per_RO = ssb_per_rach_occasion[cfg->prach_config.ssb_per_rach.value];
           int beam_index = 0;
           if(num_ssb_per_RO <= 1) {
             // ordered ssb number
@@ -685,6 +708,44 @@ void nr_initiate_ra_proc(module_id_t module_idP,
     LOG_W(NR_MAC, "random access with preamble %d: no pre-configured RA process found\n", preamble_index);
     NR_SCHED_UNLOCK(&nr_mac->sched_lock);
     return;
+  }
+
+  /*
+   * For unknown-UE four-step CBRA, reject RAPIDs outside the configured
+   * contention-based preamble set before allocating a TC-RNTI.
+   */
+  if (!UE) {
+    nr_rapid_check_t rapid_check = check_rapid_for_prach_occasion(cell, preamble_index);
+    if (!rapid_check.checked) {
+      LOG_D(NR_MAC,
+            "[RAPROC] %d.%d RAPID %u symbol %u freq-index %u not checked: %s\n",
+            frame,
+            slot,
+            preamble_index,
+            symbol,
+            freq_index,
+            rapid_check.reason);
+    } else if (!rapid_check.valid) {
+      LOG_W(NR_MAC,
+            "[RAPROC] %d.%d ignoring RAPID %u at symbol %u freq-index %u: outside valid CBRA range [0,%u)\n",
+            frame,
+            slot,
+            preamble_index,
+            symbol,
+            freq_index,
+            rapid_check.num_valid_rapids);
+      NR_SCHED_UNLOCK(&nr_mac->sched_lock);
+      return;
+    } else {
+      LOG_D(NR_MAC,
+            "[RAPROC] %d.%d RAPID %u symbol %u freq-index %u accepted in CBRA range [0,%u)\n",
+            frame,
+            slot,
+            preamble_index,
+            symbol,
+            freq_index,
+            rapid_check.num_valid_rapids);
+    }
   }
 
   if (!UE) {

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_RA.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_RA.c
@@ -734,9 +734,16 @@ void nr_initiate_ra_proc(module_id_t module_idP,
     ra->ra_state = nrRA_Msg2;
   }
 
-  LOG_A(NR_MAC, "%d.%d UE RA-RNTI %04x TC-RNTI %04x: initiating RA procedure\n", frame, slot, ra->RA_rnti, UE->rnti);
+  LOG_A(NR_MAC,
+        "%d.%d UE RA-RNTI %04x TC-RNTI %04x: initiating RA procedure for RAPID %u with TA %d units\n",
+        frame,
+        slot,
+        ra->RA_rnti,
+        UE->rnti,
+        preamble_index,
+        timing_offset);
 
-   // return current SSB order in the list of tranmitted SSBs
+  // return current SSB order in the list of tranmitted SSBs
   int n_ssb = ssb_index_from_prach(cell, frame, slot, preamble_index, freq_index, symbol);
   UE->UE_beam_index = get_beam_from_ssbidx(cell, cc->ssb_index[n_ssb]);
   LOG_I(NR_MAC, "UE %04x: Sync beam index %d\n", UE->rnti, UE->UE_beam_index);
@@ -1101,6 +1108,7 @@ static void nr_fill_rar(NR_UE_info_t *UE, uint8_t *dlsch_buffer, nfapi_nr_pusch_
   // TA command
   rar->TA1 = (uint8_t) (ra->timing_offset >> 5);    // 7 MSBs of timing advance
   rar->TA2 = (uint8_t) (ra->timing_offset & 0x1f);  // 5 LSBs of timing advance
+  const int rar_ta = rar->TA2 + (rar->TA1 << 5);
 
   // TC-RNTI
   rar->TCRNTI_1 = (uint8_t) (UE->rnti >> 8);        // 8 MSBs of rnti
@@ -1138,12 +1146,15 @@ static void nr_fill_rar(NR_UE_info_t *UE, uint8_t *dlsch_buffer, nfapi_nr_pusch_
   LOG_I(NR_MAC, "rar->TCRNTI_2 = 0x%x\n", rar->TCRNTI_2);
 #endif
   LOG_D(NR_MAC,
-        "In %s: Transmitted RAR with t_alloc %d f_alloc %d ta_command %d mcs %d freq_hopping %d tpc_command %d csi_req %d t_crnti "
-        "%x \n",
+        "In %s: %d.%d transmitted RAR for RAPID %u with t_alloc %d f_alloc %d ta_command %d mcs %d freq_hopping %d "
+        "tpc_command %d csi_req %d t_crnti %x\n",
         __FUNCTION__,
+        ra->Msg2_frame,
+        ra->Msg2_slot,
+        ra->preamble_index,
         rar->UL_GRANT_3 & 0x0f,
         (rar->UL_GRANT_3 >> 4) | (rar->UL_GRANT_2 << 4) | ((rar->UL_GRANT_1 & 0x03) << 12),
-        rar->TA2 + (rar->TA1 << 5),
+        rar_ta,
         rar->UL_GRANT_4 >> 4,
         rar->UL_GRANT_1 >> 2,
         ra->msg3_TPC,
@@ -1645,7 +1656,8 @@ static void nr_generate_Msg2(gNB_MAC_INST *nr_mac,
   // T_c according to 38.211 4.1
   float T_c_ns = 0.509;
   int numerology = ul_bwp->scs;
-  float rtt_ns = T_c_ns * 16 * 64 / (1 << numerology) * ra->timing_offset;
+  float ta_unit_ns = T_c_ns * 16 * 64 / (1 << numerology);
+  float rtt_ns = ta_unit_ns * ra->timing_offset;
   float distance_in_meters = (float) SPEED_OF_LIGHT * rtt_ns / 1000 / 1000 / 1000 / 2;
   LOG_A(NR_MAC,
         "UE %04x: %d.%d Generating RA-Msg2 DCI, RA RNTI 0x%x, state %d, preamble_index(RAPID) %d, "


### PR DESCRIPTION
Correct PRACH detector-delay conversion to NR Timing Advance units, with consistent round-to-nearest handling for long and short preambles. Keep RAR and MAC CE Timing Advance command representations distinct while preserving additive application. Share the four-step SSB/PRACH preamble decoder between UE and gNB, and reject out-of-range unknown-UE CBRA RAPIDs before allocating RA state.

Shared PRACH occasions, MsgA/two-step RA, known-UE procedures, and contention-free Random Access remain unchanged.