### PR TITLE
Cleaning header handling from #141

### DIFF
--- a/common/utils/nr/nr_common.h
+++ b/common/utils/nr/nr_common.h
@@ -198,6 +198,29 @@ typedef struct meas_s {
   val_init_t csi_rsrp_dBm;
 } meas_t;
 
+// Configuration parameters required for 5G Positioning
+// TRP Cartesian Coordinate information
+typedef struct trp_s {
+  // TRP id
+  uint32_t id;
+  // TRP x-axis value
+  int32_t x_axis;
+  // TRP y-axis value
+  int32_t y_axis;
+  // TRP z-axis value
+  int32_t z_axis;
+  // 0 = mm, 1 = cm, 2 = dm
+  uint8_t unit;
+} trp_t;
+
+#define MAX_NUM_TRPs 8
+typedef struct {
+  trp_t trps[MAX_NUM_TRPs];
+  uint8_t num_trp;
+  // Serving gNB indicator
+  bool is_serving_gNB;
+} positioning_config_t;
+
 /** @brief Returns NR RSRP index per 3GPP TS 38.133 Table 10.1.6.1-1 */
 uint8_t get_rsrp_index(int rsrp_dBm);
 

--- a/openair1/PHY/defs_nr_common.h
+++ b/openair1/PHY/defs_nr_common.h
@@ -244,29 +244,6 @@ typedef struct {
     int32_t reserved;
 } prs_meas_t;
 
-// Configuration parameters required for 5G Positioning
-// TRP Cartesian Coordinate information
-typedef struct trp_s {
-  // TRP id
-  uint32_t id;
-  // TRP x-axis value
-  int32_t x_axis;
-  // TRP y-axis value
-  int32_t y_axis;
-  // TRP z-axis value
-  int32_t z_axis;
-  // 0 = mm, 1 = cm, 2 = dm
-  uint8_t unit;
-} trp_t;
-
-#define MAX_NUM_TRPs 8
-typedef struct {
-  trp_t trps[MAX_NUM_TRPs];
-  uint8_t num_trp;
-  // Serving gNB indicator
-  bool is_serving_gNB;
-} positioning_config_t;
-
 // rel16 prs k_prime table as per ts138.211 sec.7.4.1.7.2
 #define K_PRIME_TABLE_ROW_SIZE 4
 #define K_PRIME_TABLE_COL_SIZE 12

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -18,8 +18,6 @@
 #include "L1_nr_paramdef.h"
 #include "MACRLC_nr_paramdef.h"
 #include "PHY/INIT/nr_phy_init.h"
-#include "PHY/defs_gNB.h"
-#include "PHY/defs_nr_common.h"
 #include "RRC_nr_paramsvalues.h"
 #include "T.h"
 #include "asn_SEQUENCE_OF.h"

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
@@ -22,8 +22,6 @@
 
 #include "uper_decoder.h"
 #include "uper_encoder.h"
-#include "openair1/PHY/defs_nr_common.h"
-#include "openair1/PHY/defs_gNB.h"
 #include "openair3/NRPPA/nrppa_gNB_config.h"
 #include "openair2/F1AP/lib/f1ap_positioning.h"
 

--- a/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.h
@@ -18,7 +18,6 @@
 #include "common/platform_types.h"
 #include "openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h"
 #include "openair2/LAYER2/nr_rlc/nr_rlc_configuration.h"
-#include "openair1/PHY/defs_nr_common.h"
 #include "openair2/LAYER2/NR_MAC_COMMON/nr_mac.h"
 struct NR_MeasurementTimingConfiguration;
 struct NR_PDSCH_TimeDomainResourceAllocationList;

--- a/openair3/NRPPA/nrppa_gNB_config.c
+++ b/openair3/NRPPA/nrppa_gNB_config.c
@@ -4,11 +4,10 @@
 
 #include "nrppa_gNB_config.h"
 #include "assertions.h"
-#include "openair1/PHY/defs_nr_common.h"
-#include "openair1/PHY/defs_gNB.h"
 #include "common/ran_context.h"
 #include "positioning_nr_paramdef.h"
 #include "common/config/config_userapi.h"
+#include "common/utils/LOG/log.h"
 
 positioning_config_t RCconfig_nr_positioning(void)
 {

--- a/openair3/NRPPA/nrppa_gNB_config.h
+++ b/openair3/NRPPA/nrppa_gNB_config.h
@@ -5,7 +5,7 @@
 #ifndef GNB_CONFIG_POSITIONING_H_
 #define GNB_CONFIG_POSITIONING_H_
 
-#include "openair1/PHY/defs_nr_common.h"
+#include "common/utils/nr/nr_common.h"
 
 positioning_config_t RCconfig_nr_positioning(void);
 void dump_positioning_config(const positioning_config_t *positioning_config);


### PR DESCRIPTION
This was a quick clean-up to remove L1 headers from upper layers, so I moved `positioning_config_t` to nr_common but it's still questionable that is used both in L2 and L3 and there is cross-compilation between L2 and L3. Probably a symptom of a messy implementation.