### PR TITLE
ci: fix pull_request_target fork checkout error and Node 20 deprecation warning

### DIFF
--- a/.github/workflows/jenkins-dispatch.yml
+++ b/.github/workflows/jenkins-dispatch.yml
@@ -88,11 +88,11 @@ jobs:
       protected_files_changed: ${{ steps.filter.outputs.protected }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Check changed files
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -136,10 +136,6 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-
       - name: Trigger Jenkins
         run: |
           # Write payload to a temp file to avoid shell escaping issues


### PR DESCRIPTION
- The Jenkins dispatch workflow failed on fork PRs
- Node 20 warnings on GitHub Actions

See the runs:

Failure - https://github.com/jfiedlerova/openairinterface5g/actions/runs/29862033522/job/88741052524
After applying the patch - https://github.com/jfiedlerova/openairinterface5g/actions/runs/29862676926/job/88744228846

Related commit: 8e30ec8031 ("ci: migrate Jenkins dispatch to pull_request_target")

Fixes: 
```
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

See the commit message for more details