### PR TITLE
XnAP integration: Support to build, creation of XnAP task, Xn instance, neighbour trees, encoder, decoder, handling ITTI messages and call backs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1340,7 +1340,7 @@ add_library(e1_if
 
 target_link_libraries(e1_if PRIVATE asn1_nr_rrc_hdrs asn1_lte_rrc_hdrs asn1_f1ap SECURITY ${OPENSSL_LIBRARIES} e1ap GTPV1U)
 
-target_link_libraries(L2_NR PRIVATE f1ap x2ap s1ap ngap nr_rrc e1ap nr_rlc nr_common)
+target_link_libraries(L2_NR PRIVATE f1ap x2ap s1ap ngap nr_rrc e1ap nr_rlc nr_common xnap)
 target_compile_definitions(L2_NR PRIVATE PDCP_CUCP_CUUP)
 if(OAI_AERIAL)
     target_compile_definitions(L2_NR PRIVATE ENABLE_AERIAL)
@@ -1868,7 +1868,7 @@ endif()
 
 # force the generation of ASN.1 so that we don't need to wait during the build
 target_link_libraries(nr-softmodem PRIVATE
-  asn1_lte_rrc asn1_nr_rrc asn1_s1ap asn1_ngap asn1_m2ap asn1_m3ap asn1_x2ap asn1_f1ap asn1_lpp asn1_nrppa)
+  asn1_lte_rrc asn1_nr_rrc asn1_s1ap asn1_ngap asn1_m2ap asn1_m3ap asn1_x2ap asn1_xnap asn1_f1ap asn1_lpp asn1_nrppa)
 
 add_executable(nr-cuup
   executables/nr-cuup.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1287,6 +1287,7 @@ set (GNB_APP_SRC
   ${OPENAIR2_DIR}/GNB_APP/gnb_config.c
   ${OPENAIR2_DIR}/GNB_APP/gnb_config_common.c
   ${OPENAIR2_DIR}/GNB_APP/gnb_config_ng.c
+  ${OPENAIR2_DIR}/GNB_APP/gnb_config_xn.c
   )
 
 set (MCE_APP_SRC

--- a/common/openairinterface5g_limits.h
+++ b/common/openairinterface5g_limits.h
@@ -7,7 +7,9 @@
 
 #        define MAX_MOBILES_PER_GNB 16
 #        define NUMBER_OF_eNB_MAX 1
+#ifndef NUMBER_OF_gNB_MAX
 #        define NUMBER_OF_gNB_MAX 1
+#endif
 #        define NUMBER_OF_RU_MAX 2
 #        define NUMBER_OF_NR_RU_MAX 2
 #        define NUMBER_OF_UCI_MAX 16

--- a/common/utils/ocp_itti/all_msg.h
+++ b/common/utils/ocp_itti/all_msg.h
@@ -16,3 +16,4 @@
 #include "openair2/COMMON/e1ap_messages_def.h"
 #include "openair2/COMMON/ngap_messages_def.h"
 #include "openair2/COMMON/nrppa_messages_def.h"
+#include "openair2/COMMON/xnap_messages_def.h"

--- a/common/utils/ocp_itti/intertask_interface.h
+++ b/common/utils/ocp_itti/intertask_interface.h
@@ -203,6 +203,7 @@ typedef struct IttiMsgText_s {
 #include <openair2/COMMON/nas_messages_types.h>
 #include <openair2/COMMON/s1ap_messages_types.h>
 #include <openair2/COMMON/x2ap_messages_types.h>
+#include <openair2/COMMON/xnap_messages_types.h>
 #include <openair2/COMMON/m2ap_messages_types.h>
 #include <openair2/COMMON/m3ap_messages_types.h>
 #include <openair2/COMMON/sctp_messages_types.h>
@@ -271,6 +272,7 @@ typedef struct {
   TASK_DEF(TASK_NGAP, 200)            \
   TASK_DEF(TASK_NRPPA, 200)           \
   TASK_DEF(TASK_X2AP, 200)            \
+  TASK_DEF(TASK_XNAP, 200)            \
   TASK_DEF(TASK_M2AP_ENB, 200)        \
   TASK_DEF(TASK_M2AP_MCE, 200)        \
   TASK_DEF(TASK_M3AP, 200)            \

--- a/openair2/COMMON/ngap_messages_types.h
+++ b/openair2/COMMON/ngap_messages_types.h
@@ -390,9 +390,23 @@ typedef struct ngap_register_gnb_req_s {
 
 //-------------------------------------------------------------------------------------------//
 // NGAP -> gNB application layer messages
+
+typedef struct ngap_amf_region_info_s {
+  plmn_id_t plmn;
+  uint8_t amf_region_id;
+} ngap_amf_region_info_t;
+
+#define NGAP_MAX_NB_AMF_REGIONS 16
+
 typedef struct ngap_register_gnb_cnf_s {
   /* Nb of AMF connected */
   uint8_t          nb_amf;
+  uint32_t gNB_id;
+  uint32_t tac;
+  uint8_t num_plmn;
+  ngap_plmn_t plmn[PLMN_LIST_MAX_SIZE];
+  uint8_t num_amf_regions;
+  ngap_amf_region_info_t amf_region_info[NGAP_MAX_NB_AMF_REGIONS];
 } ngap_register_gnb_cnf_t;
 
 typedef struct ngap_deregistered_gnb_ind_s {

--- a/openair2/COMMON/xnap_messages_def.h
+++ b/openair2/COMMON/xnap_messages_def.h
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+/* gNB application layer -> XNAP messages */
+MESSAGE_DEF(XNAP_REGISTER_GNB_REQ, MESSAGE_PRIORITY_MED, xnap_register_gnb_req_t, xnap_register_gnb_req)
+
+/* RRC -> XNAP messages */
+MESSAGE_DEF(XNAP_F1_SETUP_DONE_IND, MESSAGE_PRIORITY_MED, xnap_f1_setup_done_ind_t, xnap_f1_setup_done_ind)

--- a/openair2/COMMON/xnap_messages_def.h
+++ b/openair2/COMMON/xnap_messages_def.h
@@ -7,3 +7,7 @@ MESSAGE_DEF(XNAP_REGISTER_GNB_REQ, MESSAGE_PRIORITY_MED, xnap_register_gnb_req_t
 
 /* RRC -> XNAP messages */
 MESSAGE_DEF(XNAP_F1_SETUP_DONE_IND, MESSAGE_PRIORITY_MED, xnap_f1_setup_done_ind_t, xnap_f1_setup_done_ind)
+
+/* XNAP -> RRC messages */
+MESSAGE_DEF(XNAP_SETUP_IND,          MESSAGE_PRIORITY_MED, xnap_setup_ind_t,          xnap_setup_ind)
+MESSAGE_DEF(XNAP_PEER_SHUTDOWN_IND,  MESSAGE_PRIORITY_MED, xnap_peer_shutdown_ind_t,  xnap_peer_shutdown_ind)

--- a/openair2/COMMON/xnap_messages_types.h
+++ b/openair2/COMMON/xnap_messages_types.h
@@ -10,6 +10,11 @@
 #include "common/platform_types.h"
 #include "common/platform_constants.h"
 
+#define XNAP_MAX_NB_CANDIDATES 8
+
+#define XNAP_REGISTER_GNB_REQ(mSGpTR)     (mSGpTR)->ittiMsg.xnap_register_gnb_req
+#define XNAP_F1_SETUP_DONE_IND(mSGpTR)    (mSGpTR)->ittiMsg.xnap_f1_setup_done_ind
+
 typedef struct {
   // PLMN Identity (M)
   plmn_id_t plmn;
@@ -59,6 +64,27 @@ typedef struct {
   uint16_t num_tai;
   xnap_tai_support_t *tai_support;
 } xnap_setup_resp_t;
+
+typedef struct xnap_sctp_s {
+  uint16_t sctp_in_streams;
+  uint16_t sctp_out_streams;
+} xnap_sctp_t;
+
+typedef struct xnap_net_config_t {
+  char *gnb_xn_interface_ip_address;
+  uint8_t nb_of_candidate_gNBs;
+  char *candidate_gnb_address_for_xnc[XNAP_MAX_NB_CANDIDATES];
+  xnap_sctp_t sctp_streams;
+} xnap_net_config_t;
+
+typedef struct xnap_register_gnb_req_s {
+  xnap_setup_req_t ng_setup_info;
+  xnap_net_config_t net_config;
+} xnap_register_gnb_req_t;
+
+typedef struct xnap_f1_setup_done_ind_s {
+  uint64_t gNB_DU_id;
+} xnap_f1_setup_done_ind_t;
 
 typedef enum xnap_cause_radio_network_e {
     XNAP_CAUSE_RADIO_NETWORK_LAYER_CELL_NOT_AVAILABLE,

--- a/openair2/COMMON/xnap_messages_types.h
+++ b/openair2/COMMON/xnap_messages_types.h
@@ -9,11 +9,14 @@
 #include "common/utils/ds/byte_array.h"
 #include "common/platform_types.h"
 #include "common/platform_constants.h"
+#include "openair2/COMMON/sctp_messages_types.h"
 
 #define XNAP_MAX_NB_CANDIDATES 8
 
 #define XNAP_REGISTER_GNB_REQ(mSGpTR)     (mSGpTR)->ittiMsg.xnap_register_gnb_req
 #define XNAP_F1_SETUP_DONE_IND(mSGpTR)    (mSGpTR)->ittiMsg.xnap_f1_setup_done_ind
+#define XNAP_SETUP_IND(mSGpTR)            (mSGpTR)->ittiMsg.xnap_setup_ind
+#define XNAP_PEER_SHUTDOWN_IND(mSGpTR)    (mSGpTR)->ittiMsg.xnap_peer_shutdown_ind
 
 typedef struct {
   // PLMN Identity (M)
@@ -85,6 +88,15 @@ typedef struct xnap_register_gnb_req_s {
 typedef struct xnap_f1_setup_done_ind_s {
   uint64_t gNB_DU_id;
 } xnap_f1_setup_done_ind_t;
+
+typedef struct xnap_setup_ind_s {
+  uint32_t gnb_id;
+  sctp_assoc_t assoc_id;
+} xnap_setup_ind_t;
+
+typedef struct xnap_peer_shutdown_ind_s {
+  uint32_t gnb_id;
+} xnap_peer_shutdown_ind_t;
 
 typedef enum xnap_cause_radio_network_e {
     XNAP_CAUSE_RADIO_NETWORK_LAYER_CELL_NOT_AVAILABLE,

--- a/openair2/GNB_APP/gnb_app.c
+++ b/openair2/GNB_APP/gnb_app.c
@@ -28,6 +28,8 @@
 #include "gnb_config.h"
 #include "openair2/LAYER2/NR_MAC_gNB/mac_proto.h"
 #include "openair2/GNB_APP/gnb_config_ng.h"
+#include "openair2/GNB_APP/gnb_config_xn.h"
+#include "openair2/XNAP/xnap_gNB.h"
 
 extern RAN_CONTEXT_t RC;
 /*------------------------------------------------------------------------------*/
@@ -77,6 +79,21 @@ uint32_t gNB_app_register_x2(uint32_t gnb_id_start, uint32_t gnb_id_end) {
   return register_gnb_x2_pending;
 }
 
+void gNB_app_register_xn(instance_t instance, ngap_register_gnb_cnf_t *cnf)
+{
+  MessageDef *msg_p = itti_alloc_new_message(TASK_GNB_APP, 0, XNAP_REGISTER_GNB_REQ);
+  xnap_register_gnb_req_t *msg = &XNAP_REGISTER_GNB_REQ(msg_p);
+
+  msg->net_config = read_ip_config_xn(instance);
+  msg->ng_setup_info = read_ng_setup_info(cnf, instance);
+
+  LOG_I(GNB_APP, "Sending XNAP_REGISTER_GNB_REQ for gNB ID %u with %d no of candidates\n",
+        msg->ng_setup_info.gNB_id,
+        msg->net_config.nb_of_candidate_gNBs);
+
+  itti_send_msg_to_task (TASK_XNAP, GNB_MODULE_ID_TO_INSTANCE(instance), msg_p);
+}
+
 /*------------------------------------------------------------------------------*/
 
 void *gNB_app_task(void *args_p)
@@ -92,6 +109,7 @@ void *gNB_app_task(void *args_p)
   int cell_to_activate = 0;
   itti_mark_task_ready (TASK_GNB_APP);
   ngran_node_t node_type = get_node_type();
+  const bool xn_enabled = is_xnap_enabled();
 
   if (RC.nb_nr_inst > 0) {
     if (node_type == ngran_gNB_CUCP) {
@@ -103,6 +121,13 @@ void *gNB_app_task(void *args_p)
       // this sends the E1AP_REGISTER_REQ to CU-CP so it sets up the socket
       // it does NOT use the E1AP part
       itti_send_msg_to_task(TASK_CUCP_E1, 0, msg);
+    }
+
+    if (node_type == ngran_gNB_CUCP || node_type == ngran_gNB_CU || node_type == ngran_gNB) {
+      if (xn_enabled) {
+        if (itti_create_task(TASK_XNAP, xnap_task, NULL) < 0)
+          LOG_E(XNAP, "Create task for XNAP failed\n");
+      }
     }
 
     if (node_type == ngran_gNB_CUUP) {
@@ -142,6 +167,9 @@ void *gNB_app_task(void *args_p)
     case NGAP_REGISTER_GNB_CNF:
       LOG_I(GNB_APP, "[gNB %ld] Received %s: associated AMF %d\n", instance, msg_name,
             NGAP_REGISTER_GNB_CNF(msg_p).nb_amf);
+      if (xn_enabled && NGAP_REGISTER_GNB_CNF(msg_p).nb_amf > 0) {
+        gNB_app_register_xn(instance, &NGAP_REGISTER_GNB_CNF(msg_p));
+      }
       break;
 
     case F1AP_SETUP_RESP:

--- a/openair2/GNB_APP/gnb_app.h
+++ b/openair2/GNB_APP/gnb_app.h
@@ -6,8 +6,10 @@
 #define GNB_APP_H_
 
 #include <stdint.h>
+#include "ngap_messages_types.h"
 
 void *gNB_app_task(void *args_p);
 uint32_t gNB_app_register(uint32_t gnb_id_start, uint32_t gnb_id_end);
 uint32_t gNB_app_register_x2(uint32_t gnb_id_start, uint32_t gnb_id_end);
+void gNB_app_register_xn(instance_t instance, ngap_register_gnb_cnf_t *cnf);
 #endif /* GNB_APP_H_ */

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -42,7 +42,6 @@
 #include "nfapi_pnf.h"
 #include "nfapi_vnf.h"
 #include "ngap_gNB.h"
-#include "ngap_messages_types.h"
 #include "nr_common.h"
 #include "oai_asn1.h"
 #include "prs_nr_paramdef.h"

--- a/openair2/GNB_APP/gnb_config_xn.c
+++ b/openair2/GNB_APP/gnb_config_xn.c
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include "gnb_config_xn.h"
+#include <string.h>
+#include "assertions.h"
+#include "common/utils/LOG/log.h"
+#include "common/utils/utils.h"
+#include "gnb_paramdef.h"
+#include "openair3/SCTP/sctp_default_values.h"
+
+xnap_net_config_t read_ip_config_xn(uint32_t gnb_idx)
+{
+  xnap_net_config_t nc = {0};
+  paramdef_t XnCandidateParams[] = XN_CANDIDATE_PARAMS_DESC;
+  paramlist_def_t XnCandidateList = {GNB_CONFIG_STRING_CANDIDATE_GNB_IPV4_ADDRESS_FOR_XNC, NULL, 0};
+  paramdef_t SCTPParams[] = GNBSCTPPARAMS_DESC;
+  char aprefix[MAX_OPTNAME_SIZE * 2 + 8];
+  sprintf(aprefix, "%s.[%i].%s", GNB_CONFIG_STRING_GNB_LIST, gnb_idx, GNB_CONFIG_STRING_XN_PARAMETERS);
+  config_getlist(config_get_if(), &XnCandidateList, XnCandidateParams, sizeofArray(XnCandidateParams), aprefix);
+  AssertFatal(XnCandidateList.numelt <= XNAP_MAX_NB_CANDIDATES,
+              "Xn candidates limit exceeded (%d > %d)\n", XnCandidateList.numelt, XNAP_MAX_NB_CANDIDATES);
+
+  LOG_I(XNAP, "Number of candidate gNBs configured: %d\n", XnCandidateList.numelt);
+  for (int l = 0; l < XnCandidateList.numelt; l++) {
+    nc.nb_of_candidate_gNBs++;
+    nc.candidate_gnb_address_for_xnc[l] =
+        strdup(*gpd(XnCandidateList.paramarray[l], sizeofArray(XnCandidateParams), GNB_CONFIG_STRING_CANDIDATE_GNB_ADDRESS_FOR_XNC)->strptr);
+    LOG_I(XNAP, "Candidate gNB %d address: %s \n", l + 1, nc.candidate_gnb_address_for_xnc[l]);
+  }
+
+  paramdef_t XnParams[] = XNPARAMS_DESC;
+  const int nb_xn_params = sizeofArray(XnParams);
+  config_get(config_get_if(), XnParams, nb_xn_params, aprefix);
+  char **gnb_xn_ip_strptr = gpd(XnParams, nb_xn_params, GNB_CONFIG_STRING_GNB_IPV4_ADDRESS_FOR_XNC)->strptr;
+  AssertFatal(gnb_xn_ip_strptr != NULL, "gNB IP not added in the CU/gNB configuration file\n");
+  nc.gnb_xn_interface_ip_address = strdup(*gnb_xn_ip_strptr);
+
+  nc.sctp_streams.sctp_out_streams = SCTP_OUT_STREAMS;
+  nc.sctp_streams.sctp_in_streams = SCTP_IN_STREAMS;
+  sprintf(aprefix, "%s.[%i].%s", GNB_CONFIG_STRING_GNB_LIST, 0, GNB_CONFIG_STRING_SCTP_CONFIG);
+  config_get(config_get_if(), SCTPParams, sizeofArray(SCTPParams), aprefix);
+  nc.sctp_streams.sctp_out_streams = *(SCTPParams[GNB_SCTP_OUTSTREAMS_IDX].uptr);
+  nc.sctp_streams.sctp_in_streams = *(SCTPParams[GNB_SCTP_INSTREAMS_IDX].uptr);
+
+  return nc;
+}
+
+int is_xnap_enabled(void)
+{
+  char aprefix[MAX_OPTNAME_SIZE * 2 + 8];
+  snprintf(aprefix, sizeof(aprefix), "%s.[%i].%s", GNB_CONFIG_STRING_GNB_LIST, 0, GNB_CONFIG_STRING_XN_PARAMETERS);
+  paramdef_t XnParams[] = XNPARAMS_DESC;
+  const int nb_xn_params = sizeofArray(XnParams);
+  config_get(config_get_if(), XnParams, nb_xn_params, aprefix);
+  char **gnb_xn_ip_strptr = gpd(XnParams, nb_xn_params, GNB_CONFIG_STRING_GNB_IPV4_ADDRESS_FOR_XNC)->strptr;
+
+  int xn_enabled = (gnb_xn_ip_strptr != NULL) && (*gnb_xn_ip_strptr != NULL);
+  LOG_I(XNAP, "Xn interface %s (gNB Xn-C address %s)\n",
+        xn_enabled ? "enabled" : "disabled", xn_enabled ? *gnb_xn_ip_strptr : "not configured");
+
+  return xn_enabled;
+}
+
+xnap_setup_req_t read_ng_setup_info(const ngap_register_gnb_cnf_t *cnf, uint32_t gnb_idx)
+{
+  LOG_I(XNAP, "[gNB %u] Reading info required for Xn setup from NGAP_REGISTER_GNB_CNF\n", gnb_idx);
+  xnap_setup_req_t setup_info = {0};
+
+  setup_info.gNB_id = cnf->gNB_id;
+  if (cnf->num_plmn > 0)
+    setup_info.plmn = cnf->plmn[0].plmn;
+
+  /* NGAP carries single TAC, so only one TAI support, it will become a list once NGAP support multiple TACs */
+  setup_info.num_tai = 1;
+  setup_info.tai_support = calloc_or_fail(setup_info.num_tai, sizeof(*setup_info.tai_support));
+
+  for (int i = 0; i < setup_info.num_tai; i++) {
+    xnap_tai_support_t *tai = &setup_info.tai_support[i];
+    tai->tac = cnf->tac;
+    tai->num_plmn = cnf->num_plmn;
+    tai->plmn_support = calloc_or_fail(tai->num_plmn, sizeof(*tai->plmn_support));
+
+    for (int j = 0; j < tai->num_plmn; j++) {
+      const ngap_plmn_t *src_plmn = &cnf->plmn[j];
+      xnap_plmn_support_t *plmn_support = &tai->plmn_support[j];
+
+      plmn_support->plmn = src_plmn->plmn;
+      plmn_support->num_nssai = src_plmn->num_nssai;
+
+      if (plmn_support->num_nssai > 0) {
+      plmn_support->nssai = calloc_or_fail(plmn_support->num_nssai, sizeof(*plmn_support->nssai));
+      memcpy(plmn_support->nssai, src_plmn->s_nssai, plmn_support->num_nssai * sizeof(*plmn_support->nssai));
+      }
+    }
+  }
+
+  setup_info.num_amf_regions = cnf->num_amf_regions;
+  if (setup_info.num_amf_regions > 0) {
+    setup_info.amf_region_info = calloc_or_fail(cnf->num_amf_regions, sizeof(*setup_info.amf_region_info));
+    memcpy(setup_info.amf_region_info, cnf->amf_region_info, cnf->num_amf_regions * sizeof(*setup_info.amf_region_info));
+  }
+
+  return setup_info;
+}

--- a/openair2/GNB_APP/gnb_config_xn.h
+++ b/openair2/GNB_APP/gnb_config_xn.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#ifndef XNAP_GNB_CONFIG_H_
+#define XNAP_GNB_CONFIG_H_
+#include <stdint.h>
+#include "ngap_messages_types.h"
+#include "xnap_messages_types.h"
+
+xnap_net_config_t read_ip_config_xn(uint32_t gnb_idx);
+int is_xnap_enabled(void);
+xnap_setup_req_t read_ng_setup_info(const ngap_register_gnb_cnf_t *cnf, uint32_t gnb_idx);
+
+#endif /* XNAP_GNB_CONFIG_H_ */

--- a/openair2/GNB_APP/gnb_paramdef.h
+++ b/openair2/GNB_APP/gnb_paramdef.h
@@ -799,6 +799,23 @@ typedef enum {
 /*-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------*/
 /*-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
+/* Xn configuration section */
+#define GNB_CONFIG_STRING_XN_PARAMETERS                              "Xn_INTERFACE"
+
+#define GNB_CONFIG_STRING_GNB_IPV4_ADDRESS_FOR_XNC                   "gnb_ipv4_address_for_xnc"
+
+#define XNPARAMS_DESC { \
+  {GNB_CONFIG_STRING_GNB_IPV4_ADDRESS_FOR_XNC, "interface ip address for xnc",   0,               .strptr=NULL, .defstrval=0,      TYPE_STRING, 0}, \
+}
+
+#define GNB_CONFIG_STRING_CANDIDATE_GNB_IPV4_ADDRESS_FOR_XNC         "candidate_gnb_ipv4_address_for_xnc"
+
+#define GNB_CONFIG_STRING_CANDIDATE_GNB_ADDRESS_FOR_XNC         "ip"
+
+#define XN_CANDIDATE_PARAMS_DESC { \
+  {GNB_CONFIG_STRING_CANDIDATE_GNB_ADDRESS_FOR_XNC, "candidate node ip address for xnc", 0, .strptr=NULL, .defstrval=0, TYPE_STRING, 0}, \
+}
+
 /* E1 configuration section */
 #define GNB_CONFIG_STRING_E1_PARAMETERS                   "E1_INTERFACE"
 

--- a/openair2/RRC/NR/nr_rrc_defs.h
+++ b/openair2/RRC/NR/nr_rrc_defs.h
@@ -612,6 +612,18 @@ typedef struct sib2_config_s {
 /* MR.NRScSSSINR histogram dimension (3GPP TS 28.552 §5.1.1.32). */
 #define NR_KPM_SS_SINR_NB_LEVELS 128 /* SS-SINR report level: 0..127, TS 38.133 Table 10.1.16.1-1 */
 
+/** Peer gNB with an active Xn interface, used during measurement-report
+ *  processing to decide between Xn-HO and N2-HO. */
+typedef struct rrc_xn_candidate_s {
+  RB_ENTRY(rrc_xn_candidate_s) entry;
+  /* remote gNB identity (tree key) */
+  uint32_t gnb_id;
+  /* SCTP association to that gNB */
+  sctp_assoc_t assoc_id;
+} rrc_xn_candidate_t;
+
+int rrc_xn_candidate_cmp(struct rrc_xn_candidate_s *a, struct rrc_xn_candidate_s *b);
+
 //---NR---(completely change)---------------------
 typedef struct gNB_RRC_INST_s {
 
@@ -653,6 +665,11 @@ typedef struct gNB_RRC_INST_s {
 
   RB_HEAD(rrc_cuup_tree, nr_rrc_cuup_container_t) cuups; // CU-UPs, indexed by assoc_id
   size_t num_cuups;
+
+  /* Peer gNBs reachable over an active Xn interface, indexed by gnb_id.
+   * Populated by XNAP_SETUP_IND; consulted during measurement-report
+   * processing to prefer Xn-HO over N2-HO when a Xn link is available. */
+  RB_HEAD(rrc_xn_cand_tree, rrc_xn_candidate_s) xn_candidates;
 
   // PDCP configuration parameters loaded during startup
   nr_pdcp_configuration_t pdcp_config;

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -409,6 +409,7 @@ void openair_rrc_gNB_configuration(gNB_RRC_INST *rrc, nr_rrc_config_t *configura
   RB_INIT(&rrc->cuups);
   RB_INIT(&rrc->dus);
   RB_INIT(&rrc->cells);
+  RB_INIT(&rrc->xn_candidates);
   rrc->configuration = *configuration;
 }
 
@@ -3973,6 +3974,15 @@ void *rrc_gnb_task(void *args_p)
 
       case NR_RRC_NRDC_TIMEOUT:
         rrc_gnb_nrdc_timeout(RC.nrrrc[instance], &NR_RRC_NRDC_TIMEOUT(msg_p));
+        break;
+
+      /* Messages from XNAP task */
+      case XNAP_SETUP_IND:
+        rrc_add_xn_candidate(RC.nrrrc[instance], XNAP_SETUP_IND(msg_p).gnb_id, XNAP_SETUP_IND(msg_p).assoc_id);
+        break;
+
+      case XNAP_PEER_SHUTDOWN_IND:
+        rrc_remove_xn_candidate(RC.nrrrc[instance], XNAP_PEER_SHUTDOWN_IND(msg_p).gnb_id);
         break;
 
       default:

--- a/openair2/RRC/NR/rrc_gNB_du.c
+++ b/openair2/RRC/NR/rrc_gNB_du.c
@@ -38,6 +38,10 @@
 #include "rrc_messages_types.h"
 #include "s1ap_messages_types.h"
 #include "tree.h"
+#include "intertask_interface.h"
+#include "openair2/COMMON/xnap_messages_types.h"
+#include "openair2/GNB_APP/gnb_config.h"
+#include "openair2/GNB_APP/gnb_config_xn.h"
 #include "uper_decoder.h"
 #include "common/utils/oai_asn1.h"
 #include "utils.h"
@@ -852,6 +856,14 @@ void rrc_gNB_process_f1_setup_req(f1ap_setup_req_t *req, sctp_assoc_t assoc_id)
   LOG_I(NR_RRC, "DU %ld (%s): sending F1 Setup Response\n", req->gNB_DU_id, req->gNB_DU_name);
   rrc->mac_rrc.f1_setup_response(assoc_id, &resp);
   free_f1ap_setup_response(&resp);
+
+  /* F1 Setup Response sent; tell XNAP to start setting up Xn */
+  const bool xn_enabled = is_xnap_enabled();
+  if (xn_enabled) {
+    MessageDef *xn_msg = itti_alloc_new_message(TASK_RRC_GNB, rrc->module_id, XNAP_F1_SETUP_DONE_IND);
+    XNAP_F1_SETUP_DONE_IND(xn_msg).gNB_DU_id = req->gNB_DU_id;
+    itti_send_msg_to_task(TASK_XNAP, rrc->module_id, xn_msg);
+  }
 
   /* we need to setup one default UE for phy-test and do-ra modes in the MAC */
   if (get_softmodem_params()->phy_test > 0 || get_softmodem_params()->do_ra > 0)

--- a/openair2/RRC/NR/rrc_gNB_mobility.c
+++ b/openair2/RRC/NR/rrc_gNB_mobility.c
@@ -26,6 +26,60 @@
 #include "openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_rc_extern.h"
 #endif
 
+/* ------------------------------ Xn candidate tree ----------------------------------------*/
+int rrc_xn_candidate_cmp(struct rrc_xn_candidate_s *a, struct rrc_xn_candidate_s *b)
+{
+  if (a->gnb_id < b->gnb_id) return -1;
+  if (a->gnb_id > b->gnb_id) return  1;
+  return 0;
+}
+
+RB_GENERATE(rrc_xn_cand_tree, rrc_xn_candidate_s, entry, rrc_xn_candidate_cmp);
+
+static rrc_xn_candidate_t *rrc_xn_candidate_alloc(uint32_t gnb_id, sctp_assoc_t assoc_id)
+{
+  rrc_xn_candidate_t *cand = calloc_or_fail(1, sizeof(*cand));
+  cand->gnb_id = gnb_id;
+  cand->assoc_id = assoc_id;
+  return cand;
+}
+
+static void rrc_xn_candidate_free(rrc_xn_candidate_t *cand)
+{
+  free(cand);
+}
+
+void rrc_add_xn_candidate(gNB_RRC_INST *rrc, uint32_t gnb_id, sctp_assoc_t assoc_id)
+{
+  /* Update assoc_id if the gNB_id is already registered (reconnect). */
+  rrc_xn_candidate_t key = {.gnb_id = gnb_id};
+  rrc_xn_candidate_t *existing = RB_FIND(rrc_xn_cand_tree, &rrc->xn_candidates, &key);
+  if (existing) {
+    existing->assoc_id = assoc_id;
+    LOG_I(NR_RRC, "Xn candidate gNB_id 0x%x updated (assoc_id %d)\n", gnb_id, assoc_id);
+    return;
+  }
+
+  rrc_xn_candidate_t *cand = rrc_xn_candidate_alloc(gnb_id, assoc_id);
+  rrc_xn_candidate_t *dup = RB_INSERT(rrc_xn_cand_tree, &rrc->xn_candidates, cand);
+  AssertFatal(dup == NULL, "duplicate Xn candidate gNB_id 0x%x despite RB_FIND miss above\n", gnb_id);
+  LOG_I(NR_RRC, "Xn candidate gNB_id 0x%x registered (assoc_id %d)\n", gnb_id, assoc_id);
+}
+
+void rrc_remove_xn_candidate(gNB_RRC_INST *rrc, uint32_t gnb_id)
+{
+  rrc_xn_candidate_t key = {.gnb_id = gnb_id};
+  rrc_xn_candidate_t *cand = RB_FIND(rrc_xn_cand_tree, &rrc->xn_candidates, &key);
+  if (!cand) {
+    LOG_W(NR_RRC, "Xn candidate gNB_id 0x%x not found for removal\n", gnb_id);
+    return;
+  }
+  RB_REMOVE(rrc_xn_cand_tree, &rrc->xn_candidates, cand);
+  rrc_xn_candidate_free(cand);
+  LOG_I(NR_RRC, "Xn candidate gNB_id 0x%x removed (peer disconnected)\n", gnb_id);
+}
+/* ----------------------------------------------------------------------------------------- */
+
 nr_handover_context_t *alloc_ho_ctx(ho_ctx_type_t type)
 {
   nr_handover_context_t *ho_ctx = calloc_or_fail(1, sizeof(*ho_ctx));

--- a/openair2/RRC/NR/rrc_gNB_mobility.h
+++ b/openair2/RRC/NR/rrc_gNB_mobility.h
@@ -9,6 +9,8 @@
 #include "common/utils/ds/byte_array.h"
 #include "nr_rrc_defs.h"
 
+RB_PROTOTYPE(rrc_xn_cand_tree, rrc_xn_candidate_s, entry, rrc_xn_candidate_cmp);
+
 /* forward declarations */
 typedef struct gNB_RRC_INST_s gNB_RRC_INST;
 typedef struct gNB_RRC_UE_s gNB_RRC_UE_t;
@@ -96,6 +98,9 @@ byte_array_t *get_meas_timing_config(const NR_MeasurementTimingConfiguration_t *
 void nr_rrc_apply_target_context(gNB_RRC_UE_t *UE);
 
 bool nr_rrc_update_cell_assoc_after_ho(gNB_RRC_UE_t *UE);
+
+void rrc_add_xn_candidate(gNB_RRC_INST *rrc, uint32_t gnb_id, sctp_assoc_t assoc_id);
+void rrc_remove_xn_candidate(gNB_RRC_INST *rrc, uint32_t gnb_id);
 
 const nr_neighbour_cell_t *get_neighbour_cell_by_pci(const neighbour_cell_configuration_t *cell, int pci);
 void nr_HO_F1_trigger_telnet(gNB_RRC_INST *rrc, uint32_t rrc_ue_id);

--- a/openair2/XNAP/CMakeLists.txt
+++ b/openair2/XNAP/CMakeLists.txt
@@ -3,8 +3,9 @@
 add_subdirectory(lib)
 add_subdirectory(MESSAGES)
 
-add_library(xnap xnap_common.c)
+add_library(xnap xnap_common.c xnap_gNB.c xnap_gNB_itti_messaging.c)
 target_link_libraries(xnap PUBLIC asn1_xnap xnap_lib)
+target_link_libraries(xnap PRIVATE asn1_lte_rrc_hdrs asn1_nr_rrc_hdrs log_headers)
 
 if(ENABLE_TESTS)
   add_subdirectory(tests)

--- a/openair2/XNAP/CMakeLists.txt
+++ b/openair2/XNAP/CMakeLists.txt
@@ -3,7 +3,7 @@
 add_subdirectory(lib)
 add_subdirectory(MESSAGES)
 
-add_library(xnap xnap_common.c xnap_gNB.c xnap_gNB_itti_messaging.c)
+add_library(xnap xnap_common.c xnap_gNB.c xnap_gNB_itti_messaging.c xnap_gNB_handlers.c xnap_gNB_encoder.c)
 target_link_libraries(xnap PUBLIC asn1_xnap xnap_lib)
 target_link_libraries(xnap PRIVATE asn1_lte_rrc_hdrs asn1_nr_rrc_hdrs log_headers)
 

--- a/openair2/XNAP/CMakeLists.txt
+++ b/openair2/XNAP/CMakeLists.txt
@@ -2,10 +2,19 @@
 
 add_subdirectory(lib)
 add_subdirectory(MESSAGES)
+add_subdirectory(tests/xn-simulator)
 
 add_library(xnap xnap_common.c xnap_gNB.c xnap_gNB_itti_messaging.c xnap_gNB_handlers.c xnap_gNB_encoder.c)
 target_link_libraries(xnap PUBLIC asn1_xnap xnap_lib)
 target_link_libraries(xnap PRIVATE asn1_lte_rrc_hdrs asn1_nr_rrc_hdrs log_headers)
+
+# Separate build of the XNAP sources for xn-simulator-test only: overrides
+# NUMBER_OF_gNB_MAX so the simulator can hold multiple XnAP instances in one
+# process, without affecting the real gNB build (which links "xnap" above).
+add_library(xnap_sim xnap_common.c xnap_gNB.c xnap_gNB_itti_messaging.c xnap_gNB_handlers.c xnap_gNB_encoder.c)
+target_link_libraries(xnap_sim PUBLIC asn1_xnap xnap_lib)
+target_link_libraries(xnap_sim PRIVATE asn1_lte_rrc_hdrs asn1_nr_rrc_hdrs log_headers)
+target_compile_definitions(xnap_sim PRIVATE NUMBER_OF_gNB_MAX=8)
 
 if(ENABLE_TESTS)
   add_subdirectory(tests)

--- a/openair2/XNAP/tests/xn-simulator/CMakeLists.txt
+++ b/openair2/XNAP/tests/xn-simulator/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+add_executable(xn-simulator-test xn-simulator.c
+               ${OPENAIR2_DIR}/GNB_APP/gnb_config_common.c
+               ${OPENAIR2_DIR}/GNB_APP/gnb_config_ng.c
+               ${OPENAIR2_DIR}/GNB_APP/gnb_config_xn.c)
+target_link_libraries(xn-simulator-test PRIVATE
+		      CONFIG_LIB ITTI SCTP_CLIENT
+		      f1ap xnap_sim ngap SECURITY
+		      softmodem_common)
+target_link_libraries(xn-simulator-test PRIVATE asn1_xnap asn1_lte_rrc_hdrs asn1_nr_rrc_hdrs)
+add_dependencies(xn-simulator-test params_libconfig)
+target_include_directories(xn-simulator-test PRIVATE
+                           ${CMAKE_SOURCE_DIR}
+                           ${CMAKE_CURRENT_SOURCE_DIR})

--- a/openair2/XNAP/tests/xn-simulator/README.md
+++ b/openair2/XNAP/tests/xn-simulator/README.md
@@ -1,0 +1,106 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+This is a simple standalone tester for the Xn Application Protocol (XNAP) between gNBs. It runs several gNB instances in a single process, each with its own configuration file, and validates the Xn Setup procedure over real SCTP associations and real ASN.1 encoding/decoding, without overhead of any F1, or a full Radio Access Network stack (PHY/MAC/RLC).
+
+[[_TOC_]]
+
+# Motivation
+- This tester is a lightweight, deterministic tool to **test the XNAP layer directly**.
+- Developers can validate Xn Setup Request/Response/Failure handling between two or more gNBs without full Radio Access Network (PHY/MAC/RLC) or real radios.
+- Multiple gNB instances (each a fully independent config file) run inside one process, so an N-way Xn mesh can be exercised with a single binary invocation.
+
+# Overview
+From a schematic point of view, the tester's instances and their Xn interconnections look like this (for 3-instance setup):
+```
+        gNB0 (0xe00, 127.0.0.10:38422)
+          |        \
+          Xn         Xn
+          |            \
+        gNB1 ---- Xn ---- gNB2
+    (0xe01, 127.0.0.20)  (0xe02, 127.0.0.30)
+
+        +---------------------------+
+        | xn-simulator-test process |
+        |  gNB0 | gNB1 | gNB2       |
+        +---------------------------+
+```
+
+Each instance is a real gNB config (one `-O <file>` per instance) that lists the other instances as `candidate_gnb_ipv4_address_for_xnc`, so every instance opens an SCTP association and attempts Xn Setup toward every other one over loopback.
+
+Inside the process, each instance is driven through the same ITTI tasks used by the real gNB, but the NGAP registration and RRC/F1 layers are replaced by minimal test stubs so only the XNAP stack is under test:
+```
+main()  --NGAP_REGISTER_GNB_REQ-->  TASK_NGAP
+TASK_NGAP  --NGAP_REGISTER_GNB_CNF-->  TASK_GNB_APP (stub)
+TASK_GNB_APP  --XNAP_REGISTER_GNB_REQ-->      TASK_XNAP  (create Xn instance)
+TASK_GNB_APP  --XNAP_F1_SETUP_DONE_IND-->     TASK_XNAP  ("cell up, start Xn")
+TASK_XNAP <==SCTP/ASN.1==> peer instance's TASK_XNAP     (Xn Setup Req/Resp/Failure)
+TASK_XNAP  --XNAP_SETUP_IND / XNAP_PEER_SHUTDOWN_IND-->  TASK_RRC_GNB (stub)
+```
+`TASK_XNAP` is the real, unmodified XNAP stack (`openair2/XNAP`). `TASK_GNB_APP` and `TASK_RRC_GNB` are test-only stubs defined in `xn-simulator.c`: the former just forwards the NGAP confirmation into the real XNAP registration and the latter sends the fake F1-setup-done messages and also counts `XNAP_SETUP_IND` across all instance pairs and exits the process once every pair has completed Xn Setup (or reports `XNAP_PEER_SHUTDOWN_IND` on SCTP teardown).
+
+The following messages/procedures are integrated and tested:
+
+* **XNAP:** Xn Setup Request/Response/Failure, over real SCTP associations between instances.
+* **SCTP:** `SCTP_NEW_ASSOCIATION_IND/RESP`, `SCTP_CLOSE_ASSOCIATION`/shutdown notifications.
+* **RRC (stub):** Adds/removes the Xn neighbour RB tree entries on Xn setup success / SCTP shutdown.
+
+A test scenario is fixed to these steps:
+1. The 5G Core Network is deployed via Docker.
+2. The tester loads N independent config files (`-O file1 -O file2 ...`), one gNB instance per file.
+3. The tester connects each gNB instance to the AMF and establishes the NGAP connection (NG Setup).
+4. For each gNB instance, NG setup confirmation followed by F1 setup done indication triggers Xn.
+5. Each instance starts SCTP listener and opens an SCTP association to each of its configured candidate gNBs and performs Xn Setup Request/Response.
+6. The tester waits until every ordered pair of instances has completed Xn Setup, then exits successfully.
+
+# Usage
+To run this test, you need to setup the 5G Core Network, build the tester and configuration file for each simulated gNB instance.
+
+**1. Core Network Deployment**
+
+Pull the required Docker images for the OAI 5G Core:
+
+    docker pull oaisoftwarealliance/ims:latest
+    docker pull oaisoftwarealliance/oai-amf:v2.2.1
+    docker pull oaisoftwarealliance/oai-nrf:v2.2.1
+    docker pull oaisoftwarealliance/oai-smf:v2.2.1
+    docker pull oaisoftwarealliance/oai-udr:v2.2.1
+    docker pull oaisoftwarealliance/oai-upf:v2.2.1
+    docker pull oaisoftwarealliance/oai-udm:v2.2.1
+    docker pull oaisoftwarealliance/oai-ausf:v2.2.1
+
+Deploy the network using the docker compose file:
+
+    cd doc/tutorial_resources/oai-cn5g
+    docker compose -f docker-compose.yaml up -d
+
+At the end of all experiments, you can also undeploy the network with:
+    docker compose -f docker-compose.yaml down -t 0
+
+**2. Building the Tester**
+
+You can build the tester as follows:
+
+    cd ~/openairinterface5g
+    mkdir build && cd build && cmake .. -GNinja && ninja xn-simulator-test
+
+**3. Running the Tester**
+
+Start the tester with one `-O <config file>` per simulated gNB instance. The repository ships a ready-made 3-instance loopback mesh alongside this README:
+
+```bash
+    openairinterface5g/build$ ./openair2/XNAP/tests/xn-simulator/xn-simulator-test \
+      -O ../openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci0.xn.rfsim.conf \
+      -O ../openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci1.xn.rfsim.conf \
+      -O ../openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci2.xn.rfsim.conf
+```
+
+A single `-O <file>` also works (no peers configured in that file will simply have no one to set up Xn with).
+
+Look for `Xn setup flow completed successfully for all N gNB instance(s)!` in the logs; the process exits with `EXIT_SUCCESS` once every configured pair has completed Xn Setup.
+
+# Limitations
+- The tester only exercises Xn Setup; it does not cover Handover-related Xn procedures (e.g. Handover Request/Ack, SN Status Transfer, UE Context Release).
+- All instances share one process and one `xnap_sim` build (compiled with a raised `NUMBER_OF_gNB_MAX`); it is not representative of separate gNB processes/hosts.
+
+# Future Enhancements
+- Extend coverage to Xn-based Handover procedures.

--- a/openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci0.xn.rfsim.conf
+++ b/openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci0.xn.rfsim.conf
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+Active_gNBs = ( "gNB-OAI");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    =  0xe00;
+    gNB_name  =  "gNB-OAI";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  1;
+    plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345678L;
+
+    ////////// Physical parameters:
+
+    do_CSIRS                                                  = 1;
+    do_SRS                                                    = "periodic";
+
+    #uess_agg_levels = [0,1,2,2,1]
+    servingCellConfigCommon = (
+    {
+ #spCellConfigCommon
+
+      physCellId                                                    = 0;
+
+#  downlinkConfigCommon
+    #frequencyInfoDL
+      # this is 3600 MHz + 43 PRBs@30kHz SCS (same as initial BWP)
+      absoluteFrequencySSB                                             = 641280;
+      dl_frequencyBand                                                 = 78;
+      # this is 3600 MHz
+      dl_absoluteFrequencyPointA                                       = 640008;
+      #scs-SpecificCarrierList
+        dl_offstToCarrier                                              = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing                                           = 1;
+        dl_carrierBandwidth                                            = 106;
+     #initialDownlinkBWP
+      #genericParameters
+        # this is RBstart=27,L=48 (275*(L-1))+RBstart
+        initialDLBWPlocationAndBandwidth                               = 28875; # 6366 12925 12956 28875 12952
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing                                   = 1;
+      #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero                              = 12;
+        initialDLBWPsearchSpaceZero                                     = 0;
+
+  #uplinkConfigCommon
+     #frequencyInfoUL
+      ul_frequencyBand                                              = 78;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 106;
+      pMax                                                          = 20;
+     #initialUplinkBWP
+      #genericParameters
+        initialULBWPlocationAndBandwidth                            = 28875;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+        #rach-ConfigGeneric
+          prach_ConfigurationIndex                                  = 98;
+#prach_msg1_FDM
+#0 = one, 1=two, 2=four, 3=eight
+          prach_msg1_FDM                                            = 0;
+          prach_msg1_FrequencyStart                                 = 0;
+          zeroCorrelationZoneConfig                                 = 13;
+          preambleReceivedTargetPower                               = -96;
+#preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+          preambleTransMax                                          = 6;
+#powerRampingStep
+# 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep                                            = 1;
+#ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+#1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+#one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
+#ra_ContentionResolutionTimer
+#(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer                                = 7;
+        rsrp_ThresholdSSB                                           = 19;
+#prach-RootSequenceIndex_PR
+#1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR                                  = 2;
+        prach_RootSequenceIndex                                     = 1;
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        #
+        msg1_SubcarrierSpacing                                      = 1,
+# restrictedSetConfig
+# 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig                                         = 0,
+
+        msg3_DeltaPreamble                                          = 1;
+        p0_NominalWithGrant                                         =-90;
+
+# pucch-ConfigCommon setup :
+# pucchGroupHopping
+# 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping                                           = 0;
+        hoppingId                                                   = 40;
+        p0_nominal                                                  = -90;
+
+      ssb_PositionsInBurst_Bitmap                                   = 1;
+
+# ssb_periodicityServingCell
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+# dmrs_TypeA_position
+# 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+  #tdd-UL-DL-ConfigurationCommon
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 6;
+      nrofDownlinkSlots                                             = 7;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 2;
+      nrofUplinkSymbols                                             = 4;
+
+      ssPBCH_BlockPower                                             = -25;
+  }
+
+  );
+
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+    Xn_INTERFACE :
+    {
+      gnb_ipv4_address_for_xnc             = "127.0.0.10";
+      candidate_gnb_ipv4_address_for_xnc   = ({ ip = "127.0.0.20";}, { ip = "127.0.0.30";});
+    };
+
+    ////////// AMF parameters:
+    amf_ip_address = ({ ipv4 = "192.168.70.132"; });
+
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.70.129/24";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "127.0.0.10";
+        GNB_PORT_FOR_S1U                         = 2152; # Spec 2152
+    };
+
+  }
+);
+
+MACRLCs = (
+{
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 150;
+  pucch_TargetSNRx10          = 200;
+}
+);
+
+L1s = (
+{
+  tr_n_preference       = "local_mac";
+  prach_dtx_threshold   = 120;
+  pucch0_dtx_threshold  = 100;
+  ofdm_offset_divisor   = 8; #set this to UINT_MAX for offset 0
+}
+);
+
+RUs = (
+{
+  local_rf       = "yes"
+  nb_tx          = 1
+  nb_rx          = 1
+  att_tx         = 12;
+  att_rx         = 12;
+  bands          = [78];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 114;
+  eNB_instances  = [0];
+  clock_src = "internal";
+}
+);
+
+
+rfsimulator = (
+{
+  serveraddr = "server";
+  serverport = 4043;
+  options = (); #("saviq"); or/and "chanmod"
+  modelname = "AWGN";
+  IQfile = "/tmp/rfsimulator.iqs";
+}
+);
+
+security = {
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms = ( "nea0" );
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms = ( "nia2", "nia0" );
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level                      ="info";
+  hw_log_level                          ="info";
+  phy_log_level                         ="info";
+  mac_log_level                         ="info";
+  rlc_log_level                         ="info";
+  pdcp_log_level                        ="info";
+  rrc_log_level                         ="info";
+  ngap_log_level                        ="debug";
+  f1ap_log_level                        ="debug";
+};
+
+e2_agent = {
+  near_ric_ip_addr = "127.0.0.1";
+  #sm_dir = "/path/where/the/SMs/are/located/"
+  sm_dir = "/usr/local/lib/flexric/"
+};

--- a/openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci1.xn.rfsim.conf
+++ b/openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci1.xn.rfsim.conf
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+Active_gNBs = ( "gNB-OAI");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    =  0xe01;
+    gNB_name  =  "gNB-OAI";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  1;
+    plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 87654321L;
+
+    ////////// Physical parameters:
+
+    do_CSIRS                                                  = 1;
+    do_SRS                                                    = "periodic";
+
+    #uess_agg_levels = [0,1,2,2,1]
+    servingCellConfigCommon = (
+    {
+ #spCellConfigCommon
+
+      physCellId                                                    = 1;
+
+#  downlinkConfigCommon
+    #frequencyInfoDL
+      # this is 3600 MHz + 43 PRBs@30kHz SCS (same as initial BWP)
+      absoluteFrequencySSB                                             = 641280;
+      dl_frequencyBand                                                 = 78;
+      # this is 3600 MHz
+      dl_absoluteFrequencyPointA                                       = 640008;
+      #scs-SpecificCarrierList
+        dl_offstToCarrier                                              = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing                                           = 1;
+        dl_carrierBandwidth                                            = 106;
+     #initialDownlinkBWP
+      #genericParameters
+        # this is RBstart=27,L=48 (275*(L-1))+RBstart
+        initialDLBWPlocationAndBandwidth                               = 28875; # 6366 12925 12956 28875 12952
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing                                   = 1;
+      #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero                              = 12;
+        initialDLBWPsearchSpaceZero                                     = 0;
+
+  #uplinkConfigCommon
+     #frequencyInfoUL
+      ul_frequencyBand                                              = 78;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 106;
+      pMax                                                          = 20;
+     #initialUplinkBWP
+      #genericParameters
+        initialULBWPlocationAndBandwidth                            = 28875;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+        #rach-ConfigGeneric
+          prach_ConfigurationIndex                                  = 98;
+#prach_msg1_FDM
+#0 = one, 1=two, 2=four, 3=eight
+          prach_msg1_FDM                                            = 0;
+          prach_msg1_FrequencyStart                                 = 0;
+          zeroCorrelationZoneConfig                                 = 13;
+          preambleReceivedTargetPower                               = -96;
+#preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+          preambleTransMax                                          = 6;
+#powerRampingStep
+# 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep                                            = 1;
+#ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+#1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+#one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
+#ra_ContentionResolutionTimer
+#(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer                                = 7;
+        rsrp_ThresholdSSB                                           = 19;
+#prach-RootSequenceIndex_PR
+#1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR                                  = 2;
+        prach_RootSequenceIndex                                     = 1;
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        #
+        msg1_SubcarrierSpacing                                      = 1,
+# restrictedSetConfig
+# 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig                                         = 0,
+
+        msg3_DeltaPreamble                                          = 1;
+        p0_NominalWithGrant                                         =-90;
+
+# pucch-ConfigCommon setup :
+# pucchGroupHopping
+# 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping                                           = 0;
+        hoppingId                                                   = 40;
+        p0_nominal                                                  = -90;
+
+      ssb_PositionsInBurst_Bitmap                                   = 1;
+
+# ssb_periodicityServingCell
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+# dmrs_TypeA_position
+# 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+  #tdd-UL-DL-ConfigurationCommon
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 6;
+      nrofDownlinkSlots                                             = 7;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 2;
+      nrofUplinkSymbols                                             = 4;
+
+      ssPBCH_BlockPower                                             = -25;
+  }
+
+  );
+
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+    Xn_INTERFACE :
+    {
+      gnb_ipv4_address_for_xnc             = "127.0.0.20";
+      candidate_gnb_ipv4_address_for_xnc   = ({ ip = "127.0.0.10";}, { ip = "127.0.0.30";});
+    };
+
+    ////////// AMF parameters:
+    amf_ip_address = ({ ipv4 = "192.168.70.132"; });
+
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.70.129/24";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "127.0.0.20";
+        GNB_PORT_FOR_S1U                         = 2152; # Spec 2152
+    };
+
+  }
+);
+
+MACRLCs = (
+{
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 150;
+  pucch_TargetSNRx10          = 200;
+}
+);
+
+L1s = (
+{
+  tr_n_preference       = "local_mac";
+  prach_dtx_threshold   = 120;
+  pucch0_dtx_threshold  = 100;
+  ofdm_offset_divisor   = 8; #set this to UINT_MAX for offset 0
+}
+);
+
+RUs = (
+{
+  local_rf       = "yes"
+  nb_tx          = 1
+  nb_rx          = 1
+  att_tx         = 12;
+  att_rx         = 12;
+  bands          = [78];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 114;
+  eNB_instances  = [0];
+  clock_src = "internal";
+}
+);
+
+
+rfsimulator = (
+{
+  serveraddr = "server";
+  serverport = 4043;
+  options = (); #("saviq"); or/and "chanmod"
+  modelname = "AWGN";
+  IQfile = "/tmp/rfsimulator.iqs";
+}
+);
+
+security = {
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms = ( "nea0" );
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms = ( "nia2", "nia0" );
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level                      ="info";
+  hw_log_level                          ="info";
+  phy_log_level                         ="info";
+  mac_log_level                         ="info";
+  rlc_log_level                         ="info";
+  pdcp_log_level                        ="info";
+  rrc_log_level                         ="info";
+  ngap_log_level                        ="debug";
+  f1ap_log_level                        ="debug";
+};
+
+e2_agent = {
+  near_ric_ip_addr = "127.0.0.1";
+  #sm_dir = "/path/where/the/SMs/are/located/"
+  sm_dir = "/usr/local/lib/flexric/"
+};

--- a/openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci2.xn.rfsim.conf
+++ b/openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci2.xn.rfsim.conf
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+Active_gNBs = ( "gNB-OAI");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    =  0xe02;
+    gNB_name  =  "gNB-OAI";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  1;
+    plmn_list = ({ mcc = 001; mnc = 01; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12341234L;
+
+    ////////// Physical parameters:
+
+    do_CSIRS                                                  = 1;
+    do_SRS                                                    = "periodic";
+
+    #uess_agg_levels = [0,1,2,2,1]
+    servingCellConfigCommon = (
+    {
+ #spCellConfigCommon
+
+      physCellId                                                    = 2;
+
+#  downlinkConfigCommon
+    #frequencyInfoDL
+      # this is 3600 MHz + 43 PRBs@30kHz SCS (same as initial BWP)
+      absoluteFrequencySSB                                             = 641280;
+      dl_frequencyBand                                                 = 78;
+      # this is 3600 MHz
+      dl_absoluteFrequencyPointA                                       = 640008;
+      #scs-SpecificCarrierList
+        dl_offstToCarrier                                              = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing                                           = 1;
+        dl_carrierBandwidth                                            = 106;
+     #initialDownlinkBWP
+      #genericParameters
+        # this is RBstart=27,L=48 (275*(L-1))+RBstart
+        initialDLBWPlocationAndBandwidth                               = 28875; # 6366 12925 12956 28875 12952
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing                                   = 1;
+      #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero                              = 12;
+        initialDLBWPsearchSpaceZero                                     = 0;
+
+  #uplinkConfigCommon
+     #frequencyInfoUL
+      ul_frequencyBand                                              = 78;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 106;
+      pMax                                                          = 20;
+     #initialUplinkBWP
+      #genericParameters
+        initialULBWPlocationAndBandwidth                            = 28875;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+        #rach-ConfigGeneric
+          prach_ConfigurationIndex                                  = 98;
+#prach_msg1_FDM
+#0 = one, 1=two, 2=four, 3=eight
+          prach_msg1_FDM                                            = 0;
+          prach_msg1_FrequencyStart                                 = 0;
+          zeroCorrelationZoneConfig                                 = 13;
+          preambleReceivedTargetPower                               = -96;
+#preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+          preambleTransMax                                          = 6;
+#powerRampingStep
+# 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep                                            = 1;
+#ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+#1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+#one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
+#ra_ContentionResolutionTimer
+#(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer                                = 7;
+        rsrp_ThresholdSSB                                           = 19;
+#prach-RootSequenceIndex_PR
+#1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR                                  = 2;
+        prach_RootSequenceIndex                                     = 1;
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        #
+        msg1_SubcarrierSpacing                                      = 1,
+# restrictedSetConfig
+# 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig                                         = 0,
+
+        msg3_DeltaPreamble                                          = 1;
+        p0_NominalWithGrant                                         =-90;
+
+# pucch-ConfigCommon setup :
+# pucchGroupHopping
+# 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping                                           = 0;
+        hoppingId                                                   = 40;
+        p0_nominal                                                  = -90;
+
+      ssb_PositionsInBurst_Bitmap                                   = 1;
+
+# ssb_periodicityServingCell
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+# dmrs_TypeA_position
+# 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+  #tdd-UL-DL-ConfigurationCommon
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 6;
+      nrofDownlinkSlots                                             = 7;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 2;
+      nrofUplinkSymbols                                             = 4;
+
+      ssPBCH_BlockPower                                             = -25;
+  }
+
+  );
+
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+    Xn_INTERFACE :
+    {
+      gnb_ipv4_address_for_xnc             = "127.0.0.30";
+      candidate_gnb_ipv4_address_for_xnc   = ({ ip = "127.0.0.10";}, { ip = "127.0.0.20";});
+    };
+
+    ////////// AMF parameters:
+    amf_ip_address = ({ ipv4 = "192.168.70.132"; });
+
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.70.129/24";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "127.0.0.30";
+        GNB_PORT_FOR_S1U                         = 2152; # Spec 2152
+    };
+
+  }
+);
+
+MACRLCs = (
+{
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 150;
+  pucch_TargetSNRx10          = 200;
+}
+);
+
+L1s = (
+{
+  tr_n_preference       = "local_mac";
+  prach_dtx_threshold   = 120;
+  pucch0_dtx_threshold  = 100;
+  ofdm_offset_divisor   = 8; #set this to UINT_MAX for offset 0
+}
+);
+
+RUs = (
+{
+  local_rf       = "yes"
+  nb_tx          = 1
+  nb_rx          = 1
+  att_tx         = 12;
+  att_rx         = 12;
+  bands          = [78];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 114;
+  eNB_instances  = [0];
+  clock_src = "internal";
+}
+);
+
+
+rfsimulator = (
+{
+  serveraddr = "server";
+  serverport = 4043;
+  options = (); #("saviq"); or/and "chanmod"
+  modelname = "AWGN";
+  IQfile = "/tmp/rfsimulator.iqs";
+}
+);
+
+security = {
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms = ( "nea0" );
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms = ( "nia2", "nia0" );
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level                      ="info";
+  hw_log_level                          ="info";
+  phy_log_level                         ="info";
+  mac_log_level                         ="info";
+  rlc_log_level                         ="info";
+  pdcp_log_level                        ="info";
+  rrc_log_level                         ="info";
+  ngap_log_level                        ="debug";
+  f1ap_log_level                        ="debug";
+};
+
+e2_agent = {
+  near_ric_ip_addr = "127.0.0.1";
+  #sm_dir = "/path/where/the/SMs/are/located/"
+  sm_dir = "/usr/local/lib/flexric/"
+};

--- a/openair2/XNAP/tests/xn-simulator/xn-simulator.c
+++ b/openair2/XNAP/tests/xn-simulator/xn-simulator.c
@@ -1,0 +1,302 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include "common/ran_context.h"
+#include "nfapi/oai_integration/vendor_ext.h"
+#include "openair2/GNB_APP/gnb_config_ng.h"
+#include "openair2/GNB_APP/gnb_config_xn.h"
+#include "openair2/GNB_APP/gnb_paramdef.h"
+#include "openair2/XNAP/xnap_gNB.h"
+#include "openair3/SCTP/sctp_default_values.h"
+
+RAN_CONTEXT_t RC;
+THREAD_STRUCT thread_struct;
+uint64_t downlink_frequency[MAX_NUM_CCs][4];
+int64_t uplink_frequency_offset[MAX_NUM_CCs][4];
+int oai_exit = 0;
+
+/* Multi-instance support. */
+static uint32_t nb_gnb_inst = 0;
+static uint32_t *gnb_id_tab = NULL;
+static uint32_t *tac_tab = NULL;
+static uint16_t *mcc_tab = NULL;
+static uint16_t *mnc_tab = NULL;
+static uint8_t *mnc_len_tab = NULL;
+
+static xnap_net_config_t *xn_net_config_tab = NULL;
+
+uint32_t gnb_id = 0;
+uint32_t tac = 1;
+uint16_t mcc = 1;
+uint16_t mnc = 1;
+uint8_t mnc_len = 2;
+
+char *gnb_ipv4_address_for_NGU = NULL;
+
+void exit_function(const char *file, const char *function, const int line, const char *s, const int assert)
+{
+  UNUSED(assert);
+  LOG_E(GNB_APP, "error at %s:%d:%s: %s\n", file, line, function, s);
+  abort();
+}
+
+nfapi_mode_t nfapi_mod = -1;
+void nfapi_setmode(nfapi_mode_t nfapi_mode)
+{
+  nfapi_mod = nfapi_mode;
+}
+nfapi_mode_t nfapi_getmode(void)
+{
+  return nfapi_mod;
+}
+
+ngran_node_t get_node_type()
+{
+  return ngran_gNB_CUUP;
+}
+
+configmodule_interface_t *uniqCfg = NULL;
+
+/* Looks up the Xn/SCTP config cached for this gNB instance at startup (each
+ * instance's config file is loaded, extracted, then unloaded in turn, so it
+ * is no longer available via config_get_if() by the time Xn registration runs). */
+static xnap_net_config_t xn_net_config_from_cache(uint32_t gnb_idx)
+{
+  AssertFatal(xn_net_config_tab != NULL && gnb_idx < nb_gnb_inst,
+              "No cached Xn network config for gNB instance %u (nb_gnb_inst=%u)\n",
+              gnb_idx, nb_gnb_inst);
+  return xn_net_config_tab[gnb_idx];
+}
+
+void gNB_app_register_xn(instance_t instance, ngap_register_gnb_cnf_t *cnf)
+{
+  MessageDef *msg_p = itti_alloc_new_message(TASK_GNB_APP, 0, XNAP_REGISTER_GNB_REQ);
+  xnap_register_gnb_req_t *msg = &XNAP_REGISTER_GNB_REQ(msg_p);
+  msg->net_config = xn_net_config_from_cache(instance);
+  msg->ng_setup_info = read_ng_setup_info(cnf, instance);
+  LOG_I(GNB_APP,
+        "[gNB %ld] Sending XNAP_REGISTER_GNB_REQ for gNB ID %u with %d candidate(s)\n",
+        instance,
+        msg->ng_setup_info.gNB_id,
+        msg->net_config.nb_of_candidate_gNBs);
+  itti_send_msg_to_task(TASK_XNAP, GNB_MODULE_ID_TO_INSTANCE(instance), msg_p);
+
+  MessageDef *xn_msg = itti_alloc_new_message(TASK_RRC_GNB, instance, XNAP_F1_SETUP_DONE_IND);
+  XNAP_F1_SETUP_DONE_IND(xn_msg).gNB_DU_id = msg->ng_setup_info.gNB_id;
+  itti_send_msg_to_task(TASK_XNAP, instance, xn_msg);
+}
+
+void *gNB_app_task(void *args_p)
+{
+  UNUSED(args_p);
+  MessageDef *msg_p = NULL;
+  const char *msg_name = NULL;
+  instance_t instance;
+  int result;
+  /* for no gcc warnings */
+  (void)instance;
+
+  itti_mark_task_ready(TASK_GNB_APP);
+  do {
+    itti_receive_msg(TASK_GNB_APP, &msg_p);
+    msg_name = ITTI_MSG_NAME(msg_p);
+    instance = ITTI_MSG_DESTINATION_INSTANCE(msg_p);
+    switch (ITTI_MSG_ID(msg_p)) {
+      case TERMINATE_MESSAGE:
+        LOG_W(GNB_APP, " *** Exiting GNB_APP thread\n");
+        itti_exit_task();
+        break;
+
+      case NGAP_REGISTER_GNB_CNF:
+        LOG_I(GNB_APP,
+              "[gNB %ld] Received %s: associated AMF %d\n",
+              instance,
+              msg_name,
+              NGAP_REGISTER_GNB_CNF(msg_p).nb_amf);
+        LOG_I(GNB_APP, "[gNB %ld] Starting Xn procedure sequence\n", instance);
+        gNB_app_register_xn(instance, &NGAP_REGISTER_GNB_CNF(msg_p));
+        break;
+
+      default:
+        LOG_E(GNB_APP, "Received unexpected message %s\n", msg_name);
+        break;
+    }
+    result = itti_free(ITTI_MSG_ORIGIN_ID(msg_p), msg_p);
+    AssertFatal(result == EXIT_SUCCESS, "Failed to free memory (%d)!\n", result);
+  } while (1);
+  return NULL;
+}
+
+void *rrc_gnb_task(void *args_p)
+{
+  UNUSED(args_p);
+  MessageDef *msg_p;
+  instance_t instance;
+  int result;
+  static uint32_t nb_done = 0;
+
+  itti_mark_task_ready(TASK_RRC_GNB);
+  LOG_I(NR_RRC, "Entering main loop of NR_RRC message task\n");
+
+  while (1) {
+    itti_receive_msg(TASK_RRC_GNB, &msg_p);
+    const char *msg_name_p = ITTI_MSG_NAME(msg_p);
+    instance = ITTI_MSG_DESTINATION_INSTANCE(msg_p);
+    LOG_D(NR_RRC,
+          "RRC GNB Task Received %s for instance %ld from task %s\n",
+          ITTI_MSG_NAME(msg_p),
+          instance,
+          ITTI_MSG_ORIGIN_NAME(msg_p));
+
+    switch (ITTI_MSG_ID(msg_p)) {
+      case TERMINATE_MESSAGE:
+        LOG_W(NR_RRC, " *** Exiting NR_RRC thread\n");
+        itti_exit_task();
+        break;
+
+      case XNAP_SETUP_IND:
+        nb_done++;
+        LOG_I(NR_RRC, "[gNB %ld] Received Xn setup indication %u / %u for %u instance(s))\n", instance, nb_done, nb_gnb_inst * (nb_gnb_inst -1), nb_gnb_inst);
+        if (nb_done >= (nb_gnb_inst * (nb_gnb_inst - 1))) {
+          LOG_I(NR_RRC, "Xn setup flow completed successfully for all %u gNB instance(s)!\n", nb_gnb_inst);
+          exit(EXIT_SUCCESS);
+        }
+        break;
+
+      case XNAP_PEER_SHUTDOWN_IND:
+        nb_done++;
+        LOG_I(NR_RRC,
+              "[gNB %ld] Received Xn peer shutdown indications %u of %u instance(s) done)\n",
+              instance, nb_done, nb_gnb_inst);
+        if (nb_done >= nb_gnb_inst) {
+          LOG_I(NR_RRC, "Xn setup flow completed successfully for all %u gNB instance(s)!\n", nb_gnb_inst);
+          exit(EXIT_SUCCESS);
+        }
+        break;
+
+      default:
+        LOG_E(NR_RRC, "[gNB %ld] Received unexpected message %s\n", instance, msg_name_p);
+        break;
+    }
+    result = itti_free(ITTI_MSG_ORIGIN_ID(msg_p), msg_p);
+    AssertFatal(result == EXIT_SUCCESS, "Failed to free memory (%d)!\n", result);
+    msg_p = NULL;
+  }
+}
+
+static int extract_conf_files(int argc, char **argv, char **Ofiles, int max_files)
+{
+  int n = 0;
+  for (int i = 0; i < argc - 1; i++) {
+    if (strlen(argv[i]) >= 2 && argv[i][1] == 'O') {
+      if (n >= max_files) {
+        fprintf(stderr, "[XN-SIM] warning: more than %d -O files given, ignoring \"%s\"\n", max_files, argv[i + 1]);
+        continue;
+      }
+      Ofiles[n++] = argv[i + 1];
+    }
+  }
+  return n;
+}
+
+int main(int argc, char **argv)
+{
+  /* --- collect every -O file from the real command line -------------- */
+  char *Ofiles[8];
+  int nOfiles = extract_conf_files(argc, argv, Ofiles, sizeofArray(Ofiles));
+  nb_gnb_inst = (nOfiles > 0) ? nOfiles : 1;
+
+  gnb_id_tab = calloc_or_fail(nb_gnb_inst, sizeof(*gnb_id_tab));
+  tac_tab = calloc_or_fail(nb_gnb_inst, sizeof(*tac_tab));
+  mcc_tab = calloc_or_fail(nb_gnb_inst, sizeof(*mcc_tab));
+  mnc_tab = calloc_or_fail(nb_gnb_inst, sizeof(*mnc_tab));
+  mnc_len_tab = calloc_or_fail(nb_gnb_inst, sizeof(*mnc_len_tab));
+  xn_net_config_tab = calloc_or_fail(nb_gnb_inst, sizeof(*xn_net_config_tab));
+
+  char **synth_argv = calloc_or_fail(3, sizeof(*synth_argv));
+  int synth_argc;
+  if (nOfiles > 0) {
+    synth_argv[0] = argv[0];
+    synth_argv[1] = "-O";
+    synth_argv[2] = Ofiles[0];
+    synth_argc = 3;
+  }
+
+  uniqCfg = load_configmodule(nOfiles > 0 ? synth_argc : argc, nOfiles > 0 ? synth_argv : argv, CONFIG_ENABLECMDLINEONLY);
+  if (uniqCfg == NULL) {
+    exit_fun("[SOFTMODEM] Error, configuration module init failed\n");
+  }
+
+  logInit();
+  set_softmodem_sighandler();
+
+  LOG_I(GNB_APP, "%u gNB instance(s) / config file(s) for the Xn simulator\n", nb_gnb_inst);
+
+  /* Initialize ITTI tasks before we start sending any registration
+   * message, exactly as in the single-instance version. */
+  itti_init(TASK_MAX, tasks_info);
+  int rc;
+  rc = itti_create_task(TASK_SCTP, sctp_eNB_task, NULL);
+  AssertFatal(rc >= 0, "Create task for SCTP failed\n");
+  rc = itti_create_task(TASK_NGAP, ngap_gNB_task, NULL);
+  AssertFatal(rc >= 0, "Create task for NGAP failed\n");
+  rc = itti_create_task(TASK_XNAP, xnap_task, NULL);
+  AssertFatal(rc >= 0, "Create task for XNAP failed\n");
+  rc = itti_create_task(TASK_RRC_GNB, rrc_gnb_task, NULL);
+  AssertFatal(rc >= 0, "Create task for RRC failed\n");
+  rc = itti_create_task(TASK_GNB_APP, gNB_app_task, NULL);
+  AssertFatal(rc >= 0, "Create task for GNB APP failed\n");
+
+  /* --- load, extract, unload each file in turn - fully independent,
+   * never merged, never more than one file open at a time. File 0's
+   * config is already loaded above, so this loop does NOT reload it. */
+  for (uint32_t i = 0; i < nb_gnb_inst; i++) {
+    if (i > 0) {
+      char **this_argv = calloc_or_fail(3, sizeof(*this_argv));
+      this_argv[0] = argv[0];
+      this_argv[1] = "-O";
+      this_argv[2] = Ofiles[i];
+      uniqCfg = load_configmodule(3, this_argv, CONFIG_ENABLECMDLINEONLY);
+      if (uniqCfg == NULL) {
+        exit_fun("[SOFTMODEM] Error, configuration module init failed\n");
+      }
+    }
+
+    MessageDef *msg_p = itti_alloc_new_message(TASK_GNB_APP, 0, NGAP_REGISTER_GNB_REQ);
+    RCconfig_NR_NG(msg_p, 0);
+
+    gnb_id_tab[i] = NGAP_REGISTER_GNB_REQ(msg_p).gNB_id;
+    tac_tab[i] = NGAP_REGISTER_GNB_REQ(msg_p).tac;
+    mcc_tab[i] = NGAP_REGISTER_GNB_REQ(msg_p).plmn[0].plmn.mcc;
+    mnc_tab[i] = NGAP_REGISTER_GNB_REQ(msg_p).plmn[0].plmn.mnc;
+    mnc_len_tab[i] = NGAP_REGISTER_GNB_REQ(msg_p).plmn[0].plmn.mnc_digit_length;
+    xn_net_config_tab[i] = read_ip_config_xn(0);
+
+    if (i == 0) {
+      gnb_id = gnb_id_tab[0];
+      tac = tac_tab[0];
+      mcc = mcc_tab[0];
+      mnc = mnc_tab[0];
+      mnc_len = mnc_len_tab[0];
+    }
+
+    LOG_I(GNB_APP,
+          "Sending NGAP_REGISTER_GNB_REQ to TASK_NGAP for gNB instance %u (gNB ID %u, file %s)\n",
+          i,
+          gnb_id_tab[i],
+          (nOfiles > 0) ? Ofiles[i] : "(default)");
+    itti_send_msg_to_task(TASK_NGAP, i, msg_p);
+
+    if (i < nb_gnb_inst - 1) {
+      end_configmodule(uniqCfg);
+      uniqCfg = NULL;
+    }
+  }
+
+  printf("TYPE <CTRL-C> TO TERMINATE\n");
+  itti_wait_tasks_end(NULL);
+  logClean();
+  printf("Bye.\n");
+  return 0;
+}

--- a/openair2/XNAP/xnap_common.c
+++ b/openair2/XNAP/xnap_common.c
@@ -2,30 +2,46 @@
  * SPDX-License-Identifier: LicenseRef-CSSL-1.0
  */
 
-#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 #include "xnap_common.h"
-#include "XNAP_XnAP-PDU.h"
+#include "common/openairinterface5g_limits.h"
+#include "common/utils/LOG/log.h"
+#include "assertions.h"
 
-ssize_t XNAP_generate_initiating_message(uint8_t **buffer,
-                                         uint32_t *length,
-                                         XNAP_ProcedureCode_t procedureCode,
-                                         XNAP_Criticality_t criticality,
-                                         asn_TYPE_descriptor_t *td,
-                                         void *sptr)
+/* Single key: assoc_id. A peer only ever exists in the tree while its SCTP
+ * association is up, so assoc_id is always valid here. */
+int xnap_peer_compare(struct xnap_peer_s *p1, struct xnap_peer_s *p2)
 {
-  XNAP_XnAP_PDU_t pdu;
-  ssize_t encoded;
-  memset(&pdu, 0, sizeof(XNAP_XnAP_PDU_t));
-  pdu.present = XNAP_XnAP_PDU_PR_initiatingMessage;
-  pdu.choice.initiatingMessage->procedureCode = procedureCode;
-  pdu.choice.initiatingMessage->criticality = criticality;
-  ANY_fromType_aper((ANY_t *)&pdu.choice.initiatingMessage->value, td, sptr);
-
-  if ((encoded = aper_encode_to_new_buffer(&asn_DEF_XNAP_XnAP_PDU, 0, &pdu, (void **)buffer)) < 0) {
-    return -1;
-  }
-
-  *length = encoded;
-  return encoded;
+  if (p1->assoc_id < p2->assoc_id) return -1;
+  if (p1->assoc_id > p2->assoc_id) return  1;
+  return 0;
 }
 
+RB_GENERATE(xnap_peer_map, xnap_peer_s, entry, xnap_peer_compare);
+
+static xnap_gnb_inst_t *xnap_inst[NUMBER_OF_gNB_MAX] = {0};
+
+xnap_gnb_inst_t *xnap_get_inst(instance_t instance)
+{
+  AssertFatal(instance < sizeofArray(xnap_inst), "instance %ld exceeds limit\n", instance);
+  return xnap_inst[instance];
+}
+
+void xnap_create_inst(instance_t instance, xnap_setup_req_t *setup_info, xnap_net_config_t *net_config)
+{
+  AssertFatal(instance < sizeofArray(xnap_inst), "instance %ld exceeds limit\n", instance);
+  AssertFatal(xnap_inst[instance] == NULL, "Double call to Xn instance %ld\n", instance);
+
+  xnap_gnb_inst_t *inst = calloc_or_fail(1, sizeof(*inst));
+
+  inst->setup_info = *setup_info;
+  inst->net_config = *net_config;
+
+  RB_INIT(&inst->peers);
+
+  xnap_inst[instance] = inst;
+
+  LOG_I(XNAP, "Created Xn instance %ld (gNB_id 0x%x) with %u candidate(s)\n",
+        instance, inst->setup_info.gNB_id, inst->net_config.nb_of_candidate_gNBs);
+}

--- a/openair2/XNAP/xnap_common.c
+++ b/openair2/XNAP/xnap_common.c
@@ -28,6 +28,32 @@ xnap_gnb_inst_t *xnap_get_inst(instance_t instance)
   return xnap_inst[instance];
 }
 
+xnap_peer_t *xnap_get_peer_by_assoc(xnap_gnb_inst_t *inst, sctp_assoc_t assoc_id)
+{
+  xnap_peer_t temp = {.assoc_id = assoc_id};
+  return RB_FIND(xnap_peer_map, &inst->peers, &temp);
+}
+
+xnap_peer_t *xnap_add_peer(instance_t instance, xnap_gnb_inst_t *inst, sctp_assoc_t assoc_id, uint16_t in_streams, uint16_t out_streams)
+{
+  xnap_peer_t *peer = calloc_or_fail(1, sizeof(*peer));
+  peer->assoc_id = assoc_id;
+  peer->state = XNAP_PEER_STATE_WAITING;
+  peer->in_streams = in_streams;
+  peer->out_streams = out_streams;
+
+  xnap_peer_t *dup = RB_INSERT(xnap_peer_map, &inst->peers, peer);
+  AssertFatal(dup == NULL, "[gNB %ld] duplicate Xn peer for assoc_id %d\n", instance, assoc_id);
+
+  return peer;
+}
+
+void xnap_remove_peer(xnap_gnb_inst_t *inst, xnap_peer_t *peer)
+{
+  RB_REMOVE(xnap_peer_map, &inst->peers, peer);
+  free(peer);
+}
+
 void xnap_create_inst(instance_t instance, xnap_setup_req_t *setup_info, xnap_net_config_t *net_config)
 {
   AssertFatal(instance < sizeofArray(xnap_inst), "instance %ld exceeds limit\n", instance);

--- a/openair2/XNAP/xnap_common.h
+++ b/openair2/XNAP/xnap_common.h
@@ -17,8 +17,8 @@ typedef enum {
   XNAP_PEER_STATE_CONNECTED,
 } xnap_peer_state_t;
 
-/* A peer is inserted when SCTP is up and keyed solely by assoc_id, and
- * a peer is removed from the tree the moment its association goes down. */
+/* A peer is inserted when SCTP association is live and keyed only by assoc_id
+ * and is removed from the tree the moment its association goes down. */
 typedef struct xnap_peer_s {
   RB_ENTRY(xnap_peer_s) entry;
   sctp_assoc_t assoc_id;
@@ -46,6 +46,19 @@ RB_PROTOTYPE(xnap_peer_map, xnap_peer_s, entry, xnap_peer_compare);
 
 xnap_gnb_inst_t *xnap_get_inst(instance_t instance);
 
+/* Lookup a connected/connecting peer by its (unique) assoc_id. */
+xnap_peer_t *xnap_get_peer_by_assoc(xnap_gnb_inst_t *inst, sctp_assoc_t assoc_id);
+
+/* Allocate a peer for a newly-up SCTP association, insert it in the tree
+ * keyed by assoc_id, and return it. AssertFatal()s if assoc_id is already
+ * present (would indicate an SCTP/ITTI-layer bug). */
+xnap_peer_t *xnap_add_peer(instance_t instance, xnap_gnb_inst_t *inst, sctp_assoc_t assoc_id, uint16_t in_streams, uint16_t out_streams);
+
+/* Remove and free a peer, e.g. on SCTP shutdown/close. */
+void xnap_remove_peer(xnap_gnb_inst_t *inst, xnap_peer_t *peer);
+
 void xnap_create_inst(instance_t instance, xnap_setup_req_t *setup_info, xnap_net_config_t *net_config);
+
+#define XNAP_NON_UE_STREAM_ID 0
 
 #endif /* XNAP_COMMON_H_ */

--- a/openair2/XNAP/xnap_common.h
+++ b/openair2/XNAP/xnap_common.h
@@ -5,40 +5,47 @@
 #ifndef XNAP_COMMON_H_
 #define XNAP_COMMON_H_
 
-#include "XNAP_XnAP-PDU.h"
-#include "common/openairinterface5g_limits.h"
-#include "oai_asn1.h"
-#include "XNAP_ProtocolIE-Field.h"
-#include "XNAP_InitiatingMessage.h"
-#include "XNAP_ProtocolIE-ContainerPair.h"
-#include "XNAP_ProtocolExtensionField.h"
-#include "XNAP_ProtocolExtensionContainer.h"
-#include "XNAP_asn_constant.h"
+#include "tree.h"
+#include "common/platform_types.h"
+#include "openair2/COMMON/sctp_messages_types.h"
+#include "openair2/COMMON/xnap_messages_types.h"
 
-#ifndef XNAP_PORT
-#define XNAP_PORT 38422
-#endif
+typedef enum {
+  /* SCTP up, XnSetup in progress */
+  XNAP_PEER_STATE_WAITING = 0,
+  /* XnSetup exchange complete */
+  XNAP_PEER_STATE_CONNECTED,
+} xnap_peer_state_t;
 
-#define XNAP_FIND_PROTOCOLIE_BY_ID(IE_TYPE, ie, container, IE_ID, mandatory)                                                   \
-  do {                                                                                                                         \
-    IE_TYPE **ptr;                                                                                                             \
-    ie = NULL;                                                                                                                 \
-    for (ptr = container->protocolIEs.list.array; ptr < &container->protocolIEs.list.array[container->protocolIEs.list.count]; \
-         ptr++) {                                                                                                              \
-      if ((*ptr)->id == IE_ID) {                                                                                               \
-        ie = *ptr;                                                                                                             \
-        break;                                                                                                                 \
-      }                                                                                                                        \
-    }                                                                                                                          \
-    if (mandatory)                                                                                                             \
-      DevAssert(ie != NULL);                                                                                                   \
-  } while (0)
+/* A peer is inserted when SCTP is up and keyed solely by assoc_id, and
+ * a peer is removed from the tree the moment its association goes down. */
+typedef struct xnap_peer_s {
+  RB_ENTRY(xnap_peer_s) entry;
+  sctp_assoc_t assoc_id;
+  xnap_peer_state_t state;
+  /* negotiated SCTP in-streams */
+  uint16_t in_streams;
+  /* negotiated SCTP out-streams */
+  uint16_t out_streams;
+  /* filled after Xn Setup Response */
+  uint32_t remote_gnb_id;
+} xnap_peer_t;
 
-ssize_t xnap_generate_initiating_message(uint8_t **buffer,
-                                         uint32_t *length,
-                                         XNAP_ProcedureCode_t procedureCode,
-                                         XNAP_Criticality_t criticality,
-                                         asn_TYPE_descriptor_t *td,
-                                         void *sptr);
+/* Per-local-gNB Xn state, indexed by instance number. */
+typedef struct xnap_gnb_inst_s {
+  /* local gNB's own identity/capabilities */
+  xnap_setup_req_t setup_info;
+  xnap_net_config_t net_config;
+  RB_HEAD(xnap_peer_map, xnap_peer_s) peers;
+  /* set once Xn bring-up (listener bind + initial dials) has been started
+   * for this instance; never cleared, independent of peer connectivity */
+  bool xn_started;
+} xnap_gnb_inst_t;
+
+RB_PROTOTYPE(xnap_peer_map, xnap_peer_s, entry, xnap_peer_compare);
+
+xnap_gnb_inst_t *xnap_get_inst(instance_t instance);
+
+void xnap_create_inst(instance_t instance, xnap_setup_req_t *setup_info, xnap_net_config_t *net_config);
 
 #endif /* XNAP_COMMON_H_ */

--- a/openair2/XNAP/xnap_default_values.h
+++ b/openair2/XNAP/xnap_default_values.h
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#ifndef XNAP_DEFAULT_VALUES_H_
+#define XNAP_DEFAULT_VALUES_H_
+
+/* 3GPP TS 38.422 */
+#define XNAP_PORT_NUMBER (38422)
+#define XNAP_SCTP_PPID   (61)
+
+#endif /* XNAP_DEFAULT_VALUES_H_ */

--- a/openair2/XNAP/xnap_gNB.c
+++ b/openair2/XNAP/xnap_gNB.c
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include "common/platform_types.h"
+#include "common/utils/LOG/log.h"
+#include "intertask_interface.h"
+#include "xnap_messages_types.h"
+
+void *xnap_task(void *args)
+{
+  UNUSED(args);
+  LOG_I(XNAP, "Starting XnAP task\n");
+  itti_mark_task_ready(TASK_XNAP);
+
+  while (1) {
+    MessageDef *msg = NULL;
+    itti_receive_msg(TASK_XNAP, &msg);
+    const instance_t instance = ITTI_MSG_DESTINATION_INSTANCE(msg);
+    const int msgType = ITTI_MSG_ID(msg);
+    LOG_D(XNAP, "XnAP received %s for instance %ld\n", ITTI_MSG_NAME(msg), instance);
+
+    switch (msgType) {
+      default:
+        LOG_E(XNAP, "Unknown message type %d (%s)\n", msgType, ITTI_MSG_NAME(msg));
+        break;
+    }
+
+    int result = itti_free(ITTI_MSG_ORIGIN_ID(msg), msg);
+    AssertFatal(result == EXIT_SUCCESS, "Failed to free ITTI message (%d)\n", result);
+    msg = NULL;
+  }
+}

--- a/openair2/XNAP/xnap_gNB.c
+++ b/openair2/XNAP/xnap_gNB.c
@@ -153,6 +153,41 @@ static void xnap_gNB_handle_sctp_association_resp(instance_t instance, const sct
   xnap_gNB_generate_xn_setup_request(instance, inst, peer);
 }
 
+/* To aware that there is a peer sent SCTP connection request before Xn setup request */
+static void xnap_gNB_handle_sctp_association_ind(instance_t instance, const sctp_new_association_ind_t *ind)
+{
+  xnap_gnb_inst_t *inst = xnap_get_inst(instance);
+  AssertFatal(inst != NULL, "Xn instance %ld not found\n", instance);
+
+  if (xnap_get_peer_by_assoc(inst, ind->assoc_id) != NULL) {
+    LOG_W(XNAP, "[gNB %ld] SCTP_NEW_ASSOCIATION_IND: assoc_id %d already registered\n", instance, ind->assoc_id);
+    return;
+  }
+
+  xnap_add_peer(instance, inst, ind->assoc_id, ind->in_streams, ind->out_streams);
+
+  LOG_I(XNAP, "[gNB %ld] Incoming Xn connection: assoc_id %d — waiting for XnSetupRequest\n", instance, ind->assoc_id);
+}
+
+static void xnap_gNB_handle_sctp_close_association(instance_t instance, const sctp_close_association_t *close)
+{
+  xnap_gnb_inst_t *inst = xnap_get_inst(instance);
+  if (inst == NULL) {
+    LOG_W(XNAP, "[gNB %ld] SCTP_CLOSE_ASSOCIATION: instance not found\n", instance);
+    return;
+  }
+
+  xnap_peer_t *peer = xnap_get_peer_by_assoc(inst, close->assoc_id);
+  if (peer == NULL) {
+    LOG_W(XNAP, "[gNB %ld] SCTP_CLOSE_ASSOCIATION: no peer for assoc_id %d\n",
+          instance, close->assoc_id);
+    return;
+  }
+
+  xnap_handle_xn_setup_message(instance, inst, peer, 1);
+  xnap_remove_peer(inst, peer);
+}
+
 void *xnap_task(void *args)
 {
   UNUSED(args);
@@ -177,6 +212,14 @@ void *xnap_task(void *args)
 
       case SCTP_NEW_ASSOCIATION_RESP:
         xnap_gNB_handle_sctp_association_resp(instance, &SCTP_NEW_ASSOCIATION_RESP(msg));
+        break;
+
+      case SCTP_NEW_ASSOCIATION_IND:
+        xnap_gNB_handle_sctp_association_ind(instance, &SCTP_NEW_ASSOCIATION_IND(msg));
+        break;
+
+      case SCTP_CLOSE_ASSOCIATION:
+        xnap_gNB_handle_sctp_close_association(instance, &SCTP_CLOSE_ASSOCIATION(msg));
         break;
 
       default:

--- a/openair2/XNAP/xnap_gNB.c
+++ b/openair2/XNAP/xnap_gNB.c
@@ -13,8 +13,32 @@
 #include "xnap_default_values.h"
 #include "xnap_common.h"
 #include "xnap_gNB.h"
+#include "lib/xnap_gNB_interface_management.h"
+#include "xnap_gNB_itti_messaging.h"
+#include "xnap_gNB_handlers.h"
+#include "xnap_gNB_encoder.h"
 
-/* Phase 1: create the Xn instance and store its config. */
+static void xnap_gNB_generate_xn_setup_request(instance_t instance, xnap_gnb_inst_t *inst, const xnap_peer_t *peer)
+{
+  const xnap_setup_req_t *req = &inst->setup_info;
+
+  XNAP_XnAP_PDU_t *pdu = encode_xn_setup_request(req);
+  AssertFatal(pdu != NULL, "[gNB %ld] encode_xn_setup_request() failed\n", instance);
+
+  uint8_t *buffer = NULL;
+  uint32_t length = 0;
+  int rc = xnap_gNB_encode_pdu(pdu, &buffer, &length);
+  ASN_STRUCT_FREE(asn_DEF_XNAP_XnAP_PDU, pdu);
+  AssertFatal(rc == 0, "[gNB %ld] xnap_gNB_encode_pdu() failed for XnSetupRequest\n", instance);
+
+  LOG_I(XNAP, "[gNB %ld] Sending XnSetupRequest to peer assoc_id %d (%u bytes)\n",
+        instance, peer->assoc_id, length);
+
+  /* XnSetup is non-UE-associated signalling — always stream 0 */
+  xnap_gNB_itti_send_sctp_data(instance, peer->assoc_id, buffer, length, XNAP_NON_UE_STREAM_ID);
+}
+
+/* Phase 1: create the Xn instance and store its config */
 static void xnap_gNB_handle_register_gnb(instance_t instance, xnap_register_gnb_req_t *req)
 {
   xnap_create_inst(instance, &req->ng_setup_info, &req->net_config);
@@ -50,6 +74,10 @@ static void xnap_gNB_handle_f1_setup_done(instance_t instance, const xnap_f1_set
   memcpy(addr_buf, local_ip, addr_len);
   itti_send_msg_to_task(TASK_SCTP, instance, listen_msg);
 
+  /* Candidates are not yet peers (no SCTP association exists): they are
+   * addressed directly by their index in net_config, which doubles as
+   * ulp_cnx_id so the eventual SCTP_NEW_ASSOCIATION_RESP can be matched back
+   * to the candidate that was dialled. */
   const uint8_t nb_candidates = inst->net_config.nb_of_candidate_gNBs;
   LOG_I(XNAP, "[gNB %ld] F1 Setup Response sent (DU %lu) — listening on %s port %u, connecting to %u candidate(s)\n",
         instance, ind->gNB_DU_id, local_ip, XNAP_PORT_NUMBER, nb_candidates);
@@ -78,6 +106,53 @@ static void xnap_gNB_handle_f1_setup_done(instance_t instance, const xnap_f1_set
   }
 }
 
+/* To handle SCTP association response received from the candidates to which the SCTP connection request was sent */
+static void xnap_gNB_handle_sctp_association_resp(instance_t instance, const sctp_new_association_resp_t *resp)
+{
+  xnap_gnb_inst_t *inst = xnap_get_inst(instance);
+  AssertFatal(inst != NULL, "Xn instance %ld not found\n", instance);
+
+  /* Case 1: peer already has a live association, keyed by assoc_id.
+   * Remote opened the SCTP connection to us first — i.e. a simultaneous connect.
+   * assoc_id == -1 means SCTP (UNREACHABLE); */
+  xnap_peer_t *peer = NULL;
+  if (resp->assoc_id != -1)
+    peer = xnap_get_peer_by_assoc(inst, resp->assoc_id);
+  if (peer != NULL) {
+    if (resp->sctp_state != SCTP_STATE_ESTABLISHED) {
+      LOG_W(XNAP, "[gNB %ld] SCTP_NEW_ASSOCIATION_RESP: peer assoc_id %d %s\n", instance, resp->assoc_id,
+            resp->sctp_state == SCTP_STATE_SHUTDOWN ? "shut down" : "unexpected state");
+      xnap_handle_xn_setup_message(instance, inst, peer, 1 /* shutdown */);
+      xnap_remove_peer(inst, peer);
+      return;
+    }
+    /* Remote opened sctp first via IND, already keyed by assoc_id.
+     * Update streams and return — peer is the initiator and will send XnSetupRequest. */
+    LOG_I(XNAP, "[gNB %ld] SCTP_NEW_ASSOCIATION_RESP: peer assoc_id %d already registered "
+          "via IND (simultaneous connect), updating streams\n", instance, resp->assoc_id);
+    peer->in_streams  = resp->in_streams;
+    peer->out_streams = resp->out_streams;
+    return;
+  }
+
+  /* Case 2: no peer exists yet — this is the result of our own outgoing
+   * connect attempt for candidate resp->ulp_cnx_id. */
+  if (resp->sctp_state != SCTP_STATE_ESTABLISHED) {
+    LOG_W(XNAP, "[gNB %ld] SCTP association failed for candidate %u (%s)\n",
+          instance, resp->ulp_cnx_id,
+          resp->sctp_state == SCTP_STATE_SHUTDOWN ? "shutdown" : "unreachable");
+    return;
+  }
+
+  peer = xnap_add_peer(instance, inst, resp->assoc_id, resp->in_streams, resp->out_streams);
+
+  LOG_I(XNAP, "[gNB %ld] SCTP association established with candidate %u assoc_id %d "
+        "(in_streams %u out_streams %u) — sending XnSetupRequest\n",
+        instance, resp->ulp_cnx_id, resp->assoc_id, resp->in_streams, resp->out_streams);
+
+  xnap_gNB_generate_xn_setup_request(instance, inst, peer);
+}
+
 void *xnap_task(void *args)
 {
   UNUSED(args);
@@ -98,6 +173,10 @@ void *xnap_task(void *args)
 
       case XNAP_F1_SETUP_DONE_IND:
         xnap_gNB_handle_f1_setup_done(instance, &XNAP_F1_SETUP_DONE_IND(msg));
+        break;
+
+      case SCTP_NEW_ASSOCIATION_RESP:
+        xnap_gNB_handle_sctp_association_resp(instance, &SCTP_NEW_ASSOCIATION_RESP(msg));
         break;
 
       default:

--- a/openair2/XNAP/xnap_gNB.c
+++ b/openair2/XNAP/xnap_gNB.c
@@ -122,7 +122,7 @@ static void xnap_gNB_handle_sctp_association_resp(instance_t instance, const sct
     if (resp->sctp_state != SCTP_STATE_ESTABLISHED) {
       LOG_W(XNAP, "[gNB %ld] SCTP_NEW_ASSOCIATION_RESP: peer assoc_id %d %s\n", instance, resp->assoc_id,
             resp->sctp_state == SCTP_STATE_SHUTDOWN ? "shut down" : "unexpected state");
-      xnap_handle_xn_setup_message(instance, inst, peer, 1 /* shutdown */);
+      xnap_handle_xn_setup_message(instance, peer, 1 /* shutdown */);
       xnap_remove_peer(inst, peer);
       return;
     }
@@ -184,8 +184,18 @@ static void xnap_gNB_handle_sctp_close_association(instance_t instance, const sc
     return;
   }
 
-  xnap_handle_xn_setup_message(instance, inst, peer, 1);
+  xnap_handle_xn_setup_message(instance, peer, 1);
   xnap_remove_peer(inst, peer);
+}
+
+/* To handle all the messages coming through Xn interface through call back table */
+static void xnap_gNB_handle_sctp_data_ind(instance_t instance, sctp_data_ind_t *ind)
+{
+  int result;
+  DevAssert(ind != NULL);
+  xnap_gNB_handle_message(instance, ind->assoc_id, ind->stream, ind->buffer, ind->buffer_length);
+  result = itti_free(TASK_UNKNOWN, ind->buffer);
+  AssertFatal(result == EXIT_SUCCESS, "Failed to free memory (%d)!\n", result);
 }
 
 void *xnap_task(void *args)
@@ -220,6 +230,10 @@ void *xnap_task(void *args)
 
       case SCTP_CLOSE_ASSOCIATION:
         xnap_gNB_handle_sctp_close_association(instance, &SCTP_CLOSE_ASSOCIATION(msg));
+        break;
+
+      case SCTP_DATA_IND:
+        xnap_gNB_handle_sctp_data_ind(instance, &SCTP_DATA_IND(msg));
         break;
 
       default:

--- a/openair2/XNAP/xnap_gNB.c
+++ b/openair2/XNAP/xnap_gNB.c
@@ -6,8 +6,77 @@
 #include <stdlib.h>
 #include "common/platform_types.h"
 #include "common/utils/LOG/log.h"
-#include "intertask_interface.h"
-#include "xnap_messages_types.h"
+#include "common/utils/ocp_itti/intertask_interface.h"
+#include "assertions.h"
+#include "openair2/COMMON/sctp_messages_types.h"
+#include "openair2/COMMON/xnap_messages_types.h"
+#include "xnap_default_values.h"
+#include "xnap_common.h"
+#include "xnap_gNB.h"
+
+/* Phase 1: create the Xn instance and store its config. */
+static void xnap_gNB_handle_register_gnb(instance_t instance, xnap_register_gnb_req_t *req)
+{
+  xnap_create_inst(instance, &req->ng_setup_info, &req->net_config);
+}
+
+/* Phase 2: F1 Setup Response has been sent
+ * bind a local SCTP listener (for incoming Xn connections) and dial every configured candidate gNB and
+ * handle multi-DU and DU re-setup creating duplicate SCTP listener and dialing the candidates again */
+static void xnap_gNB_handle_f1_setup_done(instance_t instance, const xnap_f1_setup_done_ind_t *ind)
+{
+  xnap_gnb_inst_t *inst = xnap_get_inst(instance);
+  if (inst == NULL) {
+    LOG_E(XNAP, "Xn failed to start because Xn instance %ld not found (either NG Setup Fail or F1 setup done ind came before NG Setup)\n", instance);
+    return;
+  }
+
+  if (inst->xn_started) {
+    LOG_D(XNAP, "[gNB %ld] Xn already started for this instance, ignoring redundant F1 Setup Done (DU %lu)\n",
+          instance, ind->gNB_DU_id);
+    return;
+  }
+  inst->xn_started = true;
+
+  const char *local_ip = inst->net_config.gnb_xn_interface_ip_address;
+  size_t addr_len = strlen(local_ip) + 1;
+
+  MessageDef *listen_msg = itti_alloc_new_message_sized(TASK_XNAP, instance, SCTP_INIT_MSG, sizeof(sctp_init_t) + addr_len);
+  sctp_init_t *init = &SCTP_INIT_MSG(listen_msg);
+  init->port = XNAP_PORT_NUMBER;
+  init->ppid = XNAP_SCTP_PPID;
+  char *addr_buf = (char *)(init + 1);
+  init->bind_address = addr_buf;
+  memcpy(addr_buf, local_ip, addr_len);
+  itti_send_msg_to_task(TASK_SCTP, instance, listen_msg);
+
+  const uint8_t nb_candidates = inst->net_config.nb_of_candidate_gNBs;
+  LOG_I(XNAP, "[gNB %ld] F1 Setup Response sent (DU %lu) — listening on %s port %u, connecting to %u candidate(s)\n",
+        instance, ind->gNB_DU_id, local_ip, XNAP_PORT_NUMBER, nb_candidates);
+
+  for (uint16_t candidate_id = 0; candidate_id < nb_candidates; candidate_id++) {
+    const char *remote_ip = inst->net_config.candidate_gnb_address_for_xnc[candidate_id];
+
+    MessageDef *msg = itti_alloc_new_message(TASK_XNAP, instance, SCTP_NEW_ASSOCIATION_REQ);
+    sctp_new_association_req_t *req = &msg->ittiMsg.sctp_new_association_req;
+
+    req->ulp_cnx_id = candidate_id;
+    req->port = XNAP_PORT_NUMBER;
+    req->ppid = XNAP_SCTP_PPID;
+    req->in_streams = inst->net_config.sctp_streams.sctp_in_streams;
+    req->out_streams = inst->net_config.sctp_streams.sctp_out_streams;
+
+    req->local_address.ipv4 = 1;
+    strncpy(req->local_address.ipv4_address, local_ip, sizeof(req->local_address.ipv4_address) - 1);
+
+    req->remote_address.ipv4 = 1;
+    strncpy(req->remote_address.ipv4_address, remote_ip, sizeof(req->remote_address.ipv4_address) - 1);
+
+    LOG_I(XNAP, "[gNB %ld] Initiating SCTP connection to candidate %u at %s port %u\n", instance, candidate_id, remote_ip, XNAP_PORT_NUMBER);
+
+    itti_send_msg_to_task(TASK_SCTP, instance, msg);
+  }
+}
 
 void *xnap_task(void *args)
 {
@@ -23,6 +92,14 @@ void *xnap_task(void *args)
     LOG_D(XNAP, "XnAP received %s for instance %ld\n", ITTI_MSG_NAME(msg), instance);
 
     switch (msgType) {
+      case XNAP_REGISTER_GNB_REQ:
+        xnap_gNB_handle_register_gnb(instance, &XNAP_REGISTER_GNB_REQ(msg));
+        break;
+
+      case XNAP_F1_SETUP_DONE_IND:
+        xnap_gNB_handle_f1_setup_done(instance, &XNAP_F1_SETUP_DONE_IND(msg));
+        break;
+
       default:
         LOG_E(XNAP, "Unknown message type %d (%s)\n", msgType, ITTI_MSG_NAME(msg));
         break;

--- a/openair2/XNAP/xnap_gNB.h
+++ b/openair2/XNAP/xnap_gNB.h
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#ifndef XNAP_GNB_H_
+#define XNAP_GNB_H_
+
+#include <stdint.h>
+
+void *xnap_task(void *arg);
+
+#endif /* XNAP_GNB_H_ */

--- a/openair2/XNAP/xnap_gNB_encoder.c
+++ b/openair2/XNAP/xnap_gNB_encoder.c
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include "xnap_gNB_encoder.h"
+#include "asn_application.h"
+#include "asn_codecs.h"
+#include "assertions.h"
+#include "common/utils/LOG/log.h"
+#include "xer_encoder.h"
+
+int xnap_gNB_encode_pdu(XNAP_XnAP_PDU_t *pdu, uint8_t **buffer, uint32_t *len)
+{
+  DevAssert(pdu != NULL);
+  DevAssert(buffer != NULL);
+  DevAssert(len != NULL);
+
+  if (LOG_DEBUGFLAG(DEBUG_ASN1))
+    xer_fprint(stdout, &asn_DEF_XNAP_XnAP_PDU, pdu);
+
+  char errbuf[4096];
+  size_t errlen = sizeof(errbuf);
+  if (asn_check_constraints(&asn_DEF_XNAP_XnAP_PDU, pdu, errbuf, &errlen)) {
+    LOG_E(XNAP, "Constraint validation failed: %s\n", errbuf);
+  }
+
+  asn_encode_to_new_buffer_result_t res =
+      asn_encode_to_new_buffer(NULL, ATS_ALIGNED_CANONICAL_PER, &asn_DEF_XNAP_XnAP_PDU, pdu);
+  AssertFatal(res.result.encoded > 0, "Failed to encode XNAP PDU (present=%d)\n", pdu->present);
+  *buffer = res.buffer;
+  *len = res.result.encoded;
+  return 0;
+}

--- a/openair2/XNAP/xnap_gNB_encoder.h
+++ b/openair2/XNAP/xnap_gNB_encoder.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#ifndef XNAP_GNB_ENCODER_H_
+#define XNAP_GNB_ENCODER_H_
+
+#include <stdint.h>
+#include "lib/xnap_lib_includes.h"
+
+int xnap_gNB_encode_pdu(XNAP_XnAP_PDU_t *pdu, uint8_t **buffer, uint32_t *len)
+__attribute__((warn_unused_result));
+
+#endif /* XNAP_GNB_ENCODER_H_ */

--- a/openair2/XNAP/xnap_gNB_handlers.c
+++ b/openair2/XNAP/xnap_gNB_handlers.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include <stdlib.h>
+#include "xnap_gNB_handlers.h"
+#include "xnap_gNB.h"
+#include "xnap_common.h"
+#include "common/utils/LOG/log.h"
+#include "common/utils/ocp_itti/intertask_interface.h"
+#include "assertions.h"
+#include "xnap_gNB_encoder.h"
+#include "lib/xnap_gNB_interface_management.h"
+#include "lib/xnap_gNB_mobility_management.h"
+#include "aper_decoder.h"
+
+/* Helper for SCTP Shutdown or Xn setup */
+void xnap_handle_xn_setup_message(instance_t instance, xnap_gnb_inst_t *inst, xnap_peer_t *peer, int sctp_shutdown)
+{
+  if (sctp_shutdown) {
+    if (peer->state == XNAP_PEER_STATE_CONNECTED || peer->state == XNAP_PEER_STATE_WAITING) {
+      LOG_W(XNAP, "[gNB %ld] Xn peer assoc_id %d (gNB_id 0x%x) disconnected\n", instance, peer->assoc_id, peer->remote_gnb_id);
+
+      /* Notify RRC only if XnSetup had completed — i.e. the peer was CONNECTED
+       * and RRC holds a candidate entry for it.  WAITING peers never reached
+       * RRC so there is nothing to remove. */
+      if (peer->state == XNAP_PEER_STATE_CONNECTED && peer->remote_gnb_id != 0) {
+        MessageDef *msg = itti_alloc_new_message(TASK_XNAP, inst->instance, XNAP_PEER_SHUTDOWN_IND);
+        XNAP_PEER_SHUTDOWN_IND(msg).gnb_id = peer->remote_gnb_id;
+        itti_send_msg_to_task(TASK_RRC_GNB, inst->instance, msg);
+      }
+
+      /* Peers only ever exist in the tree while their SCTP association is up */
+      RB_REMOVE(xnap_peer_map, &inst->peers, peer);
+      inst->nb_peers--;
+      free(peer);
+      /* TODO: release XNAP UE contexts using this link */
+    }
+  } else {
+    peer->state = XNAP_PEER_STATE_CONNECTED;
+    LOG_I(XNAP, "[gNB %ld] Xn peer assoc_id %d (gNB_id 0x%x) setup complete — notifying RRC\n",
+          instance, peer->assoc_id, peer->remote_gnb_id);
+
+    /* Notify RRC so it can register this peer as an Xn-capable candidate */
+    MessageDef *msg = itti_alloc_new_message(TASK_XNAP, inst->instance, XNAP_SETUP_IND);
+    XNAP_SETUP_IND(msg).gnb_id   = peer->remote_gnb_id;
+    XNAP_SETUP_IND(msg).assoc_id = peer->assoc_id;
+    itti_send_msg_to_task(TASK_RRC_GNB, inst->instance, msg);
+  }
+}

--- a/openair2/XNAP/xnap_gNB_handlers.c
+++ b/openair2/XNAP/xnap_gNB_handlers.c
@@ -2,7 +2,6 @@
  * SPDX-License-Identifier: LicenseRef-CSSL-1.0
  */
 
-#include <stdlib.h>
 #include "xnap_gNB_handlers.h"
 #include "xnap_gNB.h"
 #include "xnap_common.h"
@@ -13,27 +12,23 @@
 #include "lib/xnap_gNB_interface_management.h"
 #include "lib/xnap_gNB_mobility_management.h"
 #include "aper_decoder.h"
+#include "xnap_gNB_itti_messaging.h"
 
-/* Helper for SCTP Shutdown or Xn setup */
-void xnap_handle_xn_setup_message(instance_t instance, xnap_gnb_inst_t *inst, xnap_peer_t *peer, int sctp_shutdown)
+/* Notify RRC of a peer's Xn Setup completion or SCTP-level shutdown. */
+void xnap_handle_xn_setup_message(instance_t instance, xnap_peer_t *peer, int sctp_shutdown)
 {
   if (sctp_shutdown) {
     if (peer->state == XNAP_PEER_STATE_CONNECTED || peer->state == XNAP_PEER_STATE_WAITING) {
       LOG_W(XNAP, "[gNB %ld] Xn peer assoc_id %d (gNB_id 0x%x) disconnected\n", instance, peer->assoc_id, peer->remote_gnb_id);
 
-      /* Notify RRC only if XnSetup had completed — i.e. the peer was CONNECTED
-       * and RRC holds a candidate entry for it.  WAITING peers never reached
-       * RRC so there is nothing to remove. */
+      /* Notify RRC only if XnSetup had completed because RRC has an entry,
+       * WAITING peers never reached RRC so there is nothing to remove. */
       if (peer->state == XNAP_PEER_STATE_CONNECTED && peer->remote_gnb_id != 0) {
-        MessageDef *msg = itti_alloc_new_message(TASK_XNAP, inst->instance, XNAP_PEER_SHUTDOWN_IND);
+        MessageDef *msg = itti_alloc_new_message(TASK_XNAP, instance, XNAP_PEER_SHUTDOWN_IND);
         XNAP_PEER_SHUTDOWN_IND(msg).gnb_id = peer->remote_gnb_id;
-        itti_send_msg_to_task(TASK_RRC_GNB, inst->instance, msg);
+        itti_send_msg_to_task(TASK_RRC_GNB, instance, msg);
       }
 
-      /* Peers only ever exist in the tree while their SCTP association is up */
-      RB_REMOVE(xnap_peer_map, &inst->peers, peer);
-      inst->nb_peers--;
-      free(peer);
       /* TODO: release XNAP UE contexts using this link */
     }
   } else {
@@ -42,9 +37,272 @@ void xnap_handle_xn_setup_message(instance_t instance, xnap_gnb_inst_t *inst, xn
           instance, peer->assoc_id, peer->remote_gnb_id);
 
     /* Notify RRC so it can register this peer as an Xn-capable candidate */
-    MessageDef *msg = itti_alloc_new_message(TASK_XNAP, inst->instance, XNAP_SETUP_IND);
+    MessageDef *msg = itti_alloc_new_message(TASK_XNAP, instance, XNAP_SETUP_IND);
     XNAP_SETUP_IND(msg).gnb_id   = peer->remote_gnb_id;
     XNAP_SETUP_IND(msg).assoc_id = peer->assoc_id;
-    itti_send_msg_to_task(TASK_RRC_GNB, inst->instance, msg);
+    itti_send_msg_to_task(TASK_RRC_GNB, instance, msg);
   }
+}
+
+typedef int (*xnap_message_decoded_callback)(instance_t instance,
+                                              sctp_assoc_t assoc_id,
+                                              uint32_t stream,
+                                              xnap_gnb_inst_t *inst,
+                                              xnap_peer_t *peer,
+                                              XNAP_XnAP_PDU_t *pdu);
+
+static int send_xn_setup_failure(instance_t instance, xnap_peer_t *peer, xnap_cause_group_t type, uint8_t value)
+{
+  const xnap_setup_failure_t fail = {.cause = {.type = type, .value = value}};
+  XNAP_XnAP_PDU_t *fail_pdu = encode_xn_setup_failure(&fail);
+  AssertFatal(fail_pdu != NULL, "[gNB %ld] encode_xn_setup_failure() failed\n", instance);
+  uint8_t *buffer = NULL;
+  uint32_t length = 0;
+  int rc = xnap_gNB_encode_pdu(fail_pdu, &buffer, &length);
+  ASN_STRUCT_FREE(asn_DEF_XNAP_XnAP_PDU, fail_pdu);
+  AssertFatal(rc == 0, "[gNB %ld] xnap_gNB_encode_pdu() failed for XnSetupFailure\n", instance);
+  xnap_gNB_itti_send_sctp_data(instance, peer->assoc_id, buffer, length, XNAP_NON_UE_STREAM_ID);
+  return -1;
+}
+
+static int xnap_gNB_handle_xn_setup_request(instance_t instance,
+                                             sctp_assoc_t assoc_id,
+                                             uint32_t stream,
+                                             xnap_gnb_inst_t *inst,
+                                             xnap_peer_t *peer,
+                                             XNAP_XnAP_PDU_t *pdu)
+{
+  UNUSED(assoc_id);
+  UNUSED(stream);
+
+  xnap_setup_req_t req = {0};
+  if (!decode_xn_setup_request(&req, pdu)) {
+    LOG_E(XNAP, "[gNB %ld] Failed to decode XnSetupRequest from assoc_id %d\n",
+          instance, peer->assoc_id);
+    return -1;
+  }
+
+  peer->remote_gnb_id = req.gNB_id;
+
+  /* Reject if the peer belongs to a different PLMN — most common failure
+   * in misconfigured or cross-operator deployments (TS 38.423 §8.3.5) */
+  const plmn_id_t *peer_plmn  = &req.plmn;
+  const plmn_id_t *local_plmn = &inst->setup_info.plmn;
+  if (peer_plmn->mcc != local_plmn->mcc || peer_plmn->mnc != local_plmn->mnc) {
+    LOG_W(XNAP, "[gNB %ld] XnSetupRequest from assoc_id %d (gNB_id 0x%x): "
+          "PLMN mismatch (peer MCC/MNC %u/%u, local %u/%u) — rejecting\n",
+          instance, peer->assoc_id, peer->remote_gnb_id,
+          peer_plmn->mcc, peer_plmn->mnc, local_plmn->mcc, local_plmn->mnc);
+    free_xnap_setup_request(&req);
+    return send_xn_setup_failure(instance, peer, XNAP_CAUSE_MISC, XNAP_CAUSE_MISC_O_AND_M_INTERVENTION);
+  }
+
+  free_xnap_setup_request(&req);
+
+  LOG_I(XNAP, "[gNB %ld] XnSetupRequest from peer assoc_id %d (gNB_id 0x%x) — sending XnSetupResponse\n",
+        instance, peer->assoc_id, peer->remote_gnb_id);
+
+  xnap_setup_resp_t resp = {
+    .gNB_id = inst->setup_info.gNB_id,
+    .plmn = inst->setup_info.plmn,
+    .num_tai = inst->setup_info.num_tai,
+    .tai_support = inst->setup_info.tai_support,
+  };
+
+  XNAP_XnAP_PDU_t *resp_pdu = encode_xn_setup_response(&resp);
+  AssertFatal(resp_pdu != NULL, "[gNB %ld] encode_xn_setup_response() failed\n", instance);
+
+  uint8_t *buffer = NULL;
+  uint32_t length = 0;
+  int rc = xnap_gNB_encode_pdu(resp_pdu, &buffer, &length);
+  ASN_STRUCT_FREE(asn_DEF_XNAP_XnAP_PDU, resp_pdu);
+  AssertFatal(rc == 0, "[gNB %ld] xnap_gNB_encode_pdu() failed for XnSetupResponse\n", instance);
+
+  xnap_gNB_itti_send_sctp_data(instance, peer->assoc_id, buffer, length, XNAP_NON_UE_STREAM_ID);
+
+  /* Xn interface is now active from our side — notify RRC */
+  xnap_handle_xn_setup_message(instance, peer, 0);
+  return 0;
+}
+
+static int xnap_gNB_handle_xn_setup_response(instance_t instance,
+                                              sctp_assoc_t assoc_id,
+                                              uint32_t stream,
+                                              xnap_gnb_inst_t *inst,
+                                              xnap_peer_t *peer,
+                                              XNAP_XnAP_PDU_t *pdu)
+{
+  UNUSED(assoc_id);
+  UNUSED(stream);
+  UNUSED(inst);
+
+  xnap_setup_resp_t resp = {0};
+  if (!decode_xn_setup_response(&resp, pdu)) {
+    LOG_E(XNAP, "[gNB %ld] Failed to decode XnSetupResponse from assoc_id %d\n",
+          instance, peer->assoc_id);
+    return -1;
+  }
+
+  peer->remote_gnb_id = resp.gNB_id;
+  free_xnap_setup_response(&resp);
+
+  xnap_handle_xn_setup_message(instance, peer, 0);
+  return 0;
+}
+
+static const char *xnap_cause_group2str(xnap_cause_group_t t)
+{
+  switch (t) {
+    case XNAP_CAUSE_RADIO_NETWORK: return "radioNetwork";
+    case XNAP_CAUSE_TRANSPORT:     return "transport";
+    case XNAP_CAUSE_PROTOCOL:      return "protocol";
+    case XNAP_CAUSE_MISC:          return "misc";
+    default:                       return "unknown";
+  }
+}
+
+static int xnap_gNB_handle_xn_setup_failure(instance_t instance,
+                                             sctp_assoc_t assoc_id,
+                                             uint32_t stream,
+                                             xnap_gnb_inst_t *inst,
+                                             xnap_peer_t *peer,
+                                             XNAP_XnAP_PDU_t *pdu)
+{
+  UNUSED(assoc_id);
+  UNUSED(stream);
+
+  xnap_setup_failure_t fail = {0};
+  if (!decode_xn_setup_failure(&fail, pdu)) {
+    LOG_E(XNAP, "[gNB %ld] Failed to decode XnSetupFailure from assoc_id %d\n",
+          instance, peer->assoc_id);
+    return -1;
+  }
+
+  LOG_W(XNAP, "[gNB %ld] XnSetupFailure from peer assoc_id %d (gNB_id 0x%x): "
+        "cause %s value=%d — Xn interface not established\n",
+        instance, peer->assoc_id, peer->remote_gnb_id,
+        xnap_cause_group2str(fail.cause.type), fail.cause.value);
+
+  xnap_remove_peer(inst, peer);
+
+  free_xnap_setup_failure(&fail);
+  return 0;
+}
+
+/* Callback table
+ * Indexed by [procedureCode][direction-1]
+ * where direction is:  0 = initiatingMessage, 1 = successfulOutcome, 2 = unsuccessfulOutcome
+ * Procedure codes taken from XNAP_ProcedureCode.h (TS 38.423 v16.2.0)
+ */
+static const xnap_message_decoded_callback xnap_messages_callback[][3] = {
+  {0, 0, 0}, /*  0 handoverPreparation */
+  {0, 0, 0}, /*  1 sNStatusTransfer */
+  {0, 0, 0}, /*  2 handoverCancel */
+  {0, 0, 0}, /*  3 retrieveUEContext */
+  {0, 0, 0}, /*  4 rANPaging */
+  {0, 0, 0}, /*  5 xnUAddressIndication */
+  {0, 0, 0}, /*  6 uEContextRelease */
+  {0, 0, 0}, /*  7 sNGRANnodeAdditionPreparation */
+  {0, 0, 0}, /*  8 sNGRANnodeReconfigurationCompletion */
+  {0, 0, 0}, /*  9 mNGRANnodeinitiatedSNGRANnodeModificationPrep */
+  {0, 0, 0}, /* 10 sNGRANnodeinitiatedSNGRANnodeModificationPrep */
+  {0, 0, 0}, /* 11 mNGRANnodeinitiatedSNGRANnodeRelease */
+  {0, 0, 0}, /* 12 sNGRANnodeinitiatedSNGRANnodeRelease */
+  {0, 0, 0}, /* 13 sNGRANnodeCounterCheck */
+  {0, 0, 0}, /* 14 sNGRANnodeChange */
+  {0, 0, 0}, /* 15 rRCTransfer */
+  {0, 0, 0}, /* 16 xnRemoval */
+  {xnap_gNB_handle_xn_setup_request, xnap_gNB_handle_xn_setup_response, xnap_gNB_handle_xn_setup_failure}, /* 17 xnSetup */
+  {0, 0, 0}, /* 18 nGRANnodeConfigurationUpdate */
+  {0, 0, 0}, /* 19 cellActivation */
+  {0, 0, 0}, /* 20 reset */
+  {0, 0, 0}, /* 21 errorIndication */
+  {0, 0, 0}, /* 22 privateMessage */
+  {0, 0, 0}, /* 23 notificationControl */
+  {0, 0, 0}, /* 24 activityNotification */
+  {0, 0, 0}, /* 25 e_UTRA_NR_CellResourceCoordination */
+  {0, 0, 0}, /* 26 secondaryRATDataUsageReport */
+  {0, 0, 0}, /* 27 deactivateTrace */
+  {0, 0, 0}, /* 28 traceStart */
+  {0, 0, 0}, /* 29 handoverSuccess */
+  {0, 0, 0}, /* 30 conditionalHandoverCancel */
+  {0, 0, 0}, /* 31 earlyStatusTransfer */
+  {0, 0, 0}, /* 32 failureIndication */
+  {0, 0, 0}, /* 33 handoverReport */
+  {0, 0, 0}, /* 34 resourceStatusReportingInitiation */
+  {0, 0, 0}, /* 35 resourceStatusReporting */
+  {0, 0, 0}, /* 36 mobilitySettingsChange */
+  {0, 0, 0}, /* 37 accessAndMobilityIndication */
+};
+
+static const char *xnap_direction2str(int dir)
+{
+  static const char *const s[] = {"", "initiatingMessage", "successfulOutcome", "unsuccessfulOutcome"};
+  return (dir >= 0 && dir <= 3) ? s[dir] : "unknown";
+}
+
+static XNAP_XnAP_PDU_t *xnap_gNB_decode_pdu(const uint8_t *const buf, uint32_t len)
+{
+  DevAssert(buf != NULL);
+  asn_codec_ctx_t st = {.max_stack_size = 100 * 1000};
+  XNAP_XnAP_PDU_t *pdu = NULL;
+  asn_dec_rval_t dec = aper_decode(&st, &asn_DEF_XNAP_XnAP_PDU, (void **)&pdu, buf, len, 0, 0);
+
+  if (LOG_DEBUGFLAG(DEBUG_ASN1)) {
+    LOG_E(XNAP, "----------------- ASN1 DECODER PRINT START----------------- \n");
+    xer_fprint(stdout, &asn_DEF_XNAP_XnAP_PDU, pdu);
+    LOG_E(XNAP, "----------------- ASN1 DECODER PRINT END ----------------- \n");
+  }
+
+  return dec.code == RC_OK ? pdu : NULL;
+}
+
+int xnap_gNB_handle_message(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, const uint8_t *buf, uint32_t len)
+{
+  xnap_gnb_inst_t *inst = xnap_get_inst(instance);
+  AssertFatal(inst != NULL, "Xn instance %ld not found\n", instance);
+
+  xnap_peer_t *peer = xnap_get_peer_by_assoc(inst, assoc_id);
+  if (peer == NULL) {
+    LOG_E(XNAP, "[gNB %ld] xnap_gNB_handle_message: no peer for assoc_id %d\n", instance, assoc_id);
+    return -1;
+  }
+
+  XNAP_XnAP_PDU_t *pdu = xnap_gNB_decode_pdu(buf, len);
+  if (pdu == NULL) {
+    LOG_E(XNAP, "[gNB %ld] Failed to decode XnAP PDU from assoc_id %d\n", instance, assoc_id);
+    return -1;
+  }
+
+  /* Checking procedure Code and direction of message */
+  if (pdu->choice.initiatingMessage->procedureCode >= (long)(sizeof(xnap_messages_callback) / (3 * sizeof(xnap_message_decoded_callback)))
+      || pdu->present > XNAP_XnAP_PDU_PR_unsuccessfulOutcome) {
+    LOG_E(XNAP,
+          "[gNB %ld] [SCTP %d] Either procedureCode %ld or direction %d exceed expected\n",
+          instance,
+          assoc_id,
+          pdu->choice.initiatingMessage->procedureCode,
+          pdu->present);
+    ASN_STRUCT_FREE(asn_DEF_XNAP_XnAP_PDU, pdu);
+    return -1;
+  }
+
+  int ret;
+  if (xnap_messages_callback[pdu->choice.initiatingMessage->procedureCode][pdu->present - 1] == NULL) {
+    // No handler present. This can mean not implemented or no procedure for this direction.
+    LOG_W(XNAP,
+          "[gNB %ld] [SCTP %d] No handler for procedureCode %ld in %s\n",
+          instance,
+          assoc_id,
+          pdu->choice.initiatingMessage->procedureCode,
+          xnap_direction2str(pdu->present));
+    ret = 0;
+  } else {
+    /* Calling the right handler */
+    LOG_D(XNAP, "Calling handler with instance %ld\n", instance);
+    ret = (*xnap_messages_callback[pdu->choice.initiatingMessage->procedureCode][pdu->present - 1])(instance, assoc_id, stream, inst, peer, pdu);
+  }
+
+  ASN_STRUCT_FREE(asn_DEF_XNAP_XnAP_PDU, pdu);
+  return ret;
 }

--- a/openair2/XNAP/xnap_gNB_handlers.h
+++ b/openair2/XNAP/xnap_gNB_handlers.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#ifndef XNAP_GNB_HANDLERS_H_
+#define XNAP_GNB_HANDLERS_H_
+
+#include <stdint.h>
+#include "common/platform_types.h"
+#include "openair2/COMMON/sctp_messages_types.h"
+#include "xnap_common.h"
+
+void xnap_handle_xn_setup_message(instance_t instance, xnap_gnb_inst_t *inst, xnap_peer_t *peer, int sctp_shutdown);
+
+#endif /* XNAP_GNB_HANDLERS_H_ */

--- a/openair2/XNAP/xnap_gNB_handlers.h
+++ b/openair2/XNAP/xnap_gNB_handlers.h
@@ -10,6 +10,7 @@
 #include "openair2/COMMON/sctp_messages_types.h"
 #include "xnap_common.h"
 
-void xnap_handle_xn_setup_message(instance_t instance, xnap_gnb_inst_t *inst, xnap_peer_t *peer, int sctp_shutdown);
+void xnap_handle_xn_setup_message(instance_t instance, xnap_peer_t *peer, int sctp_shutdown);
+int xnap_gNB_handle_message(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, const uint8_t *buf, uint32_t len);
 
 #endif /* XNAP_GNB_HANDLERS_H_ */

--- a/openair2/XNAP/xnap_gNB_itti_messaging.c
+++ b/openair2/XNAP/xnap_gNB_itti_messaging.c
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "intertask_interface.h"
+#include "sctp_messages_types.h"
+
+void xnap_gNB_itti_send_sctp_data(instance_t instance,
+                                   sctp_assoc_t assoc_id,
+                                   uint8_t *buffer,
+                                   uint32_t length,
+                                   uint16_t stream)
+{
+  MessageDef *msg = itti_alloc_new_message(TASK_XNAP, instance, SCTP_DATA_REQ);
+  sctp_data_req_t *req = &msg->ittiMsg.sctp_data_req;
+  req->assoc_id = assoc_id;
+  req->buffer = buffer;
+  req->buffer_length = length;
+  req->stream = stream;
+  itti_send_msg_to_task(TASK_SCTP, instance, msg);
+}

--- a/openair2/XNAP/xnap_gNB_itti_messaging.h
+++ b/openair2/XNAP/xnap_gNB_itti_messaging.h
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+/*!
+ * \brief xnap itti messages handlers for gNB
+ */
+
+#ifndef XNAP_GNB_ITTI_MESSAGING_H_
+#define XNAP_GNB_ITTI_MESSAGING_H_
+
+#include <assertions.h>
+#include <netinet/sctp.h>
+#include <stdint.h>
+
+void xnap_gNB_itti_send_sctp_data(instance_t instance,
+                                   sctp_assoc_t assoc_id,
+                                   uint8_t *buffer,
+                                   uint32_t length,
+                                   uint16_t stream);
+
+#endif /* XNAP_GNB_ITTI_MESSAGING_H_ */
+

--- a/openair3/NGAP/ngap_gNB_handlers.c
+++ b/openair3/NGAP/ngap_gNB_handlers.c
@@ -44,6 +44,46 @@ char *ngap_direction2String(int ngap_dir) {
   };
   return(ngap_direction_String[ngap_dir]);
 }
+
+static void ngap_send_register_gnb_cnf(ngap_gNB_instance_t *inst)
+{
+  MessageDef *message_p = itti_alloc_new_message(TASK_NGAP, 0, NGAP_REGISTER_GNB_CNF);
+  ngap_register_gnb_cnf_t *cnf = &NGAP_REGISTER_GNB_CNF(message_p);
+
+  cnf->nb_amf = inst->ngap_amf_associated_nb;
+  cnf->gNB_id = inst->gNB_id;
+  cnf->tac = inst->tac;
+  cnf->num_plmn = inst->num_plmn;
+  memcpy(cnf->plmn, inst->plmn, inst->num_plmn * sizeof(*inst->plmn));
+
+  int r = 0;
+  ngap_gNB_amf_data_t *amf_node;
+  struct served_guami_s *guami;
+  struct plmn_identity_s *plmn;
+  struct served_region_id_s *region;
+  RB_FOREACH(amf_node, ngap_amf_map, &inst->ngap_amf_head) {
+    STAILQ_FOREACH(guami, &amf_node->served_guami, next) {
+      if (r >= NGAP_MAX_NB_AMF_REGIONS)
+        break;
+      ngap_amf_region_info_t *amf_region = &cnf->amf_region_info[r];
+      STAILQ_FOREACH(plmn, &guami->served_plmns, next) {
+        amf_region->plmn.mcc = plmn->mcc;
+        amf_region->plmn.mnc = plmn->mnc;
+        amf_region->plmn.mnc_digit_length = plmn->mnc_digit_length;
+        break;
+      }
+      STAILQ_FOREACH(region, &guami->served_region_ids, next) {
+        amf_region->amf_region_id = region->amf_region_id;
+        break;
+      }
+      r++;
+    }
+  }
+  cnf->num_amf_regions = r;
+
+  itti_send_msg_to_task(TASK_GNB_APP, inst->instance, message_p);
+}
+
 void ngap_handle_ng_setup_message(ngap_gNB_amf_data_t *amf_desc_p, int sctp_shutdown) {
   if (sctp_shutdown) {
     /* A previously connected AMF has been shutdown */
@@ -85,9 +125,7 @@ void ngap_handle_ng_setup_message(ngap_gNB_amf_data_t *amf_desc_p, int sctp_shut
 
     /* If there are no more pending messages, inform gNB app */
     if (amf_desc_p->ngap_gNB_instance->ngap_amf_pending_nb == 0) {
-      MessageDef *message_p = itti_alloc_new_message(TASK_NGAP, 0, NGAP_REGISTER_GNB_CNF);
-      NGAP_REGISTER_GNB_CNF(message_p).nb_amf = amf_desc_p->ngap_gNB_instance->ngap_amf_associated_nb;
-      itti_send_msg_to_task(TASK_GNB_APP, amf_desc_p->ngap_gNB_instance->instance, message_p);
+      ngap_send_register_gnb_cnf(amf_desc_p->ngap_gNB_instance);
     }
   }
 }


### PR DESCRIPTION
This PR integrates XnAP layer as per 3GPP TS 38.423v16.2.0, which includes the following:

- Add support to get NG setup info from NGAP that is required for Xn setup request
    - Update the existing ngap_register_gnb_cnf message type with gNB id, tac, plmn, amf region info
    - Helper to create an ITTI msg and send the info from NGAP to GNB_APP
- Add Xn_INTERFACE configuration section in gnb_paramdef.h
    - gNB ipv4 address, Candidate gNBs ip addresses
- Add support to build XnAP module
- Xn registration: Read configuration, create XNAP task and initiate Xn setup
    - Read NG setup information (tac, plmn, tai support, amf region info)
    - Read Xn interface configuration (gNB address, Candidate gNB addresses)
    - Create XNAP task and support to handle ITTI messages
    - Add xnap default values (PPID and SCTP port)
- Create Xn instance and RB tree for Xn peers, handling XNAP tasks triggered by NG setup
    - Create and get Xn instance functions, Add type definitions
    - Handling the XNAP task XNAP_REGISTER_GNB_REQ
- Handle SCTP_NEW_ASSOCIATION_RESP, Encoder, Xn setup request
    - Handle XnAP task SCTP_NEW_ASSOCIATION_RESP
        - Handle SCTP shutdown and Xn setup indication, Add message type defs and ITTI message defs
        - Send Xn setup request on SCTP successful connection
    - Encoder for XnAP messages
- Create RB tree for Xn neighbours at RRC and handle SCTP SHUTDOWN and XN Setup Indication
    - Create RB tree for Xn neighbours, add/remove Xn neighbour on xn setup/sctp shutdown notification
- XNAP task to handle SCTP_NEW_ASSOCIATION_IND and SCTP_CLOSE_ASSOCIATION
    - XnAP to add/remove peers when ever there is an sctp association req/sctp connection is closed
- XnAP Task SCTP_DATA_IND
    - Common decoder and dispatch with callback table, and handling Xn setup req/resp/failure
    - Reject duplicate xn association if the remote gNB is already a peer
- Standalone lightweight XnAP simulator for testing XnAP procedures between multiple gNB instances
    - Sample Config files
    - README doc

**Notes:**
- The SCTP connection and Xn setup procedure starts only when CUCP/CU/monolithic-gNB is up.
- NG setup confirmation creates Xn instance, starts Xn SCTP listener and dial the configured peers (deferred full compliance with 3GPP TS 38.401 sec 8.5-1 for now)
- SCTP uses SCTP_INIT_MSG to dial the configured peers (instead of SCTP_MULTI_REQ)
- Redialing peers periodically if the SCTP is unreachable/Xn-setup fails is not in the scope of this PR

**How to Test:**

**Method 1:** Using xn-simulator-test binary
**Step 1:** Start [OAI CN5G ](https://github.com/duranta-project/openairinterface5g/blob/develop/doc/NR_SA_Tutorial_OAI_CN5G.md)
**Step 2:** Build xn-simulator
```
cd ~/openairinterface5g
    mkdir build && cd build && cmake .. -GNinja && ninja xn-simulator-test
```
**Step3:** Start the tester with one `-O <config_file.conf>' per simulated gNB instance
```
openairinterface5g/build$ ./openair2/XNAP/tests/xn-simulator/xn-simulator-test \
      -O ../openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci0.xn.rfsim.conf \
      -O ../openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci1.xn.rfsim.conf \
      -O ../openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci2.xn.rfsim.conf
```
**Step4:** Observe the successful SCTP connections and Xn setup req/resp among the gNB instances then XnAP notifiying RRC about the Xn peers.
<br>

**Method 2:** Using nr-softmodem binary
 **Step 1:** Start [OAI CN5G ](https://github.com/duranta-project/openairinterface5g/blob/develop/doc/NR_SA_Tutorial_OAI_CN5G.md)
**Step 2:** Run the multiple instances of nr-softmodem in [RFSim mode](https://github.com/duranta-project/openairinterface5g/blob/develop/radio/rfsimulator/README.md) in different terminals with the below command and configuration files attached (run only the gNB instances as this PR meant for SCTP, Xn setup message exchange between gNBs/CUCPs/CUs):
**gNB0 in terminal 1:** 
```
sudo ./nr-softmodem -O ../../../build/openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci0.xn.rfsim.conf --gNBs.[0].min_rxtxtime 6 --rfsim --rfsimulator.[0].serveraddr 127.0.0.10
```

**gNB1 in terminal 2:**
```
sudo ./nr-softmodem -O ../../../build/openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci1.xn.rfsim.conf --gNBs.[0].min_rxtxtime 6 --rfsim --rfsimulator.[0].serveraddr 127.0.0.20
```
**gNB2 in terminal 3:**
```
sudo ./nr-softmodem -O ../../../build/openair2/XNAP/tests/xn-simulator/gnb.sa.band78.fr1.106PRB.pci2.xn.rfsim.conf --gNBs.[0].min_rxtxtime 6 --rfsim --rfsimulator.[0].serveraddr 127.0.0.30
```
**Step 3:** Observe the successful SCTP connections and Xn setup req/resp then XnAP notifiying RRC about Xn peers
<br><br>

**Acknowledgement:**

> This work has been partially carried out as part of Xn Handover development at the Indian Institute of Science (IISc), Bengaluru.