### PR TITLE
Reorganize MAC stats, make compact, print RSSI

### DIFF
--- a/doc/MAC/mac-usage.md
+++ b/doc/MAC/mac-usage.md
@@ -126,7 +126,7 @@ Example:
 UE RNTI 2460 CU-UE-ID 2 in-sync PH 28 dB PCMAX 24 dBm, average RSRP -74 (8 meas), average SINR 40.0 (32 meas)
 UE 2460: CSI [CQI 15 RI 2 PMI (14,1)] SRS [UL-RI 2 TPMI 0]
 UE 2460: dlsch_rounds 32917/5113/1504/560, dlsch_errors 211, pucch0_DTX 1385 (SNR 19.8+0.2 dB) RSSI -44.2, BLER 0.19557 MCS (1) 23 CCE fail 3
-UE 2460: ulsch_rounds 3756/353/182/179, ulsch_errors 170, ulsch_DTX 285, BLER 0.33021 MCS (1) 27 (Qm 8 deltaMCS 0 dB) NPRB 5 SNR 31.0 (-1.0) dB CCE fail 0
+UE 2460: ulsch_rounds 3756/353/182/179, ulsch_errors 170, ulsch_DTX 285, BLER 0.33021 MCS (1) 27 (Qm 8 deltaMCS 0 dB) NPRB 5 SNR 31.0 (-1.0) dB RSSI -39.8 CCE fail 0
 UE 2460: LCID 1,2,4 goodput DL  120.50 UL   12.30 Mbps
 ```
 
@@ -212,6 +212,7 @@ The third and fourth line show HARQ-related information:
 * ULSCH `SNR`: the current SNR that the gNB receives the UE PUSCH signal with.
   This value should be close to the target SNR; in paranthesis, the difference
   to the target SNR.
+* ULSCH `RSSI`: as for PUCCH. Use `MACRLCs.[0].pusch_RSSI_Threshold` to limit.
 * Both ULSCH/DLSCH `CCE fail`: lists the number of failed CCE attempts. If this
   number gets high, it signifies that the scheduler tried to scheduled this UE,
   but could not allocate the DCI.

--- a/doc/MAC/mac-usage.md
+++ b/doc/MAC/mac-usage.md
@@ -124,8 +124,7 @@ Example:
 
 ```
 UE RNTI 2460 CU-UE-ID 2 in-sync PH 28 dB PCMAX 24 dBm, average RSRP -74 (8 meas), average SINR 40.0 (32 meas)
-UE 2460: CQI 15, RI 2, PMI (14,1)
-UE 2460: UL-RI 2 TPMI 0
+UE 2460: CSI [CQI 15 RI 2 PMI (14,1)] SRS [UL-RI 2 TPMI 0]
 UE 2460: dlsch_rounds 32917/5113/1504/560, dlsch_errors 211, pucch0_DTX 1385 (SNR 19.8+0.2 dB), BLER 0.19557 MCS (1) 23 CCE fail 3, goodput 120.50 Mbps
 UE 2460: ulsch_rounds 3756/353/182/179, ulsch_errors 170, ulsch_DTX 285, BLER 0.33021 MCS (1) 27 (Qm 8 deltaMCS 0 dB) NPRB 5 SNR 31.0 (-1.0) dB CCE fail 0, goodput 12.30 Mbps
 UE 2460: LCID 1: TX            651 RX           3031 bytes
@@ -151,7 +150,7 @@ In the first line,
 * `SINR` (`40.0`): measured signal to interference and noise ratio of the SSB
   received at the UE. Maximum value that can be reported by the UE is 40.0 dB.
 
-The second and third line reflect channel state information (CSI) as
+The second line reflects channel state information (CSI) as
 reported by the UE, and only appear if CSI-RS/SRS are enabled and _received_
 (for some bands, they cannot be enabled):
 
@@ -166,7 +165,7 @@ reported by the UE, and only appear if CSI-RS/SRS are enabled and _received_
   around quickly. It can jump when objects move around the UE
 * `UL-RI`, `TPMI`: same as DL.
 
-The fourth and fifth line show HARQ-related information:
+The third and fourth line show HARQ-related information:
 
 * `dlsch_rounds A/B/C/D` (`32917/5113/1504/560`). This is the number of
   transmissions by the gNB for each round of the HARQ protocol. `A` is the first

--- a/doc/MAC/mac-usage.md
+++ b/doc/MAC/mac-usage.md
@@ -125,7 +125,7 @@ Example:
 ```
 UE RNTI 2460 CU-UE-ID 2 in-sync PH 28 dB PCMAX 24 dBm, average RSRP -74 (8 meas), average SINR 40.0 (32 meas)
 UE 2460: CSI [CQI 15 RI 2 PMI (14,1)] SRS [UL-RI 2 TPMI 0]
-UE 2460: dlsch_rounds 32917/5113/1504/560, dlsch_errors 211, pucch0_DTX 1385 (SNR 19.8+0.2 dB), BLER 0.19557 MCS (1) 23 CCE fail 3
+UE 2460: dlsch_rounds 32917/5113/1504/560, dlsch_errors 211, pucch0_DTX 1385 (SNR 19.8+0.2 dB) RSSI -44.2, BLER 0.19557 MCS (1) 23 CCE fail 3
 UE 2460: ulsch_rounds 3756/353/182/179, ulsch_errors 170, ulsch_DTX 285, BLER 0.33021 MCS (1) 27 (Qm 8 deltaMCS 0 dB) NPRB 5 SNR 31.0 (-1.0) dB CCE fail 0
 UE 2460: LCID 1,2,4 goodput DL  120.50 UL   12.30 Mbps
 ```
@@ -182,6 +182,10 @@ The third and fourth line show HARQ-related information:
   `dlsch_rounds`.
 * `(SNR x+y dB)`: PUCCH SNR where `x` is the average PUCCH SNR and `y` the
   difference to the target (positive: above SNR, negative: below)
+* PUCCH `RSSI`: the received signal strength indicator, either in dBm or dBFs.
+  For OAI L1, this is in dBFs, and a value below -20 should be present to avoid
+  clipping of input signal. If it is higher, use
+  `MACRLCs.[0].pucch_RSSI_Threshold` to limit TPC and therefore RSSI.
 * `DLSCH BLER` is the current measured block-error rate of the DLSCH. Basically
   a moving average of `B`/`A` in `dlsch_rounds`. This is something that should always
   be close to the target bler that the MAC scheduler uses. typically 10-30% if

--- a/doc/MAC/mac-usage.md
+++ b/doc/MAC/mac-usage.md
@@ -125,11 +125,9 @@ Example:
 ```
 UE RNTI 2460 CU-UE-ID 2 in-sync PH 28 dB PCMAX 24 dBm, average RSRP -74 (8 meas), average SINR 40.0 (32 meas)
 UE 2460: CSI [CQI 15 RI 2 PMI (14,1)] SRS [UL-RI 2 TPMI 0]
-UE 2460: dlsch_rounds 32917/5113/1504/560, dlsch_errors 211, pucch0_DTX 1385 (SNR 19.8+0.2 dB), BLER 0.19557 MCS (1) 23 CCE fail 3, goodput 120.50 Mbps
-UE 2460: ulsch_rounds 3756/353/182/179, ulsch_errors 170, ulsch_DTX 285, BLER 0.33021 MCS (1) 27 (Qm 8 deltaMCS 0 dB) NPRB 5 SNR 31.0 (-1.0) dB CCE fail 0, goodput 12.30 Mbps
-UE 2460: LCID 1: TX            651 RX           3031 bytes
-UE 2460: LCID 2: TX              0 RX              0 bytes
-UE 2460: LCID 4: TX     1526169592 RX          16152 bytes
+UE 2460: dlsch_rounds 32917/5113/1504/560, dlsch_errors 211, pucch0_DTX 1385 (SNR 19.8+0.2 dB), BLER 0.19557 MCS (1) 23 CCE fail 3
+UE 2460: ulsch_rounds 3756/353/182/179, ulsch_errors 170, ulsch_DTX 285, BLER 0.33021 MCS (1) 27 (Qm 8 deltaMCS 0 dB) NPRB 5 SNR 31.0 (-1.0) dB CCE fail 0
+UE 2460: LCID 1,2,4 goodput DL  120.50 UL   12.30 Mbps
 ```
 
 In the first line,
@@ -213,15 +211,13 @@ The third and fourth line show HARQ-related information:
 * Both ULSCH/DLSCH `CCE fail`: lists the number of failed CCE attempts. If this
   number gets high, it signifies that the scheduler tried to scheduled this UE,
   but could not allocate the DCI.
-* Both ULSCH/DLSCH `goodput`: smoothed (EWMA) goodput in Mbps, reflecting the
-  actual MAC-layer throughput achieved by the UE.
 
-In the last lines:
+In the last line:
 
-* `LCID X` shows the amount of MAC SDU/RLC PDU data for Logical Channel ID with
-  ID `X` in transmit and receive directions. LCIDs 1 and 2 are mapped to SRBs 1
-  and 2. LCIDs 4 and onward are mapped to DRBs 1 onward. If you have an LCID 4,
-  it means you have a PDU session.
+* `MAC goodput` for `DL` and `UL`: smoothed (EWMA) goodput in Mbps, reflecting
+  the actual MAC-layer throughput achieved by the UE excluding retransmissions,
+  i.e., only counting the amount of "new data". This might be much lower than
+  the maximum throughput if there are many retransmissions.
 
 ## Configuration of the MAC
 

--- a/openair1/PHY/NR_TRANSPORT/pucch_rx.c
+++ b/openair1/PHY/NR_TRANSPORT/pucch_rx.c
@@ -374,7 +374,7 @@ void nr_decode_pucch0(PHY_VARS_gNB *gNB,
   uci_pdu->rnti = pucch_pdu->rnti;
   uci_pdu->ul_cqi = cqi;
   uci_pdu->timing_advance = 0xffff; // currently not valid
-  uci_pdu->rssi = 1280 - (10 * dB_fixed(32767 * 32767) - dB_fixed_times10(signal_energy_ant0));
+  uci_pdu->rssi = 1280 - (10 * dB_fixed(32767 * 32767) - dB_fixed_times10(signal_energy));
 
   if (pucch_pdu->bit_len_harq == 0) {
     uci_pdu->sr.sr_confidence_level = SNRtimes10 < gNB->pucch0_thres;

--- a/openair1/SCHED_NR/phy_procedures_nr_gNB.c
+++ b/openair1/SCHED_NR/phy_procedures_nr_gNB.c
@@ -474,7 +474,9 @@ static void nr_fill_indication(const PHY_VARS_gNB *gNB,
   crc->ul_cqi = cqi;
   crc->timing_advance = timing_advance_update;
   // in terms of dBFS range -128 to 0 with 0.1 step
-  crc->rssi = (dtx_flag == 0) ? 1280 - (10 * dB_fixed(32767 * 32767) - dB_fixed_times10(pusch->ulsch_power[0])) : 0;
+  int n_rx = pusch_pdu->param_v4.numSpatialStreamIndices;
+  uint16_t rssi = 1280 - (10 * dB_fixed(32767 * 32767) - dB_fixed_times10(pusch->ulsch_power_tot / n_rx));
+  crc->rssi = (dtx_flag == 0) ? rssi : 0;
 
   pdu->handle = pusch_pdu->handle;
   pdu->rnti = pusch_pdu->rnti;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -4394,6 +4394,12 @@ float nr_mac_get_snr(const nr_power_control_t *pc)
   return pc->avg_snr + pc->tpc_in_flight;
 }
 
+float nr_mac_get_rssi(const nr_power_control_t *pc)
+{
+  // in FAPI scale: convert to dBm/dBFs
+  return pc->avg_rssi / 10.f - 128.f;
+}
+
 /**
  * @brief Calculates the difference of current average SNR to the target SNR
  * set in the power control loop.

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -2407,10 +2407,21 @@ static int collect_ul_candidates(gNB_MAC_INST *mac,
                                  int sched_slot)
 {
   int numUE = 0;
+  const frame_structure_t *fs = &mac->frame_structure;
+  const float ul_slots_per_s = (float)get_ul_slots_per_period(fs) / fs->numb_slots_period * fs->numb_slots_frame * 100;
 
   UE_iterator (UE_list, UE) {
     if (numUE >= max_candidates)
       break;
+
+    /* Per-slot UL goodput EWMA (bps) — update once per DL slot, called for up
+     * to every UL slot. current_bytes was set by the previous slot's dispatch.
+     * Slow EWMA (alpha=0.001) for stable display. */
+    NR_mac_dir_stats_t *stats = &UE->mac_stats.ul;
+    float instant_bps = (float)stats->current_bytes * 8.0f * ul_slots_per_s;
+    UE->ul_thr_ue = (1 - 0.01f) * UE->ul_thr_ue + 0.01f * instant_bps;
+    UE->ul_thr_ue_display = (1 - 0.001f) * UE->ul_thr_ue_display + 0.001f * instant_bps;
+    stats->current_bytes = 0;
 
     NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
     if (!nr_mac_ue_is_active(UE))
@@ -2418,7 +2429,6 @@ static int collect_ul_candidates(gNB_MAC_INST *mac,
 
     LOG_D(NR_MAC, "collect_ul_candidates: preparing UL scheduling for UE %04x\n", UE->rnti);
     NR_UE_UL_BWP_t *current_BWP = &UE->current_UL_BWP;
-    NR_mac_dir_stats_t *stats = &UE->mac_stats.ul;
     stats->current_rbs = 0;
 
     bwp_info_t bi = get_pusch_bwp_start_size(UE);
@@ -2552,17 +2562,6 @@ void nr_ulsch_preprocessor(gNB_MAC_INST *nr_mac, post_process_pusch_t *pp_pusch)
    * might starve HARQ processes that need a retransmission in a specific slot
    * but we might not necessarily reach it */
   bool last_dl = (current.s % fs->numb_slots_period) == (fs->period_cfg.num_dl_slots - 1);
-  /* Per-slot UL goodput EWMA (bps) — update once per DL slot, before the scheduling loop.
-   * current_bytes was set by the previous slot's dispatch.
-   * Fast EWMA (alpha=0.01) for PF scheduling, slow (alpha=0.001) for stable display. */
-  const float dl_slots_per_s = (float)get_dl_slots_per_period(fs) / fs->numb_slots_period * fs->numb_slots_frame * 100;
-  UE_iterator (nr_mac->UE_info.connected_ue_list, UE) {
-    NR_mac_dir_stats_t *stats = &UE->mac_stats.ul;
-    float instant_bps = (float)stats->current_bytes * 8.0f * dl_slots_per_s;
-    UE->ul_thr_ue = (1 - 0.01f) * UE->ul_thr_ue + 0.01f * instant_bps;
-    UE->ul_thr_ue_display = (1 - 0.001f) * UE->ul_thr_ue_display + 0.001f * instant_bps;
-    stats->current_bytes = 0;
-  }
 
   fsn_t *next = &nr_mac->ul_next;
   while (max_dci > 0) {

--- a/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
@@ -563,6 +563,7 @@ void post_process_ulsch(gNB_MAC_INST *nr_mac,
                         int sched_srs);
 
 float nr_mac_get_snr(const nr_power_control_t *pc);
+float nr_mac_get_rssi(const nr_power_control_t *pc);
 void nr_mac_pc_snr(nr_power_control_t *pc, int snrx10, int rssi);
 void nr_mac_pc_reset_snr(nr_power_control_t *pc, int snrx10, int rssi);
 void nr_mac_set_target_snrx10(nr_power_control_t *pc, int target_snrx10);

--- a/openair2/LAYER2/NR_MAC_gNB/main.c
+++ b/openair2/LAYER2/NR_MAC_gNB/main.c
@@ -83,12 +83,6 @@ void *nrmac_stats_thread(void *arg) {
   return NULL;
 }
 
-void clear_mac_stats(gNB_MAC_INST *gNB) {
-  UE_iterator(gNB->UE_info.connected_ue_list, UE) {
-    memset(&UE->mac_stats,0,sizeof(UE->mac_stats));
-  }
-}
-
 static char *st_append(char *start, const char *end, const char *format, ...)
 {
   size_t space = end - start;

--- a/openair2/LAYER2/NR_MAC_gNB/main.c
+++ b/openair2/LAYER2/NR_MAC_gNB/main.c
@@ -165,7 +165,7 @@ size_t dump_mac_stats(gNB_MAC_INST *gNB, char *output, size_t strlen, bool reset
     output = st_append(output,
                        end,
                        ", dlsch_errors %" PRIu64
-                       ", pucch0_DTX %d (SNR %.1f%+.1f dB), BLER %.5f MCS (%d) %d CCE fail %d, goodput %.2f Mbps\n",
+                       ", pucch0_DTX %d (SNR %.1f%+.1f dB), BLER %.5f MCS (%d) %d CCE fail %d\n",
                        stats->dl.errors,
                        stats->pucch0_DTX,
                        pucch_snr,
@@ -173,8 +173,7 @@ size_t dump_mac_stats(gNB_MAC_INST *gNB, char *output, size_t strlen, bool reset
                        sched_ctrl->dl_bler_stats.bler,
                        UE->current_DL_BWP.mcsTableIdx,
                        sched_ctrl->dl_bler_stats.mcs,
-                       sched_ctrl->dl_cce_fail,
-                       UE->dl_thr_ue_display / 1e6);
+                       sched_ctrl->dl_cce_fail);
     if (reset_rsrp) {
       stats->num_rsrp_meas = 0;
       stats->cumul_rsrp = 0;
@@ -194,7 +193,7 @@ size_t dump_mac_stats(gNB_MAC_INST *gNB, char *output, size_t strlen, bool reset
         output,
         end,
         ", ulsch_errors %" PRIu64
-        ", ulsch_DTX %d, BLER %.5f MCS (%d) %d (Qm %d deltaMCS %d dB) NPRB %d SNR %.1f (%+.1f) dB CCE fail %d, goodput %.2f Mbps\n",
+        ", ulsch_DTX %d, BLER %.5f MCS (%d) %d (Qm %d deltaMCS %d dB) NPRB %d SNR %.1f (%+.1f) dB CCE fail %d\n",
         stats->ul.errors,
         stats->ulsch_DTX,
         sched_ctrl->ul_bler_stats.bler,
@@ -205,19 +204,17 @@ size_t dump_mac_stats(gNB_MAC_INST *gNB, char *output, size_t strlen, bool reset
         UE->mac_stats.NPRB,
         snr,
         diff_target,
-        sched_ctrl->ul_cce_fail,
-        UE->ul_thr_ue_display / 1e6);
+        sched_ctrl->ul_cce_fail);
 
-    for (int i = 0; i < seq_arr_size(&sched_ctrl->lc_config); i++) {
+    // UE always has LCID 1 for SRB 1
+    output = st_append(output, end, "UE %04x: LCIDs 1", UE->rnti);
+    for (int i = 1; i < seq_arr_size(&sched_ctrl->lc_config); i++) {
       const nr_lc_config_t *c = seq_arr_at(&sched_ctrl->lc_config, i);
-      output = st_append(output,
-                         end,
-                         "UE %04x: LCID %d: TX %14"PRIu64" RX %14"PRIu64" bytes\n",
-                         UE->rnti,
-                         c->lcid,
-                         stats->dl.lc_bytes[c->lcid],
-                         stats->ul.lc_bytes[c->lcid]);
+      output = st_append(output, end, ",%d", c->lcid);
     }
+    float dl_thr = UE->dl_thr_ue_display / 1e6;
+    float ul_thr = UE->ul_thr_ue_display / 1e6;
+    output = st_append(output, end, " goodput DL %7.2f UL %7.2f Mbps\n",  dl_thr, ul_thr);
   }
   DevAssert(output <= end);
   return output - begin;

--- a/openair2/LAYER2/NR_MAC_gNB/main.c
+++ b/openair2/LAYER2/NR_MAC_gNB/main.c
@@ -190,12 +190,13 @@ size_t dump_mac_stats(gNB_MAC_INST *gNB, char *output, size_t strlen, bool reset
       output = st_append(output, end, "/%"PRIu64, stats->ul.rounds[i]);
 
     float snr = nr_mac_get_snr(&sched_ctrl->pusch_pc);
+    float rssi = nr_mac_get_rssi(&sched_ctrl->pusch_pc);
     float diff_target = (snr * 10.0f - sched_ctrl->pusch_pc.target_snrx10) / 10.0f;
     output = st_append(
         output,
         end,
         ", ulsch_errors %" PRIu64
-        ", ulsch_DTX %d, BLER %.5f MCS (%d) %d (Qm %d deltaMCS %d dB) NPRB %d SNR %.1f (%+.1f) dB CCE fail %d\n",
+        ", ulsch_DTX %d, BLER %.5f MCS (%d) %d (Qm %d deltaMCS %d dB) NPRB %d SNR %.1f (%+.1f) dB RSSI %.1f dBm CCE fail %d\n",
         stats->ul.errors,
         stats->ulsch_DTX,
         sched_ctrl->ul_bler_stats.bler,
@@ -206,6 +207,7 @@ size_t dump_mac_stats(gNB_MAC_INST *gNB, char *output, size_t strlen, bool reset
         UE->mac_stats.NPRB,
         snr,
         diff_target,
+        rssi,
         sched_ctrl->ul_cce_fail);
 
     // UE always has LCID 1 for SRB 1

--- a/openair2/LAYER2/NR_MAC_gNB/main.c
+++ b/openair2/LAYER2/NR_MAC_gNB/main.c
@@ -141,18 +141,16 @@ size_t dump_mac_stats(gNB_MAC_INST *gNB, char *output, size_t strlen, bool reset
 
     output = st_append(output, end, "\n");
 
-    if(sched_ctrl->CSI_report.cri_ri_li_pmi_cqi_report.print_report)
-      output = st_append(output,
-                         end,
-                         "UE %04x: CQI %d, RI %d, PMI (%d,%d)\n",
-                         UE->rnti,
-                         sched_ctrl->CSI_report.cri_ri_li_pmi_cqi_report.wb_cqi_1tb,
-                         sched_ctrl->CSI_report.cri_ri_li_pmi_cqi_report.ri+1,
-                         sched_ctrl->CSI_report.cri_ri_li_pmi_cqi_report.pmi_x1,
-                         sched_ctrl->CSI_report.cri_ri_li_pmi_cqi_report.pmi_x2);
-
-    if (stats->srs_stats[0] != '\0') {
-      output = st_append(output, end, "UE %04x: %s\n", UE->rnti, stats->srs_stats);
+    bool csirep = sched_ctrl->CSI_report.cri_ri_li_pmi_cqi_report.print_report;
+    bool srsrep = stats->srs_stats[0] != '\0';
+    if(csirep || srsrep) {
+      output = st_append(output, end, "UE %04x:", UE->rnti);
+      const struct CRI_RI_LI_PMI_CQI *r = &sched_ctrl->CSI_report.cri_ri_li_pmi_cqi_report;
+      if (csirep)
+        output = st_append(output, end, " CSI [CQI %d RI %d PMI (%d,%d)]", r->wb_cqi_1tb, r->ri + 1, r->pmi_x1, r->pmi_x2);
+      if (srsrep)
+        output = st_append(output, end, " SRS [%s]", stats->srs_stats);
+      output = st_append(output, end, "\n");
     }
 
     output = st_append(output,

--- a/openair2/LAYER2/NR_MAC_gNB/main.c
+++ b/openair2/LAYER2/NR_MAC_gNB/main.c
@@ -162,14 +162,16 @@ size_t dump_mac_stats(gNB_MAC_INST *gNB, char *output, size_t strlen, bool reset
 
     float pucch_snr = nr_mac_get_snr(&sched_ctrl->pucch_pc);
     float pucch_snr_diff = (pucch_snr * 10.0f - sched_ctrl->pucch_pc.target_snrx10) / 10.0f;
+    float pucch_rssi = nr_mac_get_rssi(&sched_ctrl->pucch_pc);
     output = st_append(output,
                        end,
                        ", dlsch_errors %" PRIu64
-                       ", pucch0_DTX %d (SNR %.1f%+.1f dB), BLER %.5f MCS (%d) %d CCE fail %d\n",
+                       ", pucch0_DTX %d (SNR %.1f%+.1f dB) RSSI %.1f, BLER %.5f MCS (%d) %d CCE fail %d\n",
                        stats->dl.errors,
                        stats->pucch0_DTX,
                        pucch_snr,
                        pucch_snr_diff,
+                       pucch_rssi,
                        sched_ctrl->dl_bler_stats.bler,
                        UE->current_DL_BWP.mcsTableIdx,
                        sched_ctrl->dl_bler_stats.mcs,


### PR DESCRIPTION
- Show the goodput in a separate line and get rid of absolute LCID byte counters
- Show DL/UL channel quality indicators (CQI/SRS) in a single line
- Show RSSI