### PR TITLE
hotfix: restore pucch rx performance

### DIFF
--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -6,6 +6,7 @@
  * \brief primitives used by gNB for BCH, RACH, ULSCH, DLSCH scheduling
  */
 
+#include "nfapi_nr_interface_scf.h"
 #include <softmodem-common.h>
 #include "assertions.h"
 
@@ -1474,7 +1475,9 @@ void nr_configure_pucch(nfapi_nr_pucch_pdu_t *pucch_pdu,
                         uint8_t O_sr,
                         int r_pucch,
                         nr_beam_mode_t beam_mode,
-                        uint16_t ant_port_idx)
+                        uint16_t ant_port_start,
+                        uint16_t *ssi,
+                        uint16_t num_ant)
 {
   NR_PUCCH_Resource_t *pucchres;
   NR_PUCCH_FormatConfig_t *pucchfmt;
@@ -1688,8 +1691,9 @@ void nr_configure_pucch(nfapi_nr_pucch_pdu_t *pucch_pdu,
   pucch_pdu->beamforming.dig_bf_interface = 1;
   const uint16_t fapi_beam = convert_to_fapi_beam(UE->UE_beam_index, beam_mode);
   pucch_pdu->beamforming.prgs_list[0].dig_bf_interface_list[0].beam_idx = fapi_beam;
-  pucch_pdu->param_v4.numSpatialStreamIndices = 1;
-  pucch_pdu->param_v4.spatialStreamIndices[0] = ant_port_idx;
+  pucch_pdu->param_v4.numSpatialStreamIndices = num_ant;
+  for (int i = 0; i < num_ant; i++)
+    pucch_pdu->param_v4.spatialStreamIndices[i] = ssi[ant_port_start + i];
 }
 
 void set_r_pucch_parms(int rsetindex,

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_uci.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_uci.c
@@ -81,7 +81,9 @@ static void nr_fill_nfapi_pucch(gNB_MAC_INST *nrmac, frame_t frame, slot_t slot,
                      pucch->sr_flag,
                      pucch->r_pucch,
                      nrmac->beam_info.beam_mode,
-                     ant_ports_to_use);
+                     ant_ports_to_use,
+                     nrmac->radio_config.spatial_stream_index,
+                     nrmac->radio_config.pusch_AntennaPorts);
 }
 
 //Differential RSRP values Table 10.1.6.1-2 from 38.133

--- a/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
@@ -215,7 +215,9 @@ void nr_configure_pucch(nfapi_nr_pucch_pdu_t *pucch_pdu,
                         uint8_t O_sr,
                         int r_pucch,
                         nr_beam_mode_t mode,
-                        uint16_t ant_port_idx);
+                        uint16_t ant_port_idx,
+                        uint16_t *ssi,
+                        uint16_t num_ant);
 
 void find_search_space(int ss_type,
                        NR_BWP_Downlink_t *bwp,


### PR DESCRIPTION
Set number of pucch rx ports same as pusch ports to improve detector performance.