### PR TITLE
Fix NGAP/RRC bugs reported by ProFuzzer

### DIFF
--- a/openair2/RRC/NR/MESSAGES/asn1_msg.c
+++ b/openair2/RRC/NR/MESSAGES/asn1_msg.c
@@ -961,12 +961,9 @@ int do_nrMeasurementReport_SA(long trigger_to_measid,
   return ((enc_rval.encoded + 7) / 8);
 }
 
-int do_NR_DLInformationTransfer(uint8_t *buffer,
-                                size_t buffer_len,
-                                uint8_t transaction_id,
-                                uint32_t pdu_length,
-                                uint8_t *pdu_buffer)
+byte_array_t do_NR_DLInformationTransfer(uint8_t transaction_id, uint32_t pdu_length, uint8_t *pdu_buffer)
 {
+  byte_array_t msg = {0};
   NR_DL_DCCH_Message_t dl_dcch_msg = {0};
   dl_dcch_msg.message.present = NR_DL_DCCH_MessageType_PR_c1;
   asn1cCalloc(dl_dcch_msg.message.choice.c1, c1);
@@ -977,18 +974,20 @@ int do_NR_DLInformationTransfer(uint8_t *buffer,
   infoTransfer->criticalExtensions.present = NR_DLInformationTransfer__criticalExtensions_PR_dlInformationTransfer;
 
   asn1cCalloc(infoTransfer->criticalExtensions.choice.dlInformationTransfer, dlInfoTransfer);
-  asn1cCalloc(dlInfoTransfer->dedicatedNAS_Message, msg);
-  // we will free the caller buffer, that is ok in the present code logic (else it will leak memory) but not natural,
-  // comprehensive code design
-  msg->buf = pdu_buffer;
-  msg->size = pdu_length;
+  asn1cCalloc(dlInfoTransfer->dedicatedNAS_Message, nas);
+  /* Takes ownership of pdu_buffer, freed below via ASN_STRUCT_FREE_CONTENTS_ONLY */
+  nas->buf = pdu_buffer;
+  nas->size = pdu_length;
 
-  asn_enc_rval_t r = uper_encode_to_buffer(&asn_DEF_NR_DL_DCCH_Message, NULL, (void *)&dl_dcch_msg, buffer, buffer_len);
-  AssertFatal(r.encoded > 0, "ASN1 message encoding failed (%s, %ld)!\n", "DLInformationTransfer", r.encoded);
+  int val = uper_encode_to_new_buffer(&asn_DEF_NR_DL_DCCH_Message, NULL, &dl_dcch_msg, (void **)&msg.buf);
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NR_DL_DCCH_Message, &dl_dcch_msg);
-  LOG_D(NR_RRC, "DLInformationTransfer Encoded %zd bytes\n", r.encoded);
-  // for (int i=0;i<encoded;i++) printf("%02x ",(*buffer)[i]);
-  return (r.encoded + 7) / 8;
+  if (val <= 0) {
+    LOG_E(NR_RRC, "ASN1 message encoding failed (DLInformationTransfer, %d)!\n", val);
+    return msg;
+  }
+  msg.len = val;
+  LOG_D(NR_RRC, "DLInformationTransfer Encoded %ld bytes\n", msg.len);
+  return msg;
 }
 
 int do_NR_ULInformationTransfer(uint8_t **buffer, uint32_t pdu_length, uint8_t *pdu_buffer)

--- a/openair2/RRC/NR/MESSAGES/asn1_msg.h
+++ b/openair2/RRC/NR/MESSAGES/asn1_msg.h
@@ -126,11 +126,7 @@ int do_NR_RRCReconfigurationComplete_for_nsa(uint8_t *buffer, size_t buffer_size
 
 int do_NR_RRCReconfigurationComplete(uint8_t *buffer, size_t buffer_size, const uint8_t Transaction_id);
 
-int do_NR_DLInformationTransfer(uint8_t *buffer,
-                                size_t buffer_len,
-                                uint8_t transaction_id,
-                                uint32_t pdu_length,
-                                uint8_t *pdu_buffer);
+byte_array_t do_NR_DLInformationTransfer(uint8_t Transaction_id, uint32_t pdu_length, uint8_t *pdu_buffer);
 
 int do_NR_ULInformationTransfer(uint8_t **buffer,
                                 uint32_t pdu_length,

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -1913,16 +1913,20 @@ void rrc_forward_ue_nas_message(gNB_RRC_INST *rrc, gNB_RRC_UE_t *UE)
 
   LOG_UE_DL_EVENT(UE, "Send DL Information Transfer [%ld bytes]\n", UE->nas_pdu.len);
 
-  uint8_t buffer[4096];
   unsigned int xid = rrc_gNB_get_next_transaction_identifier(rrc->module_id);
-  uint32_t length = do_NR_DLInformationTransfer(buffer, sizeof(buffer), xid, UE->nas_pdu.len, UE->nas_pdu.buf);
-  LOG_DUMPMSG(NR_RRC, DEBUG_RRC, buffer, length, "[MSG] RRC DL Information Transfer\n");
-  rb_id_t srb_id = UE->Srb[2].Active ? DL_SCH_LCID_DCCH1 : DL_SCH_LCID_DCCH;
-  const uint32_t msg_id = NR_DL_DCCH_MessageType__c1_PR_dlInformationTransfer;
-  nr_rrc_transfer_protected_rrc_message(rrc, UE, srb_id, msg_id, buffer, length);
-  // no need to free UE->nas_pdu.buf, do_NR_DLInformationTransfer() did that
+  byte_array_t msg = do_NR_DLInformationTransfer(xid, UE->nas_pdu.len, UE->nas_pdu.buf);
+  /* do_NR_DLInformationTransfer() takes ownership of the NAS buffer */
   UE->nas_pdu.buf = NULL;
   UE->nas_pdu.len = 0;
+  if (msg.buf == NULL || msg.len <= 0) {
+    LOG_E(NR_RRC, "UE %d: failed to encode DLInformationTransfer\n", UE->rrc_ue_id);
+    return;
+  }
+  LOG_DUMPMSG(NR_RRC, DEBUG_RRC, msg.buf, msg.len, "[MSG] RRC DL Information Transfer\n");
+  rb_id_t srb_id = UE->Srb[2].Active ? DL_SCH_LCID_DCCH1 : DL_SCH_LCID_DCCH;
+  const uint32_t msg_id = NR_DL_DCCH_MessageType__c1_PR_dlInformationTransfer;
+  nr_rrc_transfer_protected_rrc_message(rrc, UE, srb_id, msg_id, msg.buf, msg.len);
+  free_byte_array(msg);
 }
 
 static void handle_ueCapabilityInformation(gNB_RRC_INST *rrc, gNB_RRC_UE_t *UE, const NR_UECapabilityInformation_t *ue_cap_info)

--- a/openair3/NGAP/ngap_gNB_decoder.c
+++ b/openair3/NGAP/ngap_gNB_decoder.c
@@ -104,10 +104,10 @@ static int ngap_gNB_decode_initiating_message(NGAP_NGAP_PDU_t *pdu) {
       break;
 
     default:
+      /* Unknown or wrong-direction initiating procedure: fail closed without
+       * aborting the process (TS 38.413 §10.3.4.1). TODO: Send Error Indication */
       NGAP_ERROR("Unknown procedure ID (%d) for initiating message\n",
                  (int)pdu->choice.initiatingMessage->procedureCode);
-      AssertFatal( 0, "Unknown procedure ID (%d) for initiating message\n",
-                   (int)pdu->choice.initiatingMessage->procedureCode);
       return -1;
   }
 

--- a/openair3/NGAP/ngap_gNB_paging.c
+++ b/openair3/NGAP/ngap_gNB_paging.c
@@ -160,10 +160,10 @@ bool decode_ng_paging(ngap_paging_ind_t *out, const NGAP_NGAP_PDU_t *pdu)
   // TAI List for Paging (M)
   NGAP_FIND_PROTOCOLIE_BY_ID(NGAP_PagingIEs_t, ie, container, NGAP_ProtocolIE_ID_id_TAIListForPaging, true);
 
-  // Validate TAI list count
+  // Validate TAI list count (1..maxnoofTAIforPaging)
   int tai_count = ie->value.choice.TAIListForPaging.list.count;
-  if (tai_count > NGAP_MAX_NO_TAI_PAGING) {
-    NGAP_ERROR("Invalid TAI list count: %d (must be <= %d)\n", tai_count, NGAP_MAX_NO_TAI_PAGING);
+  if (tai_count < 1 || tai_count > NGAP_MAX_NO_TAI_PAGING) {
+    NGAP_ERROR("Invalid TAI list count: %d (must be 1..%d)\n", tai_count, NGAP_MAX_NO_TAI_PAGING);
     return false;
   }
 


### PR DESCRIPTION
ProFuzzer tests identified three confirmed crash paths that allow a remote peer to kill the gNB process with a single SCTP packet.

This PR eliminates all three `AssertFatal`/`DevAssert` DoS crashes. 

Note: NGReset handler, Error Indication remain tracked as follow-up.

# Fixes

- Bug 1: `AssertFatal` on unknown/wrong-direction initiating procedure code
- Bug 2: `AssertFatal` on oversized NAS-PDU in `do_NR_DLInformationTransfer()`
- Bug 3: `DevAssert(n_tai > 0)` on empty `TAIListForPaging`