### PR TITLE
Beamforming on O-RU

### DIFF
--- a/executables/nr-oru.c
+++ b/executables/nr-oru.c
@@ -456,6 +456,17 @@ static void dl_symbol_process(ORU_t *oru, int frame, int slot, int symbol, c16_t
   dl_symbol_completed(oru, abs_symbol);
 }
 
+static void set_dl_symbol_beam_ids(RU_t *ru, int slot, int symbol, const uint16_t *beam_ids)
+{
+  if (!ru->common.beam_id || !beam_ids)
+    return;
+
+  NR_DL_FRAME_PARMS *fp = ru->nr_frame_parms;
+  int symbol_in_frame = slot * fp->symbols_per_slot + symbol;
+  for (int aatx = 0; aatx < ru->nb_tx; aatx++)
+    ru->common.beam_id[symbol_in_frame][aatx] = beam_ids[aatx];
+}
+
 static pthread_mutex_t south_read_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t south_read_cond = PTHREAD_COND_INITIALIZER;
 static bool south_read_ready = false;
@@ -541,7 +552,8 @@ void *oru_north_read_worker(void *arg)
   while (!oai_exit) {
     int frame = -1, slot = -1, symbol = -1;
     uint64_t hyper_frame;
-    int ret = oru_fh_tx_read_symbol(oru->fronthaul, (uint32_t **)txDataF_ptr, ru->nb_tx, &hyper_frame, &frame, &slot, &symbol);
+    uint16_t beam_ids[ru->nb_tx];
+    int ret = oru_fh_tx_read_symbol(oru->fronthaul, (uint32_t **)txDataF_ptr, ru->nb_tx, &hyper_frame, &frame, &slot, &symbol, beam_ids);
     if (ret != 0) {
       LOG_E(PHY, "[RU_thread] read data error: frame %d, slot %d, symbol %d\n", frame, slot, symbol);
       continue;
@@ -555,6 +567,7 @@ void *oru_north_read_worker(void *arg)
     if (timestamp < 0) {
       continue;
     }
+    set_dl_symbol_beam_ids(ru, slot, symbol, beam_ids);
     uint64_t abs_symbol = num_frames * (fp->slots_per_frame * fp->symbols_per_slot) + slot * fp->symbols_per_slot + symbol;
     dl_symbol_process(oru, frame, slot, symbol, txDataF_ptr, timestamp, abs_symbol);
     if (frame % 256 == 0 && slot == 0 && symbol == 0) {

--- a/executables/nr-oru.c
+++ b/executables/nr-oru.c
@@ -31,6 +31,9 @@
 #define CONFIG_STRING_ORU_NUM_UL_SLOTS "num_ul_slots"
 #define CONFIG_STRING_ORU_NUM_DL_SYMBOLS "num_dl_symbols"
 #define CONFIG_STRING_ORU_NUM_UL_SYMBOLS "num_ul_symbols"
+#define CONFIG_STRING_NB_FH_STREAMS "nb_fh_streams"
+#define CONFIG_STRING_CODEBOOK_NB_BEAMS "codebook_nb_beams"
+#define CONFIG_STRING_CODEBOOK_WEIGHTS "codebook_weights"
 #define CONFIG_STRING_ORU_TX_CORE "tx_core"
 #define CONFIG_STRING_ORU_NUM_DL_THREADS "num_dl_threads"
 
@@ -47,6 +50,9 @@
 #define HLP_ORU_NUM_UL_SLOTS "set the number of UL Slots in TDD"
 #define HLP_ORU_NUM_DL_SYMBOLS "set the number of DL symbols in the mixed slot"
 #define HLP_ORU_NUM_UL_SYMBOLS "set the number of UL symbols in the mixed slot"
+#define HLP_NB_FH_STREAMS "number of fronthaul streams from DU (0=passthrough, enables codebook beamforming when > 0)"
+#define HLP_CODEBOOK_NB_BEAMS "number of beams in the O-RU codebook"
+#define HLP_CODEBOOK_WEIGHTS "Q15 codebook weights: nb_beams * nb_tx * nb_fh_streams interleaved Re/Im pairs"
 #define HLP_ORU_THREEQUARTER_FS "set the 3/4 sampling frequency"
 
 // clang-format off
@@ -65,6 +71,9 @@
   {CONFIG_STRING_ORU_NUM_UL_SLOTS,              HLP_ORU_NUM_UL_SLOTS,               0,    .uptr=NULL,       .defintval=1,                 TYPE_UINT,         0}, \
   {CONFIG_STRING_ORU_NUM_DL_SYMBOLS,            HLP_ORU_NUM_DL_SYMBOLS,             0,    .uptr=NULL,       .defintval=7,                 TYPE_UINT,         0}, \
   {CONFIG_STRING_ORU_NUM_UL_SYMBOLS,            HLP_ORU_NUM_UL_SYMBOLS,             0,    .uptr=NULL,       .defintval=3,                 TYPE_UINT,         0}, \
+  {CONFIG_STRING_NB_FH_STREAMS,                 HLP_NB_FH_STREAMS,                  0,    .iptr=NULL,       .defintval=0,                 TYPE_INT,          0}, \
+  {CONFIG_STRING_CODEBOOK_NB_BEAMS,             HLP_CODEBOOK_NB_BEAMS,              0,    .iptr=NULL,       .defintval=0,                 TYPE_INT,          0}, \
+  {CONFIG_STRING_CODEBOOK_WEIGHTS,              HLP_CODEBOOK_WEIGHTS,               0,    .iptr=NULL,       .defintarrayval=NULL,          TYPE_INTARRAY,     0}, \
   {CONFIG_STRING_ORU_TX_CORE,                   "The CPU core to be used to deploy south write thread for O-RU.", 0, .iptr=NULL, .defintval=-1, TYPE_INT, 0}, \
   {CONFIG_STRING_ORU_NUM_DL_THREADS,            "Number of parallel DL reader threads for O-RU.", 0, .iptr=NULL, .defintval=1, TYPE_INT, 0}, \
 }
@@ -229,6 +238,49 @@ int get_oru_options(ORU_t *oru)
   oru->num_UL_slots = *gpd(param, nump, CONFIG_STRING_ORU_NUM_UL_SLOTS)->iptr;
   oru->num_DL_symbols = *gpd(param, nump, CONFIG_STRING_ORU_NUM_DL_SYMBOLS)->iptr;
   oru->num_UL_symbols = *gpd(param, nump, CONFIG_STRING_ORU_NUM_UL_SYMBOLS)->iptr;
+  oru->codebook.nb_fh_streams = *gpd(param, nump, CONFIG_STRING_NB_FH_STREAMS)->iptr;
+  oru->codebook.nb_beams = *gpd(param, nump, CONFIG_STRING_CODEBOOK_NB_BEAMS)->iptr;
+  AssertFatal(oru->codebook.nb_fh_streams >= 0, "nb_fh_streams %d must be non-negative\n", oru->codebook.nb_fh_streams);
+  if (oru->codebook.nb_fh_streams > 0) {
+    AssertFatal(oru->codebook.nb_fh_streams <= ORU_CODEBOOK_MAX_STREAMS,
+                "nb_fh_streams %d exceeds maximum %d\n",
+                oru->codebook.nb_fh_streams,
+                ORU_CODEBOOK_MAX_STREAMS);
+    AssertFatal(oru->codebook.nb_beams > 0 && oru->codebook.nb_beams <= ORU_CODEBOOK_MAX_BEAMS,
+                "codebook_nb_beams %d invalid (range 1..%d)\n",
+                oru->codebook.nb_beams,
+                ORU_CODEBOOK_MAX_BEAMS);
+    AssertFatal(oru->ru->nb_tx <= ORU_CODEBOOK_MAX_NB_TX, "nb_tx %d exceeds maximum %d\n", oru->ru->nb_tx, ORU_CODEBOOK_MAX_NB_TX);
+    AssertFatal(oru->codebook.nb_fh_streams <= oru->ru->nb_tx,
+                "nb_fh_streams %d must not exceed nb_tx %d\n",
+                oru->codebook.nb_fh_streams,
+                oru->ru->nb_tx);
+    paramdef_t *wgt = gpd(param, nump, CONFIG_STRING_CODEBOOK_WEIGHTS);
+    int expected = oru->codebook.nb_beams * oru->ru->nb_tx * oru->codebook.nb_fh_streams * 2;
+    AssertFatal(wgt->numelt == expected,
+                "codebook_weights: expected %d elements (nb_beams=%d * nb_tx=%d * nb_fh_streams=%d * 2)\n",
+                expected,
+                oru->codebook.nb_beams,
+                oru->ru->nb_tx,
+                oru->codebook.nb_fh_streams);
+    int idx = 0;
+    for (int b = 0; b < oru->codebook.nb_beams; b++)
+      for (int t = 0; t < oru->ru->nb_tx; t++)
+        for (int s = 0; s < oru->codebook.nb_fh_streams; s++) {
+          AssertFatal(wgt->iptr[idx] >= INT16_MIN && wgt->iptr[idx] <= INT16_MAX,
+                      "codebook_weights[%d] value %d out of Q15 range\n", idx, wgt->iptr[idx]);
+          oru->codebook.w[b][t][s].r = (int16_t)wgt->iptr[idx++];
+          AssertFatal(wgt->iptr[idx] >= INT16_MIN && wgt->iptr[idx] <= INT16_MAX,
+                      "codebook_weights[%d] value %d out of Q15 range\n", idx, wgt->iptr[idx]);
+          oru->codebook.w[b][t][s].i = (int16_t)wgt->iptr[idx++];
+        }
+    LOG_I(NR_PHY,
+          "Codebook beamforming enabled: nb_fh_streams=%d nb_beams=%d nb_tx=%d\n",
+          oru->codebook.nb_fh_streams,
+          oru->codebook.nb_beams,
+          oru->ru->nb_tx);
+  }
+
   oru->tx_write.core = *gpd(param, nump, CONFIG_STRING_ORU_TX_CORE)->iptr;
   oru->num_dl_read_threads = *gpd(param, nump, CONFIG_STRING_ORU_NUM_DL_THREADS)->iptr;
   AssertFatal(oru->num_dl_read_threads > 0 && oru->num_dl_read_threads <= MAX_DL_READ_THREADS,
@@ -467,6 +519,48 @@ static void set_dl_symbol_beam_ids(RU_t *ru, int slot, int symbol, const uint16_
     ru->common.beam_id[symbol_in_frame][aatx] = beam_ids[aatx];
 }
 
+static int16_t saturate_int16(int32_t value)
+{
+  if (value > INT16_MAX)
+    return INT16_MAX;
+  if (value < INT16_MIN)
+    return INT16_MIN;
+  return (int16_t)value;
+}
+
+static void apply_codebook_weights(const c16_t **fh_in,
+                                   c16_t **tx_out,
+                                   int nb_tx,
+                                   int nb_fh,
+                                   int n_re,
+                                   const oru_codebook_t *cb,
+                                   uint16_t beam_id)
+{
+  int bidx;
+  if (beam_id < (uint16_t)cb->nb_beams) {
+    bidx = beam_id;
+  } else {
+    LOG_W(PHY, "beam_id %u out of range (nb_beams=%d), falling back to beam 0\n", beam_id, cb->nb_beams);
+    bidx = 0;
+  }
+  c32_t acc[n_re];
+  for (int txru = 0; txru < nb_tx; txru++) {
+    memset(acc, 0, sizeof(acc));
+    for (int s = 0; s < nb_fh; s++) {
+      c16_t w = cb->w[bidx][txru][s];
+      for (int re = 0; re < n_re; re++) {
+        c16_t term = c16mulShift(fh_in[s][re], w, 15);
+        acc[re].r += term.r;
+        acc[re].i += term.i;
+      }
+    }
+    for (int re = 0; re < n_re; re++) {
+      tx_out[txru][re].r = saturate_int16(acc[re].r);
+      tx_out[txru][re].i = saturate_int16(acc[re].i);
+    }
+  }
+}
+
 static pthread_mutex_t south_read_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t south_read_cond = PTHREAD_COND_INITIALIZER;
 static bool south_read_ready = false;
@@ -514,11 +608,23 @@ void *oru_north_read_worker(void *arg)
   RU_t *ru = (RU_t *)oru->ru;
   NR_DL_FRAME_PARMS *fp = ru->nr_frame_parms;
 
+  const int nb_fh = (oru->codebook.nb_fh_streams > 0) ? oru->codebook.nb_fh_streams : ru->nb_tx;
+
   __attribute__((aligned(64))) c16_t txDataF[ru->nb_tx][fp->N_RB_DL * NR_NB_SC_PER_RB];
   memset(txDataF, 0, sizeof(txDataF));
   c16_t *txDataF_ptr[ru->nb_tx];
-  for (int aatx = 0; aatx < ru->nb_tx; aatx++) {
+  for (int aatx = 0; aatx < ru->nb_tx; aatx++)
     txDataF_ptr[aatx] = txDataF[aatx];
+
+  __attribute__((aligned(64))) c16_t txDataF_fh_buf[nb_fh][fp->N_RB_DL * NR_NB_SC_PER_RB];
+  c16_t *txDataF_fh_ptr[nb_fh];
+  if (oru->codebook.nb_fh_streams > 0) {
+    memset(txDataF_fh_buf, 0, sizeof(txDataF_fh_buf));
+    for (int i = 0; i < nb_fh; i++)
+      txDataF_fh_ptr[i] = txDataF_fh_buf[i];
+  } else {
+    for (int i = 0; i < nb_fh; i++)
+      txDataF_fh_ptr[i] = txDataF_ptr[i];
   }
   uint32_t start_frame, start_slot;
   uint64_t start_hyper_frame;
@@ -553,11 +659,14 @@ void *oru_north_read_worker(void *arg)
     int frame = -1, slot = -1, symbol = -1;
     uint64_t hyper_frame;
     uint16_t beam_ids[ru->nb_tx];
-    int ret = oru_fh_tx_read_symbol(oru->fronthaul, (uint32_t **)txDataF_ptr, ru->nb_tx, &hyper_frame, &frame, &slot, &symbol, beam_ids);
+    int ret =
+        oru_fh_tx_read_symbol(oru->fronthaul, (uint32_t **)txDataF_fh_ptr, nb_fh, &hyper_frame, &frame, &slot, &symbol, beam_ids);
     if (ret != 0) {
       LOG_E(PHY, "[RU_thread] read data error: frame %d, slot %d, symbol %d\n", frame, slot, symbol);
       continue;
     }
+    for (int i = nb_fh; i < ru->nb_tx; i++)
+      beam_ids[i] = beam_ids[0];
     if (start_hyper_frame > hyper_frame) {
       continue;
     }
@@ -568,6 +677,14 @@ void *oru_north_read_worker(void *arg)
       continue;
     }
     set_dl_symbol_beam_ids(ru, slot, symbol, beam_ids);
+    if (oru->codebook.nb_fh_streams > 0)
+      apply_codebook_weights((const c16_t **)txDataF_fh_ptr,
+                             txDataF_ptr,
+                             ru->nb_tx,
+                             nb_fh,
+                             fp->N_RB_DL * NR_NB_SC_PER_RB,
+                             &oru->codebook,
+                             beam_ids[0]);
     uint64_t abs_symbol = num_frames * (fp->slots_per_frame * fp->symbols_per_slot) + slot * fp->symbols_per_slot + symbol;
     dl_symbol_process(oru, frame, slot, symbol, txDataF_ptr, timestamp, abs_symbol);
     if (frame % 256 == 0 && slot == 0 && symbol == 0) {

--- a/executables/nr-oru.h
+++ b/executables/nr-oru.h
@@ -11,6 +11,16 @@
 #include "openair2/LAYER2/NR_MAC_COMMON/nr_prach_config.h"
 #include "openair1/PHY/defs_gNB.h"
 
+#define ORU_CODEBOOK_MAX_BEAMS 64
+#define ORU_CODEBOOK_MAX_NB_TX 8
+#define ORU_CODEBOOK_MAX_STREAMS 4
+
+typedef struct {
+  int nb_fh_streams;
+  int nb_beams;
+  c16_t w[ORU_CODEBOOK_MAX_BEAMS][ORU_CODEBOOK_MAX_NB_TX][ORU_CODEBOOK_MAX_STREAMS];
+} oru_codebook_t;
+
 #define MAX_DL_READ_THREADS 8
 
 typedef struct {
@@ -67,6 +77,7 @@ typedef struct {
   time_stats_t rx_prach;
   time_stats_t rx;
   prach_item_t prach_item;
+  oru_codebook_t codebook;
   bool threequarter_fs;
 
   // Real-time Self-diagnosis metrics

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -247,25 +247,24 @@ static void rx_rf(RU_t *ru, int *frame, int *slot)
   stop_meas(&ru->rx_fhaul);
 }
 
-static radio_tx_gpio_flag_t get_gpio_flags(RU_t *ru, int slot)
+static radio_tx_gpio_flag_t get_gpio_flags(RU_t *ru, int slot, int symbol)
 {
   radio_tx_gpio_flag_t flags_gpio = 0;
   NR_DL_FRAME_PARMS *fp = ru->nr_frame_parms;
   openair0_config_t *cfg0 = &ru->openair0_cfg;
+  const int symbols_per_frame = fp->slots_per_frame * fp->symbols_per_slot;
+  const int symbol_in_frame = slot * fp->symbols_per_slot + symbol;
+  const int prev_symbol_in_frame = (symbol_in_frame + symbols_per_frame - 1) % symbols_per_frame;
 
   switch (cfg0->gpio_controller) {
     case RU_GPIO_CONTROL_GENERIC:
-      // currently we switch beams at the beginning of a slot and we take the beam index of the first symbol of this slot
-      // we only send the beam to the gpio if the beam is different from the previous slot
-
       if (ru->common.beam_id) {
-        int prev_slot = (slot - 1 + fp->slots_per_frame) % fp->slots_per_frame;
         uint16_t **beam_ids = ru->common.beam_id;
-        uint16_t prev_beam = beam_ids[prev_slot * fp->symbols_per_slot][0];
-        int beam = beam_ids[slot * fp->symbols_per_slot][0];
+        uint16_t prev_beam = beam_ids[prev_symbol_in_frame][0];
+        int beam = beam_ids[symbol_in_frame][0];
         if (prev_beam != beam) {
           flags_gpio = beam | TX_GPIO_CHANGE; // enable change of gpio
-          LOG_I(HW, "slot %d, beam %d\n", slot, beam_ids[slot * fp->symbols_per_slot][0]);
+          LOG_I(HW, "slot %d, symbol %d, beam %d\n", slot, symbol, beam_ids[symbol_in_frame][0]);
         }
       }
       break;
@@ -274,15 +273,15 @@ static radio_tx_gpio_flag_t get_gpio_flags(RU_t *ru, int slot)
       // the beam index is written in bits 8-10 of the flags
       // bit 11 enables the gpio programming
       int beam = 0;
-      if ((slot % 10 == 0) && ru->common.beam_id && (ru->common.beam_id[slot * fp->symbols_per_slot][0] < 64)) {
+      if ((slot % 10 == 0) && ru->common.beam_id && (ru->common.beam_id[symbol_in_frame][0] < 64)) {
         // beam = ru->common.beam_id[0][slot*fp->symbols_per_slot] | 64;
         beam = 1024; // hardcoded now for beam32 boresight
         // beam = 127; //for the sake of trying beam63
-        LOG_D(HW, "slot %d, beam %d\n", slot, beam);
+        LOG_D(HW, "slot %d, symbol %d, beam %d\n", slot, symbol, beam);
       }
       flags_gpio = beam | TX_GPIO_CHANGE;
       // flags_gpio |= beam << 8; // MSB 8 bits are used for beam
-      LOG_I(HW, "slot %d, beam %d, flags_gpio %d\n", slot, beam, flags_gpio);
+      LOG_I(HW, "slot %d, symbol %d, beam %d, flags_gpio %d\n", slot, symbol, beam, flags_gpio);
       break;
     }
     default:
@@ -360,7 +359,7 @@ int tx_rf_symbols(RU_t *ru, int frame, int slot, uint64_t timestamp, int start_s
   }
 
   if (ru->openair0_cfg.gpio_controller != RU_GPIO_CONTROL_NONE)
-    flags_gpio = get_gpio_flags(ru, slot);
+    flags_gpio = get_gpio_flags(ru, slot, start_symbol);
 
   const int flags = flags_burst | (flags_gpio << 4);
   proc->first_tx = 0;
@@ -1185,4 +1184,3 @@ static void NRRCconfig_RU(configmodule_interface_t *cfg)
   } // j=0..num_rus
   return;
 }
-

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -264,7 +264,7 @@ static radio_tx_gpio_flag_t get_gpio_flags(RU_t *ru, int slot, int symbol)
         int beam = beam_ids[symbol_in_frame][0];
         if (prev_beam != beam) {
           flags_gpio = beam | TX_GPIO_CHANGE; // enable change of gpio
-          LOG_I(HW, "slot %d, symbol %d, beam %d\n", slot, symbol, beam_ids[symbol_in_frame][0]);
+          LOG_D(HW, "slot %d, symbol %d, beam %d\n", slot, symbol, beam_ids[symbol_in_frame][0]);
         }
       }
       break;
@@ -281,7 +281,7 @@ static radio_tx_gpio_flag_t get_gpio_flags(RU_t *ru, int slot, int symbol)
       }
       flags_gpio = beam | TX_GPIO_CHANGE;
       // flags_gpio |= beam << 8; // MSB 8 bits are used for beam
-      LOG_I(HW, "slot %d, symbol %d, beam %d, flags_gpio %d\n", slot, symbol, beam, flags_gpio);
+      LOG_D(HW, "slot %d, symbol %d, beam %d, flags_gpio %d\n", slot, symbol, beam, flags_gpio);
       break;
     }
     default:

--- a/fronthaul/oru/oru_fh.c
+++ b/fronthaul/oru/oru_fh.c
@@ -226,12 +226,12 @@ void oru_fh_cleanup(void *handle)
   free(fh);
 }
 
-int oru_fh_tx_read_symbol(void *handle, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol)
+int oru_fh_tx_read_symbol(void *handle, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol, uint16_t *beam_ids)
 {
   if (!handle)
     return -1;
   oru_fh_t *fh = (oru_fh_t *)handle;
-  read_dl_iq(fh->packet_processor, txdataF, nb_tx, hyper_frame, frame, slot, symbol);
+  read_dl_iq(fh->packet_processor, txdataF, nb_tx, hyper_frame, frame, slot, symbol, beam_ids);
   return 0;
 }
 

--- a/fronthaul/oru/oru_fh.h
+++ b/fronthaul/oru/oru_fh.h
@@ -80,9 +80,10 @@ int oru_fh_get_ready_jobs(void *handle);
  * @param frame Pointer to store the frame number of the read symbol.
  * @param slot Pointer to store the slot number of the read symbol.
  * @param symbol Pointer to store the symbol number.
+ * @param beam_ids Array to store the C-plane beam ID per TX antenna.
  * @return 0 on success or -1 on failure
  */
-int oru_fh_tx_read_symbol(void *handle, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol);
+int oru_fh_tx_read_symbol(void *handle, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol, uint16_t *beam_ids);
 
 /**
  * @brief Get the UTC anchor point mapping between 5G time and system time.

--- a/fronthaul/oru/oru_packet_processor.c
+++ b/fronthaul/oru/oru_packet_processor.c
@@ -47,8 +47,8 @@
 
 typedef struct {
   struct {
-    bool cplane_received;
     int section_id;
+    uint16_t beam_id;
     struct {
       int start_prbc;
       int num_prbc;
@@ -507,8 +507,8 @@ static void handle_dl_cplane_packet(oru_packet_processor_context_t *ctx,
       job->comp_method = FH_COMP_NONE;
       job->iq_width = 16;
       for (int j = 0; j < MAX_ANTENNAS; j++) {
-        job->per_antenna[j].cplane_received = false;
         job->per_antenna[j].num_rx_fragments = 0;
+        job->per_antenna[j].beam_id = 0;
         for (int k = 0; k < MAX_RX_FRAGMENTS; k++) {
           job->per_antenna[j].rx_fragments[k].iq_data = NULL;
           job->per_antenna[j].rx_fragments[k].mbuf = NULL;
@@ -521,13 +521,9 @@ static void handle_dl_cplane_packet(oru_packet_processor_context_t *ctx,
         ctx->stats.cplane_err_late++;
         return;
       }
-      if (job->per_antenna[ant_id].cplane_received) {
-        ctx->stats.cplane_err_dup++;
-        ctx->stats.cplane_err_dup_dl++;
-        return;
-      }
     }
     job->per_antenna[ant_id].section_id = section->hdr.u1.common.sectionId;
+    job->per_antenna[ant_id].beam_id = section->hdr.u.s1.beamId;
     job->expected_iq += section->hdr.u1.common.numPrbc == 0 ? ctx->num_prb : section->hdr.u1.common.numPrbc;
     job->comp_method = (fh_comp_method_t)hdr->udComp.udCompMeth;
     job->iq_width = hdr->udComp.udIqWidth == 0 ? XRAN_IQ_BITS_UNCOMPRESSED : hdr->udComp.udIqWidth;
@@ -886,7 +882,7 @@ static void unpack_iq(c16_t *txdataF, const uint8_t *iqdata, int start_prb, int 
   }
 }
 
-void read_dl_iq(void *context, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol)
+void read_dl_iq(void *context, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol, uint16_t *beam_ids)
 {
   oru_packet_processor_context_t *ctx = (oru_packet_processor_context_t *)context;
   if (ctx == NULL)
@@ -907,6 +903,8 @@ void read_dl_iq(void *context, uint32_t **txdataF, int nb_tx, uint64_t *hyper_fr
   *symbol = absolute_gps_symbol % NR_SYMBOLS_PER_SLOT;
 
   for (int aatx = 0; aatx < nb_tx; aatx++) {
+    if (beam_ids)
+      beam_ids[aatx] = job->per_antenna[aatx].beam_id;
     memset(txdataF[aatx], 0, ctx->num_prb * NR_NB_SC_PER_RB * sizeof(uint32_t));
     if (job->per_antenna[aatx].num_rx_fragments == 0) {
       continue;

--- a/fronthaul/oru/oru_packet_processor.h
+++ b/fronthaul/oru/oru_packet_processor.h
@@ -107,7 +107,7 @@ void handle_uplane_packet(void *context, void *pkt);
 void handle_cplane_packet(void *context, void *pkt);
 void print_packet_processor_stats(void *context);
 void get_packet_processor_stats(void *context, oru_packet_processor_stats_t *out_stats);
-void read_dl_iq(void *context, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol);
+void read_dl_iq(void *context, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol, uint16_t *beam_ids);
 int get_ready_job_count(void *context);
 int poll_ul_job(void *context, ul_job_t *job);
 void get_dl_symbol_bitmask(void *context, const uint8_t **bitmask, uint16_t *bit_length);

--- a/fronthaul/oru/tests/test_oru_fh.c
+++ b/fronthaul/oru/tests/test_oru_fh.c
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
       int f, s, sym;
       uint64_t hf;
       while (oru_fh_get_ready_jobs(handle) > 0) {
-        oru_fh_tx_read_symbol(handle, txData, 1, &hf, &f, &s, &sym);
+        oru_fh_tx_read_symbol(handle, txData, 1, &hf, &f, &s, &sym, NULL);
       }
     }
   }

--- a/fronthaul/oru/tests/test_oru_packet_processor.c
+++ b/fronthaul/oru/tests/test_oru_packet_processor.c
@@ -234,6 +234,7 @@ void test_cplane_uplane_match()
       (struct xran_cp_radioapp_section1 *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_cp_radioapp_section1));
   memset(sec, 0, sizeof(*sec));
   sec->hdr.u.s1.numSymbol = 1;
+  sec->hdr.u.s1.beamId = 37;
   sec->hdr.u1.common.numPrbc = 1;
   *((uint64_t *)sec) = rte_be_to_cpu_64(*((uint64_t *)sec));
 
@@ -296,11 +297,13 @@ void test_cplane_uplane_match()
 
   int frame, slot, symbol;
   uint64_t hyper_frame;
+  uint16_t beam_ids[1] = {0};
   do {
-    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol);
+    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol, beam_ids);
   } while (!(frame == (target_sym / num_symbols_per_frame) % 1024 && symbol == target_sym % 14));
 
   assert(symbol == target_sym % 14);
+  assert(beam_ids[0] == 37);
   uint16_t *out_iq = (uint16_t *)output_iq;
   assert(out_iq[0] == 0x00FF);
   assert(out_iq[1] == 0x11EE);
@@ -423,7 +426,7 @@ void test_frame_wrap_around()
   int frame, slot, symbol;
   uint64_t hyper_frame;
   do {
-    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol);
+    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol, NULL);
   } while (!(frame == (target_sym / num_symbols_per_frame) % 1024 && symbol == target_sym % 14));
 
   assert(frame == (target_sym / num_symbols_per_frame) % 1024);
@@ -555,7 +558,7 @@ void test_cplane_14_symbols()
     uint64_t hyper_frame;
     uint64_t sym_i = target_sym + i;
     do {
-      read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol);
+      read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol, NULL);
     } while (!(frame == (sym_i / num_symbols_per_frame) % 1024 && symbol == sym_i % 14));
 
     assert(frame == (sym_i / num_symbols_per_frame) % 1024);
@@ -682,7 +685,7 @@ void test_other_bw_4ant_prb_offset()
   int frame, slot, symbol;
   uint64_t hyper_frame;
   do {
-    read_dl_iq(ctx, txdataF, 4, &hyper_frame, &frame, &slot, &symbol);
+    read_dl_iq(ctx, txdataF, 4, &hyper_frame, &frame, &slot, &symbol, NULL);
   } while (!(frame == frameId && symbol == startSymbolId));
 
   // Verify memory contents for each antenna
@@ -1438,7 +1441,7 @@ void test_hyper_frame_calculation()
   int frame, slot, symbol;
   uint64_t hyper_frame = 0xFFFFFFFF;
   do {
-    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol);
+    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol, NULL);
   } while (!(frame == (target_sym / num_symbols_per_frame) % 1024 && symbol == target_sym % 14));
 
   assert(hyper_frame == 3);

--- a/fronthaul/oru/tests/test_oru_pcap.c
+++ b/fronthaul/oru/tests/test_oru_pcap.c
@@ -215,7 +215,7 @@ int main(int argc, char *argv[])
             int f, sl, sy;
             uint64_t hf;
             while (get_ready_job_count(ctx) > 0) {
-              read_dl_iq(ctx, txdataF, MAX_ANTENNAS, &hf, &f, &sl, &sy);
+              read_dl_iq(ctx, txdataF, MAX_ANTENNAS, &hf, &f, &sl, &sy, NULL);
             }
           }
           last_tick_sym = current_sym;
@@ -243,7 +243,7 @@ int main(int argc, char *argv[])
     int f, sl, sy;
     uint64_t hf;
     while (get_ready_job_count(ctx) > 0) {
-      read_dl_iq(ctx, txdataF, MAX_ANTENNAS, &hf, &f, &sl, &sy);
+      read_dl_iq(ctx, txdataF, MAX_ANTENNAS, &hf, &f, &sl, &sy, NULL);
     }
   }
 

--- a/fronthaul/xran_pkt/tests/xran_pcap_dump.c
+++ b/fronthaul/xran_pkt/tests/xran_pcap_dump.c
@@ -176,11 +176,12 @@ void packet_handler(u_char *user, const struct pcap_pkthdr *pkthdr, const u_char
               if (section) {
                 section->hdr.u1.second_4byte = rte_be_to_cpu_32(section->hdr.u1.second_4byte);
                 section->hdr.u.first_4byte = rte_be_to_cpu_32(section->hdr.u.first_4byte);
-                printf("  [Sec 1] SectionID: %d  StartPRB: %d  NumPRB: %d  NumSym: %d\n",
+                printf("  [Sec 1] SectionID: %d  StartPRB: %d  NumPRB: %d  NumSym: %d  BeamID: %d\n",
                        section->hdr.u1.common.sectionId,
                        section->hdr.u1.common.startPrbc,
                        section->hdr.u1.common.numPrbc,
-                       section->hdr.u.s1.numSymbol);
+                       section->hdr.u.s1.numSymbol,
+                       section->hdr.u.s1.beamId);
               }
               break;
             }

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.band77.mu1.106rb.2x2_catb.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.band77.mu1.106rb.2x2_catb.conf
@@ -1,0 +1,185 @@
+Active_gNBs = ( "gNB-OAI");
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    gNB_ID    =  0xe00;
+    gNB_name  =  "gNB-OAI";
+    tracking_area_code  =  40960;
+    plmn_list = ({ mcc = 208; mnc = 95; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+    nr_cellid = 12345678L;
+    min_rxtxtime = 4;
+    pdsch_AntennaPorts_XP = 2;
+    pdsch_AntennaPorts_N1 = 1;
+    maxMIMO_layers        = 2;
+    pusch_AntennaPorts    = 2;
+    do_CSIRS              = 0;
+    do_SRS                = "none";
+    sib1_tda              = 15;
+
+    servingCellConfigCommon = (
+    {
+      physCellId                                                    = 0;
+      absoluteFrequencySSB                                          = 669984;
+      dl_frequencyBand                                              = 77;
+      dl_absoluteFrequencyPointA                                    = 668712;
+      dl_offstToCarrier                                             = 0;
+      dl_subcarrierSpacing                                          = 1;
+      dl_carrierBandwidth                                           = 106;
+      initialDLBWPlocationAndBandwidth                              = 28875;
+      initialDLBWPsubcarrierSpacing                                 = 1;
+      initialDLBWPcontrolResourceSetZero                            = 11;
+      initialDLBWPsearchSpaceZero                                   = 0;
+      ul_frequencyBand                                              = 77;
+      ul_offstToCarrier                                             = 0;
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 106;
+      pMax                                                          = 23;
+      initialULBWPlocationAndBandwidth                              = 28875;
+      initialULBWPsubcarrierSpacing                                 = 1;
+      prach_ConfigurationIndex                                      = 157;
+      prach_msg1_FDM                                                = 0;
+      prach_msg1_FrequencyStart                                     = 0;
+      zeroCorrelationZoneConfig                                     = 0;
+      preambleReceivedTargetPower                                   = -100;
+      preambleTransMax                                              = 7;
+      powerRampingStep                                              = 2;
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                  = 4;
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB                     = 15;
+      ra_ContentionResolutionTimer                                  = 7;
+      rsrp_ThresholdSSB                                             = 19;
+      prach_RootSequenceIndex_PR                                    = 2;
+      prach_RootSequenceIndex                                       = 1;
+      msg1_SubcarrierSpacing                                        = 1,
+      restrictedSetConfig                                           = 0,
+      msg3_DeltaPreamble                                            = 2;
+      p0_NominalWithGrant                                           = -100;
+      pucchGroupHopping                                             = 0;
+      hoppingId                                                     = 0;
+      p0_nominal                                                    = -96;
+      ssb_PositionsInBurst_Bitmap                                   = 0x1;
+      ssb_periodicityServingCell                                    = 2;
+      dmrs_TypeA_Position                                           = 0;
+      subcarrierSpacing                                             = 1;
+      referenceSubcarrierSpacing                                    = 1;
+      dl_UL_TransmissionPeriodicity                                 = 5;
+      nrofDownlinkSlots                                             = 3;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 1;
+      nrofUplinkSymbols                                             = 4;
+      ssPBCH_BlockPower                                             = 0;
+    }
+    );
+
+    SCTP :
+    {
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+    amf_ip_address = ({ ipv4 = "192.168.70.136"; });
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.70.129";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "192.168.70.129";
+        GNB_PORT_FOR_S1U                         = 2152;
+    };
+  }
+);
+
+MACRLCs = (
+{
+  num_cc                      = 1;
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 200;
+  pucch_TargetSNRx10          = 200;
+  ul_bler_target_upper        = .35;
+  ul_bler_target_lower        = .15;
+  pusch_FailureThres          = 100;
+
+  # Preconfigured analog beamforming: maps DL beam index to O-RU codebook beam ID
+  set_analog_beamforming      = "lophy";
+  beam_duration               = 1;
+  beams_per_period            = 2;
+  beam_weights                = [0, 1];
+}
+);
+
+L1s = (
+{
+  num_cc = 1;
+  tr_n_preference = "local_mac";
+  prach_dtx_threshold = 110;
+  pucch0_dtx_threshold = 80;
+  pusch_dtx_threshold = -100;
+  tx_amp_backoff_dB = 36;
+  L1_rx_thread_core = 11;
+  L1_tx_thread_core = 12;
+  phase_compensation = 0;
+}
+);
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 2;
+  nb_rx          = 2;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  ru_thread_core = 10;
+  sl_ahead       = 5;
+  tr_preference  = "raw_if4p5";
+  do_precoding   = 0;
+}
+);
+
+security = {
+  ciphering_algorithms = ( "nea0" );
+  integrity_algorithms = ( "nia2", "nia0" );
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};
+
+fhi_72 = {
+  dpdk_devices = ("0000:01:11.2", "0000:01:11.3");
+  system_core = 7;
+  io_core = 8;
+  worker_cores = (9);
+  ru_addr = ("00:11:22:44:64:66", "00:11:22:44:64:67");
+  mtu = 9600;
+  fh_config = ({
+    T1a_cp_dl = (285, 470);
+    T1a_cp_ul = (285, 470);
+    T1a_up = (300, 450);
+    Ta4 = (400, 440);
+    Ta3_up = (200, 350);
+    T2a_up = (300, 450);
+    ru_config = {
+      # Must be "dynamic" when iq_width < 16: O-RU sends per-section compression headers
+      comp_hdr_type = "dynamic";
+      iq_width = 16;
+      iq_width_prach = 16;
+    };
+  });
+};

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.band77.mu1.106rb.2x2_catb.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.band77.mu1.106rb.2x2_catb.conf
@@ -1,0 +1,71 @@
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+ORUs = (
+{
+  tx_bw = [106];
+  rx_bw = [106];
+  carrier_tx = [4049760];
+  carrier_rx = [4049760];
+  prach_config_index = 157;
+  prach_msg1_start = 0;
+  tdd_period = 5;
+  num_dl_slots = 3;
+  num_dl_symbols = 6;
+  num_ul_slots = 1;
+  num_ul_symbols = 4;
+  numerology = 1;
+  fronthaul = {
+    # Mellanox Virtual Functions on Spark configured via spark-setup-ifs.sh
+    dpdk_devices = ("0000:01:11.0", "0000:01:11.1");
+    rx_core = 20;
+    # Matches O-DU MAC addresses in setup_du_ifs_for_spark.sh
+    du_mac_addr = ("00:11:22:44:54:00", "00:11:22:44:54:01");
+    mtu = 9216;
+    T2a_up = (300, 3200);
+    T2a_cp = (285, 3200);
+    prach_eaxc_offset = 1;
+    extra_eal_args = ("--file-prefix", "ru");
+    # IQ compression: 0=none  1=BFP  2=BLKSCALE  3=ULAW
+    # Must match iq_width setting on the O-DU side (fhi_72.fh_config.ru_config.iq_width)
+    comp_type = 0;
+  }
+  nb_fh_streams = 2;
+  codebook_nb_beams = 2;
+  # Q15 weights, layout: beam x tx_antenna x fh_stream x (Re, Im)
+  codebook_weights = [32767,0, 0,0, 0,0, 32767,0,
+                       32767,0, 0,0, 0,0, 0,32767];
+});
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 2; # 2x2 MIMO setup
+  nb_rx          = 2;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  sl_ahead       = 5;
+  tr_preference  = "raw_if4p5"; # Activate FHI7.2
+  do_precoding   = 0;
+  # PRACH configuration
+  num_tp_cores = 4;
+  tp_cores = [16,17,18,19];
+});
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};


### PR DESCRIPTION
This PR adds beam ID handling and codebook-based weight application to the O-RU.

The O-RU reads the beam ID from each incoming C-plane section and passes it through to the symbol processing path. When nb_fh_streams is set, the O-RU applies weight matrix to map the fronthaul streams to the full TX antenna array, selecting the codebook row by beam ID. 

The codebook is configured at startup via nb_fh_streams, codebook_nb_beams, and codebook_weights. The weights are zero-initialized by default and must be provided explicitly. Based on the received beam ID, the corresponding weights are selected and applied to produce the TX antenna signals.

This PR does not include dynamic beam ID selection. That could be extended in a future PR, by adding a feedback loop.