### PR TITLE
Implement n_pc_wm == 1 option for polar code

### DIFF
--- a/openair1/PHY/CODING/nrPolar_tools/nr_polar_procedures.c
+++ b/openair1/PHY/CODING/nrPolar_tools/nr_polar_procedures.c
@@ -246,9 +246,30 @@ void nr_polar_info_bit_pattern(uint8_t *ibp,
   }
 
   if (n_PC > 0) {
-    AssertFatal(n_pc_wm == 0, "Q_PC_N computation for n_pc_wm = %i is not implemented yet!\n", n_pc_wm);
+    AssertFatal(n_pc_wm <= 1, "n_pc_wm = %i is not valid (only 0 and 1 allowed)\n", n_pc_wm);
+
+    // As per 5.3.1.2 of 38.212, denote the set of bit indices for parity check bits as Q_PC_N
+    // A number of (n_PC - n_pc_wm) parity check bits are placed in the (n_PC - n_pc_wm) least reliable bit indices
     for (int n = 0; n < n_PC - n_pc_wm; n++) {
       Q_PC_N[n] = Q_I_N[n];
+    }
+
+    // A number of n_pc_wm other parity check bits are placed in the bit indices of minimum row weight of most reliable bit indices
+    if (n_pc_wm == 1) {
+      // tilde{Q_I}^N = K most reliable indices of bar{Q_I}^N = Q_I_N[n_PC .. K+n_PC-1].
+      // Find minimum row weight over this range; on ties, keep the most reliable
+      // (later position, since Q_I_N is ascending by reliability).
+      int min_weight = INT_MAX;
+      int best_pos = -1;
+      for (int n = n_PC; n <= (K + n_PC) - 1; n++) {
+        const int w = __builtin_popcount((unsigned)Q_I_N[n]);
+        if (w <= min_weight) {
+          min_weight = w;
+          best_pos = n;
+        }
+      }
+      AssertFatal(best_pos >= 0, "No candidate found in tilde{Q_I}^N for n_pc_wm = 1 (K=%u, n_PC=%u)", K, n_PC);
+      Q_PC_N[n_PC - 1] = Q_I_N[best_pos];
     }
   }
 
@@ -266,7 +287,7 @@ void nr_polar_info_bit_pattern(uint8_t *ibp,
     }
   }
 
-  // Information and Parity Chack Bit Pattern
+  // Information and Parity Check Bit Pattern
   for (int n = 0; n <= N - 1; n++) {
     ibp[n] = 0;
     for (int m = 0; m <= (K + n_PC) - 1; m++) {


### PR DESCRIPTION
This PR implements the missing `n_pc_wm == 1` option for polar procedures, relevant for some CSI reporting configurations. See:` ./nr_pucchsim -R 273 -i 1 -P 2 -q 16 -b 13 -n300`

Assisted-by: Claude:claude-sonnet-5

Closes: #112 