### PR TITLE
GTP: Error Indication enc/dec lib in stack and trigger PDU Session Resource Notify

### DIFF
--- a/doc/GTP/gtp-design.md
+++ b/doc/GTP/gtp-design.md
@@ -1,0 +1,241 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# GTP-U design
+
+[[_TOC_]]
+
+## Introduction
+
+OAI's GTP-U implementation lives in `openair3/ocp-gtpu/`. It provides the UDP/GTP-U
+user-plane (UP) tunnels used for S1-U (eNB-S-GW), N3 (gNB-UPF), F1-U (CU-DU), and related paths.
+This document covers module layout, GTP-U extension headers, G-PDU RX, and Error
+Indication. A shorter overview of the GTP thread and tunnel API remains
+in [SW_archi.md](../SW_archi.md) (section "GTP" / "New GTP").
+
+### Relevant Specs
+
+* 3GPP TS 29.281: GTP-U
+* 3GPP TS 38.415: PDU Session User Plane Protocol
+* 3GPP TS 38.425: NR User Plane Protocol
+* 3GPP TS 23.527: 5G System Restoration procedures
+* 3GPP TS 38.413: NGAP (PDU Session Resource Notify)
+* 3GPP TS 38.463: E1AP (Bearer Context Modification Required / Confirm)
+
+### Source layout
+
+| Path | Role |
+|------|------|
+| `gtp_itf.h/.cpp` | Endpoints, tunnels, TX/RX, Error Indication, G-PDU RX extension walk |
+| `gtpu_extensions.{h,c}` | GTP-U extension headers: TX serialize |
+| `tests/test_gtp.cpp` | Unit tests |
+
+## G-PDU
+
+Per TS 29.281 definitions: a **T-PDU** (Transport PDU) is the original user data
+packet being tunnelled, typically an IP datagram (also Ethernet frame or
+unstructured PDU Data). A **G-PDU** is that T-PDU plus the GTP-U header:
+
+```text
+G-PDU (message type 255):
+  octets 1-8      mandatory GTP-U header
+  octets 9-12     optional header (if E=1 or S=1 or PN=1)
+  (variable)      extension header chain (if E=1; clause 5.2)
+  (remainder)     T-PDU: original user packet (e.g. IP datagram)
+
+Signalling GTP-PDU (e.g. Error Indication):
+  octets 1-8      mandatory GTP-U header
+  octets 9-12     optional header (if E/S/PN set)
+  (remainder)     IE list
+```
+
+Error Indication and other GTP-U signalling messages are GTP-PDUs that are not
+G-PDUs: their body is an IE list, not a T-PDU.
+
+## GTP-U header layout
+
+TS 29.281 clause 5.1 (Figure 5.1-1). Every GTP-U message starts with a fixed
+mandatory part (`Gtpv1uMsgHeaderT`, 8 octets), then an optional 4-octet block when
+any of E, S, or PN is set in octet 1:
+
+```text
+Mandatory (8 octets):
+  octet 1     PN | S | E | spare | PT | version
+  octet 2     message type
+  octets 3-4  message length
+  octets 5-8  TEID
+
+Optional (4 octets, present if E=1 or S=1 or PN=1):
+  octets 9-10 sequence number
+  octet 11    N-PDU number
+  octet 12    next extension header type
+```
+
+What follows depends on message type and flags:
+
+* G-PDU with `E=1`: extension header chain (clause 5.2), then T-PDU
+* G-PDU with `E=0`: T-PDU starts immediately after the header
+* Error Indication: IE list after the header (see Error Indication)
+
+`gtpv1u_header_len()` in `gtp_itf.cpp` returns the byte offset where the body
+(extensions, T-PDU, or IEs) begins. G-PDU RX and Error Indication decode call it
+before parsing what comes next.
+
+## Extension headers
+
+TX uses `gtpu_extension_header_t` and `serialize_extension()` in
+`gtpu_extensions.{h,c}` (`gtpv1uCreateAndSendMsg()` chains extensions for G-PDU TX).
+
+G-PDU RX still walks the 29.281 chain inline inside `Gtpv1uHandleGpdu()`
+(`gtp_itf.cpp`): packed TS 38.415 PDU Session Information (QFI / RQI) for Next
+Extension Header Type `0x85` (PDU Session Container), and `nrup_lib` decode for
+type `0x84` (38.425 DL USER DATA / DDDS).
+
+Per TS 29.281 clause 5.1: when `E=1`, the optional 4 octets are present and
+octet 12 holds the first Next Extension Header Type. Per clause 5.2.1, each
+extension header length is a positive multiple of 4 octets (`m+1 = n*4`): the
+Extension Header Length field is in units of 4 octets and must be non-zero.
+
+```text
+Per extension header (Length field x 4 octets):
+  octet 1       Extension Header Length (unit = 4 octets, must be != 0)
+  octets 2..N-1 Extension Header Content
+  octet N       Next Extension Header Type (0 = end of chain)
+```
+
+GTP Next Extension Header Type (TS 29.281 Fig. 5.2.1-3) handled in OAI today:
+
+| Type | GTP name (29.281) | Content | TX `gtpu_extension_header_t` |
+|------|-------------------|---------|------------------------------|
+| `0x84` | NR RAN Container | TS 38.425 NR-U: DL USER DATA, DL DATA DELIVERY STATUS | `GTPU_EXT_DL_USER_DATA`, `GTPU_EXT_DL_DATA_DELIVERY_STATUS` |
+| `0x85` | PDU Session Container | TS 38.415: UL PDU Session Information (QFI) | `GTPU_EXT_UL_PDU_SESSION_INFORMATION` |
+
+## G-PDU RX
+
+`Gtpv1uHandleGpdu()`:
+
+```mermaid
+flowchart TD
+  A["Validate version / PT"] --> B{"te2ue_mapping.find TEID"}
+  B -->|miss| C{"TEID != 0?"}
+  C -->|yes| C1["gtpv1uSendErrorIndication"]
+  C -->|no| C2[drop]
+  C1 --> C2
+  B -->|hit| HL{"gtpv1u_header_len >= 0?"}
+  HL -->|no| Z[return GTPNOK]
+  HL -->|yes| D{"E == 1?"}
+  D -->|yes| E["extension processing<br/>PDU Session Container 0x85 - TS 38.415<br/>NR RAN Container 0x84 - TS 38.425 / nrup_lib"]
+  D -->|no| F{"T-PDU len > 0?"}
+  E --> F
+  F -->|yes| G{"callBackSDAP set?"}
+  G -->|yes| G1["N3 callBackSDAP"]
+  G -->|no| G2["F1 callBack"]
+  G1 --> J[done]
+  G2 --> TX{"F1 only: report_delivered<br/>SN mod 5 eq 0"}
+  F -->|no| TX
+  TX -->|yes| I["fillDlDeliveryStatusReport + TX DDDS"]
+  TX -->|no| J
+  I --> J
+```
+
+## Error Indication
+
+Message type 26 (TS 29.281). Body is an IE list after the GTP-U header
+(Table 7.3.1-1: TEID Data I, Peer Address, optional Recovery Time Stamp / Private
+Extension).
+
+Typical layout (TS 29.281 clause 7.3.1, header description in
+[GTP-U header layout](#gtp-u-header-layout)):
+
+* `S=1`, `E=0`, `PN=0`, header TEID = `0` (clause 5.1, not tunnel-scoped).
+* Failed TEID is only in **TEID Data I** (TV, clause 8.3).
+* **Peer Address** (TLV, clause 8.4): GTP-U IP of the node that detected the
+  error.
+* Optional Recovery Time Stamp / Private Extension (not implemented in OAI).
+* RX compatibility (`gtpv1u_decode_error_indication()` only): if `S=0` or header
+  TEID is non-zero, log a warning and continue.
+
+```text
+Header: type=26, TEID=0, S=1 -> IEs from octet 13
+  TEID Data I (TV, 8.3)      - TEID in error
+  Peer Address (TLV, 8.4)    - IPv4 or IPv6
+  Recovery / Private Ext.    - optional; OAI TX omits
+```
+
+Trigger: with unknown TEID in `te2ue_mapping` always drop the inbound G-PDU,
+if TEID is not 0 also TX Error Indication to the UDP originator, if TEID = 0
+drop only with no Error Indication (TS 29.281 §7.3.1 / TS 23.527 §5.2.1).
+
+### APIs (`gtp_itf.h`)
+
+* `gtpv1u_encode_error_indication()` / `gtpv1u_decode_error_indication()`
+* Per-tunnel `errorIndicationCallBack` on tunnel create (`newGtpuCreateTunnel` /
+  `gtpv1u_create_ngu_tunnel`)
+
+### Implementation
+
+**Spec (TS 23.527 §5.3.3.1):** on N3 Error Indication from the UPF, the 5G-AN
+shall release PDU session resources immediately and shall send NGAP PDU Session
+Resource Notify (38.413 §8.2.4).
+N3 GTP-U (29.281) belongs to CUUP so has no NGAP binding, therefore in OAI
+the indication is forwarded to CU-CP **Bearer Context Modification Required**
+(§8.3.3) which is used by CU-UP to inform CU-CP about issues in the UP.
+
+TX: unknown inbound G-PDU TEID (TS 29.281 clause 7.3.1 / TS 23.527 clause 5.2.1):
+`Gtpv1uHandleGpdu()` always drops the G-PDU and if header TEID is not all zeros
+it also calls `gtpv1uSendErrorIndication()`.
+
+**Not implemented:** F1-U Error Indication transmission and handling
+
+```mermaid
+sequenceDiagram
+  participant Peer as UDP peer
+  participant GTP as GTP-U
+
+  Peer->>GTP: G-PDU (unknown TEID)
+  GTP->>GTP: drop G-PDU
+  GTP->>Peer: Error Indication (TEID-I in IE body)
+```
+
+RX (N3 Error Indication from UPF). CU-UP to CU-CP direct/e1ap deployment
+(`cuup_cucp_direct` vs `cuup_cucp_e1ap`):
+
+```mermaid
+sequenceDiagram
+  participant UPF as UPF
+  participant AMF as AMF
+  participant GTP as GTP-U
+  participant CUUP as gNB-CU-UP
+  participant CUCP as gNB-CU-CP
+  participant DU as gNB-DU
+  participant UE as UE
+
+  UPF->>GTP: Error Indication (N3)
+  GTP->>GTP: Gtpv1uHandleError()
+  GTP->>GTP: gtpv1u_decode_error_indication()
+  GTP->>CUUP: n3_error_indication()<br/>release N3 / F1-U / SDAP
+  alt mono / F1 integrated (nr-softmodem)
+    CUUP->>CUCP: bearer_mod_required_direct()<br/>Bearer Context Modification Required
+  else E1 split (nr-cuup)
+    CUUP->>CUCP: bearer_mod_required_e1ap()<br/>Bearer Context Modification Required
+  end
+  CUCP->>CUCP: rrc_gNB_process_e1_bearer_context_mod_required()
+  CUCP->>CUUP: bearer_context_mod_confirm()<br/>Bearer Context Modification Confirm
+  CUCP->>DU: rrc_send_f1_ue_context_modification_request()<br/>F1 UE Context Modification Request<br/>+ RRCReconfiguration
+  DU->>CUCP: F1 UE Context Modification Response
+  DU->>UE: RRCReconfiguration
+  UE->>DU: RRCReconfigurationComplete
+  DU->>CUCP: F1 UL RRC Message Transfer
+  CUCP->>CUCP: handle_rrcReconfigurationComplete()
+  CUCP->>AMF: NGAP PDU Session Resource Notify
+```
+
+## Tests
+
+`openair3/ocp-gtpu/tests/test_gtp.cpp` (`test_gtp`):
+
+* `basic_conn`: tunnel setup, F1 G-PDU (`callBack`)
+* `basic_conn_qfi`: N3 G-PDU with QFI (`callBackSDAP`)
+* `multi_qos_flows`: multiple QFIs, one PDU session
+* `nrup_ddds`: DL USER DATA RX (Report Delivered), DDDS TX
+* `error_indication_decode` / `encode`: Error Indication IE codec + negative cases
+

--- a/doc/README.md
+++ b/doc/README.md
@@ -70,6 +70,7 @@ Legacy unmaintained files:
 - General software architecture notes: [SW_archi.md](./SW_archi.md)
 - [Information on E1](./E1AP/E1-design.md)
 - [Information on F1](./F1AP/F1-design.md)
+- [Information on GTP-U](./GTP/gtp-design.md)
 - [Information on how NR nFAPI works](./NR_NFAPI_archi.md)
 - [Flow graph of the L1 in gNB](SW-archi-graph.md)
 - [L1 threads in NR-UE](./nr-ue-design.md)

--- a/openair1/SIMULATION/NR_PHY/dlsim.c
+++ b/openair1/SIMULATION/NR_PHY/dlsim.c
@@ -153,6 +153,7 @@ int dummy_nr_ue_ul_indication(nr_uplink_indication_t *ul_info) { return(0);  }
 
 void e1_bearer_context_setup(const e1ap_bearer_setup_req_t *req) { abort(); }
 void e1_bearer_context_modif(const e1ap_bearer_mod_req_t *req) { abort(); }
+void e1_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *conf) { abort(); }
 void e1_bearer_release_cmd(const e1ap_bearer_release_cmd_t *cmd) { abort(); }
 
 int8_t nr_rrc_RA_succeeded(const module_id_t mod_id, const uint8_t gNB_index) {

--- a/openair1/SIMULATION/NR_PHY/psbchsim.c
+++ b/openair1/SIMULATION/NR_PHY/psbchsim.c
@@ -38,6 +38,10 @@ void e1_bearer_context_modif(const e1ap_bearer_mod_req_t *req)
 {
   abort();
 }
+void e1_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *conf)
+{
+  abort();
+}
 void e1_bearer_release_cmd(const e1ap_bearer_release_cmd_t *cmd)
 {
   abort();

--- a/openair1/SIMULATION/NR_PHY/srssim.c
+++ b/openair1/SIMULATION/NR_PHY/srssim.c
@@ -61,6 +61,10 @@ void e1_bearer_context_modif(const e1ap_bearer_mod_req_t *req)
 {
   abort();
 }
+void e1_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *conf)
+{
+  abort();
+}
 void e1_bearer_release_cmd(const e1ap_bearer_release_cmd_t *cmd)
 {
   abort();

--- a/openair1/SIMULATION/NR_PHY/ulsim.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim.c
@@ -115,6 +115,7 @@ void signal_ue_id(void /* const gNB_RRC_UE_t *rrc_ue_context, const uint16_t cla
 
 void e1_bearer_context_setup(const e1ap_bearer_setup_req_t *req) { abort(); }
 void e1_bearer_context_modif(const e1ap_bearer_mod_req_t *req) { abort(); }
+void e1_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *conf) { abort(); }
 void e1_bearer_release_cmd(const e1ap_bearer_release_cmd_t *cmd) { abort(); }
 
 int8_t nr_rrc_RA_succeeded(const module_id_t mod_id, const uint8_t gNB_index) {

--- a/openair1/SIMULATION/NR_PHY/ulsim_mu_mimo.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim_mu_mimo.c
@@ -129,6 +129,10 @@ void e1_bearer_context_modif(const e1ap_bearer_mod_req_t *req)
 {
   abort();
 }
+void e1_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *conf)
+{
+  abort();
+}
 void e1_bearer_release_cmd(const e1ap_bearer_release_cmd_t *cmd)
 {
   abort();

--- a/openair2/COMMON/e1ap_messages_def.h
+++ b/openair2/COMMON/e1ap_messages_def.h
@@ -29,6 +29,10 @@ MESSAGE_DEF(E1AP_BEARER_CONTEXT_MODIFICATION_REQ , MESSAGE_PRIORITY_MED , e1ap_b
 MESSAGE_DEF(E1AP_BEARER_CONTEXT_MODIFICATION_RESP, MESSAGE_PRIORITY_MED, e1ap_bearer_modif_resp_t, e1ap_bearer_modif_resp)
 /* E1AP Bearer Context Modification Failure: gNB-CU-UP -> gNB-CU-CP */
 MESSAGE_DEF(E1AP_BEARER_CONTEXT_MODIFICATION_FAIL, MESSAGE_PRIORITY_MED, e1ap_bearer_context_mod_failure_t, e1ap_bearer_modif_fail)
+/* E1AP Bearer Context Modification Required: gNB-CU-UP -> gNB-CU-CP */
+MESSAGE_DEF(E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED, MESSAGE_PRIORITY_MED, e1ap_bearer_mod_required_t, e1ap_bearer_mod_required)
+/* E1AP Bearer Context Modification Confirm: gNB-CU-CP -> gNB-CU-UP */
+MESSAGE_DEF(E1AP_BEARER_CONTEXT_MODIFICATION_CONFIRM, MESSAGE_PRIORITY_MED, e1ap_bearer_mod_confirm_t, e1ap_bearer_mod_confirm)
 /* E1AP Bearer Context Release Request: gNB-CU-CP -> gNB-CU-UP */
 MESSAGE_DEF(E1AP_BEARER_CONTEXT_RELEASE_CMD, MESSAGE_PRIORITY_MED, e1ap_bearer_release_cmd_t, e1ap_bearer_release_cmd)
 /* E1AP Bearer Context Release Response: gNB-CU-UP -> gNB-CU-CP */

--- a/openair2/COMMON/e1ap_messages_types.h
+++ b/openair2/COMMON/e1ap_messages_types.h
@@ -34,6 +34,8 @@
 #define E1AP_BEARER_CONTEXT_MODIFICATION_REQ(mSGpTR)      (mSGpTR)->ittiMsg.e1ap_bearer_mod_req
 #define E1AP_BEARER_CONTEXT_MODIFICATION_RESP(mSGpTR)     (mSGpTR)->ittiMsg.e1ap_bearer_modif_resp
 #define E1AP_BEARER_CONTEXT_MODIFICATION_FAIL(mSGpTR)     (mSGpTR)->ittiMsg.e1ap_bearer_modif_fail
+#define E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED(mSGpTR) (mSGpTR)->ittiMsg.e1ap_bearer_mod_required
+#define E1AP_BEARER_CONTEXT_MODIFICATION_CONFIRM(mSGpTR)  (mSGpTR)->ittiMsg.e1ap_bearer_mod_confirm
 #define E1AP_BEARER_CONTEXT_RELEASE_CMD(mSGpTR)           (mSGpTR)->ittiMsg.e1ap_bearer_release_cmd
 #define E1AP_BEARER_CONTEXT_RELEASE_CPLT(mSGpTR)          (mSGpTR)->ittiMsg.e1ap_bearer_release_cplt
 #define E1AP_LOST_CONNECTION(mSGpTR)                      (mSGpTR)->ittiMsg.e1ap_lost_connection
@@ -660,5 +662,22 @@ typedef struct e1ap_bearer_context_mod_failure_s {
   // NG-RAN PDU Session Resource Modified List (O)
   e1ap_cause_t cause;
 } e1ap_bearer_context_mod_failure_t;
+
+/**
+ * Bearer Context Modification Required (9.2.2.7 3GPP TS 38.463)
+ * (gNB-CU-UP -> gNB-CU-CP)
+ */
+typedef struct e1ap_bearer_mod_required_s {
+  uint32_t gNB_cu_cp_ue_id;
+  uint32_t gNB_cu_up_ue_id;
+  int numPDUSessionsRem;
+  pdu_session_to_remove_t *pduSessionRem;
+} e1ap_bearer_mod_required_t;
+
+/** Bearer Context Modification Confirm (9.2.2.8 3GPP TS 38.463) */
+typedef struct e1ap_bearer_mod_confirm_s {
+  uint32_t gNB_cu_cp_ue_id;
+  uint32_t gNB_cu_up_ue_id;
+} e1ap_bearer_mod_confirm_t;
 
 #endif /* E1AP_MESSAGES_TYPES_H */

--- a/openair2/COMMON/ngap_messages_def.h
+++ b/openair2/COMMON/ngap_messages_def.h
@@ -45,6 +45,7 @@ MESSAGE_DEF(NGAP_UE_CONTEXT_RELEASE_COMPLETE, MESSAGE_PRIORITY_MED, ngap_ue_rele
 MESSAGE_DEF(NGAP_PDUSESSION_SETUP_RESP          , MESSAGE_PRIORITY_MED, ngap_pdusession_setup_resp_t          , ngap_pdusession_setup_resp)
 MESSAGE_DEF(NGAP_PDUSESSION_MODIFY_RESP          , MESSAGE_PRIORITY_MED, ngap_pdusession_modify_resp_t          , ngap_pdusession_modify_resp)
 MESSAGE_DEF(NGAP_PDUSESSION_RELEASE_RESPONSE    , MESSAGE_PRIORITY_MED, ngap_pdusession_release_resp_t        , ngap_pdusession_release_resp)
+MESSAGE_DEF(NGAP_PDUSESSION_RESOURCE_NOTIFY     , MESSAGE_PRIORITY_MED, ngap_pdusession_resource_notify_t    , ngap_pdusession_resource_notify)
 MESSAGE_DEF(NGAP_HANDOVER_REQUIRED, MESSAGE_PRIORITY_MED, ngap_handover_required_t, ngap_handover_required)
 MESSAGE_DEF(NGAP_HANDOVER_FAILURE, MESSAGE_PRIORITY_MED, ngap_handover_failure_t, ngap_handover_failure)
 MESSAGE_DEF(NGAP_HANDOVER_REQUEST_ACKNOWLEDGE, MESSAGE_PRIORITY_MED, ngap_handover_request_ack_t, ngap_handover_request_ack)

--- a/openair2/COMMON/ngap_messages_types.h
+++ b/openair2/COMMON/ngap_messages_types.h
@@ -53,6 +53,7 @@
 #define NGAP_UE_CONTEXT_RELEASE_REQ(mSGpTR)     (mSGpTR)->ittiMsg.ngap_ue_release_req
 #define NGAP_PDUSESSION_RELEASE_COMMAND(mSGpTR)      (mSGpTR)->ittiMsg.ngap_pdusession_release_command
 #define NGAP_PDUSESSION_RELEASE_RESPONSE(mSGpTR)     (mSGpTR)->ittiMsg.ngap_pdusession_release_resp
+#define NGAP_PDUSESSION_RESOURCE_NOTIFY(mSGpTR)      (mSGpTR)->ittiMsg.ngap_pdusession_resource_notify
 
 #define NGAP_UL_RAN_STATUS_TRANSFER(mSGpTR) (mSGpTR)->ittiMsg.ngap_ul_ran_status_transfer
 #define NGAP_DL_RAN_STATUS_TRANSFER(mSGpTR) (mSGpTR)->ittiMsg.ngap_dl_ran_status_transfer
@@ -302,6 +303,12 @@ typedef struct ngap_cause_s {
   CAUSE_DEF(NGAP_CAUSE_RADIO_NETWORK_INSUFFICIENT_UE_CAPABILITIES, 51)
 
 typedef enum { FOREACH_CAUSE_RADIO_NETWORK(TO_ENUM) } ngap_cause_radio_network_t;
+
+/* Transport Cause (9.3.1.2 of 3GPP TS 38.413) */
+typedef enum {
+  NGAP_CAUSE_TRANSPORT_RESOURCE_UNAVAILABLE = 0,
+  NGAP_CAUSE_TRANSPORT_UNSPECIFIED = 1,
+} ngap_cause_transport_t;
 
 /** NGAP protocol cause values (9.3.1.2 of 3GPP TS 38.413) */
 #define FOREACH_CAUSE_PROTOCOL(CAUSE_DEF)                                  \
@@ -994,6 +1001,18 @@ typedef struct ngap_pdusession_release_resp_s {
   uint16_t nb_of_pdusessions_released;
   pdusession_release_t pdusession_release[NR_MAX_NB_PDU_SESSIONS];
 } ngap_pdusession_release_resp_t;
+
+typedef struct ngap_pdusession_notify_item_s {
+  uint8_t pdu_session_id;
+  ngap_cause_t cause;
+} ngap_pdusession_notify_item_t;
+
+/** NGAP PDU Session Resource Notify (8.2.4 of 3GPP TS 38.413) */
+typedef struct ngap_pdusession_resource_notify_s {
+  uint32_t gNB_ue_ngap_id;
+  int nb_pdu_sessions_released;
+  ngap_pdusession_notify_item_t pdu_sessions[NR_MAX_NB_PDU_SESSIONS];
+} ngap_pdusession_resource_notify_t;
 
 /** NG PAGING PROCEDURES (9.2.4. of 3GPP TS 38.413) */
 

--- a/openair2/E1AP/e1ap.c
+++ b/openair2/E1AP/e1ap.c
@@ -451,7 +451,7 @@ int e1apCUUP_handle_BEARER_CONTEXT_MODIFICATION_CONFIRM(sctp_assoc_t assoc_id, e
     free_e1ap_context_mod_confirm(&conf);
     return -1;
   }
-  LOG_I(E1AP, "Received Bearer Context Modification Confirm for CU-CP UE E1AP ID %u\n", conf.gNB_cu_cp_ue_id);
+  e1_bearer_context_mod_confirm(&conf);
   free_e1ap_context_mod_confirm(&conf);
   return 0;
 }

--- a/openair2/E1AP/e1ap.c
+++ b/openair2/E1AP/e1ap.c
@@ -40,7 +40,9 @@ const e1ap_message_processing_t e1ap_message_processing[E1AP_NUM_MSG_HANDLERS][3
     {e1apCUUP_handle_BEARER_CONTEXT_MODIFICATION_REQUEST,
      e1apCUCP_handle_BEARER_CONTEXT_MODIFICATION_RESPONSE,
      e1apCUCP_handle_BEARER_CONTEXT_MODIFICATION_FAILURE}, /* bearerContextModification */
-    {0, 0, 0}, /* bearerContextModificationRequired */
+    {e1apCUCP_handle_BEARER_CONTEXT_MODIFICATION_REQUIRED,
+     e1apCUUP_handle_BEARER_CONTEXT_MODIFICATION_CONFIRM,
+     0}, /* bearerContextModificationRequired */
     {e1apCUUP_handle_BEARER_CONTEXT_RELEASE_COMMAND, e1apCUCP_handle_BEARER_CONTEXT_RELEASE_COMPLETE, 0}, /* bearerContextRelease */
     {0, 0, 0}, /* bearerContextReleaseRequired */
     {0, 0, 0} /* bearerContextInactivityNotification */
@@ -412,6 +414,48 @@ int e1apCUCP_handle_BEARER_CONTEXT_MODIFICATION_FAILURE(sctp_assoc_t assoc_id, e
   return 0;
 }
 
+static int e1apCUUP_send_BEARER_CONTEXT_MODIFICATION_REQUIRED(sctp_assoc_t assoc_id, const e1ap_bearer_mod_required_t *req)
+{
+  E1AP_E1AP_PDU_t *pdu = encode_E1_bearer_context_mod_required(req);
+  return e1ap_encode_send(UPtype, assoc_id, pdu, 0, __func__);
+}
+
+int e1apCUCP_handle_BEARER_CONTEXT_MODIFICATION_REQUIRED(sctp_assoc_t assoc_id, e1ap_upcp_inst_t *inst, const E1AP_E1AP_PDU_t *pdu)
+{
+  UNUSED(inst);
+  e1ap_bearer_mod_required_t required = {0};
+  if (!decode_E1_bearer_context_mod_required(pdu, &required)) {
+    free_e1ap_context_mod_required(&required);
+    return -1;
+  }
+  MessageDef *msg = itti_alloc_new_message(TASK_CUUP_E1, 0, E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED);
+  msg->ittiMsgHeader.originInstance = assoc_id;
+  E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED(msg) = cp_bearer_context_mod_required(&required);
+  free_e1ap_context_mod_required(&required);
+  itti_send_msg_to_task(TASK_RRC_GNB, 0, msg);
+  return 0;
+}
+
+static int e1apCUCP_send_BEARER_CONTEXT_MODIFICATION_CONFIRM(sctp_assoc_t assoc_id, const e1ap_bearer_mod_confirm_t *conf)
+{
+  E1AP_E1AP_PDU_t *pdu = encode_E1_bearer_context_mod_confirm(conf);
+  return e1ap_encode_send(CPtype, assoc_id, pdu, 0, __func__);
+}
+
+int e1apCUUP_handle_BEARER_CONTEXT_MODIFICATION_CONFIRM(sctp_assoc_t assoc_id, e1ap_upcp_inst_t *inst, const E1AP_E1AP_PDU_t *pdu)
+{
+  UNUSED(assoc_id);
+  UNUSED(inst);
+  e1ap_bearer_mod_confirm_t conf = {0};
+  if (!decode_E1_bearer_context_mod_confirm(&conf, pdu)) {
+    free_e1ap_context_mod_confirm(&conf);
+    return -1;
+  }
+  LOG_I(E1AP, "Received Bearer Context Modification Confirm for CU-CP UE E1AP ID %u\n", conf.gNB_cu_cp_ue_id);
+  free_e1ap_context_mod_confirm(&conf);
+  return 0;
+}
+
 /*
   BEARER CONTEXT RELEASE
 */
@@ -664,6 +708,11 @@ void *E1AP_CUCP_task(void *arg)
         free_e1ap_context_mod_request(&E1AP_BEARER_CONTEXT_MODIFICATION_REQ(msg));
         break;
 
+      case E1AP_BEARER_CONTEXT_MODIFICATION_CONFIRM:
+        e1apCUCP_send_BEARER_CONTEXT_MODIFICATION_CONFIRM(assoc_id, &E1AP_BEARER_CONTEXT_MODIFICATION_CONFIRM(msg));
+        free_e1ap_context_mod_confirm(&E1AP_BEARER_CONTEXT_MODIFICATION_CONFIRM(msg));
+        break;
+
       case E1AP_BEARER_CONTEXT_RELEASE_CMD:
         e1apCUCP_send_BEARER_CONTEXT_RELEASE_COMMAND(assoc_id, &E1AP_BEARER_CONTEXT_RELEASE_CMD(msg));
         free_e1_bearer_context_release_command(&E1AP_BEARER_CONTEXT_RELEASE_CMD(msg));
@@ -756,6 +805,14 @@ void *E1AP_CUUP_task(void *arg)
         AssertFatal(inst, "no E1 instance found for instance %ld\n", myInstance);
         e1apCUUP_send_BEARER_CONTEXT_MODIFICATION_FAILURE(inst->cuup.assoc_id, fail);
         free_E1_bearer_context_mod_failure(fail);
+      } break;
+
+      case E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED: {
+        const e1ap_bearer_mod_required_t *req = &E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED(msg);
+        const e1ap_upcp_inst_t *inst = getCxtE1(myInstance);
+        AssertFatal(inst, "no E1 instance found for instance %ld\n", myInstance);
+        e1apCUUP_send_BEARER_CONTEXT_MODIFICATION_REQUIRED(inst->cuup.assoc_id, req);
+        free_e1ap_context_mod_required(req);
       } break;
 
       case E1AP_BEARER_CONTEXT_RELEASE_CPLT: {

--- a/openair2/E1AP/e1ap.h
+++ b/openair2/E1AP/e1ap.h
@@ -27,6 +27,10 @@ int e1apCUCP_handle_BEARER_CONTEXT_MODIFICATION_RESPONSE(sctp_assoc_t assoc_id, 
 
 int e1apCUCP_handle_BEARER_CONTEXT_MODIFICATION_FAILURE(sctp_assoc_t assoc_id, e1ap_upcp_inst_t *inst, const E1AP_E1AP_PDU_t *pdu);
 
+int e1apCUCP_handle_BEARER_CONTEXT_MODIFICATION_REQUIRED(sctp_assoc_t assoc_id, e1ap_upcp_inst_t *inst, const E1AP_E1AP_PDU_t *pdu);
+
+int e1apCUUP_handle_BEARER_CONTEXT_MODIFICATION_CONFIRM(sctp_assoc_t assoc_id, e1ap_upcp_inst_t *inst, const E1AP_E1AP_PDU_t *pdu);
+
 void e1apCUUP_send_BEARER_CONTEXT_SETUP_RESPONSE(sctp_assoc_t assoc_id, const e1ap_bearer_setup_resp_t *resp);
 
 int e1apCUUP_handle_BEARER_CONTEXT_RELEASE_COMMAND(sctp_assoc_t assoc_id, e1ap_upcp_inst_t *inst, const E1AP_E1AP_PDU_t *pdu);

--- a/openair2/E1AP/e1ap_common.c
+++ b/openair2/E1AP/e1ap_common.c
@@ -83,80 +83,12 @@ void E1AP_free_transaction_identifier(long id) {
   LOG_E(E1AP, "Couldn't find transaction ID %ld in list\n", id);
 }
 
-int e1ap_decode_initiating_message(E1AP_E1AP_PDU_t *pdu) {
-  DevAssert(pdu != NULL);
-
-  switch(pdu->choice.initiatingMessage->procedureCode) {
-    case E1AP_ProcedureCode_id_gNB_CU_UP_E1Setup:
-      break;
-
-    case E1AP_ProcedureCode_id_gNB_CU_UP_ConfigurationUpdate:
-      break;
-
-    case E1AP_ProcedureCode_id_bearerContextSetup:
-      break;
-
-    case E1AP_ProcedureCode_id_bearerContextModification:
-      break;
-
-    case E1AP_ProcedureCode_id_bearerContextRelease:
-      break;
-
-    default:
-      LOG_E(E1AP, "Unsupported procedure code (%d) for initiating message\n",
-            (int)pdu->choice.initiatingMessage->procedureCode);
-      return -1;
-  }
-  return 0;
-}
-
-int e1ap_decode_successful_outcome(E1AP_E1AP_PDU_t *pdu) {
-  DevAssert(pdu != NULL);
-  switch(pdu->choice.successfulOutcome->procedureCode) {
-    case E1AP_ProcedureCode_id_gNB_CU_UP_E1Setup:
-      break;
-
-    case E1AP_ProcedureCode_id_bearerContextSetup:
-      break;
-
-    case E1AP_ProcedureCode_id_bearerContextModification:
-      break;
-
-    case E1AP_ProcedureCode_id_bearerContextRelease:
-      break;
-
-    default:
-      LOG_E(E1AP, "Unsupported procedure code (%d) for successful message\n",
-            (int)pdu->choice.successfulOutcome->procedureCode);
-      return -1;
-  }
-  return 0;
-}
-
-int e1ap_decode_unsuccessful_outcome(E1AP_E1AP_PDU_t *pdu) {
-  DevAssert(pdu != NULL);
-  switch(pdu->choice.unsuccessfulOutcome->procedureCode) {
-    case E1AP_ProcedureCode_id_gNB_CU_UP_E1Setup:
-      break;
-
-    default:
-      LOG_E(E1AP, "Unsupported procedure code (%d) for unsuccessful message\n",
-            (int)pdu->choice.unsuccessfulOutcome->procedureCode);
-      return -1;
-  }
-  return 0;
-}
-
-int e1ap_decode_pdu(E1AP_E1AP_PDU_t *pdu, const uint8_t *const buffer, uint32_t length) {
-  asn_dec_rval_t dec_ret;
+int e1ap_decode_pdu(E1AP_E1AP_PDU_t *pdu, const uint8_t *const buffer, uint32_t length)
+{
   DevAssert(buffer != NULL);
-  dec_ret = aper_decode(NULL,
-                        &asn_DEF_E1AP_E1AP_PDU,
-                        (void **)&pdu,
-                        buffer,
-                        length,
-                        0,
-                        0);
+  DevAssert(pdu != NULL);
+
+  asn_dec_rval_t dec_ret = aper_decode(NULL, &asn_DEF_E1AP_E1AP_PDU, (void **)&pdu, buffer, length, 0, 0);
 
   if (LOG_DEBUGFLAG(DEBUG_ASN1)) {
     LOG_E(E1AP, "----------------- ASN1 DECODER PRINT START----------------- \n");
@@ -165,26 +97,11 @@ int e1ap_decode_pdu(E1AP_E1AP_PDU_t *pdu, const uint8_t *const buffer, uint32_t 
   }
 
   if (dec_ret.code != RC_OK) {
-    AssertFatal(1==0,"Failed to decode pdu\n");
+    LOG_E(E1AP, "Failed to decode E1AP PDU\n");
     return -1;
   }
 
-  switch(pdu->present) {
-    case E1AP_E1AP_PDU_PR_initiatingMessage:
-      return e1ap_decode_initiating_message(pdu);
-
-    case E1AP_E1AP_PDU_PR_successfulOutcome:
-      return e1ap_decode_successful_outcome(pdu);
-
-    case E1AP_E1AP_PDU_PR_unsuccessfulOutcome:
-      return e1ap_decode_unsuccessful_outcome(pdu);
-
-    default:
-      LOG_E(E1AP, "Unknown presence (%d) or not implemented\n", (int)pdu->present);
-      break;
-  }
-
-  return -1;
+  return 0;
 }
 
 int e1ap_encode_send(E1_t type, sctp_assoc_t assoc_id, E1AP_E1AP_PDU_t *pdu, uint16_t stream, const char *func)
@@ -199,10 +116,11 @@ int e1ap_encode_send(E1_t type, sctp_assoc_t assoc_id, E1AP_E1AP_PDU_t *pdu, uin
 
   char errbuf[2048]; /* Buffer for error message */
   size_t errlen = sizeof(errbuf); /* Size of the buffer */
-  int ret = asn_check_constraints(&asn_DEF_E1AP_E1AP_PDU, pdu, errbuf, &errlen);
-
-  if(ret) {
+  if (asn_check_constraints(&asn_DEF_E1AP_E1AP_PDU, pdu, errbuf, &errlen)) {
+    xer_fprint(stdout, &asn_DEF_E1AP_E1AP_PDU, pdu);
     LOG_E(E1AP, "%s: Constraint validation failed: %s\n", func, errbuf);
+    ASN_STRUCT_FREE(asn_DEF_E1AP_E1AP_PDU, pdu);
+    return -1;
   }
 
   void *buffer = NULL;
@@ -213,6 +131,7 @@ int e1ap_encode_send(E1_t type, sctp_assoc_t assoc_id, E1AP_E1AP_PDU_t *pdu, uin
     LOG_E(E1AP, "%s: Failed to encode E1AP message\n", func);
     return -1;
   }
+
   MessageDef *message = itti_alloc_new_message((type == CPtype) ? TASK_CUCP_E1 : TASK_CUUP_E1, 0, SCTP_DATA_REQ);
   sctp_data_req_t *s = &message->ittiMsg.sctp_data_req;
   s->assoc_id = assoc_id;

--- a/openair2/E1AP/lib/e1ap_bearer_context_management.c
+++ b/openair2/E1AP/lib/e1ap_bearer_context_management.c
@@ -2749,3 +2749,314 @@ void free_E1_bearer_context_mod_failure(const e1ap_bearer_context_mod_failure_t 
   UNUSED(msg);
   // do nothing
 }
+
+/* ============================================
+ *   E1AP Bearer Context Modification Required
+ * ============================================ */
+
+/** @brief Encode PDU Session Resource To Remove Item */
+static void e1_encode_pdu_session_to_remove_item(E1AP_PDU_Session_Resource_To_Remove_Item_t *out, const pdu_session_to_remove_t *in)
+{
+  // PDU Session ID (M)
+  out->pDU_Session_ID = in->sessionId;
+  // Cause (O) - PDU-Session-Resource-To-Remove-Item-ExtIEs id-Cause
+  if (in->cause.type != E1AP_CAUSE_NOTHING) {
+    E1AP_ProtocolExtensionContainer_4961P104_t *ext = calloc_or_fail(1, sizeof(*ext));
+    out->iE_Extensions = (struct E1AP_ProtocolExtensionContainer *)ext;
+    asn1cSequenceAdd(ext->list, E1AP_PDU_Session_Resource_To_Remove_Item_ExtIEs_t, ie);
+    ie->id = E1AP_ProtocolIE_ID_id_Cause;
+    ie->criticality = E1AP_Criticality_ignore;
+    ie->extensionValue.present = E1AP_PDU_Session_Resource_To_Remove_Item_ExtIEs__extensionValue_PR_Cause;
+    ie->extensionValue.choice.Cause = e1_encode_cause_ie(&in->cause);
+  }
+}
+
+/** @brief Decode PDU Session Resource To Remove Item */
+static bool e1_decode_pdu_session_to_remove_item(pdu_session_to_remove_t *out, const E1AP_PDU_Session_Resource_To_Remove_Item_t *in)
+{
+  *out = (pdu_session_to_remove_t){0};
+  // PDU Session ID (M)
+  out->sessionId = in->pDU_Session_ID;
+  // Cause (O)
+  if (in->iE_Extensions != NULL) {
+    const E1AP_ProtocolExtensionContainer_4961P104_t *ext = (const E1AP_ProtocolExtensionContainer_4961P104_t *)in->iE_Extensions;
+    for (int i = 0; i < ext->list.count; i++) {
+      const E1AP_PDU_Session_Resource_To_Remove_Item_ExtIEs_t *ie = ext->list.array[i];
+      AssertFatal(ie != NULL, "ext->list.array[i] shall not be null");
+      if (ie->id != E1AP_ProtocolIE_ID_id_Cause)
+        continue;
+      _EQ_CHECK_INT(ie->extensionValue.present, E1AP_PDU_Session_Resource_To_Remove_Item_ExtIEs__extensionValue_PR_Cause);
+      out->cause = e1_decode_cause_ie(&ie->extensionValue.choice.Cause);
+      break;
+    }
+  }
+  return true;
+}
+
+/** @brief Bearer Context Modification Required encoding (9.2.2.7, 3GPP TS 38.463)
+ *         gNB-CU-UP -> gNB-CU-CP */
+E1AP_E1AP_PDU_t *encode_E1_bearer_context_mod_required(const e1ap_bearer_mod_required_t *msg)
+{
+  E1AP_E1AP_PDU_t *pdu = calloc_or_fail(1, sizeof(*pdu));
+  pdu->present = E1AP_E1AP_PDU_PR_initiatingMessage;
+  asn1cCalloc(pdu->choice.initiatingMessage, type);
+  type->procedureCode = E1AP_ProcedureCode_id_bearerContextModificationRequired;
+  type->criticality = E1AP_Criticality_reject;
+  type->value.present = E1AP_InitiatingMessage__value_PR_BearerContextModificationRequired;
+  E1AP_BearerContextModificationRequired_t *out = &type->value.choice.BearerContextModificationRequired;
+
+  // gNB-CU-CP UE E1AP ID (M)
+  asn1cSequenceAdd(out->protocolIEs.list, E1AP_BearerContextModificationRequiredIEs_t, ie1);
+  ie1->id = E1AP_ProtocolIE_ID_id_gNB_CU_CP_UE_E1AP_ID;
+  ie1->criticality = E1AP_Criticality_reject;
+  ie1->value.present = E1AP_BearerContextModificationRequiredIEs__value_PR_GNB_CU_CP_UE_E1AP_ID;
+  ie1->value.choice.GNB_CU_CP_UE_E1AP_ID = msg->gNB_cu_cp_ue_id;
+
+  // gNB-CU-UP UE E1AP ID (M)
+  asn1cSequenceAdd(out->protocolIEs.list, E1AP_BearerContextModificationRequiredIEs_t, ie2);
+  ie2->id = E1AP_ProtocolIE_ID_id_gNB_CU_UP_UE_E1AP_ID;
+  ie2->criticality = E1AP_Criticality_reject;
+  ie2->value.present = E1AP_BearerContextModificationRequiredIEs__value_PR_GNB_CU_UP_UE_E1AP_ID;
+  ie2->value.choice.GNB_CU_UP_UE_E1AP_ID = msg->gNB_cu_up_ue_id;
+
+  // System Bearer Context Modification Required (M)
+  asn1cSequenceAdd(out->protocolIEs.list, E1AP_BearerContextModificationRequiredIEs_t, ie3);
+  ie3->id = E1AP_ProtocolIE_ID_id_System_BearerContextModificationRequired;
+  ie3->criticality = E1AP_Criticality_reject;
+  ie3->value.present = E1AP_BearerContextModificationRequiredIEs__value_PR_System_BearerContextModificationRequired;
+  E1AP_System_BearerContextModificationRequired_t *sys = &ie3->value.choice.System_BearerContextModificationRequired;
+  sys->present = E1AP_System_BearerContextModificationRequired_PR_nG_RAN_BearerContextModificationRequired;
+  E1AP_ProtocolIE_Container_4932P33_t *msgNGRAN_list = calloc_or_fail(1, sizeof(*msgNGRAN_list));
+  sys->choice.nG_RAN_BearerContextModificationRequired = (struct E1AP_ProtocolIE_Container *)msgNGRAN_list;
+
+  // NG-RAN PDU Session Resource To Remove List (O)
+  if (msg->numPDUSessionsRem > 0 && msg->pduSessionRem != NULL) {
+    asn1cSequenceAdd(msgNGRAN_list->list, E1AP_NG_RAN_BearerContextModificationRequired_t, msgNGRAN);
+    msgNGRAN->id = E1AP_ProtocolIE_ID_id_PDU_Session_Resource_To_Remove_List;
+    msgNGRAN->criticality = E1AP_Criticality_reject;
+    msgNGRAN->value.present = E1AP_NG_RAN_BearerContextModificationRequired__value_PR_PDU_Session_Resource_To_Remove_List;
+    E1AP_PDU_Session_Resource_To_Remove_List_t *pdu2Remove = &msgNGRAN->value.choice.PDU_Session_Resource_To_Remove_List;
+    for (const pdu_session_to_remove_t *i = msg->pduSessionRem; i < msg->pduSessionRem + msg->numPDUSessionsRem; i++) {
+      asn1cSequenceAdd(pdu2Remove->list, E1AP_PDU_Session_Resource_To_Remove_Item_t, ieC4_1);
+      e1_encode_pdu_session_to_remove_item(ieC4_1, i);
+    }
+  }
+  return pdu;
+}
+
+/** @brief Bearer Context Modification Required decoding (9.2.2.7, 3GPP TS 38.463)
+ *         gNB-CU-UP -> gNB-CU-CP */
+bool decode_E1_bearer_context_mod_required(const E1AP_E1AP_PDU_t *pdu, e1ap_bearer_mod_required_t *out)
+{
+  DevAssert(pdu != NULL);
+  _EQ_CHECK_INT(pdu->present, E1AP_E1AP_PDU_PR_initiatingMessage);
+  const E1AP_InitiatingMessage_t *im = pdu->choice.initiatingMessage;
+  _EQ_CHECK_LONG(im->procedureCode, E1AP_ProcedureCode_id_bearerContextModificationRequired);
+  _EQ_CHECK_INT(im->value.present, E1AP_InitiatingMessage__value_PR_BearerContextModificationRequired);
+  const E1AP_BearerContextModificationRequired_t *in = &im->value.choice.BearerContextModificationRequired;
+
+  // Mandatory IEs (TS 38.463 9.2.2.7)
+  E1AP_BearerContextModificationRequiredIEs_t *ie = NULL;
+  E1AP_LIB_FIND_IE(E1AP_BearerContextModificationRequiredIEs_t, ie, in, E1AP_ProtocolIE_ID_id_gNB_CU_CP_UE_E1AP_ID, true);
+  E1AP_LIB_FIND_IE(E1AP_BearerContextModificationRequiredIEs_t, ie, in, E1AP_ProtocolIE_ID_id_gNB_CU_UP_UE_E1AP_ID, true);
+  E1AP_LIB_FIND_IE(E1AP_BearerContextModificationRequiredIEs_t, ie, in, E1AP_ProtocolIE_ID_id_System_BearerContextModificationRequired, true);
+
+  for (int i = 0; i < in->protocolIEs.list.count; i++) {
+    ie = in->protocolIEs.list.array[i];
+    AssertFatal(ie != NULL, "in->protocolIEs.list.array[i] shall not be null");
+    switch (ie->id) {
+      case E1AP_ProtocolIE_ID_id_gNB_CU_CP_UE_E1AP_ID:
+        _EQ_CHECK_INT(ie->value.present, E1AP_BearerContextModificationRequiredIEs__value_PR_GNB_CU_CP_UE_E1AP_ID);
+        out->gNB_cu_cp_ue_id = ie->value.choice.GNB_CU_CP_UE_E1AP_ID;
+        break;
+      case E1AP_ProtocolIE_ID_id_gNB_CU_UP_UE_E1AP_ID:
+        _EQ_CHECK_INT(ie->value.present, E1AP_BearerContextModificationRequiredIEs__value_PR_GNB_CU_UP_UE_E1AP_ID);
+        out->gNB_cu_up_ue_id = ie->value.choice.GNB_CU_UP_UE_E1AP_ID;
+        break;
+      case E1AP_ProtocolIE_ID_id_System_BearerContextModificationRequired: {
+        _EQ_CHECK_INT(ie->value.present,
+                      E1AP_BearerContextModificationRequiredIEs__value_PR_System_BearerContextModificationRequired);
+        const E1AP_System_BearerContextModificationRequired_t *modReq = &ie->value.choice.System_BearerContextModificationRequired;
+        switch (modReq->present) {
+          case E1AP_System_BearerContextModificationRequired_PR_NOTHING:
+            PRINT_ERROR("System Bearer Context Modification Required: no choice present\n");
+            break;
+          case E1AP_System_BearerContextModificationRequired_PR_e_UTRAN_BearerContextModificationRequired:
+            PRINT_ERROR("UTRAN in Bearer Context Modification Required not supported\n");
+            return false;
+          case E1AP_System_BearerContextModificationRequired_PR_nG_RAN_BearerContextModificationRequired: {
+            AssertFatal(modReq->choice.nG_RAN_BearerContextModificationRequired != NULL,
+                        "nG_RAN_BearerContextModificationRequired shall not be null");
+            const E1AP_ProtocolIE_Container_4932P33_t *msgNGRAN_list =
+                (const E1AP_ProtocolIE_Container_4932P33_t *)modReq->choice.nG_RAN_BearerContextModificationRequired;
+            for (int j = 0; j < msgNGRAN_list->list.count; j++) {
+              const E1AP_NG_RAN_BearerContextModificationRequired_t *msgNGRAN = msgNGRAN_list->list.array[j];
+              switch (msgNGRAN->id) {
+                case E1AP_ProtocolIE_ID_id_PDU_Session_Resource_To_Remove_List: {
+                  _EQ_CHECK_INT(msgNGRAN->value.present,
+                                E1AP_NG_RAN_BearerContextModificationRequired__value_PR_PDU_Session_Resource_To_Remove_List);
+                  const E1AP_PDU_Session_Resource_To_Remove_List_t *remList =
+                      &msgNGRAN->value.choice.PDU_Session_Resource_To_Remove_List;
+                  out->numPDUSessionsRem = remList->list.count;
+                  if (out->numPDUSessionsRem <= 0 || out->numPDUSessionsRem > NR_MAX_NB_PDU_SESSIONS) {
+                    PRINT_ERROR("PDU Session Resource To Remove List count %d out of range (1..%d)\n",
+                                out->numPDUSessionsRem,
+                                NR_MAX_NB_PDU_SESSIONS);
+                    return false;
+                  }
+                  out->pduSessionRem = calloc_or_fail(out->numPDUSessionsRem, sizeof(*out->pduSessionRem));
+                  for (int k = 0; k < remList->list.count; k++)
+                    CHECK_E1AP_DEC(e1_decode_pdu_session_to_remove_item(&out->pduSessionRem[k], remList->list.array[k]));
+                  break;
+                }
+                default:
+                  PRINT_ERROR("Unknown msgNGRAN->id in Bearer Context Modification Required\n");
+                  return false;
+              }
+            }
+            break;
+          }
+          default:
+            PRINT_ERROR("System Bearer Context Modification Required: No valid choice present.\n");
+            break;
+        }
+        break;
+      }
+      default:
+        PRINT_ERROR("%s decoding failure: IE %ld is invalid\n", __func__, ie->id);
+        return false;
+    }
+  }
+  return true;
+}
+
+/** @brief E1AP Bearer Context Modification Required: deep copy */
+e1ap_bearer_mod_required_t cp_bearer_context_mod_required(const e1ap_bearer_mod_required_t *msg)
+{
+  e1ap_bearer_mod_required_t cp = *msg;
+  cp.pduSessionRem = NULL;
+  if (msg->numPDUSessionsRem > 0 && msg->pduSessionRem != NULL) {
+    cp.pduSessionRem = calloc_or_fail(msg->numPDUSessionsRem, sizeof(*cp.pduSessionRem));
+    for (int i = 0; i < msg->numPDUSessionsRem; i++)
+      cp.pduSessionRem[i] = msg->pduSessionRem[i];
+  }
+  return cp;
+}
+
+/** @brief E1AP Bearer Context Modification Required: equality check */
+bool eq_bearer_context_mod_required(const e1ap_bearer_mod_required_t *a, const e1ap_bearer_mod_required_t *b)
+{
+  _EQ_CHECK_INT(a->gNB_cu_cp_ue_id, b->gNB_cu_cp_ue_id);
+  _EQ_CHECK_INT(a->gNB_cu_up_ue_id, b->gNB_cu_up_ue_id);
+  _EQ_CHECK_INT(a->numPDUSessionsRem, b->numPDUSessionsRem);
+  _EQ_CHECK_OPTIONAL_PTR(a, b, pduSessionRem);
+  if (a->pduSessionRem != NULL && b->pduSessionRem != NULL) {
+    for (int i = 0; i < a->numPDUSessionsRem; i++) {
+      _EQ_CHECK_LONG(a->pduSessionRem[i].sessionId, b->pduSessionRem[i].sessionId);
+      _EQ_CHECK_INT(a->pduSessionRem[i].cause.type, b->pduSessionRem[i].cause.type);
+      _EQ_CHECK_INT(a->pduSessionRem[i].cause.value, b->pduSessionRem[i].cause.value);
+    }
+  }
+  return true;
+}
+
+/** @brief E1AP Bearer Context Modification Required: free */
+void free_e1ap_context_mod_required(const e1ap_bearer_mod_required_t *msg)
+{
+  free(msg->pduSessionRem);
+}
+
+/* ============================================
+ *   E1AP Bearer Context Modification Confirm
+ * ============================================ */
+
+/** @brief Bearer Context Modification Confirm encoding (9.2.2.8, 3GPP TS 38.463)
+ *         gNB-CU-CP -> gNB-CU-UP */
+E1AP_E1AP_PDU_t *encode_E1_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *msg)
+{
+  E1AP_E1AP_PDU_t *pdu = calloc_or_fail(1, sizeof(*pdu));
+  pdu->present = E1AP_E1AP_PDU_PR_successfulOutcome;
+  // Message Type (M)
+  asn1cCalloc(pdu->choice.successfulOutcome, type);
+  type->procedureCode = E1AP_ProcedureCode_id_bearerContextModificationRequired;
+  type->criticality = E1AP_Criticality_reject;
+  type->value.present = E1AP_SuccessfulOutcome__value_PR_BearerContextModificationConfirm;
+  E1AP_BearerContextModificationConfirm_t *out = &type->value.choice.BearerContextModificationConfirm;
+
+  // gNB-CU-CP UE E1AP ID (M)
+  asn1cSequenceAdd(out->protocolIEs.list, E1AP_BearerContextModificationConfirmIEs_t, ie1);
+  ie1->id = E1AP_ProtocolIE_ID_id_gNB_CU_CP_UE_E1AP_ID;
+  ie1->criticality = E1AP_Criticality_reject;
+  ie1->value.present = E1AP_BearerContextModificationConfirmIEs__value_PR_GNB_CU_CP_UE_E1AP_ID;
+  ie1->value.choice.GNB_CU_CP_UE_E1AP_ID = msg->gNB_cu_cp_ue_id;
+
+  // gNB-CU-UP UE E1AP ID (M)
+  asn1cSequenceAdd(out->protocolIEs.list, E1AP_BearerContextModificationConfirmIEs_t, ie2);
+  ie2->id = E1AP_ProtocolIE_ID_id_gNB_CU_UP_UE_E1AP_ID;
+  ie2->criticality = E1AP_Criticality_reject;
+  ie2->value.present = E1AP_BearerContextModificationConfirmIEs__value_PR_GNB_CU_UP_UE_E1AP_ID;
+  ie2->value.choice.GNB_CU_UP_UE_E1AP_ID = msg->gNB_cu_up_ue_id;
+
+  return pdu;
+}
+
+/** @brief Bearer Context Modification Confirm decoding (9.2.2.8, 3GPP TS 38.463)
+ *         gNB-CU-CP -> gNB-CU-UP */
+bool decode_E1_bearer_context_mod_confirm(e1ap_bearer_mod_confirm_t *out, const E1AP_E1AP_PDU_t *pdu)
+{
+  DevAssert(pdu != NULL);
+  _EQ_CHECK_INT(pdu->present, E1AP_E1AP_PDU_PR_successfulOutcome);
+  E1AP_SuccessfulOutcome_t *type = pdu->choice.successfulOutcome;
+  _EQ_CHECK_LONG(type->procedureCode, E1AP_ProcedureCode_id_bearerContextModificationRequired);
+  _EQ_CHECK_INT(type->value.present, E1AP_SuccessfulOutcome__value_PR_BearerContextModificationConfirm);
+  const E1AP_BearerContextModificationConfirm_t *in = &type->value.choice.BearerContextModificationConfirm;
+
+  // Check mandatory IEs
+  E1AP_BearerContextModificationConfirmIEs_t *ie;
+  E1AP_LIB_FIND_IE(E1AP_BearerContextModificationConfirmIEs_t, ie, in, E1AP_ProtocolIE_ID_id_gNB_CU_CP_UE_E1AP_ID, true);
+  E1AP_LIB_FIND_IE(E1AP_BearerContextModificationConfirmIEs_t, ie, in, E1AP_ProtocolIE_ID_id_gNB_CU_UP_UE_E1AP_ID, true);
+
+  for (int i = 0; i < in->protocolIEs.list.count; i++) {
+    ie = in->protocolIEs.list.array[i];
+    AssertFatal(ie != NULL, "in->protocolIEs.list.array[i] shall not be null");
+    switch (ie->id) {
+      case E1AP_ProtocolIE_ID_id_gNB_CU_CP_UE_E1AP_ID:
+        _EQ_CHECK_INT(ie->value.present, E1AP_BearerContextModificationConfirmIEs__value_PR_GNB_CU_CP_UE_E1AP_ID);
+        out->gNB_cu_cp_ue_id = ie->value.choice.GNB_CU_CP_UE_E1AP_ID;
+        break;
+      case E1AP_ProtocolIE_ID_id_gNB_CU_UP_UE_E1AP_ID:
+        _EQ_CHECK_INT(ie->value.present, E1AP_BearerContextModificationConfirmIEs__value_PR_GNB_CU_UP_UE_E1AP_ID);
+        out->gNB_cu_up_ue_id = ie->value.choice.GNB_CU_UP_UE_E1AP_ID;
+        break;
+      case E1AP_ProtocolIE_ID_id_System_BearerContextModificationConfirm:
+        break;
+      default:
+        PRINT_ERROR("%s decoding failure: IE %ld is not handled or invalid\n", __func__, ie->id);
+        break;
+    }
+  }
+  return true;
+}
+
+/** @brief Bearer Context Modification Confirm equality check */
+bool eq_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *a, const e1ap_bearer_mod_confirm_t *b)
+{
+  _EQ_CHECK_INT(a->gNB_cu_cp_ue_id, b->gNB_cu_cp_ue_id);
+  _EQ_CHECK_INT(a->gNB_cu_up_ue_id, b->gNB_cu_up_ue_id);
+  return true;
+}
+
+/** @brief Bearer Context Modification Confirm deep copy */
+e1ap_bearer_mod_confirm_t cp_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *msg)
+{
+  // Shallow copy only
+  e1ap_bearer_mod_confirm_t cp = *msg;
+  return cp;
+}
+
+/** @brief Bearer Context Modification Confirm free */
+void free_e1ap_context_mod_confirm(const e1ap_bearer_mod_confirm_t *msg)
+{
+  UNUSED(msg);
+  // do nothing
+}

--- a/openair2/E1AP/lib/e1ap_bearer_context_management.h
+++ b/openair2/E1AP/lib/e1ap_bearer_context_management.h
@@ -59,4 +59,16 @@ void free_E1_bearer_context_mod_failure(const e1ap_bearer_context_mod_failure_t 
 e1ap_bearer_context_mod_failure_t cp_E1_bearer_context_mod_failure(const e1ap_bearer_context_mod_failure_t *msg);
 bool eq_E1_bearer_context_mod_failure(const e1ap_bearer_context_mod_failure_t *a, const e1ap_bearer_context_mod_failure_t *b);
 
+struct E1AP_E1AP_PDU *encode_E1_bearer_context_mod_required(const e1ap_bearer_mod_required_t *msg);
+bool decode_E1_bearer_context_mod_required(const struct E1AP_E1AP_PDU *pdu, e1ap_bearer_mod_required_t *out);
+void free_e1ap_context_mod_required(const e1ap_bearer_mod_required_t *msg);
+e1ap_bearer_mod_required_t cp_bearer_context_mod_required(const e1ap_bearer_mod_required_t *msg);
+bool eq_bearer_context_mod_required(const e1ap_bearer_mod_required_t *a, const e1ap_bearer_mod_required_t *b);
+
+struct E1AP_E1AP_PDU *encode_E1_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *msg);
+bool decode_E1_bearer_context_mod_confirm(e1ap_bearer_mod_confirm_t *out, const struct E1AP_E1AP_PDU *pdu);
+bool eq_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *a, const e1ap_bearer_mod_confirm_t *b);
+e1ap_bearer_mod_confirm_t cp_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *msg);
+void free_e1ap_context_mod_confirm(const e1ap_bearer_mod_confirm_t *msg);
+
 #endif /* E1AP_BEARER_CONTEXT_MANAGEMENT_H_ */

--- a/openair2/E1AP/lib/e1ap_lib_includes.h
+++ b/openair2/E1AP/lib/e1ap_lib_includes.h
@@ -64,6 +64,12 @@
 #include "E1AP_PDU-Session-Resource-To-Setup-Mod-Item.h"
 #include "E1AP_DRB-To-Setup-Mod-Item-NG-RAN.h"
 #include "E1AP_PDU-Session-Resource-To-Remove-Item.h"
+#include "E1AP_ProtocolExtensionContainer.h"
+#include "E1AP_ProtocolExtensionField.h"
+// E1 Bearer Context Modification Required / Confirm
+#include "E1AP_BearerContextModificationRequired.h"
+#include "E1AP_System-BearerContextModificationRequired.h"
+#include "E1AP_BearerContextModificationConfirm.h"
 // E1 Bearer Context Modification Response
 #include "E1AP_PDU-Session-Resource-Modified-Item.h"
 #include "E1AP_DRB-Modified-List-NG-RAN.h"

--- a/openair2/E1AP/tests/e1ap_lib_test.c
+++ b/openair2/E1AP/tests/e1ap_lib_test.c
@@ -926,6 +926,65 @@ static void test_bearer_context_modification_failure(void)
   free_E1_bearer_context_mod_failure(&cp);
 }
 
+static void test_bearer_context_modification_required(void)
+{
+  pdu_session_to_remove_t rem1 = {
+      .sessionId = 5,
+      .cause = {.type = E1AP_CAUSE_TRANSPORT, .value = E1AP_TRANSPORT_CAUSE_RESOURCE_UNAVAILABLE},
+  };
+  pdu_session_to_remove_t rem2 = pdu_session_rem_template(6); // no cause
+
+  e1ap_bearer_mod_required_t orig = {
+      .gNB_cu_cp_ue_id = 0x1234,
+      .gNB_cu_up_ue_id = 0x5678,
+      .numPDUSessionsRem = 2,
+  };
+  orig.pduSessionRem = calloc_or_fail(2, sizeof(*orig.pduSessionRem));
+  orig.pduSessionRem[0] = rem1;
+  orig.pduSessionRem[1] = rem2;
+
+  E1AP_E1AP_PDU_t *enc = encode_E1_bearer_context_mod_required(&orig);
+  E1AP_E1AP_PDU_t *dec = e1ap_encode_decode(enc);
+  e1ap_msg_free(enc);
+
+  e1ap_bearer_mod_required_t decoded = {0};
+  AssertFatal(decode_E1_bearer_context_mod_required(dec, &decoded),
+              "decode_E1_bearer_context_mod_required(): could not decode message\n");
+  e1ap_msg_free(dec);
+
+  AssertFatal(eq_bearer_context_mod_required(&orig, &decoded), "eq_bearer_context_mod_required(): decoded message doesn't match\n");
+  free_e1ap_context_mod_required(&decoded);
+
+  e1ap_bearer_mod_required_t cp = cp_bearer_context_mod_required(&orig);
+  AssertFatal(eq_bearer_context_mod_required(&orig, &cp), "eq_bearer_context_mod_required(): copied message doesn't match\n");
+  free_e1ap_context_mod_required(&cp);
+  free_e1ap_context_mod_required(&orig);
+}
+
+static void test_bearer_context_modification_confirm(void)
+{
+  e1ap_bearer_mod_confirm_t orig = {
+      .gNB_cu_cp_ue_id = 0x1234,
+      .gNB_cu_up_ue_id = 0x5678,
+  };
+
+  E1AP_E1AP_PDU_t *enc = encode_E1_bearer_context_mod_confirm(&orig);
+  E1AP_E1AP_PDU_t *dec = e1ap_encode_decode(enc);
+  e1ap_msg_free(enc);
+
+  e1ap_bearer_mod_confirm_t decoded = {0};
+  AssertFatal(decode_E1_bearer_context_mod_confirm(&decoded, dec),
+              "decode_E1_bearer_context_mod_confirm(): could not decode message\n");
+  e1ap_msg_free(dec);
+
+  AssertFatal(eq_bearer_context_mod_confirm(&orig, &decoded), "eq_bearer_context_mod_confirm(): decoded message doesn't match\n");
+
+  e1ap_bearer_mod_confirm_t cp = cp_bearer_context_mod_confirm(&orig);
+  AssertFatal(eq_bearer_context_mod_confirm(&orig, &cp), "eq_bearer_context_mod_confirm(): copied message doesn't match\n");
+  free_e1ap_context_mod_confirm(&decoded);
+  free_e1ap_context_mod_confirm(&cp);
+}
+
 int main()
 {
   // E1 Bearer Context Setup
@@ -941,6 +1000,8 @@ int main()
   test_bearer_context_modification_response();
   test_bearer_context_modification_response_fail();
   test_bearer_context_modification_failure();
+  test_bearer_context_modification_required();
+  test_bearer_context_modification_confirm();
   // Bearer Context Release
   test_bearer_context_release_command();
   test_bearer_context_release_complete();

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
@@ -70,7 +70,7 @@ static f1ap_up_tnl_t f1_drb_gtpu_create(const gtpv1u_gnb_create_tunnel_req_t *re
   instance_t f1inst = get_f1_gtp_instance();
   DevAssert(f1inst >= 0);
   gtpv1u_gnb_create_tunnel_resp_t resp = {0};
-  int ret = gtpv1u_create_ngu_tunnel(f1inst, req, &resp, DURecvCb, NULL);
+  int ret = gtpv1u_create_ngu_tunnel(f1inst, req, &resp, DURecvCb, NULL, NULL);
   AssertFatal(ret >= 0, "Unable to create GTP Tunnel for F1-U\n");
   AssertFatal(resp.gnb_addr.length == sizeof(in_addr_t),
               "GTP tunnel response address length %d does not match IPv4 size %zu\n",

--- a/openair2/LAYER2/nr_pdcp/cucp_cuup_handler.c
+++ b/openair2/LAYER2/nr_pdcp/cucp_cuup_handler.c
@@ -87,6 +87,32 @@ static NR_DRB_ToAddMod_t *get_rrc_drb_to_addmod(const DRB_nGRAN_to_setup_t *drb,
   return ie;
 }
 
+static void cuup_release_pdu_session_up(uint32_t ue_id, int pdusession_id);
+
+/** @brief N3 GTP-U Error Indication callback (TS 29.281 clause 7.3.1)
+ * TS 23.527 clause 5.3.3.1: 5G-AN shall release PDU session resources immediately
+ * and initiate NGAP PDU Session Resource Notify. Release N3/F1-U/SDAP here, then
+ * signal CU-CP via Bearer Context Modification Required (TS 38.463 clause 8.3.3)
+ * through cuup_cucp_if (direct ITTI or E1AP). */
+static void n3_error_indication(const gtpv1u_error_indication_ind_t *ind)
+{
+  if (N3GTPUInst == NULL || ind->gtp_instance != *N3GTPUInst)
+    return; // Error Indication is for N3 only
+
+  cuup_release_pdu_session_up(ind->ue_id, ind->pdusession_id);
+
+  e1ap_bearer_mod_required_t req = {0};
+  req.gNB_cu_cp_ue_id = ind->ue_id;
+  req.gNB_cu_up_ue_id = ind->ue_id;
+  req.numPDUSessionsRem = 1;
+  req.pduSessionRem = calloc_or_fail(1, sizeof(*req.pduSessionRem));
+  req.pduSessionRem[0].sessionId = ind->pdusession_id;
+  req.pduSessionRem[0].cause.type = E1AP_CAUSE_TRANSPORT;
+  req.pduSessionRem[0].cause.value = E1AP_TRANSPORT_CAUSE_RESOURCE_UNAVAILABLE;
+  get_e1_if()->bearer_mod_required(&req);
+  free_e1ap_context_mod_required(&req);
+}
+
 /** @brief Fill and send request to create GTP-U tunnel (F1-U) */
 static UP_TL_information_t f1_drb_gtpu_create(const instance_t f1inst,
                                               const gtpv1u_gnb_create_tunnel_req_t *req)
@@ -96,7 +122,7 @@ static UP_TL_information_t f1_drb_gtpu_create(const instance_t f1inst,
   LOG_I(GTPU, "Incoming DRB %d / PDU Session %d - UL TEID %d\n", req->incoming_rb_id, req->pdusession_id, req->outgoing_teid);
 
   gtpv1u_gnb_create_tunnel_resp_t resp = {0};
-  int ret = gtpv1u_create_ngu_tunnel(f1inst, req, &resp, cu_f1u_data_req, NULL);
+  int ret = gtpv1u_create_ngu_tunnel(f1inst, req, &resp, cu_f1u_data_req, NULL, NULL);
   AssertFatal(ret >= 0, "Unable to create GTP-U tunnel for F1-U\n");
   AssertFatal(resp.gnb_addr.length == sizeof(in_addr_t),
               "GTP tunnel response address length %d does not match IPv4 size %zu\n",
@@ -124,7 +150,7 @@ static UP_TL_information_t n3_gtpu_create(const gtpv1u_gnb_create_tunnel_req_t *
   LOG_I(GTPU, "N3 GTP-U tunnel: PDUSession=%d/UL TEID=0x%08x\n", req->pdusession_id, req->outgoing_teid);
 
   gtpv1u_gnb_create_tunnel_resp_t resp = {0};
-  int ret = gtpv1u_create_ngu_tunnel(n3inst, req, &resp, nr_pdcp_data_req_drb, sdap_data_req);
+  int ret = gtpv1u_create_ngu_tunnel(n3inst, req, &resp, nr_pdcp_data_req_drb, sdap_data_req, n3_error_indication);
   AssertFatal(ret >= 0, "Unable to create GTP-U tunnel for N3\n");
   AssertFatal(resp.gnb_addr.length == sizeof(in_addr_t),
               "GTP tunnel response address length %d does not match IPv4 size %zu\n",
@@ -333,6 +359,14 @@ static void release_f1_drbs(uint32_t ue_id, int pdusession_id)
   }
 }
 
+/** @brief Release UP resources for one PDU session (N3, F1-U, SDAP) */
+static void cuup_release_pdu_session_up(uint32_t ue_id, int pdusession_id)
+{
+  release_gtpu_tunnel(ue_id, pdusession_id);
+  release_f1_drbs(ue_id, pdusession_id);
+  nr_sdap_delete_entity(ue_id, pdusession_id);
+}
+
 /**
  * @brief Fill Bearer Context Modification Response and send to callback
  */
@@ -502,9 +536,7 @@ void e1_bearer_context_modif(const e1ap_bearer_mod_req_t *req)
   for (int i = 0; i < req->numPDUSessionsRem; i++) {
     modif.pduSessionMod[req->numPDUSessionsMod + i].id = req->pduSessionRem[i].sessionId;
     modif.numPDUSessionsMod++;
-    release_gtpu_tunnel(req->gNB_cu_up_ue_id, req->pduSessionRem[i].sessionId);
-    release_f1_drbs(req->gNB_cu_up_ue_id, req->pduSessionRem[i].sessionId);
-    nr_sdap_delete_entity(req->gNB_cu_up_ue_id, req->pduSessionRem[i].sessionId);
+    cuup_release_pdu_session_up(req->gNB_cu_up_ue_id, req->pduSessionRem[i].sessionId);
   }
 
   get_e1_if()->bearer_modif_response(&modif);

--- a/openair2/LAYER2/nr_pdcp/cucp_cuup_handler.c
+++ b/openair2/LAYER2/nr_pdcp/cucp_cuup_handler.c
@@ -574,6 +574,14 @@ void e1_bearer_release_cmd(const e1ap_bearer_release_cmd_t *cmd)
   get_e1_if()->bearer_release_complete(&cplt);
 }
 
+/** @brief Bearer Context Modification Confirm (TS 38.463 clause 8.3.3).
+ * UP teardown already done on Error Indication RX, Confirm is acknowledgement only. */
+void e1_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *conf)
+{
+  DevAssert(conf);
+  LOG_I(E1AP, "Received Bearer Context Modification Confirm for CU-CP UE E1AP ID %u\n", conf->gNB_cu_cp_ue_id);
+}
+
 void e1_reset(void)
 {
   /* we get the list of all UEs from the PDCP, which maintains a list */

--- a/openair2/LAYER2/nr_pdcp/cucp_cuup_handler.h
+++ b/openair2/LAYER2/nr_pdcp/cucp_cuup_handler.h
@@ -11,9 +11,11 @@ void nr_pdcp_e1_if_init(bool uses_e1);
 
 struct e1ap_bearer_setup_req_s;
 struct e1ap_bearer_mod_req_s;
+struct e1ap_bearer_mod_confirm_s;
 struct e1ap_bearer_release_cmd_s;
 void e1_bearer_context_setup(const struct e1ap_bearer_setup_req_s *req);
 void e1_bearer_context_modif(const struct e1ap_bearer_mod_req_s *req);
+void e1_bearer_context_mod_confirm(const struct e1ap_bearer_mod_confirm_s *conf);
 void e1_bearer_release_cmd(const struct e1ap_bearer_release_cmd_s *cmd);
 void e1_reset(void);
 

--- a/openair2/LAYER2/nr_pdcp/cuup_cucp_direct.c
+++ b/openair2/LAYER2/nr_pdcp/cuup_cucp_direct.c
@@ -23,6 +23,15 @@ static void bearer_modif_response_direct(const e1ap_bearer_modif_resp_t *resp)
   itti_send_msg_to_task(TASK_RRC_GNB, 0, msg);
 }
 
+static void bearer_mod_required_direct(const e1ap_bearer_mod_required_t *req)
+{
+  MessageDef *msg = itti_alloc_new_message(TASK_MAC_GNB, 0, E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED);
+  msg->ittiMsgHeader.originInstance = -1; // means monolithic
+  e1ap_bearer_mod_required_t *msg_req = &E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED(msg);
+  *msg_req = cp_bearer_context_mod_required(req);
+  itti_send_msg_to_task(TASK_RRC_GNB, 0, msg);
+}
+
 static void bearer_release_complete_direct(const e1ap_bearer_release_cplt_t *cplt)
 {
   MessageDef *msg = itti_alloc_new_message(TASK_MAC_GNB, 0, E1AP_BEARER_CONTEXT_RELEASE_CPLT);
@@ -35,5 +44,6 @@ void cuup_cucp_init_direct(e1_if_t *iface)
 {
   iface->bearer_setup_response = bearer_setup_response_direct;
   iface->bearer_modif_response = bearer_modif_response_direct;
+  iface->bearer_mod_required = bearer_mod_required_direct;
   iface->bearer_release_complete = bearer_release_complete_direct;
 }

--- a/openair2/LAYER2/nr_pdcp/cuup_cucp_e1ap.c
+++ b/openair2/LAYER2/nr_pdcp/cuup_cucp_e1ap.c
@@ -23,6 +23,14 @@ static void bearer_modif_response_e1ap(const e1ap_bearer_modif_resp_t *resp)
   itti_send_msg_to_task (TASK_CUUP_E1, 0, msg_p);
 }
 
+static void bearer_mod_required_e1ap(const e1ap_bearer_mod_required_t *req)
+{
+  MessageDef *msg_p = itti_alloc_new_message(TASK_CUUP_E1, 0, E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED);
+  e1ap_bearer_mod_required_t *msg_req = &E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED(msg_p);
+  *msg_req = cp_bearer_context_mod_required(req);
+  itti_send_msg_to_task(TASK_CUUP_E1, 0, msg_p);
+}
+
 static void bearer_release_complete_e1ap(const e1ap_bearer_release_cplt_t *cplt)
 {
   MessageDef *msg_p = itti_alloc_new_message(TASK_CUUP_E1, 0, E1AP_BEARER_CONTEXT_RELEASE_CPLT);
@@ -35,5 +43,6 @@ void cuup_cucp_init_e1ap(e1_if_t *iface)
 {
   iface->bearer_setup_response = bearer_setup_response_e1ap;
   iface->bearer_modif_response = bearer_modif_response_e1ap;
+  iface->bearer_mod_required = bearer_mod_required_e1ap;
   iface->bearer_release_complete = bearer_release_complete_e1ap;
 }

--- a/openair2/LAYER2/nr_pdcp/cuup_cucp_if.h
+++ b/openair2/LAYER2/nr_pdcp/cuup_cucp_if.h
@@ -9,14 +9,17 @@
 
 struct e1ap_bearer_setup_resp_s;
 struct e1ap_bearer_modif_resp_s;
+struct e1ap_bearer_mod_required_s;
 struct e1ap_bearer_release_cplt_s;
 typedef void (*e1_bearer_setup_response_func_t)(const struct e1ap_bearer_setup_resp_s *resp);
 typedef void (*e1_bearer_modif_response_func_t)(const struct e1ap_bearer_modif_resp_s *resp);
+typedef void (*e1_bearer_mod_required_func_t)(const struct e1ap_bearer_mod_required_s *req);
 typedef void (*e1_bearer_release_complete_func_t)(const struct e1ap_bearer_release_cplt_s *cplt);
 
 typedef struct e1_if_t {
   e1_bearer_setup_response_func_t bearer_setup_response;
   e1_bearer_modif_response_func_t bearer_modif_response;
+  e1_bearer_mod_required_func_t bearer_mod_required;
   e1_bearer_release_complete_func_t bearer_release_complete;
 } e1_if_t;
 

--- a/openair2/RRC/NR/cucp_cuup_direct.c
+++ b/openair2/RRC/NR/cucp_cuup_direct.c
@@ -22,6 +22,12 @@ static void cucp_cuup_bearer_context_modif_direct(sctp_assoc_t assoc_id, const e
   e1_bearer_context_modif(req);
 }
 
+static void cucp_cuup_bearer_context_mod_confirm_direct(sctp_assoc_t assoc_id, const e1ap_bearer_mod_confirm_t *conf)
+{
+  AssertFatal(assoc_id == -1, "illegal assoc_id %d, impossible for integrated CU\n", assoc_id);
+  e1_bearer_context_mod_confirm(conf);
+}
+
 static void cucp_cuup_bearer_context_release_cmd_direct(sctp_assoc_t assoc_id, const e1ap_bearer_release_cmd_t *cmd)
 {
   AssertFatal(assoc_id == -1, "illegal assoc_id %d, impossible for integrated CU\n", assoc_id);
@@ -31,5 +37,6 @@ static void cucp_cuup_bearer_context_release_cmd_direct(sctp_assoc_t assoc_id, c
 void cucp_cuup_message_transfer_direct_init(gNB_RRC_INST *rrc) {
   rrc->cucp_cuup.bearer_context_setup = cucp_cuup_bearer_context_setup_direct;
   rrc->cucp_cuup.bearer_context_mod = cucp_cuup_bearer_context_modif_direct;
+  rrc->cucp_cuup.bearer_context_mod_confirm = cucp_cuup_bearer_context_mod_confirm_direct;
   rrc->cucp_cuup.bearer_context_release = cucp_cuup_bearer_context_release_cmd_direct;
 }

--- a/openair2/RRC/NR/cucp_cuup_e1ap.c
+++ b/openair2/RRC/NR/cucp_cuup_e1ap.c
@@ -31,6 +31,16 @@ static void cucp_cuup_bearer_context_mod_e1ap(sctp_assoc_t assoc_id, const e1ap_
   itti_send_msg_to_task(TASK_CUCP_E1, 0, msg);
 }
 
+static void cucp_cuup_bearer_context_mod_confirm_e1ap(sctp_assoc_t assoc_id, const e1ap_bearer_mod_confirm_t *conf)
+{
+  AssertFatal(assoc_id > 0, "illegal assoc_id %d\n", assoc_id);
+  MessageDef *msg = itti_alloc_new_message(TASK_CUCP_E1, 0, E1AP_BEARER_CONTEXT_MODIFICATION_CONFIRM);
+  msg->ittiMsgHeader.originInstance = assoc_id;
+  e1ap_bearer_mod_confirm_t *conf_msg = &E1AP_BEARER_CONTEXT_MODIFICATION_CONFIRM(msg);
+  *conf_msg = cp_bearer_context_mod_confirm(conf);
+  itti_send_msg_to_task(TASK_CUCP_E1, 0, msg);
+}
+
 static void cucp_cuup_bearer_context_release_cmd_e1ap(sctp_assoc_t assoc_id, const e1ap_bearer_release_cmd_t *cmd)
 {
   AssertFatal(assoc_id > 0, "illegal assoc_id %d\n", assoc_id);
@@ -44,5 +54,6 @@ static void cucp_cuup_bearer_context_release_cmd_e1ap(sctp_assoc_t assoc_id, con
 void cucp_cuup_message_transfer_e1ap_init(gNB_RRC_INST *rrc) {
   rrc->cucp_cuup.bearer_context_setup = cucp_cuup_bearer_context_setup_e1ap;
   rrc->cucp_cuup.bearer_context_mod = cucp_cuup_bearer_context_mod_e1ap;
+  rrc->cucp_cuup.bearer_context_mod_confirm = cucp_cuup_bearer_context_mod_confirm_e1ap;
   rrc->cucp_cuup.bearer_context_release = cucp_cuup_bearer_context_release_cmd_e1ap;
 }

--- a/openair2/RRC/NR/cucp_cuup_if.h
+++ b/openair2/RRC/NR/cucp_cuup_if.h
@@ -13,10 +13,12 @@
 
 struct e1ap_bearer_setup_req_s;
 struct e1ap_bearer_mod_req_s;
+struct e1ap_bearer_mod_confirm_s;
 struct e1ap_bearer_setup_resp_s;
 struct e1ap_bearer_release_cmd_s;
 typedef void (*cucp_cuup_bearer_context_setup_func_t)(sctp_assoc_t assoc_id, const struct e1ap_bearer_setup_req_s *req);
 typedef void (*cucp_cuup_bearer_context_mod_func_t)(sctp_assoc_t assoc_id, const struct e1ap_bearer_mod_req_s *req);
+typedef void (*cucp_cuup_bearer_context_mod_confirm_func_t)(sctp_assoc_t assoc_id, const struct e1ap_bearer_mod_confirm_s *conf);
 typedef void (*cucp_cuup_bearer_context_release_func_t)(sctp_assoc_t assoc_id, const struct e1ap_bearer_release_cmd_s *cmd);
 
 struct gNB_RRC_INST_s;

--- a/openair2/RRC/NR/nr_rrc_defs.h
+++ b/openair2/RRC/NR/nr_rrc_defs.h
@@ -73,7 +73,8 @@ typedef enum pdu_session_satus_e {
   PDU_SESSION_STATUS_ESTABLISHED,
   PDU_SESSION_STATUS_TOMODIFY, // ENDC NSA
   PDU_SESSION_STATUS_FAILED,
-  PDU_SESSION_STATUS_TORELEASE, // to release DRB between eNB and UE
+  PDU_SESSION_STATUS_TORELEASE, // PDU Session Release
+  PDU_SESSION_STATUS_NOTIFYONRELEASE, // N3 GTP-U Error Indication triggers Resource Notify
 } pdu_session_status_t;
 
 typedef struct pdusession_s {
@@ -122,6 +123,7 @@ typedef enum {
   RRC_PDUSESSION_ESTABLISH,
   RRC_PDUSESSION_MODIFY,
   RRC_PDUSESSION_RELEASE,
+  RRC_PDUSESSION_RESOURCE_NOTIFY,
   RRC_UECAPABILITY_ENQUIRY,
 } rrc_action_t;
 
@@ -437,6 +439,7 @@ typedef struct nr_mac_rrc_dl_if_s {
 typedef struct cucp_cuup_if_s {
   cucp_cuup_bearer_context_setup_func_t bearer_context_setup;
   cucp_cuup_bearer_context_mod_func_t bearer_context_mod;
+  cucp_cuup_bearer_context_mod_confirm_func_t bearer_context_mod_confirm;
   cucp_cuup_bearer_context_release_func_t bearer_context_release;
 } cucp_cuup_if_t;
 

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -914,7 +914,7 @@ nr_rrc_reconfig_param_t get_RRCReconfiguration_params(gNB_RRC_INST *rrc, gNB_RRC
       LOG_D(NR_RRC, "Transfer NAS info with size %ld to RRCReconfiguration params\n", session->nas_pdu.len);
     }
     // Collect DRBs to release for PDU sessions marked for release
-    if (item->status == PDU_SESSION_STATUS_TORELEASE) {
+    if (item->status == PDU_SESSION_STATUS_TORELEASE || item->status == PDU_SESSION_STATUS_NOTIFYONRELEASE) {
       if (!params.drb_rel)
         params.drb_rel = calloc_or_fail(MAX_DRBS_PER_UE, sizeof(int));
       FOR_EACH_SEQ_ARR (drb_t *, drb, &UE->drbs) {
@@ -965,12 +965,15 @@ static void cuup_notify_reestablishment(gNB_RRC_INST *rrc, gNB_RRC_UE_t *ue_p);
   } while (0)
 
 /** @brief Set xid for all PDU sessions and derive RRC transaction action from
- * session statuses. At most one active status (NEW, TOMODIFY, TORELEASE) or reestablishment.
+ * session statuses. At most one active status (NEW, TOMODIFY, TORELEASE,
+ * NOTIFYONRELEASE) or reestablishment.
  * Status vs procedures (F1AP UE Context Setup/Modification Response only):
  * - NEW: Initial Context Setup or PDU Session Resource Setup Request;
  *   E1 then F1 Setup/Modification.
  * - TORELEASE: NGAP PDU Session Release Command -> E1 Bearer Context
  *   Modification (release) -> F1 Modification (release DRBs).
+ * - NOTIFYONRELEASE: N3 GTP-U Error Indication (TS 23.527) -> same teardown chain
+     (E1/F1) -> PDU Session Resource Notify.
  * - ESTABLISHED: Bystander when adding/releasing others.
  * - TOMODIFY: NGAP PDU Session Modify Request -> E1 Bearer Context
  *   Modification (if CU-UP) -> F1 Modification Response.
@@ -999,10 +1002,13 @@ static rrc_action_t rrc_gNB_action_from_pdusession_status(gNB_RRC_UE_t *ue_p,
     } else if (item->status == PDU_SESSION_STATUS_TORELEASE) {
       DevAssert(params->n_drb_rel > 0);
       ASSERT_PDU_ACTION_SINGLE(action, RRC_PDUSESSION_RELEASE);
-      LOG_I(NR_RRC,
-            "PDU Session Release: setting PDU Session status to TORELEASE for PDU Session %d \n",
-            item->param.pdusession_id);
+      LOG_I(NR_RRC, "PDU Session Release: setting PDU Session status to TORELEASE for PDU Session %d\n", item->param.pdusession_id);
       action = RRC_PDUSESSION_RELEASE;
+    } else if (item->status == PDU_SESSION_STATUS_NOTIFYONRELEASE) {
+      DevAssert(params->n_drb_rel > 0);
+      ASSERT_PDU_ACTION_SINGLE(action, RRC_PDUSESSION_RESOURCE_NOTIFY);
+      LOG_I(NR_RRC, "Released PDU Session %d to be notified (NOTIFYONRELEASE)\n", item->param.pdusession_id);
+      action = RRC_PDUSESSION_RESOURCE_NOTIFY;
     }
     /* ESTABLISHED and FAILED do not drive transaction action */
   }
@@ -2191,6 +2197,10 @@ static void handle_rrcReconfigurationComplete(gNB_RRC_INST *rrc, gNB_RRC_UE_t *U
       rrc_gNB_send_NGAP_PDUSESSION_RELEASE_RESPONSE(rrc, UE, xid);
       reset_delayed_action(&UE->delayed_action);
     } break;
+    case RRC_PDUSESSION_RESOURCE_NOTIFY: {
+      rrc_gNB_send_NGAP_PDUSESSION_RESOURCE_NOTIFY(rrc, UE, xid);
+      reset_delayed_action(&UE->delayed_action);
+    } break;
     case RRC_PDUSESSION_ESTABLISH:
       if (UE->n_initial_pdu > 0) {
         /* PDU sessions through initial UE context setup */
@@ -3257,6 +3267,60 @@ static void rrc_send_f1_ue_context_modification_request(const gNB_RRC_INST *rrc,
         n_rel_drbs);
 }
 
+/** @brief Mark PDU sessions to remove and start local teardown.
+ * NGAP PDU Session Resource Notify is sent after RRCReconfigurationComplete. */
+static void rrc_gNB_trigger_pdu_session_notify_on_release(gNB_RRC_INST *rrc,
+                                                          gNB_RRC_UE_t *UE,
+                                                          const pdu_session_to_remove_t *rem,
+                                                          int n_rem)
+{
+  DevAssert(rrc);
+  DevAssert(UE);
+  DevAssert(rem || n_rem == 0);
+
+  f1ap_drb_to_release_t f1_drbs_rel[MAX_DRBS_PER_UE] = {0};
+  int n_f1_drbs_rel = 0;
+
+  for (int i = 0; i < n_rem; i++) {
+    rrc_pdu_session_param_t *pduSession = find_pduSession(&UE->pduSessions, rem[i].sessionId);
+    if (!pduSession) {
+      LOG_W(NR_RRC, "UE %u: Bearer Context Modification Required: PDU session %ld not found\n", UE->rrc_ue_id, rem[i].sessionId);
+      continue;
+    }
+    if (pduSession->status == PDU_SESSION_STATUS_NOTIFYONRELEASE) {
+      LOG_W(NR_RRC, "UE %u: PDU Session %d already set to be released\n", UE->rrc_ue_id, pduSession->param.pdusession_id);
+      continue;
+    }
+
+    const int pdusession_id = pduSession->param.pdusession_id;
+    int n_session_drbs = 0;
+    FOR_EACH_SEQ_ARR (drb_t *, drb, &UE->drbs) {
+      if (drb->pdusession_id != pdusession_id)
+        continue;
+      DevAssert(n_f1_drbs_rel < MAX_DRBS_PER_UE);
+      f1_drbs_rel[n_f1_drbs_rel++].id = drb->drb_id;
+      n_session_drbs++;
+    }
+    if (n_session_drbs == 0) {
+      LOG_E(NR_RRC, "UE %d: no DRBs to release for PDU session %d\n", UE->rrc_ue_id, pdusession_id);
+      continue;
+    }
+
+    LOG_I(NR_RRC, "UE %u: Bearer Context Modification Required: release PDU session %d\n", UE->rrc_ue_id, pdusession_id);
+    pduSession->status = PDU_SESSION_STATUS_NOTIFYONRELEASE;
+  }
+
+  if (n_f1_drbs_rel == 0)
+    return;
+  if (!UE->f1_ue_context_active) {
+    LOG_W(NR_RRC, "UE %d: DRB(s) to release but F1 UE context is not active\n", UE->rrc_ue_id);
+    return;
+  }
+
+  rrc_send_f1_ue_context_modification_request(rrc, UE, 0, NULL, n_f1_drbs_rel, f1_drbs_rel);
+  init_delayed_action(&UE->delayed_action);
+}
+
 /**
  * @brief E1AP Bearer Context Setup Response processing on CU-CP
 */
@@ -3475,6 +3539,30 @@ static void rrc_gNB_process_e1_bearer_context_modif_fail(const e1ap_bearer_conte
         fail->cause.value);
 }
 
+/** @brief E1AP Bearer Context Modification Required processing on CU-CP */
+static void rrc_gNB_process_e1_bearer_context_mod_required(sctp_assoc_t assoc_id, const e1ap_bearer_mod_required_t *req)
+{
+  DevAssert(req);
+  gNB_RRC_INST *rrc = RC.nrrrc[0];
+  rrc_gNB_ue_context_t *ue_context_p = rrc_gNB_get_ue_context(rrc, req->gNB_cu_cp_ue_id);
+  if (ue_context_p == NULL) {
+    LOG_E(NR_RRC, "No UE with CU-CP UE ID %d found (Bearer Context Modification Required)\n", req->gNB_cu_cp_ue_id);
+  } else if (ue_context_p->ue_context.amf_ue_ngap_id == 0) {
+    LOG_W(NR_RRC,
+          "UE %u: Bearer Context Modification Required but UE not NGAP-associated, skip release\n",
+          ue_context_p->ue_context.rrc_ue_id);
+  } else {
+    gNB_RRC_UE_t *UE = &ue_context_p->ue_context;
+    rrc_gNB_trigger_pdu_session_notify_on_release(rrc, UE, req->pduSessionRem, req->numPDUSessionsRem);
+  }
+
+  e1ap_bearer_mod_confirm_t conf = {
+      .gNB_cu_cp_ue_id = req->gNB_cu_cp_ue_id,
+      .gNB_cu_up_ue_id = req->gNB_cu_up_ue_id,
+  };
+  rrc->cucp_cuup.bearer_context_mod_confirm(assoc_id, &conf);
+}
+
 /**
  * @brief E1AP Bearer Context Release processing
  */
@@ -3550,6 +3638,8 @@ static const char *get_pdusession_status_text(pdu_session_status_t status)
     case PDU_SESSION_STATUS_TOMODIFY: return "to-modify";
     case PDU_SESSION_STATUS_FAILED: return "failed";
     case PDU_SESSION_STATUS_TORELEASE: return "to-release";
+    case PDU_SESSION_STATUS_NOTIFYONRELEASE:
+      return "notify-on-release";
     default: AssertFatal(false, "illegal PDU status code %d\n", status); return "illegal";
   }
   return "illegal";
@@ -3809,6 +3899,12 @@ void *rrc_gnb_task(void *args_p)
 
       case E1AP_BEARER_CONTEXT_MODIFICATION_FAIL:
         rrc_gNB_process_e1_bearer_context_modif_fail(&E1AP_BEARER_CONTEXT_MODIFICATION_FAIL(msg_p));
+        break;
+
+      case E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED:
+        rrc_gNB_process_e1_bearer_context_mod_required(msg_p->ittiMsgHeader.originInstance,
+                                                       &E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED(msg_p));
+        free_e1ap_context_mod_required(&E1AP_BEARER_CONTEXT_MODIFICATION_REQUIRED(msg_p));
         break;
 
       case E1AP_BEARER_CONTEXT_RELEASE_CPLT:

--- a/openair2/RRC/NR/rrc_gNB_NGAP.c
+++ b/openair2/RRC/NR/rrc_gNB_NGAP.c
@@ -2003,6 +2003,44 @@ int rrc_gNB_process_NGAP_PDUSESSION_RELEASE_COMMAND(ngap_pdusession_release_comm
   return 0;
 }
 
+/** @brief Send NGAP PDU Session Resource Notify (TS 38.413 section 8.2.4) after local release
+ * (triggered by TS 23.527 clause 5.3.3.1) */
+void rrc_gNB_send_NGAP_PDUSESSION_RESOURCE_NOTIFY(gNB_RRC_INST *rrc, gNB_RRC_UE_t *UE, uint8_t xid)
+{
+  MessageDef *msg_p = itti_alloc_new_message(TASK_RRC_GNB, rrc->module_id, NGAP_PDUSESSION_RESOURCE_NOTIFY);
+  ngap_pdusession_resource_notify_t *notify = &NGAP_PDUSESSION_RESOURCE_NOTIFY(msg_p);
+  notify->gNB_ue_ngap_id = UE->rrc_ue_id;
+
+  FOR_EACH_SEQ_ARR (rrc_pdu_session_param_t *, session, &UE->pduSessions) {
+    if (xid != session->xid || session->status != PDU_SESSION_STATUS_NOTIFYONRELEASE)
+      continue;
+    DevAssert(notify->nb_pdu_sessions_released < NR_MAX_NB_PDU_SESSIONS);
+    ngap_pdusession_notify_item_t *item = &notify->pdu_sessions[notify->nb_pdu_sessions_released++];
+    item->pdu_session_id = session->param.pdusession_id;
+    item->cause.type = NGAP_CAUSE_TRANSPORT;
+    item->cause.value = NGAP_CAUSE_TRANSPORT_RESOURCE_UNAVAILABLE;
+  }
+
+  if (notify->nb_pdu_sessions_released == 0) {
+    LOG_E(NR_RRC, "UE %u: PDU Session Resource Notify xid %u with no sessions\n", UE->rrc_ue_id, xid);
+    itti_free(ITTI_MSG_ORIGIN_ID(msg_p), msg_p);
+    return;
+  }
+
+  const int n = notify->nb_pdu_sessions_released;
+  int released_ids[NR_MAX_NB_PDU_SESSIONS];
+  for (int i = 0; i < n; ++i)
+    released_ids[i] = notify->pdu_sessions[i].pdu_session_id;
+
+  LOG_I(NR_RRC, "NGAP PDU Session Resource Notify: rrc_ue_id %u nb_released %d\n", notify->gNB_ue_ngap_id, n);
+  itti_send_msg_to_task(TASK_NGAP, rrc->module_id, msg_p);
+  for (int i = 0; i < n; ++i)
+    rm_pduSession(&UE->pduSessions, &UE->drbs, released_ids[i]);
+
+  if (seq_arr_size(&UE->drbs) == 0 && UE->Srb[SRB2].Active)
+    rrc_gNB_cleanup_srb2_only_connected(rrc, UE);
+}
+
 /** @brief Handle NGAP Paging Indication from the AMF.
  *  For each TAI in the message, matches (PLMN + TAC) against the gNB configuration; on match,
  *  builds an F1AP Paging message and distributes it to all DUs that serve cells in that PLMN. */

--- a/openair2/RRC/NR/rrc_gNB_NGAP.h
+++ b/openair2/RRC/NR/rrc_gNB_NGAP.h
@@ -14,6 +14,7 @@
 #include "NR_RRCSetupComplete-IEs.h"
 #include "NR_UECapabilityInformation.h"
 #include "NR_UL-DCCH-Message.h"
+#include "gtpv1_u_messages_types.h"
 #include "intertask_interface.h"
 #include "ngap_messages_types.h"
 #include "nr_rrc_defs.h"
@@ -55,6 +56,8 @@ void rrc_gNB_send_NGAP_UE_CAPABILITIES_IND(gNB_RRC_INST *rrc, gNB_RRC_UE_t *UE, 
 int rrc_gNB_process_NGAP_PDUSESSION_RELEASE_COMMAND(ngap_pdusession_release_command_t *cmd, gNB_RRC_INST *rrc);
 
 void rrc_gNB_send_NGAP_PDUSESSION_RELEASE_RESPONSE(gNB_RRC_INST *rrc, gNB_RRC_UE_t *UE, uint8_t xid);
+
+void rrc_gNB_send_NGAP_PDUSESSION_RESOURCE_NOTIFY(gNB_RRC_INST *rrc, gNB_RRC_UE_t *UE, uint8_t xid);
 
 void nr_rrc_pdcp_config_security(gNB_RRC_UE_t *UE, bool enable_ciphering);
 

--- a/openair2/RRC/NR/rrc_gNB_nsa.c
+++ b/openair2/RRC/NR/rrc_gNB_nsa.c
@@ -338,7 +338,7 @@ void rrc_add_nsa_user(gNB_RRC_INST *rrc, x2ap_ENDC_sgnb_addition_req_t *m, sctp_
         .dst_addr.length = 32,
       };
       gtpv1u_gnb_create_tunnel_resp_t resp = {0};
-      int ret = gtpv1u_create_ngu_tunnel(f1inst, &req, &resp, NULL, NULL);
+      int ret = gtpv1u_create_ngu_tunnel(f1inst, &req, &resp, NULL, NULL, NULL);
       AssertFatal(ret == 0, "gtpv1u_create_ngu_tunnel failed: ret %d\n", ret);
       AssertFatal(resp.gnb_addr.length == sizeof(in_addr_t),
                   "GTP tunnel response address length %d does not match IPv4 size %zu\n",

--- a/openair3/NGAP/ngap_gNB.c
+++ b/openair3/NGAP/ngap_gNB.c
@@ -663,6 +663,10 @@ void *ngap_gNB_process_itti_msg(void *notUsed)
         ngap_gNB_pdusession_release_resp(instance, &NGAP_PDUSESSION_RELEASE_RESPONSE(received_msg));
         break;
 
+      case NGAP_PDUSESSION_RESOURCE_NOTIFY:
+        ngap_gNB_pdusession_resource_notify(instance, &NGAP_PDUSESSION_RESOURCE_NOTIFY(received_msg));
+        break;
+
       case NGAP_PATH_SWITCH_REQ:
         ngap_gNB_path_switch_request(instance, &NGAP_PATH_SWITCH_REQ(received_msg));
         break;

--- a/openair3/NGAP/ngap_gNB_pdu_session_management.c
+++ b/openair3/NGAP/ngap_gNB_pdu_session_management.c
@@ -414,3 +414,105 @@ int ngap_gNB_pdusession_release_resp(instance_t instance, ngap_pdusession_releas
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
   return 0;
 }
+
+/** @brief Encode and send NGAP PDU Session Resource Notify (8.2.4 of 3GPP TS 38.413) */
+int ngap_gNB_pdusession_resource_notify(instance_t instance, ngap_pdusession_resource_notify_t *msg)
+{
+  DevAssert(msg);
+  NGAP_NGAP_PDU_t pdu;
+  uint8_t *buffer = NULL;
+  uint32_t length;
+
+  ngap_gNB_instance_t *ngap_gNB_instance_p = ngap_gNB_get_instance(instance);
+  DevAssert(ngap_gNB_instance_p);
+
+  struct ngap_gNB_ue_context_s *ue_context_p = ngap_get_ue_context(msg->gNB_ue_ngap_id);
+  if (!ue_context_p) {
+    NGAP_WARN("Failed to find ue context associated with gNB ue ngap id: 0x%08x\n", msg->gNB_ue_ngap_id);
+    return -1;
+  }
+
+  memset(&pdu, 0, sizeof(pdu));
+  pdu.present = NGAP_NGAP_PDU_PR_initiatingMessage;
+  asn1cCalloc(pdu.choice.initiatingMessage, head);
+  head->procedureCode = NGAP_ProcedureCode_id_PDUSessionResourceNotify;
+  head->criticality = NGAP_Criticality_ignore;
+  head->value.present = NGAP_InitiatingMessage__value_PR_PDUSessionResourceNotify;
+  NGAP_PDUSessionResourceNotify_t *out = &head->value.choice.PDUSessionResourceNotify;
+
+  /* AMF-UE-NGAP-ID (mandatory) */
+  {
+    asn1cSequenceAdd(out->protocolIEs.list, NGAP_PDUSessionResourceNotifyIEs_t, ie);
+    ie->id = NGAP_ProtocolIE_ID_id_AMF_UE_NGAP_ID;
+    ie->criticality = NGAP_Criticality_reject;
+    ie->value.present = NGAP_PDUSessionResourceNotifyIEs__value_PR_AMF_UE_NGAP_ID;
+    asn_uint642INTEGER(&ie->value.choice.AMF_UE_NGAP_ID, ue_context_p->amf_ue_ngap_id);
+  }
+
+  /* RAN-UE-NGAP-ID (mandatory) */
+  {
+    asn1cSequenceAdd(out->protocolIEs.list, NGAP_PDUSessionResourceNotifyIEs_t, ie);
+    ie->id = NGAP_ProtocolIE_ID_id_RAN_UE_NGAP_ID;
+    ie->criticality = NGAP_Criticality_reject;
+    ie->value.present = NGAP_PDUSessionResourceNotifyIEs__value_PR_RAN_UE_NGAP_ID;
+    ie->value.choice.RAN_UE_NGAP_ID = msg->gNB_ue_ngap_id;
+  }
+
+  /* PDUSessionResourceReleasedListNot (optional) */
+  if (msg->nb_pdu_sessions_released > 0) {
+    if (msg->nb_pdu_sessions_released > NR_MAX_NB_PDU_SESSIONS) {
+      NGAP_WARN("PDU Session Resource Notify with invalid released list count %d for gNB_ue_ngap_id %u\n",
+                msg->nb_pdu_sessions_released,
+                msg->gNB_ue_ngap_id);
+      ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
+      return -1;
+    }
+    asn1cSequenceAdd(out->protocolIEs.list, NGAP_PDUSessionResourceNotifyIEs_t, ie);
+    ie->id = NGAP_ProtocolIE_ID_id_PDUSessionResourceReleasedListNot;
+    ie->criticality = NGAP_Criticality_ignore;
+    ie->value.present = NGAP_PDUSessionResourceNotifyIEs__value_PR_PDUSessionResourceReleasedListNot;
+    NGAP_PDUSessionResourceReleasedListNot_t *list = &ie->value.choice.PDUSessionResourceReleasedListNot;
+
+    for (int i = 0; i < msg->nb_pdu_sessions_released; i++) {
+      const ngap_pdusession_notify_item_t *released = &msg->pdu_sessions[i];
+      asn1cSequenceAdd(list->list, NGAP_PDUSessionResourceReleasedItemNot_t, item);
+      item->pDUSessionID = released->pdu_session_id;
+
+      NGAP_PDUSessionResourceNotifyReleasedTransfer_t notifyTransfer = {0};
+      encode_ngap_cause(&notifyTransfer.cause, &released->cause);
+      asn_encode_to_new_buffer_result_t res = asn_encode_to_new_buffer(NULL,
+                                                                       ATS_ALIGNED_CANONICAL_PER,
+                                                                       &asn_DEF_NGAP_PDUSessionResourceNotifyReleasedTransfer,
+                                                                       &notifyTransfer);
+      if (res.buffer == NULL || res.result.encoded <= 0) {
+        NGAP_ERROR("Failed to encode PDUSessionResourceNotifyReleasedTransfer for PDU session %u\n", released->pdu_session_id);
+        ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_PDUSessionResourceNotifyReleasedTransfer, &notifyTransfer);
+        ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
+        return -1;
+      }
+      item->pDUSessionResourceNotifyReleasedTransfer.buf = res.buffer;
+      item->pDUSessionResourceNotifyReleasedTransfer.size = res.result.encoded;
+      ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_PDUSessionResourceNotifyReleasedTransfer, &notifyTransfer);
+    }
+  }
+
+  if (ngap_gNB_encode_pdu(&pdu, &buffer, &length) < 0) {
+    NGAP_ERROR("Failed to encode PDU Session Resource Notify\n");
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
+    return -1;
+  }
+
+  /* UE associated signalling -> use the allocated stream */
+  ngap_gNB_itti_send_sctp_data_req(ngap_gNB_instance_p->instance,
+                                   ue_context_p->amf_ref->assoc_id,
+                                   buffer,
+                                   length,
+                                   ue_context_p->tx_stream);
+  NGAP_INFO("pdusession_resource_notify sent gNB_UE_NGAP_ID %u amf_ue_ngap_id %lu nb_released %d\n",
+            msg->gNB_ue_ngap_id,
+            ue_context_p->amf_ue_ngap_id,
+            msg->nb_pdu_sessions_released);
+
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
+  return 0;
+}

--- a/openair3/NGAP/ngap_gNB_pdu_session_management.h
+++ b/openair3/NGAP/ngap_gNB_pdu_session_management.h
@@ -16,4 +16,6 @@ int ngap_gNB_pdusession_modify_resp(instance_t instance, ngap_pdusession_modify_
 
 int ngap_gNB_pdusession_release_resp(instance_t instance, ngap_pdusession_release_resp_t *pdusession_release_resp_p);
 
+int ngap_gNB_pdusession_resource_notify(instance_t instance, ngap_pdusession_resource_notify_t *msg);
+
 #endif /* NGAP_GNB_PDU_SESSION_MANAGEMENT_H_ */

--- a/openair3/NGAP/ngap_msg_includes.h
+++ b/openair3/NGAP/ngap_msg_includes.h
@@ -102,4 +102,7 @@
 #include "NGAP_PathSwitchRequestTransfer.h"
 #include "NGAP_PDUSessionResourceSwitchedItem.h"
 #include "NGAP_PathSwitchRequestAcknowledgeTransfer.h"
+#include "NGAP_PDUSessionResourceNotify.h"
+#include "NGAP_PDUSessionResourceReleasedItemNot.h"
+#include "NGAP_PDUSessionResourceNotifyReleasedTransfer.h"
 #endif // NGAP_MSG_INCLUDES_H

--- a/openair3/ocp-gtpu/gtp_itf.cpp
+++ b/openair3/ocp-gtpu/gtp_itf.cpp
@@ -36,6 +36,7 @@ extern "C" {
 #define GTPU_HEADER_OPTIONAL_OCTETS (4) /* Sequence Number, N-PDU Number, Next Extension Header Type */
 /* TS 29.281 clause 8.1: IE Length field is 2 octets */
 #define GTPU_TLV_LENGTH_OCTETS (2)
+#define GTPU_IE_TYPE_OCTETS 1 /* clause 8.1 */
 
 #pragma pack(1)
 
@@ -1068,6 +1069,45 @@ static int gtpv1u_skip_gtpu_tlv_ie(const uint8_t *msg_buf, uint32_t msg_buf_len,
 
   *offset += ie_len;
   return 0;
+}
+
+/** @brief Encode Error Indication IEs (TS 29.281 Table 7.3.1-1)
+ *  @note GTP-U header is built by the caller
+ *  @return IEs length in octets */
+int gtpv1u_encode_error_indication(const gtpv1u_error_indication_t *indication, uint8_t *msg_buf, uint32_t msg_buf_cap)
+{
+  DevAssert(msg_buf);
+  DevAssert(indication);
+
+  if (indication->teid_i == 0)
+    return GTPNOK;
+
+  const uint16_t addr_octets = indication->gtpu_peer_address.length / 8;
+  if (addr_octets != GTPU_PEER_ADDRESS_IPV4_OCTETS && addr_octets != GTPU_PEER_ADDRESS_IPV6_OCTETS)
+    return GTPNOK;
+
+  /* TEID-I TV + Peer Address TLV */
+  const uint32_t ie_len = (GTPU_IE_TYPE_OCTETS + GTPU_TEID_I_VALUE_OCTETS)
+                          + (GTPU_IE_TYPE_OCTETS + GTPU_TLV_LENGTH_OCTETS + addr_octets);
+  if (msg_buf_cap < ie_len)
+    return GTPNOK;
+
+  uint8_t *p = msg_buf;
+
+  /* TEID-I (TV IE: Type + 4-octet value, no Length field) */
+  *p++ = GTPU_TEID_I;
+  const uint32_t teid_be = htonl(indication->teid_i);
+  memcpy(p, &teid_be, GTPU_TEID_I_VALUE_OCTETS);
+  p += GTPU_TEID_I_VALUE_OCTETS;
+
+  /* GTP-U Peer Address (TLV: Type + Length + address octets) */
+  *p++ = GTPU_PEER_ADDRESS;
+  const uint16_t addr_len_be = htons(addr_octets);
+  memcpy(p, &addr_len_be, GTPU_TLV_LENGTH_OCTETS);
+  p += GTPU_TLV_LENGTH_OCTETS;
+  memcpy(p, indication->gtpu_peer_address.buffer, addr_octets);
+
+  return ie_len; /* IEs length in octets */
 }
 
 /** @brief Decode a GTPv1-U Error Indication message (7.3.1, TS 29.281) */

--- a/openair3/ocp-gtpu/gtp_itf.cpp
+++ b/openair3/ocp-gtpu/gtp_itf.cpp
@@ -13,6 +13,7 @@ extern "C" {
 #include <arpa/inet.h>
 #include <sys/types.h>
 #include <netdb.h>
+#include <string.h>
 
 #include "common/platform_types.h"
 #include "common/utils/system.h"
@@ -30,6 +31,12 @@ extern "C" {
 #include "nrup_common.h"
 #include "nrup_dl_data_delivery_status.h"
 
+/* TS 29.281 clause 5.1 Figure 5.1-1 */
+#define GTPU_HEADER_MANDATORY_OCTETS (8) /* PN, S, E, spare, PT, version, msgType, teid */
+#define GTPU_HEADER_OPTIONAL_OCTETS (4) /* Sequence Number, N-PDU Number, Next Extension Header Type */
+/* TS 29.281 clause 8.1: IE Length field is 2 octets */
+#define GTPU_TLV_LENGTH_OCTETS (2)
+
 #pragma pack(1)
 
 typedef struct Gtpv1uMsgHeader {
@@ -43,6 +50,8 @@ typedef struct Gtpv1uMsgHeader {
   uint16_t msgLength;
   teid_t teid;
 } __attribute__((packed)) Gtpv1uMsgHeaderT;
+static_assert(sizeof(Gtpv1uMsgHeaderT) == GTPU_HEADER_MANDATORY_OCTETS,
+              "GTP-U header must be 8 octets (TS 29.281 5.1)");
 
 typedef struct Gtpv1uMsgHeaderOptFields {
   uint8_t seqNum1Oct;
@@ -67,14 +76,6 @@ typedef struct Gtpv1uExtHeader {
   PDUSessionContainerT pdusession_cntr;
   uint8_t NextExtHeaderType;
 } __attribute__((packed)) Gtpv1uExtHeaderT;
-
-  typedef struct Gtpv1Error {
-    Gtpv1uMsgHeaderT h;
-    uint8_t teid_data_i;
-    teid_t teid;
-    uint8_t addr_data_i;
-    uint16_t addr_len;
-  } __attribute__((packed)) Gtpv1uError;
 
 #pragma pack()
 
@@ -466,6 +467,29 @@ static void fillDlDeliveryStatusReport(gtpu_extension_header_t *ext,
       .highest_transmitted_nr_pdcp_sn = nr_pdcp_pdu_sn,
     }
   };
+}
+
+/** @brief GTP-U header length: mandatory octets plus optional E/S/PN fields when present
+ * (TS 29.281 clause 5.1).
+ * @return header length in bytes, or GTPNOK on failure */
+static int gtpv1u_header_len(const Gtpv1uMsgHeaderT *msg_hdr, uint32_t msg_buf_len)
+{
+  DevAssert(msg_hdr != NULL);
+  if (msg_buf_len < sizeof(*msg_hdr))
+    return GTPNOK;
+
+  unsigned int offset = sizeof(*msg_hdr);
+
+  /* if E, S, or PN is set then there are 4 more bytes of header */
+  if (msg_hdr->E || msg_hdr->S || msg_hdr->PN) {
+    if (offset + GTPU_HEADER_OPTIONAL_OCTETS > msg_buf_len) {
+      LOG_E(GTPU, "GTP-U header optional fields truncated (%u bytes available)\n", msg_buf_len);
+      return GTPNOK;
+    }
+    offset += GTPU_HEADER_OPTIONAL_OCTETS;
+  }
+
+  return offset;
 }
 
 static void gtpv1uEndTunnel(instance_t instance, gtpv1u_enb_end_marker_req_t *req)
@@ -1027,26 +1051,155 @@ static int Gtpv1uHandleEchoReq(int h, uint8_t *msgBuf, const struct sockaddr_in 
                                 0);
 }
 
-static int Gtpv1uHandleError(uint8_t *msgBuf, uint32_t msgBufLen)
+/** @brief Skip one TLV IE value from the current Length field offset
+ * @note TS 29.281 clause 8.1: TLV IE, where Length counts Value only */
+static int gtpv1u_skip_gtpu_tlv_ie(const uint8_t *msg_buf, uint32_t msg_buf_len, uint32_t *offset)
 {
-  if (msgBufLen < sizeof(Gtpv1uError))
-    LOG_E(GTPU, "Received GTP error indication with truncated size %u (mini size: %lu)\n", msgBufLen,sizeof(Gtpv1uError)+4);
-  Gtpv1uError *msg = ( Gtpv1uError *)msgBuf;
-  LOG_E(GTPU,
-        "Received GTP error indication: \n"
-        "   TEID 0x%x (must be 0 from TS 29.281)\n"
-        "   TV id for TEID 0x%x (must be 16)\n"
-        "   TEID in error 0x%x (should be a TEID we sent)\n"
-        "   TV id for GTP addr %u (should be 133)\n"
-        "   len for addr of UPF %u (should be IPv4 or IPv6 len)"
-        "   (TS 29.281 Sec 7.3.1 Error Handling not implemented)\n",
-        ntohl(msg->h.teid),
-        msg->teid_data_i,
-        ntohl(msg->teid),
-        msg->addr_data_i,
-        msg->addr_len);
-  int rc = GTPNOK;
-  return rc;
+  if (*offset + GTPU_TLV_LENGTH_OCTETS > msg_buf_len)
+    return GTPNOK;
+
+  uint16_t ie_len_be = 0; // TLV length (network byte order)
+  memcpy(&ie_len_be, msg_buf + *offset, sizeof ie_len_be);
+  const uint16_t ie_len = ntohs(ie_len_be);
+  *offset += GTPU_TLV_LENGTH_OCTETS;
+
+  if (*offset + ie_len > msg_buf_len)
+    return GTPNOK;
+
+  *offset += ie_len;
+  return 0;
+}
+
+/** @brief Decode a GTPv1-U Error Indication message (7.3.1, TS 29.281) */
+int gtpv1u_decode_error_indication(const uint8_t *msg_buf, uint32_t msg_buf_len, gtpv1u_error_indication_t *out)
+{
+  DevAssert(msg_buf);
+  DevAssert(out);
+
+  memset(out, 0, sizeof(*out));
+
+  if (msg_buf_len < sizeof(Gtpv1uMsgHeaderT))
+    return GTPNOK;
+
+  const Gtpv1uMsgHeaderT *msg_hdr = (const Gtpv1uMsgHeaderT *)msg_buf;
+
+  /* TS 29.281 clause 5.1: Error Indication should have S=1 and header TEID=0.
+   * Failed tunnel TEID is only in TEID Data I (clause 7.3.1 / 8.3). Some open-source
+   * UPFs deviate, accept with a warning for interoperability. */
+  if (!msg_hdr->S)
+    LOG_W(GTPU, "GTP Error Indication: S=0 (TS 29.281 clause 5.1 requires S=1)\n");
+  const teid_t hdr_teid = ntohl(msg_hdr->teid);
+  if (hdr_teid != 0)
+    LOG_W(GTPU, "GTP Error Indication: header TEID 0x%x non-zero (TS 29.281 clause 5.1 requires 0)\n", hdr_teid);
+
+  const int header_end = gtpv1u_header_len(msg_hdr, msg_buf_len);
+  if (header_end < 0)
+    return GTPNOK;
+
+  uint8_t prev_ie_type = 0;
+  uint32_t offset = header_end;
+
+  /* TS 29.281 clause 5.1: when E=1, extension headers (e.g. UDP Port §5.2.2.1)
+   * sit between the optional GTP-U header and Table 7.3.1-1 IEs. RX skips the chain. */
+  if (msg_hdr->E) {
+    uint8_t next_ext = msg_buf[offset - 1];
+    while (next_ext != NO_MORE_EXT_HDRS) {
+      if (offset >= msg_buf_len)
+        return GTPNOK;
+      const uint8_t ext_len = msg_buf[offset];
+      if (ext_len == 0 || offset + ext_len * EXT_HDR_LNTH_OCTET_UNITS > msg_buf_len)
+        return GTPNOK;
+      offset += ext_len * EXT_HDR_LNTH_OCTET_UNITS;
+      next_ext = msg_buf[offset - 1];
+    }
+  }
+
+  while (offset < msg_buf_len) {
+    const uint8_t ie_type = msg_buf[offset++];
+
+    /* Table 7.3.1-1: IE types increase with prescribed order, rejects duplicates and out-of-order IEs */
+    if (ie_type <= prev_ie_type)
+      return GTPNOK;
+    prev_ie_type = ie_type;
+
+    switch (ie_type) {
+      /* TS 29.281 clause 8.3: TEID-I is TV (Type + 4-octet value, no Length) */
+      case GTPU_TEID_I:
+        if (offset + GTPU_TEID_I_VALUE_OCTETS > msg_buf_len)
+          return GTPNOK;
+        {
+          uint32_t teid_be = 0;
+          memcpy(&teid_be, msg_buf + offset, sizeof teid_be);
+          out->teid_i = ntohl(teid_be);
+        }
+        offset += GTPU_TEID_I_VALUE_OCTETS;
+        break;
+
+      /* TS 29.281 clause 8.4: Peer Address is TLV (Type + 2-octet Length + address) */
+      case GTPU_PEER_ADDRESS: {
+        if (offset + GTPU_TLV_LENGTH_OCTETS > msg_buf_len)
+          return GTPNOK;
+        uint16_t addr_len_be = 0;
+        memcpy(&addr_len_be, msg_buf + offset, sizeof addr_len_be);
+        const uint16_t addr_len = ntohs(addr_len_be);
+        offset += GTPU_TLV_LENGTH_OCTETS;
+        if (addr_len != GTPU_PEER_ADDRESS_IPV4_OCTETS && addr_len != GTPU_PEER_ADDRESS_IPV6_OCTETS)
+          return GTPNOK;
+        if (offset + addr_len > msg_buf_len)
+          return GTPNOK;
+        memcpy(out->gtpu_peer_address.buffer, msg_buf + offset, addr_len);
+        out->gtpu_peer_address.length = addr_len * 8;
+        offset += addr_len;
+        break;
+      }
+
+      case GTPU_RECOVERY_TIME_STAMP:
+      case GTPU_PRIVATE_EXTENSION:
+        if (gtpv1u_skip_gtpu_tlv_ie(msg_buf, msg_buf_len, &offset) != 0)
+          return GTPNOK;
+        break;
+
+      default:
+        LOG_W(GTPU, "GTP Error Indication: unknown IE type %u at offset %u\n", ie_type, offset - 1);
+        return GTPNOK;
+    }
+  }
+
+  /* Table 7.3.1-1: TEID-I (8.3) and Peer Address (8.4) are mandatory */
+  if (out->teid_i == 0 || out->gtpu_peer_address.length == 0)
+    return GTPNOK;
+
+  return 0;
+}
+
+/** @brief Handle incoming GTP-U Error Indication (7.3.1, TS 29.281).
+ * Decodes mandatory IEs (Table 7.3.1-1: TEID-I 8.3, Peer Address 8.4). */
+static int Gtpv1uHandleError(int h, uint8_t *msgBuf, uint32_t msgBufLen, const struct sockaddr_in *addr)
+{
+  Gtpv1uMsgHeaderT *msgHdr = (Gtpv1uMsgHeaderT *)msgBuf;
+
+  if (msgHdr->version != 1 || msgHdr->PT != 1) {
+    LOG_E(GTPU, "[%d] Received a packet that is not GTP header\n", h);
+    return GTPNOK;
+  }
+
+  gtpv1u_error_indication_t indication = {0};
+  if (gtpv1u_decode_error_indication(msgBuf, msgBufLen, &indication) != 0) {
+    LOG_E(GTPU, "[%d] Received malformed GTP Error Indication (%u bytes)\n", h, msgBufLen);
+    return GTPNOK;
+  }
+
+  char peer_str[INET6_ADDRSTRLEN] = {0};
+  const int peer_family = (indication.gtpu_peer_address.length == GTPU_PEER_ADDRESS_IPV6_OCTETS * 8) ? AF_INET6 : AF_INET;
+  inet_ntop(peer_family, indication.gtpu_peer_address.buffer, peer_str, sizeof peer_str);
+  LOG_W(GTPU,
+        "[%d] GTP Error Indication TEID-I 0x%x GTP-U Peer Address %s UDP-from " IPV4_ADDR "\n",
+        h,
+        indication.teid_i,
+        peer_str,
+        IPV4_ADDR_FORMAT(addr->sin_addr.s_addr));
+
+  return 0;
 }
 
 static int Gtpv1uHandleSupportedExt()
@@ -1129,16 +1282,14 @@ static int Gtpv1uHandleGpdu(int h, uint8_t *msgBuf, uint32_t msgBufLen, const st
   pthread_mutex_unlock(&globGtp.gtp_lock);
 
   /* see TS 29.281 5.1 */
-  // Minimum length of GTP-U header if non of the optional fields are present
-  unsigned int offset = sizeof(Gtpv1uMsgHeaderT);
+  const int header_len = gtpv1u_header_len(msgHdr, msgBufLen);
+  if (header_len < 0)
+    return GTPNOK;
+  unsigned int offset = header_len;
 
   int8_t qfi = -1;
   bool rqi = false;
   uint32_t NR_PDCP_PDU_SN = 0;
-
-  /* if E, S, or PN is set then there are 4 more bytes of header */
-  if (msgHdr->E || msgHdr->S || msgHdr->PN)
-    offset += 4;
 
   if (msgHdr->E) {
     int next_extension_header_type = msgBuf[offset - 1];
@@ -1348,7 +1499,7 @@ static bool gtpv1uReceiveHandleMessage(int h, uint8_t buf[VLEN][BUFSIZE])
         break;
 
       case GTP_ERROR_INDICATION:
-        Gtpv1uHandleError(udpData, udpDataLen);
+        Gtpv1uHandleError(h, udpData, udpDataLen, &addr[i]);
         break;
 
       case GTP_SUPPORTED_EXTENSION_HEADER_INDICATION:

--- a/openair3/ocp-gtpu/gtp_itf.cpp
+++ b/openair3/ocp-gtpu/gtp_itf.cpp
@@ -133,6 +133,7 @@ typedef struct {
   gtpCallback callBack;
   teid_t outgoing_teid;
   gtpCallbackSDAP callBackSDAP;
+  gtpv1u_error_indication_cb_fn_t errorIndicationCallBack;
   /** PDU Session ID (1..255) */
   uint16_t pdusession_id;
 } ueidData_t;
@@ -693,7 +694,8 @@ teid_t newGtpuCreateTunnel(instance_t instance,
                            teid_t outgoing_teid,
                            transport_layer_addr_t remoteAddr,
                            gtpCallback callBack,
-                           gtpCallbackSDAP callBackSDAP)
+                           gtpCallbackSDAP callBackSDAP,
+                           gtpv1u_error_indication_cb_fn_t errorIndicationCallBack)
 {
   pthread_mutex_lock(&globGtp.gtp_lock);
   getInstRetInt(compatInst(instance));
@@ -716,6 +718,7 @@ teid_t newGtpuCreateTunnel(instance_t instance,
   globGtp.te2ue_mapping[incoming_teid].outgoing_teid = outgoing_teid;
   globGtp.te2ue_mapping[incoming_teid].callBack = callBack;
   globGtp.te2ue_mapping[incoming_teid].callBackSDAP = callBackSDAP;
+  globGtp.te2ue_mapping[incoming_teid].errorIndicationCallBack = errorIndicationCallBack;
   globGtp.te2ue_mapping[incoming_teid].pdusession_id = (uint8_t)outgoing_bearer_id;
 
   gtpv1u_bearer_t bearer = {
@@ -792,6 +795,7 @@ int gtpv1u_create_s1u_tunnel(instance_t instance,
                                       create_tunnel_req->sgw_S1u_teid[i],
                                       create_tunnel_req->sgw_addr[i],
                                       callBack,
+                                      NULL,
                                       NULL);
     create_tunnel_resp->status = 0;
     create_tunnel_resp->rnti = create_tunnel_req->rnti;
@@ -851,7 +855,8 @@ int gtpv1u_create_ngu_tunnel(const instance_t instance,
                              const gtpv1u_gnb_create_tunnel_req_t *const create_tunnel_req,
                              gtpv1u_gnb_create_tunnel_resp_t *const create_tunnel_resp,
                              gtpCallback callBack,
-                             gtpCallbackSDAP callBackSDAP)
+                             gtpCallbackSDAP callBackSDAP,
+                             gtpv1u_error_indication_cb_fn_t errorIndicationCallBack)
 {
   LOG_D(GTPU,
         "[%ld] Create tunnel for UE ID %lu, outgoing TEID 0x%x\n",
@@ -871,7 +876,8 @@ int gtpv1u_create_ngu_tunnel(const instance_t instance,
                                     create_tunnel_req->outgoing_teid,
                                     create_tunnel_req->dst_addr,
                                     callBack,
-                                    callBackSDAP);
+                                    callBackSDAP,
+                                    errorIndicationCallBack);
   /* Fill response */
   create_tunnel_resp->status = 0;
   create_tunnel_resp->ue_id = create_tunnel_req->ue_id;
@@ -1276,6 +1282,34 @@ static int Gtpv1uHandleError(int h, uint8_t *msgBuf, uint32_t msgBufLen, const s
         indication.teid_i,
         peer_str,
         IPV4_ADDR_FORMAT(addr->sin_addr.s_addr));
+
+  /* Invoke per-tunnel callback when TEID-I maps to te2ue_mapping (TS 23.527 §5.3.3.1). */
+  pthread_mutex_lock(&globGtp.gtp_lock);
+  const auto tunnel = globGtp.te2ue_mapping.find(indication.teid_i);
+  if (tunnel == globGtp.te2ue_mapping.end()) {
+    pthread_mutex_unlock(&globGtp.gtp_lock);
+    LOG_W(GTPU, "[%d] GTP Error Indication TEID-I 0x%x: no tunnel mapping, drop\n", h, indication.teid_i);
+    return 0;
+  }
+
+  gtpv1u_error_indication_ind_t ind = {
+      .gtp_instance = h,
+      .ue_id = tunnel->second.ue_id,
+      .incoming_rb_id = tunnel->second.incoming_rb_id,
+      .pdusession_id = tunnel->second.pdusession_id,
+      .teid_i = indication.teid_i,
+      .gtpu_peer_address = indication.gtpu_peer_address,
+      .udp_peer = addr->sin_addr.s_addr,
+      .udp_peer_valid = true,
+  };
+  gtpv1u_error_indication_cb_fn_t error_cb = tunnel->second.errorIndicationCallBack;
+  pthread_mutex_unlock(&globGtp.gtp_lock);
+
+  if (error_cb == nullptr) {
+    LOG_E(GTPU, "[%d] GTP Error Indication TEID-I 0x%x: no error indication callback, drop\n", h, indication.teid_i);
+    return -1;
+  }
+  error_cb(&ind);
 
   return 0;
 }

--- a/openair3/ocp-gtpu/gtp_itf.cpp
+++ b/openair3/ocp-gtpu/gtp_itf.cpp
@@ -1212,6 +1212,44 @@ int gtpv1u_decode_error_indication(const uint8_t *msg_buf, uint32_t msg_buf_len,
   return 0;
 }
 
+/** @brief Send a GTP-U Error Indication message (7.3.1, TS 29.281) */
+static int gtpv1uSendErrorIndication(int h, const struct sockaddr_in *dst, teid_t teid_in_error)
+{
+  DevAssert(dst);
+
+  transport_layer_addr_t local_addr = {0};
+  pthread_mutex_lock(&globGtp.gtp_lock);
+  getInstRetInt(h);
+  if (inst->ipVersion != 4) {
+    pthread_mutex_unlock(&globGtp.gtp_lock);
+    LOG_W(GTPU, "[%d] Error Indication TX: IPv6 local address not supported\n", h);
+    return GTPNOK;
+  }
+  local_addr.length = GTPU_PEER_ADDRESS_IPV4_OCTETS * 8;
+  memcpy(local_addr.buffer, inst->foundAddr, inst->foundAddrLen);
+  pthread_mutex_unlock(&globGtp.gtp_lock);
+
+  const gtpv1u_error_indication_t indication = {.teid_i = teid_in_error, .gtpu_peer_address = local_addr};
+  uint8_t ie_body[32];
+  const int ie_len = gtpv1u_encode_error_indication(&indication, ie_body, sizeof ie_body);
+  if (ie_len < 0) {
+    LOG_E(GTPU, "[%d] Failed to encode GTP Error Indication TEID-I 0x%x\n", h, teid_in_error);
+    return GTPNOK;
+  }
+
+  gtpv1u_bearer_t bearer = create_bearer(h, dst, 0, 0);
+  const int rc = gtpv1uCreateAndSendMsg(&bearer, GTP_ERROR_INDICATION, ie_body, ie_len, true, false, NULL, 0);
+  if (rc == 0) {
+    LOG_W(GTPU,
+          "[%d] Sent GTP Error Indication TEID-I 0x%x to " IPV4_ADDR ":%u\n",
+          h,
+          teid_in_error,
+          IPV4_ADDR_FORMAT(dst->sin_addr.s_addr),
+          ntohs(dst->sin_port));
+  }
+  return rc;
+}
+
 /** @brief Handle incoming GTP-U Error Indication (7.3.1, TS 29.281).
  * Decodes mandatory IEs (Table 7.3.1-1: TEID-I 8.3, Peer Address 8.4). */
 static int Gtpv1uHandleError(int h, uint8_t *msgBuf, uint32_t msgBufLen, const struct sockaddr_in *addr)
@@ -1314,8 +1352,14 @@ static int Gtpv1uHandleGpdu(int h, uint8_t *msgBuf, uint32_t msgBufLen, const st
   auto tunnel = globGtp.te2ue_mapping.find(ntohl(msgHdr->teid));
 
   if (tunnel == globGtp.te2ue_mapping.end()) {
-    LOG_E(GTPU, "[%d] Received a incoming packet on unknown TEID (0x%x) Dropping!\n", h, ntohl(msgHdr->teid));
+    /* TS 29.281 §7.3.1: if no context exists for a received G-PDU, discard it
+     * if the TEID is not all zeros, also return Error Indication to the originator
+     * (see also TS 23.527 §5.2.1). */
+    const teid_t bad_teid = ntohl(msgHdr->teid);
     pthread_mutex_unlock(&globGtp.gtp_lock);
+    if (bad_teid != 0 && gtpv1uSendErrorIndication(h, addr, bad_teid) != 0)
+      LOG_E(GTPU, "[%d] Error Indication TX failed for unknown TEID (0x%x)\n", h, bad_teid);
+    LOG_E(GTPU, "[%d] Received a incoming packet on unknown TEID (0x%x) Dropping!\n", h, bad_teid);
     return GTPNOK;
   }
   ueidData_t uedata = tunnel->second;

--- a/openair3/ocp-gtpu/gtp_itf.h
+++ b/openair3/ocp-gtpu/gtp_itf.h
@@ -15,6 +15,7 @@
 # define GTPU_HEADER_OVERHEAD_MAX 64
 
 #include "common/platform_types.h"
+#include "openair2/COMMON/gtpv1_u_messages_types.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -64,6 +65,20 @@ typedef struct gtpv1u_gnb_delete_tunnel_req_s gtpv1u_gnb_delete_tunnel_req_t;
                                   const bool      rqi,
                                   const int       pdusession_id);
 
+  /** @brief GTP callback payload (TS 23.527 clause 5.3.3.1) */
+  typedef struct gtpv1u_error_indication_ind_s {
+    instance_t gtp_instance;
+    ue_id_t ue_id;
+    uint16_t incoming_rb_id;
+    uint16_t pdusession_id;
+    teid_t teid_i;
+    transport_layer_addr_t gtpu_peer_address;
+    in_addr_t udp_peer;
+    bool udp_peer_valid;
+  } gtpv1u_error_indication_ind_t;
+
+  typedef void (*gtpv1u_error_indication_cb_fn_t)(const gtpv1u_error_indication_ind_t *ind);
+
   typedef struct openAddr_s {
     char originHost[HOST_NAME_MAX];
     char originService[HOST_NAME_MAX];
@@ -102,7 +117,8 @@ typedef struct gtpv1u_gnb_delete_tunnel_req_s gtpv1u_gnb_delete_tunnel_req_t;
                                const gtpv1u_gnb_create_tunnel_req_t *const create_tunnel_req_pP,
                                gtpv1u_gnb_create_tunnel_resp_t *const create_tunnel_resp_pP,
                                gtpCallback callBack,
-                               gtpCallbackSDAP callBackSDAP);
+                               gtpCallbackSDAP callBackSDAP,
+                               gtpv1u_error_indication_cb_fn_t errorIndicationCallBack);
 
   int gtpv1u_update_ue_id(const instance_t instanceP, ue_id_t old_ue_id, ue_id_t new_ue_id);
 
@@ -114,7 +130,8 @@ typedef struct gtpv1u_gnb_delete_tunnel_req_s gtpv1u_gnb_delete_tunnel_req_t;
                              teid_t outgoing_teid,
                              transport_layer_addr_t remoteAddr,
                              gtpCallback callBack,
-                             gtpCallbackSDAP callBackSDAP);
+                             gtpCallbackSDAP callBackSDAP,
+                             gtpv1u_error_indication_cb_fn_t errorIndicationCallBack);
 
   void GtpuUpdateTunnelOutgoingAddressAndTeid(instance_t instance,
                                     ue_id_t ue_id,

--- a/openair3/ocp-gtpu/gtp_itf.h
+++ b/openair3/ocp-gtpu/gtp_itf.h
@@ -138,6 +138,25 @@ typedef struct gtpv1u_gnb_delete_tunnel_req_s gtpv1u_gnb_delete_tunnel_req_t;
   int gtpv1Term(instance_t inst);
   void *gtpv1uTask(void *args);
 
+/* TS 29.281 Error Indication IEs */
+#define GTPU_TEID_I 16 /* Clause 8.3 */
+#define GTPU_PEER_ADDRESS 133 /* Clause 8.4 */
+#define GTPU_PRIVATE_EXTENSION 255 /* Clause 8.6 */
+#define GTPU_RECOVERY_TIME_STAMP 231 /* Clause 8.8 */
+#define GTPU_TEID_I_VALUE_OCTETS 4
+#define GTPU_PEER_ADDRESS_IPV4_OCTETS 4
+#define GTPU_PEER_ADDRESS_IPV6_OCTETS 16
+
+  /* TS 29.281 Table 7.3.1-1: Error Indication IEs */
+  typedef struct gtpv1u_error_indication_s {
+    // Tunnel Endpoint Identifier Data I (8.3 TS 29.281)
+    teid_t teid_i;
+    // GTPU Peer Address (8.4 TS 29.281)
+    transport_layer_addr_t gtpu_peer_address;
+  } gtpv1u_error_indication_t;
+
+  int gtpv1u_decode_error_indication(const uint8_t *msg_buf, uint32_t msg_buf_len, gtpv1u_error_indication_t *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/openair3/ocp-gtpu/gtp_itf.h
+++ b/openair3/ocp-gtpu/gtp_itf.h
@@ -156,6 +156,7 @@ typedef struct gtpv1u_gnb_delete_tunnel_req_s gtpv1u_gnb_delete_tunnel_req_t;
   } gtpv1u_error_indication_t;
 
   int gtpv1u_decode_error_indication(const uint8_t *msg_buf, uint32_t msg_buf_len, gtpv1u_error_indication_t *out);
+  int gtpv1u_encode_error_indication(const gtpv1u_error_indication_t *indication, uint8_t *msg_buf, uint32_t msg_buf_cap);
 
 #ifdef __cplusplus
 }

--- a/openair3/ocp-gtpu/tests/test_gtp.cpp
+++ b/openair3/ocp-gtpu/tests/test_gtp.cpp
@@ -101,13 +101,13 @@ static void run_basic_test(uint32_t ue_id,
    * don't provide an address yet, hence "null_addr". Install the callback
    * specific to this test. */
   transport_layer_addr_t null_addr = {.length = 32};
-  teid_t t1 = newGtpuCreateTunnel(ep1, ue_id, pdu_id, pdu_id, -1, null_addr, callBack, callBackSDAP);
+  teid_t t1 = newGtpuCreateTunnel(ep1, ue_id, pdu_id, pdu_id, -1, null_addr, callBack, callBackSDAP, NULL);
 
   /* Create the sending end on ep2. We have ep1's address/TEID, so create the
    * remote endpoint. Don't provide a callback, as this is supposed to be
    * unidirectional. */
   transport_layer_addr_t tl_addr1 = get_tl_addr(AF_INET, ip1);
-  teid_t t2 = newGtpuCreateTunnel(ep2, ue_id, pdu_id, pdu_id, t1, tl_addr1, NULL, NULL);
+  teid_t t2 = newGtpuCreateTunnel(ep2, ue_id, pdu_id, pdu_id, t1, tl_addr1, NULL, NULL, NULL);
 
   EXPECT_NE(t1, t2); // cannot be the same TEIDs
 
@@ -230,10 +230,10 @@ static void run_multi_qos_flows_test(uint32_t ue_id, long pdu_id, const uint8_t 
   EXPECT_NE(ep1, ep2);
 
   transport_layer_addr_t null_addr = {.length = 32};
-  teid_t t1 = newGtpuCreateTunnel(ep1, ue_id, pdu_id, pdu_id, -1, null_addr, NULL, recv_multi_qfi_same_pdu);
+  teid_t t1 = newGtpuCreateTunnel(ep1, ue_id, pdu_id, pdu_id, -1, null_addr, NULL, recv_multi_qfi_same_pdu, NULL);
 
   transport_layer_addr_t tl_addr1 = get_tl_addr(AF_INET, ip1);
-  teid_t t2 = newGtpuCreateTunnel(ep2, ue_id, pdu_id, pdu_id, t1, tl_addr1, NULL, NULL);
+  teid_t t2 = newGtpuCreateTunnel(ep2, ue_id, pdu_id, pdu_id, t1, tl_addr1, NULL, NULL, NULL);
   EXPECT_NE(t1, t2);
 
   in_addr_t addr2 = get_addr(AF_INET, ip2);
@@ -360,9 +360,9 @@ TEST(gtp, nrup_ddds)
   ASSERT_GE(ep2, 1);
 
   transport_layer_addr_t null_addr = {.length = 32};
-  teid_t t1 = newGtpuCreateTunnel(ep1, ue_id, pdu_id, pdu_id, -1, null_addr, NULL, NULL);
+  teid_t t1 = newGtpuCreateTunnel(ep1, ue_id, pdu_id, pdu_id, -1, null_addr, NULL, NULL, NULL);
   transport_layer_addr_t tl_addr1 = get_tl_addr(AF_INET, ip1);
-  teid_t t2 = newGtpuCreateTunnel(ep2, ue_id, pdu_id, pdu_id, t1, tl_addr1, NULL, NULL);
+  teid_t t2 = newGtpuCreateTunnel(ep2, ue_id, pdu_id, pdu_id, t1, tl_addr1, NULL, NULL, NULL);
   in_addr_t addr2 = get_addr(AF_INET, ip2);
   GtpuUpdateTunnelOutgoingAddressAndTeid(ep1, ue_id, pdu_id, addr2, t2);
 

--- a/openair3/ocp-gtpu/tests/test_gtp.cpp
+++ b/openair3/ocp-gtpu/tests/test_gtp.cpp
@@ -393,6 +393,148 @@ TEST(gtp, nrup_ddds)
   EXPECT_EQ(gtpv1Term(ep2), 0);
 }
 
+/** @brief Build a GTPv1-U Error Indication (omit an IE by leaving it zero) */
+static size_t build_error_indication(uint8_t *buf, size_t buf_cap, const gtpv1u_error_indication_t *in)
+{
+  const uint8_t peer_octets = in->gtpu_peer_address.length / 8;
+  /** TEID-I (TV): 1 type + 4 value = 5 bytes
+   * Peer Address (TLV): 1 type + 2 length + address octets */
+  const size_t teid_ie_len = (in->teid_i != 0) ? (1U + GTPU_TEID_I_VALUE_OCTETS) : 0U;
+  const size_t peer_ie_len = (peer_octets != 0) ? (1U + 2U + peer_octets) : 0U;
+  const size_t ie_len = teid_ie_len + peer_ie_len;
+  const size_t body_len = 4U + ie_len; /* optional header (S=1) + IEs */
+  const size_t total_len = 8U + body_len; /* mandatory header (8) + payload */
+
+  if (buf_cap < total_len || ie_len == 0)
+    return 0;
+
+  uint8_t *p = buf;
+
+  /* Mandatory GTP-U header (8 octets, TS 29.281 clause 5.1 Figure 5.1-1) */
+  *p++ = 0x32; /* TS 29.281 clause 5.1: S=1 for Error Indication */
+  *p++ = 26; /* Message Type: Error Indication (TS 29.281 Table 6.1-1) */
+  *p++ = (body_len >> 8) & 0xff; /* Length (network byte order) */
+  *p++ = body_len & 0xff;
+  memset(p, 0, 4); /* TEID = 0 (TS 29.281 clause 5.1) */
+  p += 4;
+
+  /* Optional GTP-U header fields (4 octets) */
+  memset(p, 0, 4); /* Sequence Number, N-PDU Number, Next Extension Header Type */
+  p += 4;
+
+  /* Message body: Error Indication IEs (TS 29.281 Table 7.3.1-1) */
+  /* TEID-I (TV IE: Type + 4-octet value) */
+  if (in->teid_i != 0) {
+    *p++ = GTPU_TEID_I;
+    uint32_t teid_be = htonl(in->teid_i);
+    memcpy(p, &teid_be, sizeof teid_be);
+    p += sizeof teid_be;
+  }
+
+  /* GTP-U Peer Address (TLV: Type + Length + address octets) */
+  if (peer_octets != 0) {
+    *p++ = GTPU_PEER_ADDRESS; /* Type */
+    *p++ = 0; /* Length (network byte order) */
+    *p++ = peer_octets; /* number of address octets */
+    memcpy(p, in->gtpu_peer_address.buffer, peer_octets);
+    p += peer_octets;
+  }
+
+  return total_len;
+}
+
+TEST(gtp, error_indication_decode)
+{
+  uint8_t buf[48] = {0};
+  gtpv1u_error_indication_t indication = {0};
+  gtpv1u_error_indication_t in = {0};
+  size_t len = 0;
+
+  in.gtpu_peer_address = get_tl_addr(AF_INET, "192.168.1.1");
+
+  /* valid mandatory IEs (TEID-I + GTP-U Peer Address) */
+  in.teid_i = 0x12345678;
+  len = build_error_indication(buf, sizeof buf, &in);
+  ASSERT_GT(len, 0U);
+  EXPECT_EQ(gtpv1u_decode_error_indication(buf, len, &indication), 0);
+  EXPECT_EQ(indication.teid_i, 0x12345678U);
+  EXPECT_EQ(indication.gtpu_peer_address.length, 32U);
+  EXPECT_EQ(indication.gtpu_peer_address.buffer[0], 192);
+  EXPECT_EQ(indication.gtpu_peer_address.buffer[3], 1);
+
+  /* truncation */
+  EXPECT_EQ(gtpv1u_decode_error_indication(buf, len - 2, &indication), GTPNOK);
+
+  /* missing mandatory IE (GTP-U Peer Address) */
+  in.teid_i = 0x12345678;
+  in.gtpu_peer_address.length = 0;
+  len = build_error_indication(buf, sizeof buf, &in);
+  ASSERT_GT(len, 0U);
+  EXPECT_EQ(gtpv1u_decode_error_indication(buf, len, &indication), GTPNOK);
+
+  /* missing mandatory IE (TEID-I) */
+  in.teid_i = 0;
+  in.gtpu_peer_address = get_tl_addr(AF_INET, "192.168.1.1");
+  len = build_error_indication(buf, sizeof buf, &in);
+  ASSERT_GT(len, 0U);
+  EXPECT_EQ(gtpv1u_decode_error_indication(buf, len, &indication), GTPNOK);
+
+  /* non-zero header TEID */
+  in.teid_i = 0x1;
+  len = build_error_indication(buf, sizeof buf, &in);
+  ASSERT_GT(len, 0U);
+  buf[7] = 1;
+  EXPECT_EQ(gtpv1u_decode_error_indication(buf, len, &indication), 0);
+  EXPECT_EQ(indication.teid_i, 0x1U);
+  EXPECT_EQ(indication.gtpu_peer_address.length, 32U);
+
+  /* S=0, 8-byte header (e.g. OAI CN5G UPF): warn and accept */
+  static const uint8_t ei_s0[] = {
+      0x30, 0x1a, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, /* flags S=0, type 26, len 12, TEID 0 */
+      0x10, 0x00, 0x00, 0x00, 0x1e, /* TEID-I 0x1e */
+      0x85, 0x00, 0x04, 192,  168,  70,   129, /* Peer Address 192.168.70.129 */
+  };
+  EXPECT_EQ(gtpv1u_decode_error_indication(ei_s0, sizeof ei_s0, &indication), 0);
+  EXPECT_EQ(indication.teid_i, 0x1eU);
+  EXPECT_EQ(indication.gtpu_peer_address.length, 32U);
+  EXPECT_EQ(indication.gtpu_peer_address.buffer[0], 192);
+  EXPECT_EQ(indication.gtpu_peer_address.buffer[3], 129);
+
+  /* optional IE present (Recovery Time Stamp) */
+  in.teid_i = 0xdeadbeef;
+  len = build_error_indication(buf, sizeof buf, &in);
+  ASSERT_GT(len, 0U);
+  uint8_t *p = buf + len;
+  *p++ = GTPU_RECOVERY_TIME_STAMP;
+  *p++ = 0;
+  *p++ = 4;
+  *p++ = 0x12;
+  *p++ = 0x34;
+  *p++ = 0x56;
+  *p++ = 0x78;
+  const size_t total_len = p - buf;
+  buf[2] = ((total_len - 8) >> 8) & 0xff;
+  buf[3] = (total_len - 8) & 0xff;
+  EXPECT_EQ(gtpv1u_decode_error_indication(buf, total_len, &indication), 0);
+  EXPECT_EQ(indication.teid_i, 0xdeadbeefU);
+  EXPECT_EQ(indication.gtpu_peer_address.length, 32U);
+
+  /* E=1 + non-zero header TEID (Open5GS lab): extensions skipped, TEID-I used */
+  static const uint8_t ei_with_extensions[] = {
+      0x36, 0x1a, 0x00, 0x18, 0x00, 0x00, 0x2c, 0xdf, /* GTP-U: E=1, S=1, type 26, TEID 0x2cdf */
+      0x00, 0x00, 0x00, 0x85, /* optional header: Next Ext = PDU Session Container (0x85) */
+      0x01, 0x00, 0x01, 0x40, /* ext 0x85, Next Ext = UDP Port (0x40) */
+      0x01, 0x00, 0x00, 0x00, /* ext 0x40, Next Ext = none */
+      0x10, 0x00, 0x00, 0x2c, 0xdf, /* TEID-I (type 16) */
+      0x85, 0x00, 0x04, 192,  168,  71,   1, /* Peer Address (type 133), 192.168.71.1 */
+  };
+  EXPECT_EQ(gtpv1u_decode_error_indication(ei_with_extensions, sizeof ei_with_extensions, &indication), 0);
+  EXPECT_EQ(indication.teid_i, 0x2cdfU);
+  EXPECT_EQ(indication.gtpu_peer_address.length, 32U);
+  EXPECT_EQ(indication.gtpu_peer_address.buffer[0], 192);
+  EXPECT_EQ(indication.gtpu_peer_address.buffer[3], 1);
+}
+
 /* ideas for tests:
  * - share IP addresses among two instances (e.g., F1-U/NG-U on same IP/port)
  * - support of IPv6

--- a/openair3/ocp-gtpu/tests/test_gtp.cpp
+++ b/openair3/ocp-gtpu/tests/test_gtp.cpp
@@ -535,6 +535,42 @@ TEST(gtp, error_indication_decode)
   EXPECT_EQ(indication.gtpu_peer_address.buffer[3], 1);
 }
 
+TEST(gtp, error_indication_encode)
+{
+  uint8_t ie[32] = {0};
+  const gtpv1u_error_indication_t in = {.teid_i = 0x12345678, .gtpu_peer_address = get_tl_addr(AF_INET, "10.0.0.1")};
+
+  const int encoded = gtpv1u_encode_error_indication(&in, ie, sizeof ie);
+  ASSERT_EQ(encoded, 1 + GTPU_TEID_I_VALUE_OCTETS + 1 + 2 + GTPU_PEER_ADDRESS_IPV4_OCTETS);
+  EXPECT_EQ(gtpv1u_encode_error_indication(&in, ie, 4), GTPNOK);
+
+  uint8_t buf[48] = {0};
+  const size_t ie_len = 12; /* TEID-I (TV IE) + GTP-U Peer Address (TLV) */
+  const size_t body_len = 4U + ie_len; /* optional 4-octet header block (S=1) + IEs */
+  const size_t len = 8U + body_len; /* mandatory 8-octet header + body */
+  uint8_t *p = buf;
+  *p++ = 0x32; /* Flags: version=1, PT=GTP, S=1 (TS 29.281 clause 5.1) */
+  *p++ = 26; /* Message Type: Error Indication */
+  *p++ = (body_len >> 8) & 0xff; /* Length (network byte order) */
+  *p++ = body_len & 0xff;
+  memset(p, 0, 4); /* TEID = 0 (TS 29.281 clause 5.1) */
+  p += 4;
+  memset(p, 0, 4); /* Optional block: Sequence Number, N-PDU Number, Next Extension Header Type */
+  p += 4;
+  memcpy(p, ie, ie_len); /* TEID-I (TV IE) + GTP-U Peer Address (TLV) */
+
+  gtpv1u_error_indication_t indication = {0};
+  EXPECT_EQ(gtpv1u_decode_error_indication(buf, len, &indication), 0);
+  EXPECT_EQ(indication.teid_i, in.teid_i);
+  EXPECT_EQ(indication.gtpu_peer_address.length, in.gtpu_peer_address.length);
+  EXPECT_EQ(memcmp(indication.gtpu_peer_address.buffer, in.gtpu_peer_address.buffer, in.gtpu_peer_address.length / 8), 0);
+
+  uint8_t ie_rt[32] = {0};
+  const int encoded_rt = gtpv1u_encode_error_indication(&indication, ie_rt, sizeof ie_rt);
+  ASSERT_EQ(encoded_rt, encoded);
+  EXPECT_EQ(memcmp(ie, ie_rt, encoded), 0);
+}
+
 /* ideas for tests:
  * - share IP addresses among two instances (e.g., F1-U/NG-U on same IP/port)
  * - support of IPv6

--- a/tests/nr-cuup/nr-cuup-load-test.c
+++ b/tests/nr-cuup/nr-cuup-load-test.c
@@ -27,6 +27,7 @@ int nr_rlc_get_available_tx_space(const rnti_t rntiP, const logical_chan_id_t ch
 softmodem_params_t *get_softmodem_params(void) { static softmodem_params_t p = {0}; return &p; }; /* in ITTI */
 void e1_bearer_context_setup(const e1ap_bearer_setup_req_t *req) { abort(); } /* CU-UP */
 void e1_bearer_context_modif(const e1ap_bearer_mod_req_t *req) { abort(); } /* CU-UP */
+void e1_bearer_context_mod_confirm(const e1ap_bearer_mod_confirm_t *conf) { abort(); } /* CU-UP */
 void e1_bearer_release_cmd(const e1ap_bearer_release_cmd_t *cmd) { abort(); } /* CU-UP */
 void e1_reset(void) { abort(); } /* CU-UP */
 instance_t *N3GTPUInst = NULL; /* CU-UP */

--- a/tests/nr-cuup/nr-cuup-load-test.c
+++ b/tests/nr-cuup/nr-cuup-load-test.c
@@ -199,7 +199,7 @@ static up_params_t setup_cuup_ue_ng(sctp_assoc_t assoc_id, const e1ap_nssai_t *n
   /* create the local tunnel (i.e., as if we were UPF) with N3-U bearer mappings */
   transport_layer_addr_t null_addr = {.length = 32};
   /* Intentionally disable non-SDAP callback on NG-U: this test must fail if packets arrive without QFI. */
-  teid_t teid_lo = newGtpuCreateTunnel(gtp_inst, ue_id, pdu_id, pdu_id, -1, null_addr, NULL, recv_ng);
+  teid_t teid_lo = newGtpuCreateTunnel(gtp_inst, ue_id, pdu_id, pdu_id, -1, null_addr, NULL, recv_ng, NULL);
   UP_TL_information_t tnl = {.teId = teid_lo};
   memcpy(&tnl.tlAddress, &addr_lo, 4);
 
@@ -301,7 +301,7 @@ static void setup_cuup_ue_f1(sctp_assoc_t assoc_id, uint32_t ue_id, instance_t g
   /* create tunnel (i.e., as if we were DU) */
   transport_layer_addr_t addr = {.length = 32};
   memcpy(addr.buffer, &rm.tl_info.tlAddress, 4);
-  teid_t teid_lo = newGtpuCreateTunnel(gtp_inst, ue_id, drb_id, drb_id, rm.tl_info.teId, addr, recv_f1, NULL);
+  teid_t teid_lo = newGtpuCreateTunnel(gtp_inst, ue_id, drb_id, drb_id, rm.tl_info.teId, addr, recv_f1, NULL, NULL);
 
   up_params_t lo = {.tl_info.teId = teid_lo, .cell_group_id = rm.cell_group_id};
   inet_pton(AF_INET, ip, &lo.tl_info.tlAddress);

--- a/tests/nrdlbench/dlbench.c
+++ b/tests/nrdlbench/dlbench.c
@@ -83,6 +83,8 @@ void signal_ue_id(void) { abort(); }
 /* E1AP stubs (pulled in by cucp_cuup_direct.c in libe1_if) */
 void e1_bearer_context_setup(const e1ap_bearer_setup_req_t *req) { abort(); }
 void e1_bearer_context_modif(const e1ap_bearer_mod_req_t *req) { abort(); }
+struct e1ap_bearer_mod_confirm_s;
+void e1_bearer_context_mod_confirm(const struct e1ap_bearer_mod_confirm_s *conf) { abort(); }
 struct e1ap_bearer_release_cmd_s;
 void e1_bearer_release_cmd(const struct e1ap_bearer_release_cmd_s *cmd) { abort(); }
 


### PR DESCRIPTION
This PR adds GTP-U Error Indication support (TS 29.281 §7.3.1 / TS 23.527 §5.2.1 and §5.3.3.1):
* decode and encode Error Indication IEs
* send Error Indication when an inbound G-PDU uses an unknown TEID
* on N3 Error Indication release the affected PDU session user plane and notify the AMF via NGAP PDU Session Resource Notify.
* CU-UP signals CU-CP with E1 Bearer Context Modification Required, CU-CP Confirms, releases DRBs over F1/RRC, then sends Notify.

**Changes:**

- GTP-U Error Indication:
  - decode/encode IEs (TEID-I, Peer Address)
  - when E=1, skip GTP-U extension headers before IEs (§5.1)
  - on unknown inbound TEID, reply with Error Indication to the peer
  - on N3 Error Indication: release local UP, then signal CU-CP
- E1AP: Bearer Context Modification Required / Confirm codec, handlers, and lib tests, also PDU decode no longer uses hard-coded procedure code lists
- NGAP: encode and send PDU Session Resource Notify (Released List)
- RRC: on Modification Required, release DRBs and send Notify after reconfiguration
- Docs: add `doc/GTP/gtp-design.md`

**How to test:**

* Error Indication RX:

1. run RAN + CN normally
2. run UL ping
3. restart UPF -> Error Indication shall be sent after UPF restart

* Error Indication TX:

[inject-EI-rx.py](https://github.com/user-attachments/files/31415462/inject-EI-rx.py)

* also, new unit tests (test_gtp)

## Lab results

With both CN5G and Open5GS, the UPF does send Error Indication, but the gNB rejects it as a malformed message. Both cases look like CN TX bugs according to TS 29.281:

* OAI CN5G sends S=0, however spec requires S=1: TS 29.281 §5.1: for Error Indication, the Sequence Number flag shall be set to 1, as it means the 4-octet optional GTP-U header fields are present. The Sequence Number value itself is ignored on Error Indication.
* Open5GS sends Header TEID != 0, however spec requires 0: TS 29.281 §5.1 and §7.3.1: for Error Indication, the Tunnel Endpoint  Identifier in the GTP-U header shall be all zeros. The tunnel that  failed is not identified by the header TEID, it is carried in the mandatory TEID Data I IE. Open5GS puts the triggering G-PDU TEID into the header (and also in  TEID-I).

See also:

CN5G pcap: [EI-OAICN5G.zip](https://github.com/user-attachments/files/31414735/EI-OAICN5G.zip)

Open5gs pcap: [EI-open5gs-02.zip](https://github.com/user-attachments/files/31414762/EI-open5gs-02.zip)



