### PR TITLE
ci: split PCF CN config out of shared mini_nonrf_config.yaml

### DIFF
--- a/ci-scripts/yaml_files/5g_rfsimulator_u0_25prb/docker-compose.yaml
+++ b/ci-scripts/yaml_files/5g_rfsimulator_u0_25prb/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
         environment:
             - TZ=Europe/paris
         volumes:
-            - ../5g_rfsimulator/mini_nonrf_config.yaml:/openair-amf/etc/config.yaml
+            - ./mini_nonrf_config.yaml:/openair-amf/etc/config.yaml
         depends_on:
             - mysql
         networks:
@@ -42,7 +42,7 @@ services:
         environment:
             - TZ=Europe/Paris
         volumes:
-            - ../5g_rfsimulator/mini_nonrf_config.yaml:/openair-smf/etc/config.yaml
+            - ./mini_nonrf_config.yaml:/openair-smf/etc/config.yaml
         depends_on:
             - oai-amf
             - oai-pcf
@@ -55,7 +55,7 @@ services:
         environment:
             - TZ=Europe/Paris
         volumes:
-            - ../5g_rfsimulator/mini_nonrf_config.yaml:/openair-pcf/etc/config.yaml
+            - ./mini_nonrf_config.yaml:/openair-pcf/etc/config.yaml
             - ./policies/policy_decisions:/openair-pcf/policies/policy_decisions
             - ./policies/pcc_rules:/openair-pcf/policies/pcc_rules
             - ./policies/traffic_rules:/openair-pcf/policies/traffic_rules
@@ -72,7 +72,7 @@ services:
         environment:
             - TZ=Europe/Paris
         volumes:
-            - ../5g_rfsimulator/mini_nonrf_config.yaml:/openair-upf/etc/config.yaml
+            - ./mini_nonrf_config.yaml:/openair-upf/etc/config.yaml
         depends_on:
             - oai-smf
         cap_add:

--- a/ci-scripts/yaml_files/5g_rfsimulator_u0_25prb/mini_nonrf_config.yaml
+++ b/ci-scripts/yaml_files/5g_rfsimulator_u0_25prb/mini_nonrf_config.yaml
@@ -43,6 +43,12 @@ nfs:
     n4:
       interface_name: eth0
       port: 8805
+  pcf:
+    host: oai-pcf
+    sbi:
+      port: 8080
+      api_version: v1
+      interface_name: eth0
 
   upf:
     host: oai-upf
@@ -77,6 +83,10 @@ database:
 snssais:
   - &embb_slice1
     sst: 1
+    sd: "FFFFFF"
+  - &embb_slice2
+    sst: 1
+    sd: "123456"
 
 ############## NF-specific configuration
 amf:
@@ -103,6 +113,7 @@ amf:
       tac: 0x0001
       nssai:
         - *embb_slice1
+        - *embb_slice2
   supported_integrity_algorithms:
     - "NIA0"
     - "NIA1"
@@ -116,7 +127,7 @@ smf:
   ue_mtu: 1500
   support_features:
     use_local_subscription_info: yes # Use infos from local_subscription_info or from UDM
-    use_local_pcc_rules: yes # Use infos from local_pcc_rules or from PCF
+    use_local_pcc_rules: no # Enforce PCC rules from PCF
   upfs:
     - host: oai-upf
       port: 8805
@@ -144,6 +155,9 @@ smf:
       - sNssai: *embb_slice1
         dnnSmfInfoList:
           - dnn: "oai"
+      - sNssai: *embb_slice2
+        dnnSmfInfoList:
+          - dnn: "openairinterface"
   local_subscription_infos:
     - single_nssai: *embb_slice1
       dnn: "oai"
@@ -151,6 +165,19 @@ smf:
         5qi: 9
         session_ambr_ul: "200Mbps"
         session_ambr_dl: "400Mbps"
+    - single_nssai: *embb_slice2
+      dnn: "openairinterface"
+      qos_profile:
+        5qi: 9
+        session_ambr_ul: "200Mbps"
+        session_ambr_dl: "400Mbps"
+
+pcf:
+  local_policy:
+    policy_decisions_path: /openair-pcf/policies/policy_decisions
+    pcc_rules_path: /openair-pcf/policies/pcc_rules
+    traffic_rules_path: /openair-pcf/policies/traffic_rules
+    qos_data_path: /openair-pcf/policies/qos_data
 
 upf:
   support_features:
@@ -162,9 +189,15 @@ upf:
       - sNssai: *embb_slice1
         dnnUpfInfoList:
           - dnn: "oai"
+      - sNssai: *embb_slice2
+        dnnUpfInfoList:
+          - dnn: "openairinterface"
 
 ## DNN configuration
 dnns:
   - dnn: "oai"
     pdu_session_type: "IPV4"
     ipv4_subnet: "12.1.1.0/24"
+  - dnn: "openairinterface"
+    pdu_session_type: "IPV4"
+    ipv4_subnet: "12.1.2.0/24"


### PR DESCRIPTION
The u0_25prb multi-QoS CI scenario needs PCF (use_local_pcc_rules: no), but in f02c84fcfc that configuration has been placed in the shared 5g_rfsimulator/mini_nonrf_config.yaml. Every other rfsim pipeline mounts that file without running oai-pcf.

In some setups different from Linux (i.e. WSL2) this causes issues.

With `use_local_pcc_rules: no`, SMF attempts associating to oai-pcf when creating SM Context even when no PCF container exists. If that HTTP call exceeds the wait timeout (100 ms), AMF gets error and does not complete the SM context creation, a later Update SM Context then fails ("Could not find Nsmf_PDUSession URI").

Native Linux is usually fine: when the failed PCF association is fast enough, context creation completes successfully.

This commit moves PCF-specific configuration into `5g_rfsimulator_u0_25prb` only. The shared config is restored to `use_local_pcc_rules: yes` and a single oai DNN (pre-f02c84fcfc status).

Changes:
- Add new file `5g_rfsimulator_u0_25prb/mini_nonrf_config.yaml` (PCF, dual-DNN, use_local_pcc_rules: no) and mount in `5g_rfsimulator_u0_25prb/docker-compose.yaml`
- Revert `5g_rfsimulator/mini_nonrf_config.yaml`

Issue reported by @thomas-schlichter. 