### PR TITLE
fix(phy, nr_ue): fix for HARQ bits length <=2 on PUSCH when 2 layers

### DIFF
--- a/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_ulsch_ue.c
@@ -866,6 +866,7 @@ static void map_overlapped_ack(uci_on_pusch_bit_type_t *template,
 {
   const int placeholder_start = (pusch_pdu->pusch_uci.harq_ack_bit_length == 1) ? 1 : 2;
   const int Qm = pusch_pdu->qam_mod_order;
+  const int nlqm = Qm * pusch_pdu->nrOfLayers;
   uint32_t ack_bits_marked = 0;
   for (uint8_t sym_iter = l1_c; sym_iter < pusch_pdu->nr_of_symbols; sym_iter++) {
     const uint32_t num_reserved_bits_on_sym = count_by_sym[sym_iter];
@@ -882,16 +883,16 @@ static void map_overlapped_ack(uci_on_pusch_bit_type_t *template,
     const int32_t num_ack_remaining = G_ack - ack_bits_marked;
     if (num_ack_remaining <= 0)
       continue;
-    AssertFatal(num_reserved_bits_on_sym % Qm == 0,
-                "reserved bits on symbol (%u) not a multiple of Qm (%d)\n",
+    AssertFatal(num_reserved_bits_on_sym % nlqm == 0,
+                "reserved bits on symbol (%u) not a multiple of nlqm (%d)\n",
                 num_reserved_bits_on_sym,
-                Qm);
-    const uint32_t num_reserved_re = num_reserved_bits_on_sym / Qm;
-    const uint32_t num_ack_re_remaining = num_ack_remaining / Qm;
+                nlqm);
+    const uint32_t num_reserved_re = num_reserved_bits_on_sym / nlqm;
+    const uint32_t num_ack_re_remaining = num_ack_remaining / nlqm;
     const uint32_t d_factor_re = get_d_factor_re(num_ack_re_remaining, num_reserved_re);
     for (uint32_t re = 0; re < num_reserved_re && ack_bits_marked < G_ack; re += d_factor_re) {
-      for (int b = 0; b < Qm; b++) {
-        uint32_t pos = reserved_indices_on_this_sym[re * Qm + b];
+      for (int b = 0; b < nlqm; b++) {
+        uint32_t pos = reserved_indices_on_this_sym[re * nlqm + b];
         int bit_in_group = pos % Qm;
         if (template[pos] == BIT_TYPE_ULSCH) // puncturing ULSCH
           template[pos] = (bit_in_group >= placeholder_start) ? BIT_TYPE_ACK_PLACEHOLDER : BIT_TYPE_ACK_RESERVED;


### PR DESCRIPTION
`map_overlapped_ack()` computed reserved RE counts using the per-layer modulation order (`Qm`), but multiplexed UCI positions are counted in bits across every layer of the PUSCH. This produced wrong RE counts and an incorrect punch-through pattern for 2-layer PUSCH transmissions. Use `Qm * nrOfLayers` instead.