### PR TITLE
fix(mac, nr_ue): remove csi_on_pusch flag for periodic CSI report handling

### DIFF
--- a/openair2/LAYER2/NR_MAC_UE/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_UE/mac_proto.h
@@ -118,8 +118,7 @@ int nr_get_csi_measurements(NR_UE_MAC_INST_t *mac,
                             frame_t frame,
                             int slot,
                             nfapi_nr_ue_csi_payload_t *csi_payload,
-                            NR_PUCCH_Resource_t **csi_pucch,
-                            bool csi_on_pusch);
+                            NR_PUCCH_Resource_t **csi_pucch);
 
 nfapi_nr_ue_csi_payload_t nr_get_csi_payload(NR_UE_MAC_INST_t *mac,
                                  int csi_report_id,

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
@@ -2667,8 +2667,7 @@ int nr_get_csi_measurements(NR_UE_MAC_INST_t *mac,
                             frame_t frame,
                             int slot,
                             nfapi_nr_ue_csi_payload_t *csi_payload,
-                            NR_PUCCH_Resource_t **csi_pucch,
-                            bool csi_on_pusch)
+                            NR_PUCCH_Resource_t **csi_pucch)
 {
   NR_UE_UL_BWP_t *current_UL_BWP = mac->current_UL_BWP;
   NR_PUCCH_Config_t *pucch_Config = current_UL_BWP ? current_UL_BWP->pucch_Config : NULL;
@@ -2722,13 +2721,17 @@ int nr_get_csi_measurements(NR_UE_MAC_INST_t *mac,
         // we discard previous report
         csi_priority = temp_priority;
         num_csi = 1;
-        *csi_payload = nr_get_csi_payload(mac, csi_report_id, csi_on_pusch ? ON_PUSCH : WIDEBAND_ON_PUCCH, csi_measconfig);
+        // 38.214 section 5.2.3: "For both Type I and Type II reports configured for PUCCH but transmitted
+        // on PUSCH, the determination of the payload for CSI part 1 and CSI part 2 follows that of PUCCH
+        // as described in Clause 5.2.4." Hence WIDEBAND_ON_PUCCH is used here regardless of whether
+        // the CSI report is sent on PUCCH or PUSCH.
+        *csi_payload = nr_get_csi_payload(mac, csi_report_id, WIDEBAND_ON_PUCCH, csi_measconfig);
       } else
         continue;
     } else {
       num_csi = 1;
       csi_priority = temp_priority;
-      *csi_payload = nr_get_csi_payload(mac, csi_report_id, csi_on_pusch ? ON_PUSCH : WIDEBAND_ON_PUCCH, csi_measconfig);
+      *csi_payload = nr_get_csi_payload(mac, csi_report_id, WIDEBAND_ON_PUCCH, csi_measconfig);
     }
   }
   return num_csi;

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
@@ -1797,7 +1797,7 @@ static bool schedule_uci_on_pusch(NR_UE_MAC_INST_t *mac,
     nfapi_nr_ue_csi_payload_t csi_payload = {0};
     NR_PUSCH_Config_t *pusch_Config = mac->current_UL_BWP->pusch_Config;
     NR_PUCCH_Resource_t *csi_pucch = NULL;
-    nr_get_csi_measurements(mac, frame_tx, slot_tx, &csi_payload, &csi_pucch, true);
+    nr_get_csi_measurements(mac, frame_tx, slot_tx, &csi_payload, &csi_pucch);
     fill_pusch_uci_struct(pusch_Config, &csi_payload, pusch_pdu);
     mux_done = true;
   }
@@ -1837,7 +1837,7 @@ static void nr_ue_pucch_scheduler(NR_UE_MAC_INST_t *mac, frame_t frame, int slot
   // CSI
   int csi_res = 0;
   if (mac->state == UE_CONNECTED)
-    csi_res = nr_get_csi_measurements(mac, frame, slot, &pucch[num_res].csi_payload, &pucch[num_res].pucch_resource, false);
+    csi_res = nr_get_csi_measurements(mac, frame, slot, &pucch[num_res].csi_payload, &pucch[num_res].pucch_resource);
   if (csi_res > 0) {
     num_res += csi_res;
   }


### PR DESCRIPTION
This bug is found when testing with OCUDU gNB over ZMQ when 2x2 MIMO, gNB configured periodic CSI report, when this periodic CSI report is multiplexed with PUSCH, we set `csi_on_pusch` to true, so the code will go to below path:
```
          if (mapping_type == ON_PUSCH) {
            p1_bits = cri_bitlen + ri_bitlen + cqi_bitlen;
            p2_bits = pmi_x1_bitlen + pmi_x2_bitlen;
            temp_payload_1 = (0/*mac->csi_measurements.cri*/ << (cqi_bitlen + ri_bitlen)) |
                             (mac->csirs_measurements.ri << cqi_bitlen) |
                             (mac->csirs_measurements.cqi);
            temp_payload_2 = (mac->csirs_measurements.i1 << pmi_x2_bitlen) |
                             mac->csirs_measurements.i2;
          }
```
which will calculate CSI part1 payload length as 5 bits, while the `else` branch will call `nr_get_csi_bitlen()` to calculate CSI part1 length as 7 bits (which matches gNB and 3rd-party signal analysis software).
The fix is we remove `csi_on_pusch` flag for periodic CSI report handling, so we get same CSI part1 length as OCUDU gNB expected.