### PR TITLE
 Reduced-complexity near-ML soft-output (LLR) MIMO detection — 2-layer 64/256QAM

### DIFF
--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
@@ -354,8 +354,12 @@ static void inner_rx(PHY_VARS_gNB *gNB,
                            rel15_ul->qam_mod_order);
     nr_idft((int32_t *)&pusch_vars->rxdataF_comp[0][symbol * buffer_length], pusch_vars->ul_valid_re_per_slot[symbol]);
   }
+  /* gNB near-ML 2-layer 256QAM gate; PTRS processing and start_meas(ulsch_llr)
+     now happen earlier, per upstream's ptrs refactor */
+  static int gnb_lbest = -1;
+  if (gnb_lbest < 0) { const char *e = getenv("OAI_LBEST"); gnb_lbest = e ? atoi(e) : 0; }
   if (nb_layer == 2) {
-    if (rel15_ul->qam_mod_order <= 6) {
+    if (rel15_ul->qam_mod_order <= 6 || (rel15_ul->qam_mod_order == 8 && gnb_lbest)) {
       nr_compute_ML_llr((c16_t *)&pusch_vars->rxdataF_comp[0][symbol * buffer_length],
                         (c16_t *)&pusch_vars->rxdataF_comp[1][symbol * buffer_length],
                         rxF_ch_maga[0],
@@ -873,9 +877,14 @@ int nr_rx_pusch_group_tp(PHY_VARS_gNB *gNB,
     for (int aarx = 0; aarx < num_sp_streams; aarx++)
       avgs = cmax(avgs, avg[nl][aarx]);
 
-  if (total_layers == 2 && rel15_ul_ref->qam_mod_order > 6)
-    joint_pv->log2_maxh = (log2_approx(avgs) >> 1) - 3; // for MMSE
-  else if (total_layers == 2)
+  if (total_layers == 2 && rel15_ul_ref->qam_mod_order > 6) {
+    // 256QAM 2-layer: the full-ML detector wants a cooler LLR scale (-2) than the
+    // linear MMSE receiver (-3); -3 saturates the ML metric and loses ~1 dB, while
+    // -2 recovers the full ML gain over MMSE (verified on TDL-A). Selected by OAI_LBEST.
+    static int ml256 = -1;
+    if (ml256 < 0) { const char *e = getenv("OAI_LBEST"); ml256 = e ? atoi(e) : 0; }
+    joint_pv->log2_maxh = (log2_approx(avgs) >> 1) + (ml256 ? -2 : -3);
+  } else if (total_layers == 2)
     joint_pv->log2_maxh = (log2_approx(avgs) >> 1) - 2 + log2_approx(num_sp_streams >> 1);
   else
     joint_pv->log2_maxh = (log2_approx(avgs) >> 1) + 1 + log2_approx(num_sp_streams >> 1);

--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
@@ -883,9 +883,16 @@ int nr_rx_pusch_group_tp(PHY_VARS_gNB *gNB,
     // -2 recovers the full ML gain over MMSE (verified on TDL-A). Selected by OAI_LBEST.
     static int ml256 = -1;
     if (ml256 < 0) { const char *e = getenv("OAI_LBEST"); ml256 = e ? atoi(e) : 0; }
-    joint_pv->log2_maxh = (log2_approx(avgs) >> 1) + (ml256 ? -2 : -3);
+    // ML (ml256): use the same mod-order correction + antenna term as the qam<=6 2-layer branch
+    // below (nr_ml_llr_maxh_off(8) + log2_approx(num_sp_streams>>1)); at nb=4 that is -3+1 = -2,
+    // matching the prior fixed -2, but it now tracks the antenna count. MMSE (!ml256) keeps -3.
+    joint_pv->log2_maxh = (log2_approx(avgs) >> 1)
+        + (ml256 ? nr_ml_llr_maxh_off(rel15_ul_ref->qam_mod_order) + log2_approx(num_sp_streams >> 1) : -3);
   } else if (total_layers == 2)
-    joint_pv->log2_maxh = (log2_approx(avgs) >> 1) - 2 + log2_approx(num_sp_streams >> 1);
+    // 2-layer QPSK/16QAM/64QAM near-ML: mod-order-dependent LLR-hotness offset (a uniform -2 tuned
+    // for 256QAM over-heats the lower orders and loses the ML gain). Same table as the UE.
+    joint_pv->log2_maxh =
+        (log2_approx(avgs) >> 1) + nr_ml_llr_maxh_off(rel15_ul_ref->qam_mod_order) + log2_approx(num_sp_streams >> 1);
   else
     joint_pv->log2_maxh = (log2_approx(avgs) >> 1) + 1 + log2_approx(num_sp_streams >> 1);
 

--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
@@ -368,24 +368,27 @@ static void inner_rx(PHY_VARS_gNB *gNB,
                         rel15_ul->qam_mod_order);
     }
     else {
-      nr_mmse_2layers(pusch_vars->rxdataF_comp,
-                      buffer_length,
-                      buffer_length,
-                      nb_rx_ant,
-                      nb_layer,
-                      rxF_ch_maga,
-                      rxF_ch_magb,
-                      rxF_ch_magc,
-                      chFext,
-                      rel15_ul->rb_size,
-                      rel15_ul->qam_mod_order,
-                      pusch_vars->log2_maxh,
-                      symbol,
-                      pusch_vars->ul_valid_re_per_slot[symbol],
-                      nvar);
+      // Fused Gram-fed 2-layer MMSE + scalar LLR (L=1). Replaces {nr_mmse_2layers + scalar loop}.
+      nr_compute_MMSE_llr(pusch_vars->rxdataF_comp,
+                          buffer_length,
+                          buffer_length,
+                          nb_rx_ant,
+                          nb_layer,
+                          rxF_ch_maga,
+                          rxF_ch_magb,
+                          rxF_ch_magc,
+                          chFext,
+                          rel15_ul->rb_size,
+                          rel15_ul->qam_mod_order,
+                          pusch_vars->log2_maxh,
+                          symbol,
+                          pusch_vars->ul_valid_re_per_slot[symbol],
+                          nvar,
+                          rho[0][0], rho[0][1], rho[1][0], rho[1][1],
+                          llr);
     }
   }
-  if (nb_layer != 2 || rel15_ul->qam_mod_order > 6)
+  if (nb_layer != 2) // 2-layer 256QAM MMSE is now handled inside nr_compute_MMSE_llr above
     for (int aatx = 0; aatx < nb_layer; aatx++)
            nr_compute_llr(&pusch_vars->rxdataF_comp[aatx][symbol * buffer_length],
                      rxF_ch_maga[aatx],

--- a/openair1/PHY/NR_TRANSPORT/tests/CMakeLists.txt
+++ b/openair1/PHY/NR_TRANSPORT/tests/CMakeLists.txt
@@ -11,3 +11,10 @@ target_link_libraries(test_llr_no_avx_256 PRIVATE PHY_NR_NO_AVX_256 GTest::gtest
 add_dependencies(tests test_llr_no_avx_256)
 add_test(NAME test_llr_no_avx_256
   COMMAND ./test_llr_no_avx_256)
+
+# 2-layer L-best MIMO LLR kernels: width equivalence (w128==w256==w512) + float-model fidelity
+add_executable(test_llr_2layer test_llr_2layer.cpp)
+target_link_libraries(test_llr_2layer PRIVATE PHY_NR nr_phy_common GTest::gtest minimal_lib)
+add_dependencies(tests test_llr_2layer)
+add_test(NAME test_llr_2layer
+  COMMAND ./test_llr_2layer)

--- a/openair1/PHY/NR_TRANSPORT/tests/test_llr_2layer.cpp
+++ b/openair1/PHY/NR_TRANSPORT/tests/test_llr_2layer.cpp
@@ -1,0 +1,224 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ *
+ * Unit tests for the 2-layer L-best MIMO soft-output (LLR) kernels.
+ *
+ * (A) Width equivalence -- the width-parameterized fixed-point SIMD kernels must
+ *     be BIT-IDENTICAL across widths: w128 (SSE->NEON) == w256 (AVX2) == w512
+ *     (AVX-512, when compiled in). This is the primary regression guard for the
+ *     width parameterization and the AVX-512 port: one source, all widths equal.
+ *
+ * (B) Fidelity vs the float reference model (nr_qam{64,256}_llr_2layer_lbest):
+ *     the fixed-point kernel must track the float L-best within a bounded best-fit
+ *     residual and sign agreement -- the same methodology as OAI_LBEST_DBG. This
+ *     catches structural/scale/sign regressions against the analytical model.
+ */
+#include "gtest/gtest.h"
+#include <stdint.h>
+#include <vector>
+#include <cstring>
+#include <cstdlib>
+
+extern "C" {
+struct configmodule_interface_s;
+struct configmodule_interface_s *uniqCfg = NULL;
+void exit_function(const char *file, const char *function, const int line, const char *s, const int assert)
+{
+  if (assert)
+    abort();
+  else
+    exit(EXIT_SUCCESS);
+}
+#include "openair1/PHY/TOOLS/tools_defs.h"
+
+// Float reference L-best (float internally, int16 out). L = candidate count
+// (L>=full reproduces the exact max-log ML search); seed_lambda unused here.
+void nr_qam64_llr_2layer_lbest(c16_t *, c16_t *, c16_t *, c16_t *, int16_t *, c16_t *, uint32_t, int, float);
+void nr_qam256_llr_2layer_lbest(c16_t *, c16_t *, c16_t *, c16_t *, int16_t *, c16_t *, uint32_t, int, float);
+
+// Width-specific fixed-point SIMD kernels (last arg = candidate pattern).
+void nr_qam64_llr_2layer_lbest_q15_simd_w128(c16_t *, c16_t *, c16_t *, c16_t *, int16_t *, c16_t *, uint32_t, int);
+void nr_qam64_llr_2layer_lbest_q15_simd_w256(c16_t *, c16_t *, c16_t *, c16_t *, int16_t *, c16_t *, uint32_t, int);
+void nr_qam256_llr_2layer_lbest_q15_simd_w128(c16_t *, c16_t *, c16_t *, c16_t *, int16_t *, c16_t *, uint32_t, int);
+void nr_qam256_llr_2layer_lbest_q15_simd_w256(c16_t *, c16_t *, c16_t *, c16_t *, int16_t *, c16_t *, uint32_t, int);
+#if defined(__AVX512BW__) && defined(__AVX512VL__) && defined(__AVX512F__)
+void nr_qam64_llr_2layer_lbest_q15_simd_w512(c16_t *, c16_t *, c16_t *, c16_t *, int16_t *, c16_t *, uint32_t, int);
+void nr_qam256_llr_2layer_lbest_q15_simd_w512(c16_t *, c16_t *, c16_t *, c16_t *, int16_t *, c16_t *, uint32_t, int);
+#define NRLB_TEST_HAVE_W512 1
+#endif
+}
+
+#include "openair1/PHY/TOOLS/phy_test_tools.hpp"
+#include <random>
+
+namespace {
+
+// A plausible 2-layer scenario: matched-filter outputs z0/z1, positive channel
+// magnitudes (Pp0/Pp1) and a cross-correlation rho, all in the Q15-ish range the
+// kernels operate on. Buffers are padded so the SIMD block loop never over-reads.
+struct Inputs2L {
+  AlignedVector512<c16_t> s0, s1, mag, magi, rho;
+};
+
+Inputs2L gen_inputs(uint32_t nb_re, unsigned seed)
+{
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int> sig(-16000, 16000), pos(3000, 16000), rh(-9000, 9000);
+  const uint32_t N = nb_re + 64; // pad against the widest (w512, 32-RE) block load
+  Inputs2L in;
+  in.s0.resize(N); in.s1.resize(N); in.mag.resize(N); in.magi.resize(N); in.rho.resize(N);
+  for (uint32_t i = 0; i < N; i++) {
+    in.s0[i] = {(int16_t)sig(rng), (int16_t)sig(rng)};
+    in.s1[i] = {(int16_t)sig(rng), (int16_t)sig(rng)};
+    const int16_t p0 = (int16_t)pos(rng), p1 = (int16_t)pos(rng);
+    in.mag[i] = {p0, p0};   // ch_mag: real part is the used magnitude (Pp0), replicated
+    in.magi[i] = {p1, p1};  // ch_mag_i: interferer magnitude (Pp1)
+    in.rho[i] = {(int16_t)rh(rng), (int16_t)rh(rng)};
+  }
+  return in;
+}
+
+// A well-conditioned scenario: each layer carries a clean constellation point
+// (z ~= step*level, the matched-filter output at high SNR), low cross-correlation,
+// and light noise. Decisions are unambiguous, so the fixed-point kernel and the
+// float model agree closely -- the regime where a fidelity bound is meaningful
+// (unlike uniform-random streams, which sit on decision boundaries by construction).
+// step derives from the seed's level<->z mapping: est = z*sqrt(K)/Pp, Pp = mag*c,
+// so z = level*Pp/sqrt(K); with mag=8192 that is ~2048/level for 64QAM (K=42) and
+// ~1000/level for 256QAM (K=170).
+Inputs2L gen_clean_inputs(uint32_t nb_re, unsigned seed, int maxlvl, int step)
+{
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int> lvlIdx(0, maxlvl / 2);   // 0..(N/2-1) -> odd levels 1,3,..,maxlvl
+  std::uniform_int_distribution<int> noise(-180, 180), sgn(0, 1);
+  const int16_t P = 8192;
+  auto level = [&]() { return (2 * lvlIdx(rng) + 1) * (sgn(rng) ? 1 : -1); };
+  const uint32_t N = nb_re + 64;
+  Inputs2L in;
+  in.s0.resize(N); in.s1.resize(N); in.mag.resize(N); in.magi.resize(N); in.rho.resize(N);
+  for (uint32_t i = 0; i < N; i++) {
+    in.s0[i] = {(int16_t)(step * level() + noise(rng)), (int16_t)(step * level() + noise(rng))};
+    in.s1[i] = {(int16_t)(step * level() + noise(rng)), (int16_t)(step * level() + noise(rng))};
+    in.mag[i] = {P, P};
+    in.magi[i] = {P, P};
+    in.rho[i] = {(int16_t)noise(rng), (int16_t)noise(rng)};  // low correlation
+  }
+  return in;
+}
+
+struct Fit {
+  double signDisagree_pct, fitScale, residFrac;
+};
+
+// Scale-invariant agreement of a fixed-point kernel output vs the float reference,
+// identical to the OAI_LBEST_DBG statistic: best-fit scale a = <p,r>/<r,r>, then
+// residual fraction ||p - a r||^2 / ||p||^2, plus the fraction of sign flips.
+Fit fit_stats(const int16_t *dut, const int16_t *ref, size_t n)
+{
+  long sdis = 0;
+  double sPR = 0, sRR = 0, sPP = 0;
+  for (size_t k = 0; k < n; k++) {
+    const double p = dut[k], r = ref[k];
+    if ((long)dut[k] * (long)ref[k] < 0)
+      sdis++;
+    sPR += p * r;
+    sRR += r * r;
+    sPP += p * p;
+  }
+  const double a = sRR > 0 ? sPR / sRR : 0;
+  const double resid = sPP - 2 * a * sPR + a * a * sRR;
+  return {100.0 * (double)sdis / (double)n, a, sPP > 0 ? resid / sPP : 0};
+}
+
+// ---- (A) width equivalence ------------------------------------------------
+
+void width_equiv_64qam(uint32_t nb_re, int pattern)
+{
+  auto in = gen_inputs(nb_re, 0x64ull + nb_re * 131 + pattern);
+  const size_t nll = (size_t)nb_re * 6;
+  AlignedVector512<int16_t> o128(nll + 64, 0), o256(nll + 64, 0);
+  nr_qam64_llr_2layer_lbest_q15_simd_w128(in.s0.data(), in.s1.data(), in.mag.data(), in.magi.data(), o128.data(), in.rho.data(), nb_re, pattern);
+  nr_qam64_llr_2layer_lbest_q15_simd_w256(in.s0.data(), in.s1.data(), in.mag.data(), in.magi.data(), o256.data(), in.rho.data(), nb_re, pattern);
+  EXPECT_EQ(0, memcmp(o128.data(), o256.data(), nll * sizeof(int16_t))) << "w128 != w256 (64QAM, nb_re=" << nb_re << ", pat=" << pattern << ")";
+#ifdef NRLB_TEST_HAVE_W512
+  AlignedVector512<int16_t> o512(nll + 64, 0);
+  nr_qam64_llr_2layer_lbest_q15_simd_w512(in.s0.data(), in.s1.data(), in.mag.data(), in.magi.data(), o512.data(), in.rho.data(), nb_re, pattern);
+  EXPECT_EQ(0, memcmp(o128.data(), o512.data(), nll * sizeof(int16_t))) << "w128 != w512 (64QAM, nb_re=" << nb_re << ", pat=" << pattern << ")";
+#endif
+}
+
+void width_equiv_256qam(uint32_t nb_re, int pattern)
+{
+  auto in = gen_inputs(nb_re, 0x256ull + nb_re * 131 + pattern);
+  const size_t nll = (size_t)nb_re * 8;
+  AlignedVector512<int16_t> o128(nll + 64, 0), o256(nll + 64, 0);
+  nr_qam256_llr_2layer_lbest_q15_simd_w128(in.s0.data(), in.s1.data(), in.mag.data(), in.magi.data(), o128.data(), in.rho.data(), nb_re, pattern);
+  nr_qam256_llr_2layer_lbest_q15_simd_w256(in.s0.data(), in.s1.data(), in.mag.data(), in.magi.data(), o256.data(), in.rho.data(), nb_re, pattern);
+  EXPECT_EQ(0, memcmp(o128.data(), o256.data(), nll * sizeof(int16_t))) << "w128 != w256 (256QAM, nb_re=" << nb_re << ", pat=" << pattern << ")";
+#ifdef NRLB_TEST_HAVE_W512
+  AlignedVector512<int16_t> o512(nll + 64, 0);
+  nr_qam256_llr_2layer_lbest_q15_simd_w512(in.s0.data(), in.s1.data(), in.mag.data(), in.magi.data(), o512.data(), in.rho.data(), nb_re, pattern);
+  EXPECT_EQ(0, memcmp(o128.data(), o512.data(), nll * sizeof(int16_t))) << "w128 != w512 (256QAM, nb_re=" << nb_re << ", pat=" << pattern << ")";
+#endif
+}
+
+// RE counts that are multiples of 32 -> every width runs pure-SIMD (no scalar
+// remainder), so the outputs must be bit-identical.
+const std::vector<uint32_t> kMul32 = {32, 64, 96, 320, 3200};
+
+}  // namespace
+
+TEST(test_llr_2layer, width_equiv_64qam_pattern0)
+{
+  for (auto n : kMul32) width_equiv_64qam(n, 0);
+}
+TEST(test_llr_2layer, width_equiv_256qam_pattern1)
+{
+  for (auto n : kMul32) width_equiv_256qam(n, 1);
+}
+// non-default patterns must be width-exact too
+TEST(test_llr_2layer, width_equiv_64qam_other_patterns)
+{
+  for (int p = 1; p <= 2; p++) for (auto n : kMul32) width_equiv_64qam(n, p);
+}
+TEST(test_llr_2layer, width_equiv_256qam_other_patterns)
+{
+  for (int p : {0, 2, 3}) for (auto n : kMul32) width_equiv_256qam(n, p);
+}
+
+// ---- (B) fidelity vs the float reference model ----------------------------
+
+TEST(test_llr_2layer, fidelity_vs_float_64qam)
+{
+  const uint32_t nb_re = 3200;
+  auto in = gen_clean_inputs(nb_re, 0xF64, 7, 2048);
+  AlignedVector512<int16_t> dut((size_t)nb_re * 6 + 64, 0), ref((size_t)nb_re * 6 + 64, 0);
+  nr_qam64_llr_2layer_lbest_q15_simd_w256(in.s0.data(), in.s1.data(), in.mag.data(), in.magi.data(), dut.data(), in.rho.data(), nb_re, 0);
+  nr_qam64_llr_2layer_lbest(in.s0.data(), in.s1.data(), in.mag.data(), in.magi.data(), ref.data(), in.rho.data(), nb_re, 64, 0.0f);
+  Fit f = fit_stats(dut.data(), ref.data(), (size_t)nb_re * 6);
+  fprintf(stderr, "[  FIT  ] 64QAM  signDisagree=%.3f%% fitScale=%.3f residFrac=%.3f\n", f.signDisagree_pct, f.fitScale, f.residFrac);
+  EXPECT_LT(f.signDisagree_pct, 1.0) << "too many LLR sign flips vs float model";
+  EXPECT_GT(f.fitScale, 0.2) << "kernel output not positively correlated with the model";
+  EXPECT_LT(f.residFrac, 0.40) << "post-scale residual too large vs float model";
+}
+
+TEST(test_llr_2layer, fidelity_vs_float_256qam)
+{
+  const uint32_t nb_re = 3200;
+  auto in = gen_clean_inputs(nb_re, 0xF256, 15, 1000);
+  AlignedVector512<int16_t> dut((size_t)nb_re * 8 + 64, 0), ref((size_t)nb_re * 8 + 64, 0);
+  nr_qam256_llr_2layer_lbest_q15_simd_w256(in.s0.data(), in.s1.data(), in.mag.data(), in.magi.data(), dut.data(), in.rho.data(), nb_re, 1);
+  nr_qam256_llr_2layer_lbest(in.s0.data(), in.s1.data(), in.mag.data(), in.magi.data(), ref.data(), in.rho.data(), nb_re, 256, 0.0f);
+  Fit f = fit_stats(dut.data(), ref.data(), (size_t)nb_re * 8);
+  fprintf(stderr, "[  FIT  ] 256QAM signDisagree=%.3f%% fitScale=%.3f residFrac=%.3f\n", f.signDisagree_pct, f.fitScale, f.residFrac);
+  EXPECT_LT(f.signDisagree_pct, 1.0) << "too many LLR sign flips vs float model";
+  EXPECT_GT(f.fitScale, 0.2) << "kernel output not positively correlated with the model";
+  EXPECT_LT(f.residFrac, 0.40) << "post-scale residual too large vs float model";
+}
+
+int main(int argc, char **argv)
+{
+  logInit();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
@@ -786,6 +786,11 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
   // Controlled by ue->do_ml (set via -E flag in dlsim, or ue->do_ml in the UE struct).
   // When false (default), MMSE equalization is used for all configurations.
   bool do_ml = ue->do_ml;
+  // ANALYSIS gate (OAI_LBEST): route 2-layer 256QAM (Qm=8) to the float L-best ML kernel
+  // (nr_compute_ML_llr case 8) instead of the MMSE+single-layer fallback. Off by default.
+  static int lbest256 = -1;
+  if (lbest256 < 0) { const char *e = getenv("OAI_LBEST"); lbest256 = e ? atoi(e) : 0; }
+  const bool ml256 = do_ml && lbest256;
 
   // Reinterpret flat dl_ch_estimates_ext as [nl][nbRx][rx_size_symbol]
   c16_t(*chFext)[nbRx][rx_size_symbol] = (void *)dl_ch_estimates_ext;
@@ -1095,8 +1100,9 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
     const uint8_t qamModOrder = dlsch->cw_info.qamModOrder;
     start_meas_nr_ue_phy(ue, DLSCH_LLR_STATS);
     for (int llr_sym = startSymbIdx; llr_sym < startSymbIdx + nbSymb; llr_sym++) {
-      if (nl == 2 && qamModOrder <= 6 && do_ml) {
-        // 2-layer QPSK/16QAM/64QAM: joint ML-LLR using inter-layer Tx correlation
+      if (nl == 2 && do_ml && (qamModOrder <= 6 || (qamModOrder == 8 && ml256))) {
+        // 2-layer QPSK/16QAM/64QAM (and 256QAM under the OAI_LBEST analysis gate):
+        // joint ML-LLR using inter-layer Tx correlation
         // rho_dl[llr_sym] is laid out as [nl*nl][rx_size_symbol]:
         // index 1 = rho[0][1], index nl (=2) = rho[1][0]
         nr_compute_ML_llr(rxdataF_comp[llr_sym][0],

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
@@ -953,18 +953,14 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
     }
     // Output shift: half channel energy (log2|h|^2/2) + MRC antenna gain.
     // Single-layer adds +1 guard bit (raw peak); multi-layer uses median so no guard needed.
-    // ML branch offset (empirical -2) tunable via OAI_ML_MAXH_OFF for the hotness sweep.
-    static int ml_maxh_off = -100;
-    if (ml_maxh_off == -100) {
-      const char *e = getenv("OAI_ML_MAXH_OFF");
-      ml_maxh_off = e ? atoi(e) : -2;
-    }
+    // ML branch offset is mod-order-dependent (nr_ml_llr_maxh_off) so the near-ML LLRs don't
+    // saturate at low mod orders; OAI_ML_MAXH_OFF overrides it for the hotness sweep.
     if (nl == 1)
       *log2_maxh = (log2_approx(avgs) >> 1) + 1 + log2_approx(nbRx >> 1);
     else if (!do_ml)
       *log2_maxh = (log2_approx(avgs) >> 1) + log2_approx(nbRx >> 1);
     else
-      *log2_maxh = (log2_approx(avgs) >> 1) + ml_maxh_off + log2_approx(nbRx >> 1);
+      *log2_maxh = (log2_approx(avgs) >> 1) + nr_ml_llr_maxh_off(dlsch->cw_info.qamModOrder) + log2_approx(nbRx >> 1);
     LOG_D(PHY, "[DLSCH] AbsSubframe %d.%d log2_maxh = %d (%d)\n", frame % 1024, nr_slot_rx, *log2_maxh, avgs);
 #if T_TRACER
     T(T_UE_PHY_PDSCH_ENERGY,

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
@@ -788,9 +788,14 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
   bool do_ml = ue->do_ml;
   // ANALYSIS gate (OAI_LBEST): route 2-layer 256QAM (Qm=8) to the float L-best ML kernel
   // (nr_compute_ML_llr case 8) instead of the MMSE+single-layer fallback. Off by default.
-  static int lbest256 = -1;
-  if (lbest256 < 0) { const char *e = getenv("OAI_LBEST"); lbest256 = e ? atoi(e) : 0; }
-  const bool ml256 = do_ml && lbest256;
+  static int lbest_gate = -1;
+  if (lbest_gate < 0) { const char *e = getenv("OAI_LBEST"); lbest_gate = e ? atoi(e) : 0; }
+  const bool ml256 = do_ml && lbest_gate;
+  // 3-layer detector selection mirrors the 2-layer path: MMSE is the default (fast linear,
+  // works for all modulations), and the hybrid ML detector (Schur-deflate one nuisance, keep
+  // the other discrete, 2-layer conditional-slice LLR) is opt-in via the do_ml/OAI_LBEST gate.
+  // The hybrid covers QPSK/16/64/256QAM. (4-layer: MMSE only for now; hybrid is a later effort.)
+  const bool ml3 = do_ml && lbest_gate && nl == 3;
 
   // Reinterpret flat dl_ch_estimates_ext as [nl][nbRx][rx_size_symbol]
   c16_t(*chFext)[nbRx][rx_size_symbol] = (void *)dl_ch_estimates_ext;
@@ -1029,9 +1034,9 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
     static int mmse_gram = -1;
     if (mmse_gram < 0) { const char *e = getenv("OAI_MMSE_GRAM"); mmse_gram = e ? atoi(e) : 1; }
 
-    if ((nl > 2) || (nl == 2 && !do_ml)) {
+    if ((nl > 2 && !ml3) || (nl == 2 && !do_ml)) {
       nr_dlsch_mmse(pdsch_buf_size_max,
-                    rx_size_symbol,
+		    rx_size_symbol,
                     nbRx,
                     nl,
                     rxdataF_comp[symbol],
@@ -1115,6 +1120,30 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
                           rho_dl[llr_sym][nl],
                           dl_valid_re[llr_sym],
                           qamModOrder);
+      } else if (ml3) {
+        // 3-layer hybrid ML (gated, float reference). For each target layer t, project the
+        // most-orthogonal nuisance + Schur-deflate, then 2-layer conditional-slice on the kept
+        // pair. rho_dl[llr_sym] is [nl*nl][rx]: rho[i][j] at index i*nl+j (= h_i^H h_j).
+        // OAI_LBEST3=2 -> exact full-ML reference instead of the hybrid; OAI_LBEST_L3 -> L.
+        static int mode3 = -1, L3 = 256;
+        if (mode3 < 0) {
+          const char *e = getenv("OAI_LBEST3"); mode3 = e ? atoi(e) : 1;
+          const char *el = getenv("OAI_LBEST_L3"); L3 = el ? atoi(el) : 256;
+        }
+        for (int t = 0; t < 3; t++) {
+          const int n1 = (t + 1) % 3, n2 = (t + 2) % 3;
+          c16_t *r_tn1 = rho_dl[llr_sym][t * nl + n1];
+          c16_t *r_tn2 = rho_dl[llr_sym][t * nl + n2];
+          c16_t *r_n1n2 = rho_dl[llr_sym][n1 * nl + n2];
+          if (mode3 == 2)
+            nr_qam_llr_3layer_ml(rxdataF_comp[llr_sym][t], rxdataF_comp[llr_sym][n1], rxdataF_comp[llr_sym][n2],
+                                 dl_ch_mag[llr_sym][t], dl_ch_mag[llr_sym][n1], dl_ch_mag[llr_sym][n2],
+                                 r_tn1, r_tn2, r_n1n2, layer_llr[llr_sym][t], dl_valid_re[llr_sym], qamModOrder);
+          else
+            nr_qam_llr_3layer_hybrid(rxdataF_comp[llr_sym][t], rxdataF_comp[llr_sym][n1], rxdataF_comp[llr_sym][n2],
+                                     dl_ch_mag[llr_sym][t], dl_ch_mag[llr_sym][n1], dl_ch_mag[llr_sym][n2],
+                                     r_tn1, r_tn2, r_n1n2, layer_llr[llr_sym][t], dl_valid_re[llr_sym], qamModOrder, L3, 0.0f);
+        }
       } else {
         nr_dlsch_llr(dlsch,
                      dl_valid_re[llr_sym],

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
@@ -953,10 +953,18 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
     }
     // Output shift: half channel energy (log2|h|^2/2) + MRC antenna gain.
     // Single-layer adds +1 guard bit (raw peak); multi-layer uses median so no guard needed.
+    // ML branch offset (empirical -2) tunable via OAI_ML_MAXH_OFF for the hotness sweep.
+    static int ml_maxh_off = -100;
+    if (ml_maxh_off == -100) {
+      const char *e = getenv("OAI_ML_MAXH_OFF");
+      ml_maxh_off = e ? atoi(e) : -2;
+    }
     if (nl == 1)
       *log2_maxh = (log2_approx(avgs) >> 1) + 1 + log2_approx(nbRx >> 1);
-    else
+    else if (!do_ml)
       *log2_maxh = (log2_approx(avgs) >> 1) + log2_approx(nbRx >> 1);
+    else
+      *log2_maxh = (log2_approx(avgs) >> 1) + ml_maxh_off + log2_approx(nbRx >> 1);
     LOG_D(PHY, "[DLSCH] AbsSubframe %d.%d log2_maxh = %d (%d)\n", frame % 1024, nr_slot_rx, *log2_maxh, avgs);
 #if T_TRACER
     T(T_UE_PHY_PDSCH_ENERGY,

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
@@ -529,7 +529,8 @@ static void nr_dlsch_mmse(uint32_t pdsch_buf_size_max,
                           unsigned char mod_order,
                           int shift,
                           int length,
-                          uint32_t noise_var)
+                          uint32_t noise_var,
+                          c16_t rho[nl * nl][pdsch_buf_size_max])
 {
   uint32_t nb_rb_0 = (length + 11) / 12;
   c16_t determ_fin[12 * nb_rb_0] __attribute__((aligned(32)));
@@ -543,19 +544,32 @@ static void nr_dlsch_mmse(uint32_t pdsch_buf_size_max,
       for (int ctx = 0; ctx < nl; ctx++)
         conjH_H_elements[aarx][rtx][ctx] = conjH_H_elements_data[aarx][rtx][ctx];
 
-  //Compute H^*H matrix elements and sub elements:(1/2^log2_maxh)*conjH_H_elements
-  for (int rtx = 0; rtx < nl; rtx++) {//row
-    for (int ctx = 0; ctx < nl; ctx++) {//column
-      for (int aarx = 0; aarx < n_rx; aarx++)  {
-        c16_t *ch0r = dl_ch_estimates_ext[rtx * n_rx + aarx];
-        c16_t *ch0c = dl_ch_estimates_ext[ctx * n_rx + aarx];
-        mult_cpx_conj_vector(ch0r,
-                            ch0c,
-                            conjH_H_elements[aarx][ctx][rtx], // sic
-                            nb_rb_0 * NR_NB_SC_PER_RB,
-                            shift);
-        if (aarx != 0)
-          nr_a_sum_b(conjH_H_elements[0][ctx][rtx], conjH_H_elements[aarx][ctx][rtx], nb_rb_0);
+  // Compute H^*H matrix elements and sub elements:(1/2^log2_maxh)*conjH_H_elements
+  if (rho) {
+    // Gram-based: rho already holds Sum_rx conj(ch_i)*ch_j >> log2_maxh (the full nl x nl Gram,
+    // diagonal included), at the same scale conjH_H uses. The chFext-based build below re-derives
+    // exactly this. conjH_H[ctx][rtx] = conj(ch_rtx)*ch_ctx = rho[rtx][ctx] (flat: rho[rtx*nl+ctx]).
+    // (Conjugate/transpose direction validated against the chFext path in dlsim.)
+    for (int rtx = 0; rtx < nl; rtx++)
+      for (int ctx = 0; ctx < nl; ctx++)
+        memcpy(conjH_H_elements[0][ctx][rtx], rho[rtx * nl + ctx], length * sizeof(c16_t));
+  } else {
+    for (int rtx = 0; rtx < nl; rtx++) { // row
+      for (int ctx = 0; ctx < nl; ctx++) { // column
+        for (int aarx = 0; aarx < n_rx; aarx++) {
+          c16_t *ch0r = dl_ch_estimates_ext[rtx * n_rx + aarx];
+          c16_t *ch0c = dl_ch_estimates_ext[ctx * n_rx + aarx];
+          /* upstream replaced nr_conjch0_mult_ch1() here: it is now static in
+             nr_compute_llr.c, and mult_cpx_conj_vector() takes the length in
+             subcarriers rather than RBs */
+          mult_cpx_conj_vector(ch0r,
+                               ch0c,
+                               conjH_H_elements[aarx][ctx][rtx], // sic
+                               nb_rb_0 * NR_NB_SC_PER_RB,
+                               shift);
+          if (aarx != 0)
+            nr_a_sum_b(conjH_H_elements[0][ctx][rtx], conjH_H_elements[aarx][ctx][rtx], nb_rb_0);
+        }
       }
     }
   }
@@ -805,7 +819,12 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
   uint8_t pilots = (dlsch_config->dlDmrsSymbPos >> symbol) & 1;
   uint8_t config_type = dlsch_config->dmrsConfigType;
 
-  const bool need_rho = do_ml ? (nl == 2 && dlsch_config->cw_info->qamModOrder <= 6) : false;
+  // rho = full nl x nl Gram (H^H H). Needed by the ML LLR kernels AND now by the Gram-based linear
+  // MMSE: nr_dlsch_mmse builds H^H H from rho instead of re-deriving it from the (per-symbol) channel
+  // estimates. Covers the linear-MMSE cases (nl>2 non-ml3; nl==2 non-ML) as well as the ML cases.
+  // Every multi-layer path (ML search, linear nl>2 / 2-layer MMSE, 2-layer 256QAM MMSE) now reads the
+  // Gram from rho, so retain it for all nl >= 2. Single-layer (nl==1, MRC) needs no rho.
+  const bool need_rho = (nl >= 2);
 
   //----------------------------------------------------------
   //--------------------- RBs extraction ---------------------
@@ -1001,6 +1020,9 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
   start_meas_nr_ue_phy(ue, DLSCH_MRC_MMSE_STATS);
   if (nb_re_pdsch) {
     const uint8_t qamModOrder = dlsch->cw_info.qamModOrder;
+    // A/B validation toggle: OAI_MMSE_GRAM=0 forces the legacy chFext Gram build (default 1 = Gram).
+    static int mmse_gram = -1;
+    if (mmse_gram < 0) { const char *e = getenv("OAI_MMSE_GRAM"); mmse_gram = e ? atoi(e) : 1; }
 
     if ((nl > 2) || (nl == 2 && !do_ml)) {
       nr_dlsch_mmse(pdsch_buf_size_max,
@@ -1015,8 +1037,9 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
                     qamModOrder,
                     *log2_maxh,
                     nb_re_pdsch,
-                    nvar);
-    } else if ((nl == 2) && (qamModOrder > 6) && do_ml) {
+                    nvar,
+                    (need_rho && mmse_gram) ? rho_dl[symbol] : NULL); // Gram-based build; OAI_MMSE_GRAM=0 -> legacy chFext
+    } else if ((nl == 2) && (qamModOrder > 6) && do_ml && !ml256) {
       nr_mmse_2layers(p_rxComp,
                       rx_size_symbol,
                       pdsch_buf_size_max,
@@ -1031,7 +1054,11 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
                       *log2_maxh,
                       0,
                       nb_re_pdsch,
-                      nvar);
+                      nvar,
+                      (need_rho && mmse_gram) ? rho_dl[symbol][0] : NULL,
+                      (need_rho && mmse_gram) ? rho_dl[symbol][1] : NULL,
+                      (need_rho && mmse_gram) ? rho_dl[symbol][nl] : NULL,
+                      (need_rho && mmse_gram) ? rho_dl[symbol][nl + 1] : NULL); // Gram; OAI_MMSE_GRAM=0 -> chFext
     }
   }
   stop_meas_nr_ue_phy(ue, DLSCH_MRC_MMSE_STATS);

--- a/openair1/PHY/nr_phy_common/inc/nr_compute_llr.h
+++ b/openair1/PHY/nr_phy_common/inc/nr_compute_llr.h
@@ -34,6 +34,17 @@ void nr_qam64_llr_2layer(c16_t *stream0_in,
                          c16_t *rho01,
                          uint32_t length);
 
+// Direct SIMD full ML 2-layer 256QAM (analogous to nr_qam64_llr_2layer for 64QAM).
+// 8 bits/RE, PAM-16 constellation, Gray-coded. Computes LLRs for stream0 in presence
+// of stream1 interference.
+void nr_qam256_llr_2layer(c16_t *stream0_in,
+                          c16_t *stream1_in,
+                          c16_t *ch_mag,
+                          c16_t *ch_mag_i,
+                          int16_t *stream0_out,
+                          c16_t *rho01,
+                          uint32_t length);
+
 // L-best (reduced-search) reference kernel for 2-layer 64QAM (one target layer).
 // Floating-point scalar reference; L==64 reproduces the full max-log search.
 // seed_lambda: 0.0f = ZF seed, = noise_var for MMSE-regularised seed.
@@ -71,6 +82,19 @@ void nr_qam256_llr_2layer_lbest(c16_t *stream0_in,
                                 int L,
                                 float seed_lambda);
 
+// Fixed-point (Q15-input) L-best 2-layer 256QAM kernel (ZF seed). Integer twin of
+// nr_qam256_llr_2layer_lbest; scale 16*sqrt(170), PAM-16 levels, 8 bits/RE.
+// pattern: 0=5x5/25cand[default], 1=3x3/9cand, 2=5-plus/5cand, other=full256.
+// Enabled via OAI_LBEST_Q15_256=1; pattern selected by OAI_LBEST_PAT256.
+void nr_qam256_llr_2layer_lbest_q15(c16_t *stream0_in,
+                                    c16_t *stream1_in,
+                                    c16_t *ch_mag,
+                                    c16_t *ch_mag_i,
+                                    int16_t *stream0_out,
+                                    c16_t *rho01,
+                                    uint32_t length,
+                                    int pattern);
+
 // Fixed-point (Q15-input) L-best 2-layer 64QAM kernel (ZF seed). Integer twin of
 // nr_qam64_llr_2layer_lbest; the SIMD-portable form of the reduced search.
 void nr_qam64_llr_2layer_lbest_q15(c16_t *stream0_in,
@@ -92,6 +116,18 @@ void nr_qam64_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
                                           c16_t *rho01,
                                           uint32_t length,
                                           int pattern);
+
+// int16/16-lane AVX2 L-best 2-layer 256QAM kernel (PAM-16, 8 bits/RE).
+// pattern: 0 = 5x5 (25 cand) [default], 1 = 3x3 (9 cand), 2 = 5-plus (5 cand).
+// Enabled via OAI_LBEST_Q15_256=1; pattern selected by OAI_LBEST_PAT256.
+void nr_qam256_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
+                                           c16_t *stream1_in,
+                                           c16_t *ch_mag,
+                                           c16_t *ch_mag_i,
+                                           int16_t *stream0_out,
+                                           c16_t *rho01,
+                                           uint32_t length,
+                                           int pattern);
 
 void nr_compute_ML_llr(c16_t *rxdataF_comp0,
                        c16_t *rxdataF_comp1,

--- a/openair1/PHY/nr_phy_common/inc/nr_compute_llr.h
+++ b/openair1/PHY/nr_phy_common/inc/nr_compute_llr.h
@@ -34,6 +34,65 @@ void nr_qam64_llr_2layer(c16_t *stream0_in,
                          c16_t *rho01,
                          uint32_t length);
 
+// L-best (reduced-search) reference kernel for 2-layer 64QAM (one target layer).
+// Floating-point scalar reference; L==64 reproduces the full max-log search.
+// seed_lambda: 0.0f = ZF seed, = noise_var for MMSE-regularised seed.
+void nr_qam64_llr_2layer_lbest(c16_t *stream0_in,
+                               c16_t *stream1_in,
+                               c16_t *ch_mag,
+                               c16_t *ch_mag_i,
+                               int16_t *stream0_out,
+                               c16_t *rho01,
+                               uint32_t length,
+                               int L,
+                               float seed_lambda);
+
+// Float reference L-best kernel for 2-layer 16QAM (building block for >2-layer hybrid).
+// L==16 == full ML. seed_lambda: 0=ZF.
+void nr_qam16_llr_2layer_lbest(c16_t *stream0_in,
+                               c16_t *stream1_in,
+                               c16_t *ch_mag,
+                               c16_t *ch_mag_i,
+                               int16_t *stream0_out,
+                               c16_t *rho01,
+                               uint32_t length,
+                               int L,
+                               float seed_lambda);
+
+// Float reference L-best kernel for 2-layer 256QAM. L==256 == full ML search
+// (analysis vehicle; no SIMD 256QAM full-search kernel exists). seed_lambda: 0=ZF.
+void nr_qam256_llr_2layer_lbest(c16_t *stream0_in,
+                                c16_t *stream1_in,
+                                c16_t *ch_mag,
+                                c16_t *ch_mag_i,
+                                int16_t *stream0_out,
+                                c16_t *rho01,
+                                uint32_t length,
+                                int L,
+                                float seed_lambda);
+
+// Fixed-point (Q15-input) L-best 2-layer 64QAM kernel (ZF seed). Integer twin of
+// nr_qam64_llr_2layer_lbest; the SIMD-portable form of the reduced search.
+void nr_qam64_llr_2layer_lbest_q15(c16_t *stream0_in,
+                                   c16_t *stream1_in,
+                                   c16_t *ch_mag,
+                                   c16_t *ch_mag_i,
+                                   int16_t *stream0_out,
+                                   c16_t *rho01,
+                                   uint32_t length,
+                                   int L);
+
+// int16/16-lane AVX2 L-best 2-layer 64QAM kernel (the optimized form).
+// pattern: 0 = 3x3 (9 cand, full BLER), 1 = 6-cand (plus + toward-seed diagonal), 2 = 5-plus.
+void nr_qam64_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
+                                          c16_t *stream1_in,
+                                          c16_t *ch_mag,
+                                          c16_t *ch_mag_i,
+                                          int16_t *stream0_out,
+                                          c16_t *rho01,
+                                          uint32_t length,
+                                          int pattern);
+
 void nr_compute_ML_llr(c16_t *rxdataF_comp0,
                        c16_t *rxdataF_comp1,
                        c16_t *ch_mag0,

--- a/openair1/PHY/nr_phy_common/inc/nr_compute_llr.h
+++ b/openair1/PHY/nr_phy_common/inc/nr_compute_llr.h
@@ -59,6 +59,33 @@ uint8_t nr_mmse_2layers(c16_t **rxdataF_comp,
                         int shift,
                         unsigned char symbol,
                         int length,
-                        uint32_t noise_var);
+                        uint32_t noise_var,
+                        c16_t *rho00,
+                        c16_t *rho01,
+                        c16_t *rho10,
+                        c16_t *rho11);
+
+// Fused 2-layer linear MMSE + scalar LLR (L=1). = nr_mmse_2layers (Gram-fed equalize) + per-layer
+// nr_compute_llr. UE: symbol=0 + pre-offset rxdataF_comp; gNB: symbol offset applied internally.
+uint8_t nr_compute_MMSE_llr(c16_t **rxdataF_comp,
+                            uint32_t buffer_length,
+                            uint32_t pdsch_buf_size_max,
+                            int nb_rx_ant,
+                            int nb_layers,
+                            c16_t ch_mag[nb_layers][pdsch_buf_size_max],
+                            c16_t ch_magb[nb_layers][pdsch_buf_size_max],
+                            c16_t ch_magc[nb_layers][pdsch_buf_size_max],
+                            c16_t ch_estimates_ext[][nb_rx_ant][buffer_length],
+                            unsigned short nb_rb,
+                            unsigned char mod_order,
+                            int shift,
+                            unsigned char symbol,
+                            int length,
+                            uint32_t noise_var,
+                            c16_t *rho00,
+                            c16_t *rho01,
+                            c16_t *rho10,
+                            c16_t *rho11,
+                            int16_t **llr);
 
 #endif /* __NR_COMPUTE_LLR__H__ */

--- a/openair1/PHY/nr_phy_common/inc/nr_compute_llr.h
+++ b/openair1/PHY/nr_phy_common/inc/nr_compute_llr.h
@@ -7,6 +7,16 @@
 
 #include "PHY/impl_defs_top.h"
 
+/**
+ * @brief Mod-order-dependent LLR-hotness offset for the 2-layer near-ML/L-best log2_maxh.
+ *
+ * The joint near-ML metric needs a mod-order-dependent fixed-point scale: 256QAM at -2, and lower
+ * orders progressively different, else the ML LLRs saturate and the ML gain over linear MMSE is
+ * lost (a single 256QAM-tuned -2 makes QPSK/16QAM ML worse than MMSE). Verified on TDL, z4, -gA.
+ * OAI_ML_MAXH_OFF forces a single value across all mod orders (hotness sweep / analysis).
+ */
+int nr_ml_llr_maxh_off(int mod_order);
+
 void nr_compute_llr(c16_t *rxdataF_comp,
                     c16_t *ch_mag,
                     c16_t *ch_magb,

--- a/openair1/PHY/nr_phy_common/inc/nr_compute_llr.h
+++ b/openair1/PHY/nr_phy_common/inc/nr_compute_llr.h
@@ -58,6 +58,21 @@ void nr_qam64_llr_2layer_lbest(c16_t *stream0_in,
                                int L,
                                float seed_lambda);
 
+// 3-layer hybrid L-best (target layer): project the most-orthogonal nuisance layer (Schur
+// deflation), keep the other discrete, run the 2-layer conditional-slice LLR on the deflated
+// pair. Qm = 4/6/8 (16/64/256QAM, same for all layers). rho_ab = h_a^H h_b.
+void nr_qam_llr_3layer_hybrid(c16_t *zt, c16_t *zn1, c16_t *zn2,
+                              c16_t *cmt, c16_t *cmn1, c16_t *cmn2,
+                              c16_t *rho_tn1, c16_t *rho_tn2, c16_t *rho_n1n2,
+                              int16_t *out, uint32_t length, int Qm, int L, float lambda);
+
+// 3-layer full-ML reference (target layer): exact max-log over discrete (x_t,x_n1) + conditional
+// x_n2 slice. For BLER comparison against the hybrid.
+void nr_qam_llr_3layer_ml(c16_t *zt, c16_t *zn1, c16_t *zn2,
+                          c16_t *cmt, c16_t *cmn1, c16_t *cmn2,
+                          c16_t *rho_tn1, c16_t *rho_tn2, c16_t *rho_n1n2,
+                          int16_t *out, uint32_t length, int Qm);
+
 // Float reference L-best kernel for 2-layer 16QAM (building block for >2-layer hybrid).
 // L==16 == full ML. seed_lambda: 0=ZF.
 void nr_qam16_llr_2layer_lbest(c16_t *stream0_in,

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -7,6 +7,7 @@
 #include "bits.h"
 #include <complex.h>
 #include <stdlib.h>
+#include <stdio.h> // OAI_LBEST_DBG diagnostic (stderr); analysis-only
 #include "PHY/sse_intrin.h"
 #include "PHY/impl_defs_top.h"
 #ifdef __aarch64__
@@ -3945,6 +3946,43 @@ void nr_compute_ML_llr(c16_t *rxdataF_comp0,
         } else {
           nr_qam64_llr_2layer(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, llr_layers0, rho0, nb_re);
           nr_qam64_llr_2layer(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re);
+        }
+        // --- OAI_LBEST_DBG: verify the ACTIVE 64QAM kernel (layer 0) vs the FLOAT full-ML
+        // reference (nr_qam64_llr_2layer_lbest, L=64 == exact max-log search) on the SAME
+        // real inputs. Accumulates scale-invariant correctness (sign disagreement), magnitude,
+        // int16 saturation fraction, best-fit scale vs ref, and post-scale residual (distortion).
+        // Analysis-only (dlsim); single-threaded static counters. Set OAI_LBEST_DBG=1.
+        {
+          static int dbg = -1;
+          if (dbg < 0) { const char *e = getenv("OAI_LBEST_DBG"); dbg = e ? atoi(e) : 0; }
+          if (dbg) {
+            static long n = 0, sdis = 0, satN = 0, gtN = 0;
+            static double sAbsP = 0, sAbsR = 0, sPR = 0, sRR = 0, sPP = 0;
+            int16_t *ref = (int16_t *)malloc((size_t)nb_re * 6 * sizeof(int16_t));
+            nr_qam64_llr_2layer_lbest(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, ref, rho0, nb_re, 64, 0.0f);
+            for (uint32_t k = 0; k < nb_re * 6; k++) {
+              const int p = llr_layers0[k], r = ref[k];
+              const int ap = p < 0 ? -p : p, ar = r < 0 ? -r : r;
+              n++;
+              if ((long)p * r < 0) sdis++;
+              if (ap >= 30000) satN++;
+              if (ap >= 128) gtN++; // int8 clip point: LDPC narrows int16->int8 (packs, sat +-127)
+              sAbsP += ap; sAbsR += ar;
+              sPR += (double)p * r; sRR += (double)r * r; sPP += (double)p * p;
+            }
+            free(ref);
+            if (n >= 200000) {
+              const double a = sRR > 0 ? sPR / sRR : 0;                  // prod ~= a*ref
+              const double resid = sPP - 2 * a * sPR + a * a * sRR;      // sum (prod - a*ref)^2
+              fprintf(stderr,
+                      "### LBEST_DBG kernel=%s N=%ld signDisagree=%.3f%% meanAbs prod=%.0f ref=%.0f "
+                      "sat|.|>=30000=%.3f%% int8clip|.|>=128=%.3f%% fitScale=%.3f residFrac=%.3f\n",
+                      lbest ? "simd16" : "legacy_full", n, 100.0 * sdis / n,
+                      sAbsP / n, sAbsR / n, 100.0 * satN / n, 100.0 * gtN / n, a,
+                      sPP > 0 ? resid / sPP : 0);
+              n = sdis = satN = gtN = 0; sAbsP = sAbsR = sPR = sRR = sPP = 0;
+            }
+          }
         }
       }
       break;

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -3924,14 +3924,11 @@ void nr_compute_ML_llr(c16_t *rxdataF_comp0,
       nr_qam16_llr_2layer(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re);
       break;
     case 6:
-      // 2-layer 64QAM. Default = full ML search (nr_qam64_llr_2layer), correct on all channels.
-      // The reduced-search L-best kernel (nr_qam64_llr_2layer_lbest_q15_simd16) is GATED OFF by
-      // default: it is only accurate on low-correlation / sparse channels (e.g. mmWave indoor,
-      // LOS-dominated), where the linear (ZF) seed predicts the ML symbol well. On correlated /
-      // selective channels (e.g. 3GPP TDL) it loses several dB and MUST NOT be used.
-      // Enable per-scenario via OAI_LBEST=1; OAI_LBEST_PAT picks the candidate set
-      // (0=3x3 [default], 1=6-cand seed-aware, 2=5-plus). TODO: replace the env gate with a
-      // proper RX-mode/config flag set by the scenario.
+      // 2-layer 64QAM. Default today = full ML search (nr_qam64_llr_2layer). The reduced-search
+      // L-best kernel (nr_qam64_llr_2layer_lbest_q15_simd16) tracks full-ML on 3GPP TDL with the
+      // hot ML LLR scaling and is faster (see nr_mimo_lbest_detector.md sec. 6a); it is opt-in via
+      // OAI_LBEST=1 for now, pending a proper RX-mode/config flag to make it the default.
+      // OAI_LBEST_PAT picks the candidate set (0=3x3 [default], 1=6-cand seed-aware, 2=5-plus).
       {
         static int lbest = -1, pat = 0;
         if (lbest < 0) {

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -3188,8 +3188,10 @@ void nr_qam16_llr_2layer_lbest(c16_t *stream0_in,
 // [-(2^kbits-1), 2^kbits-1]. sqrtN = sqrt(norm), norm = 2(4^kbits-1)/3;
 // rf = sqrtN / 2^(kbits-1) recovers ||h||^2 from the n1-scaled ch_mag.
 // ============================================================================
-static const double NR_LBEST_SQRTN[5] = {0, 0, 3.16227766016838, 6.48074069840786, 13.03840481040530};
-static const double NR_LBEST_RF[5]    = {0, 0, 1.58113883008419, 1.62018517460196, 1.62980060130066};
+// Indexed by kbits = Qm/2, for QPSK/16/64/256QAM (kbits 1/2/3/4). Index 0 (BPSK) unused.
+// sqrtN = sqrt(2*(M-1)/3), M = 4^kbits (per-axis level normalisation); RF = 2*sqrt(2*(M-1)/(3*M)).
+static const double NR_LBEST_SQRTN[5] = {0, 1.41421356237310, 3.16227766016838, 6.48074069840786, 13.03840481040530};
+static const double NR_LBEST_RF[5]    = {0, 1.41421356237310, 1.58113883008419, 1.62018517460196, 1.62980060130066};
 
 // nearest PAM-2^kbits level to v (level units), O(1) round-to-nearest-odd, clamped.
 static inline int nr_lbest_slice_gen(double v, int kbits)
@@ -3298,6 +3300,8 @@ void nr_qam_llr_3layer_hybrid(c16_t *zt, c16_t *zn1, c16_t *zn2,
                               int16_t *out, uint32_t length, int Qm, int L, float lambda)
 {
   const int kbits = Qm / 2;
+  // Qm>=2 (QPSK/16/64/256QAM, kbits 1..4). Index 0 (BPSK) unused.
+  AssertFatal(kbits >= 1 && kbits <= 4, "nr_qam_llr_3layer_hybrid: unsupported Qm=%d\n", Qm);
   const double rf = NR_LBEST_RF[kbits];
   for (uint32_t re = 0; re < length; re++) {
     const double Pt = cmt[re].r * rf, Pn1 = cmn1[re].r * rf, Pn2 = cmn2[re].r * rf;
@@ -3338,6 +3342,7 @@ void nr_qam_llr_3layer_ml(c16_t *zt, c16_t *zn1, c16_t *zn2,
                           int16_t *out, uint32_t length, int Qm)
 {
   const int kbits = Qm / 2, nlev = 1 << kbits, nbits = 2 * kbits;
+  AssertFatal(kbits >= 1 && kbits <= 4, "nr_qam_llr_3layer_ml: unsupported Qm=%d\n", Qm);
   const double sqrtN = NR_LBEST_SQRTN[kbits], NA = 1.0 / sqrtN, rf = NR_LBEST_RF[kbits];
   for (uint32_t re = 0; re < length; re++) {
     const double Pt = cmt[re].r * rf, Pn1 = cmn1[re].r * rf, Pn2 = cmn2[re].r * rf;

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -3847,6 +3847,9 @@ void nr_qam256_llr_2layer_lbest_q15(c16_t *stream0_in,
 // w512 helps on true-512-datapath server CPUs (EPYC Genoa/Turin, Xeon SP) -> opt in with
 // OAI_LBEST_W512=1 (all widths are bit-exact; verified via OAI_LBEST_DBG/DBG256). OAI_LBEST_W128=1
 // selects the NEON-equivalent path for x86 regression testing.
+// Only used on the x86 dispatch path below (aarch64 always runs w128 directly), so gate the
+// definition with the same condition to avoid an unused-function warning (-Werror) on aarch64.
+#if !(defined(SIMDE_ARM_NEON_A64V8_NATIVE) || defined(__aarch64__))
 static int nr_lbest_simd_width_mode(void)
 {
   static int mode = -1;
@@ -3864,6 +3867,7 @@ static int nr_lbest_simd_width_mode(void)
   }
   return mode;
 }
+#endif
 
 void nr_qam64_llr_2layer_lbest_q15_simd16(c16_t *stream0_in, c16_t *stream1_in, c16_t *ch_mag,
                                           c16_t *ch_mag_i, int16_t *stream0_out, c16_t *rho01,

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -2925,6 +2925,31 @@ static inline void nr_lbest_axis_bits256(int level, int *b0, int *b1, int *b2, i
   *b3 = m3 > 2 ? 1 : 0;
 }
 
+// Graded per-axis PAM-16 LLR for the target layer, from the soft seed estimate e (level units)
+// and gain g = 0.5*P0/170. The target metric m(l) = -0.5*P0/170*(l-e)^2 + const is concave with
+// vertex ~= e, so max over a bit-subset is at the level nearest e with that bit. Fills llr[b] =
+// m(l0*)-m(l1*) = g*[(l1*-e)^2 - (l0*-e)^2] for axis bits b0..b3. This is the graded replacement
+// for the hard +-LLR_SAT fallback used when a reduced candidate set does not span a bit (the
+// coarse/MSB bits a local search window cannot reach) -> keeps reduced-search speed with correct
+// MSB soft output. In the same metric units as the ML search, so spanned/unspanned bits are
+// mutually consistent.
+static inline void nr_lbest_pam16_axis_llr(float e, float g, float *llr)
+{
+  static const int levels[16] = {-15, -13, -11, -9, -7, -5, -3, -1, 1, 3, 5, 7, 9, 11, 13, 15};
+  float d0[4], d1[4];
+  for (int b = 0; b < 4; b++) { d0[b] = 1e30f; d1[b] = 1e30f; }
+  for (int k = 0; k < 16; k++) {
+    const float d = (levels[k] - e) * (levels[k] - e);
+    int bb[4];
+    nr_lbest_axis_bits256(levels[k], &bb[0], &bb[1], &bb[2], &bb[3]);
+    for (int b = 0; b < 4; b++) {
+      if (bb[b] == 0) { if (d < d0[b]) d0[b] = d; }
+      else            { if (d < d1[b]) d1[b] = d; }
+    }
+  }
+  for (int b = 0; b < 4; b++) llr[b] = g * (d1[b] - d0[b]);
+}
+
 // candidate (constellation point + squared distance to the seed) for the L-nearest sort
 // (members iL/qL, not I/Q: <complex.h> defines I as the imaginary unit)
 struct nr_lbest_cand { float d; int16_t iL, qL; };
@@ -2966,6 +2991,12 @@ void nr_qam256_llr_2layer_lbest(c16_t *stream0_in,
     const float rz2i = rr * z2i + ri * z2r;
     const float estI = ((P1 + l) * z1r - rz2r) * invdet * NR_LBEST_SQRT170; // ~ +-1..15
     const float estQ = ((P1 + l) * z1i - rz2i) * invdet * NR_LBEST_SQRT170;
+
+    // graded fallback LLRs for bits a reduced candidate set may not span (the coarse/MSB bits)
+    float axisI[4], axisQ[4];
+    const float glin = 0.5f * P0 / 170.0f * NR_LBEST_LLR_SCALE;
+    nr_lbest_pam16_axis_llr(estI, glin, axisI);
+    nr_lbest_pam16_axis_llr(estQ, glin, axisQ);
 
     // ---- candidate set C1 = L nearest of the 256 constellation points ----
     // O(256 log 256) sort by distance, take the first L (L==256 == full ML, no sort needed).
@@ -3019,12 +3050,11 @@ void nr_qam256_llr_2layer_lbest(c16_t *stream0_in,
 
     for (int p = 0; p < 8; p++) {
       float llr;
-      if (max0[p] <= -1e29f)
-        llr = -NR_LBEST_LLR_SAT;
-      else if (max1[p] <= -1e29f)
-        llr = NR_LBEST_LLR_SAT;
+      // bit order {I0,Q0,I1,Q1,I2,Q2,I3,Q3}: even p = I-axis, odd p = Q-axis, axis bit = p/2
+      if (max0[p] > -1e29f && max1[p] > -1e29f)
+        llr = (max0[p] - max1[p]) * NR_LBEST_LLR_SCALE; // spanned: ML LLR
       else
-        llr = (max0[p] - max1[p]) * NR_LBEST_LLR_SCALE;
+        llr = (p & 1) ? axisQ[p >> 1] : axisI[p >> 1];  // unspanned: graded linear (seed) LLR
       if (llr > 32767.0f) llr = 32767.0f;
       if (llr < -32768.0f) llr = -32768.0f;
       *stream0_out++ = (int16_t)llr;
@@ -3982,15 +4012,46 @@ static inline simde__m256i nr_lbest_z170d32(simde__m256i z16)
   return simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
 }
 
+// Graded per-axis PAM-16 LLR (SIMD float, 8 lanes/half): out[b] = g*(min dist^2 with bit b=1 -
+// with b=0), g = 0.5*P0/170, in the kernel's final LLR units. Closed form (no 16-level loop): the
+// nearest PAM-16 level with a given bit value = clamp(round-to-odd(est), subrange), so each bit's
+// min-distance is a couple of clamps. Only b0/b1/b2 are computed — b3 (the finest bit) is ALWAYS
+// spanned by any 3x3/5x5/5-plus window (verified), so its fallback is never used; out[3]=0.
+static inline void nr_lbest_simd_axis_llr256(simde__m256 est, simde__m256 g, simde__m256 out[4])
+{
+  const simde__m256 ONE = simde_mm256_set1_ps(1.0f), TWO = simde_mm256_set1_ps(2.0f), HALF = simde_mm256_set1_ps(0.5f);
+  // o = nearest odd to est; oa = nearest odd to |est|
+  const simde__m256 a = simde_mm256_andnot_ps(simde_mm256_set1_ps(-0.0f), est);
+#define NR_RODD(x) simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps((x), ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE)
+  const simde__m256 o = NR_RODD(est), oa = NR_RODD(a);
+#define NR_CL(x, lo, hi) simde_mm256_min_ps(simde_mm256_max_ps((x), simde_mm256_set1_ps(lo)), simde_mm256_set1_ps(hi))
+#define NR_DSQ(lvl, ref) ({ const simde__m256 _d = simde_mm256_sub_ps((lvl), (ref)); simde_mm256_mul_ps(_d, _d); })
+  // b0 (sign): pos levels [1,15] (bit 0) vs neg [-15,-1] (bit 1)
+  out[0] = simde_mm256_mul_ps(g, simde_mm256_sub_ps(NR_DSQ(NR_CL(o, -15.0f, -1.0f), est), NR_DSQ(NR_CL(o, 1.0f, 15.0f), est)));
+  // b1 (|L|>8): |L| in [1,7] (bit 0) vs [9,15] (bit 1); by symmetry work in a=|est|
+  out[1] = simde_mm256_mul_ps(g, simde_mm256_sub_ps(NR_DSQ(NR_CL(oa, 9.0f, 15.0f), a), NR_DSQ(NR_CL(oa, 1.0f, 7.0f), a)));
+  // b2 (||L|-8|>4): |L| in {5,7,9,11} (bit 0) vs {1,3}U{13,15} (bit 1)
+  const simde__m256 d2_0 = NR_DSQ(NR_CL(oa, 5.0f, 11.0f), a);
+  const simde__m256 d2_1 = simde_mm256_min_ps(NR_DSQ(NR_CL(oa, 1.0f, 3.0f), a), NR_DSQ(NR_CL(oa, 13.0f, 15.0f), a));
+  out[2] = simde_mm256_mul_ps(g, simde_mm256_sub_ps(d2_1, d2_0));
+  out[3] = simde_mm256_setzero_ps(); // b3 always spanned by the search window -> fallback never read
+#undef NR_RODD
+#undef NR_CL
+#undef NR_DSQ
+}
+
 // ZF seed for 256QAM: identical to nr_lbest_simd_seed16 except clamp to [-15,15]
-// and Pp = cm * sqrt(170)/8.
+// and Pp = cm * sqrt(170)/8. Also emits axisLLR[8] = graded per-axis PAM-16 LLRs (interleaved
+// {I0,Q0,I1,Q1,I2,Q2,I3,Q3}, int16) used as the fallback for bits the reduced search cannot span.
 static inline void nr_lbest_simd_seed16_256(simde__m256i z1r16, simde__m256i z1i16,
                                             simde__m256i z2r16, simde__m256i z2i16,
                                             simde__m256i rr16,  simde__m256i ri16,
                                             simde__m256i cm0_16, simde__m256i cm1_16,
                                             simde__m256i *centerI, simde__m256i *centerQ,
-                                            simde__m256i *dirImask, simde__m256i *dirQmask)
+                                            simde__m256i *dirImask, simde__m256i *dirQmask,
+                                            simde__m256i axisLLR[8])
 {
+  simde__m256 aL[2][8]; // [half][ {I0,Q0,I1,Q1,I2,Q2,I3,Q3} ]
   const simde__m256i SQRT170_OVER8 = simde_mm256_set1_epi32(NR_LBEST_Q_SQRT170_OVER8_Q14_SIMD);
   const simde__m256 SQRT170 = simde_mm256_set1_ps(13.038404810405298f);
   const simde__m256 HALF = simde_mm256_set1_ps(0.5f), ONE = simde_mm256_set1_ps(1.0f), TWO = simde_mm256_set1_ps(2.0f);
@@ -4013,6 +4074,12 @@ static inline void nr_lbest_simd_seed16_256(simde__m256i z1r16, simde__m256i z1i
     // soft level estimate ~ +-1..15
     const simde__m256 estI = simde_mm256_mul_ps(simde_mm256_div_ps(numr, det), SQRT170);
     const simde__m256 estQ = simde_mm256_mul_ps(simde_mm256_div_ps(numi, det), SQRT170);
+    // graded per-axis PAM-16 LLRs from the soft estimate (g = 0.5*P0/170, P0 = Pp0)
+    const simde__m256 glin = simde_mm256_mul_ps(simde_mm256_set1_ps(0.5f / 170.0f), Pp0);
+    simde__m256 aI4[4], aQ4[4];
+    nr_lbest_simd_axis_llr256(estI, glin, aI4);
+    nr_lbest_simd_axis_llr256(estQ, glin, aQ4);
+    for (int b = 0; b < 4; b++) { aL[h][2 * b] = aI4[b]; aL[h][2 * b + 1] = aQ4[b]; }
     // nearest odd level: o = 2*round((est-1)/2)+1, clamped to [-15,15]
     simde__m256 oI = simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps(estI, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
     simde__m256 oQ = simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps(estQ, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
@@ -4027,6 +4094,10 @@ static inline void nr_lbest_simd_seed16_256(simde__m256i z1r16, simde__m256i z1i
   *centerQ  = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(cQ[0], cQ[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
   *dirImask = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(dI[0], dI[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
   *dirQmask = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(dQ[0], dQ[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+  for (int p = 0; p < 8; p++) // round to nearest int16, saturating pack (final LLR units)
+    axisLLR[p] = simde_mm256_permute4x64_epi64(
+        simde_mm256_packs_epi32(simde_mm256_cvtps_epi32(aL[0][p]), simde_mm256_cvtps_epi32(aL[1][p])),
+        SIMDE_MM_SHUFFLE(3, 1, 2, 0));
 }
 
 // Per-candidate evaluation for 256QAM (8 bits/RE, PAM-16 slicer).
@@ -4087,9 +4158,9 @@ void nr_qam256_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
     nr_lbest_simd_load16(&ch_mag[re],     &cm0, &dummy);
     nr_lbest_simd_load16(&ch_mag_i[re],   &cm1, &dummy);
 
-    simde__m256i centerI, centerQ, dirImask, dirQmask;
+    simde__m256i centerI, centerQ, dirImask, dirQmask, axisLLR[8];
     nr_lbest_simd_seed16_256(z1r, z1i, z2r, z2i, rr, ri, cm0, cm1,
-                             &centerI, &centerQ, &dirImask, &dirQmask);
+                             &centerI, &centerQ, &dirImask, &dirQmask, axisLLR);
     (void)dirImask; (void)dirQmask;
 
     // per-RE-vector precomputed quantities (int16 scale, /32 shift)
@@ -4209,13 +4280,21 @@ void nr_qam256_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
 
     int16_t tmp[8][16];
     for (int p = 0; p < 8; p++) {
+      // TODO(int8-clip): these (correct, ML-faithful) 256QAM LLRs are hot for the 8-bit LDPC
+      // decoder input — OAI_LBEST_DBG256 measures ~35% of them |.|>=128 (clip int8), which can
+      // add a small high-SNR error floor. Second-order vs the graded-fallback fix above, and
+      // naive log2_maxh cooling made BLER worse (precision loss), so a proper LLR->int8 rescale
+      // (matched to the linear/MMSE path's scale) is needed, not just a shift. Not yet done.
       const simde__m256i diff = simde_mm256_subs_epi16(max0[p], max1[p]);
       // metric is at 1/8 scale -> LLR = diff*8; saturate via int32 widening
       const simde__m256i lo = simde_mm256_slli_epi32(nr_lbest_widen(diff, 0), 3);
       const simde__m256i hi = simde_mm256_slli_epi32(nr_lbest_widen(diff, 1), 3);
       simde__m256i res = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-      res = simde_mm256_blendv_epi8(res, simde_mm256_set1_epi16(-NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max0[p], SENT));
-      res = simde_mm256_blendv_epi8(res, simde_mm256_set1_epi16( NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max1[p], SENT));
+      // unspanned bit (one side has no candidate): use the graded per-axis seed LLR instead of
+      // the hard +-LLR_SAT (which wrecks the coarse/MSB bits a local search cannot span).
+      const simde__m256i unspanned = simde_mm256_or_si256(simde_mm256_cmpeq_epi16(max0[p], SENT),
+                                                          simde_mm256_cmpeq_epi16(max1[p], SENT));
+      res = simde_mm256_blendv_epi8(res, axisLLR[p], unspanned);
       simde_mm256_storeu_si256((simde__m256i *)tmp[p], res);
     }
     for (int r = 0; r < 16; r++)

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -6,6 +6,7 @@
 #include "nr_phy_common.h"
 #include "bits.h"
 #include <complex.h>
+#include <stdlib.h>
 #include "PHY/sse_intrin.h"
 #include "PHY/impl_defs_top.h"
 #ifdef __aarch64__
@@ -2501,6 +2502,1106 @@ static void nr_ml_llr_shift(int16_t *llr_layer0, int16_t *llr_layer1, uint32_t n
   }
 }
 
+// ============================================================================
+// References for the L-best / reduced-search soft-output MIMO detectors below
+// (2-layer kernels and the >2-layer hybrid). These are "partial marginalization"
+// style detectors: fully (max-log) enumerate a SUBSET of layers and treat the
+// remaining layers by a linear (ZF / Schur-complement) estimate.
+//   [PM]    E. G. Larsson, J. Jalden, "Fixed-Complexity Soft MIMO Detection via
+//           Partial Marginalization," IEEE Trans. Signal Process., 56(8):3397-3407,
+//           Aug. 2008. doi:10.1109/TSP.2008.925260
+//   [PM-HO] D. Persson, E. G. Larsson, "Partial Marginalization Soft MIMO Detection
+//           with Higher-Order Constellations," IEEE Trans. Signal Process.,
+//           59(1):453-458, Jan. 2011. doi:10.1109/TSP.2010.2068293
+//   [SUMIS] M. Cirkovic, E. G. Larsson, "SUMIS: Near-Optimal Soft-In Soft-Out MIMO
+//           Detection with Low and Fixed Complexity," IEEE Trans. Signal Process.,
+//           2014.
+//   [BCH]   D. W. Waters, J. R. Barry, "The Chase Family of Detection Algorithms for
+//           MIMO Channels," IEEE Trans. Signal Process., 56(2):739-747, Feb. 2008.
+//           doi:10.1109/TSP.2007.911315
+//   [LSD]   B. M. Hochwald, S. ten Brink, "Achieving Near-Capacity on a Multiple-
+//           Antenna Channel," IEEE Trans. Commun., 51(3):389-399, Mar. 2003.
+//           doi:10.1109/TCOMM.2003.809789
+//   [VB]    P. W. Wolniansky, G. J. Foschini, G. D. Golden, R. A. Valenzuela,
+//           "V-BLAST: ...," Proc. URSI ISSSE, 1998.  (ordered SIC / layer ordering)
+// NOTE: citations gathered automatically; DOIs/pages to be re-verified. Two elements
+// here appear under-documented vs. the above: (i) selecting which layers to enumerate
+// vs. linearize by per-RE target/interferer ORTHOGONALITY |rho_ij|^2/(rho_ii rho_jj)
+// rather than SNR-ordering ([PM]/[SUMIS] order by SNR); (ii) coded (LDPC) BLER
+// evaluation on 3GPP TDL/CDL channels (the literature is mostly uncoded BER, i.i.d.).
+// ============================================================================
+
+// ============================================================================
+// L-best (reduced-search) reference kernel for 2-layer 64QAM max-log LLR.
+//
+// PHASE 1 reference: floating-point scalar, correctness over speed. See
+// openair1/PHY/nr_phy_common/src/mimo_llr_continuous_approx.md §9 for the plan.
+//
+// Pipeline (per RE, one target layer):
+//   1. inline ZF/MMSE seed  x_hat1 = (R+lambda I)^{-1} z |_1   from (R,z)
+//   2. candidate set C1 = the L 64QAM points nearest x_hat1
+//   3. for each candidate, the nuisance layer is the exact conditional slice
+//      x2*(x1) = Q_S( (z2 - conj(rho)*x1) / P1 )   (O(1), == conditional ML)
+//   4. exact max-log metric over C1, per-bit LLR = max_{bit=0} - max_{bit=1}
+//   L == 64 evaluates the whole constellation => exact max-log == the reference
+//   the SIMD nr_qam64_llr_2layer approximates (validation anchor).
+//
+// Input buffers mirror nr_qam64_llr_2layer (same scale, drop-in):
+//   stream0_in = z1 = H0^H y (desired MRC)     stream1_in = z2 (nuisance MRC)
+//   ch_mag     = ||h0||^2 * (4/sqrt(42))        ch_mag_i  = ||h1||^2 * (4/sqrt(42))
+//   rho01      = rho = h0^H h1                   (so rho21 = conj(rho))
+// Output per RE: { y0r,y1r,y2r, y0i,y1i,y2i } (3 I-bits then 3 Q-bits), same
+// order/scale/sign (positive LLR = bit 0) as nr_qam64_llr_2layer.
+//
+// The metric is computed in Re{x1_n* z1} units (x1_n = normalized constellation
+// point), which is exactly the scale of the existing kernel's bit metric, so the
+// LLR output needs no rescale (NR_LBEST_LLR_SCALE == 1.0). Energy terms use the
+// true 0.5*P*|x|^2 max-log coefficient.
+// ============================================================================
+#define NR_LBEST_SQRT42       6.48074069840786f   // sqrt(42)
+#define NR_LBEST_NA           0.15430334996209f    // 1/sqrt(42), unit-energy 64QAM step
+#define NR_LBEST_LLR_SCALE    1.0f                 // matches nr_qam64_llr_2layer metric scale
+#define NR_LBEST_LLR_SAT      8192.0f              // fallback magnitude when a bit-subset is empty
+
+// nearest odd level in {-7,-5,-3,-1,1,3,5,7} to v (the 8-PAM slicer)
+static inline int nr_lbest_slice_pam8(float v)
+{
+  static const int levels[8] = {-7, -5, -3, -1, 1, 3, 5, 7};
+  int best = levels[0];
+  float bestd = (v - levels[0]) * (v - levels[0]);
+  for (int k = 1; k < 8; k++) {
+    float d = (v - levels[k]) * (v - levels[k]);
+    if (d < bestd) {
+      bestd = d;
+      best = levels[k];
+    }
+  }
+  return best;
+}
+
+// 64QAM Gray bits for one axis level (per nr_gen_mod_table.c):
+//   bit0 = sign (level<0),  bit1 = |level|>4,  bit2 = (|level|==1 || |level|==7)
+static inline void nr_lbest_axis_bits(int level, int *b0, int *b1, int *b2)
+{
+  int a = level < 0 ? -level : level;
+  *b0 = level < 0 ? 1 : 0;
+  *b1 = a > 4 ? 1 : 0;
+  *b2 = (a == 1 || a == 7) ? 1 : 0;
+}
+
+// One target layer of 2-layer 64QAM L-best LLR (scalar float reference).
+//   seed_lambda: 0.0f = ZF seed, = noise_var (float) = MMSE-regularised seed
+//   L:           candidate-set size (1..64); 64 == full search == max-log reference
+static void nr_qam64_llr_2layer_lbest_layer(const c16_t *stream0_in,
+                                            const c16_t *stream1_in,
+                                            const c16_t *ch_mag,
+                                            const c16_t *ch_mag_i,
+                                            int16_t *stream0_out,
+                                            const c16_t *rho01,
+                                            uint32_t length,
+                                            int L,
+                                            float seed_lambda)
+{
+  if (L < 1)
+    L = 1;
+  if (L > 64)
+    L = 64;
+  static const int levels[8] = {-7, -5, -3, -1, 1, 3, 5, 7};
+
+  for (uint32_t re = 0; re < length; re++) {
+    const float z1r = stream0_in[re].r, z1i = stream0_in[re].i;
+    const float z2r = stream1_in[re].r, z2i = stream1_in[re].i;
+    const float rr = rho01[re].r, ri = rho01[re].i; // rho = h0^H h1
+    // recover raw channel powers ||h||^2 from the QAM64_n1-scaled magnitudes
+    const float P0 = (float)ch_mag[re].r * (NR_LBEST_SQRT42 / 4.0f);
+    const float P1 = (float)ch_mag_i[re].r * (NR_LBEST_SQRT42 / 4.0f);
+
+    // ---- 1. inline ZF/MMSE seed: x_hat1 = ((P1+l) z1 - rho z2) / det ----
+    const float l = seed_lambda;
+    const float det = (P0 + l) * (P1 + l) - (rr * rr + ri * ri);
+    const float invdet = det != 0.0f ? 1.0f / det : 0.0f;
+    // rho * z2 (complex)
+    const float rz2r = rr * z2r - ri * z2i;
+    const float rz2i = rr * z2i + ri * z2r;
+    const float xh1r = ((P1 + l) * z1r - rz2r) * invdet; // ~ I-level / sqrt(42)
+    const float xh1i = ((P1 + l) * z1i - rz2i) * invdet;
+    const float estI = xh1r * NR_LBEST_SQRT42; // soft I level estimate (~ +-1..7)
+    const float estQ = xh1i * NR_LBEST_SQRT42;
+
+    // ---- 2. candidate set C1 = L nearest constellation points to x_hat1 ----
+    // (reference: rank all 64 by Euclidean distance; production = per-axis slice)
+    int candI[64], candQ[64];
+    float cand_d[64];
+    int nc = 0;
+    for (int qi = 0; qi < 8; qi++) {
+      for (int ii = 0; ii < 8; ii++) {
+        float dI = estI - levels[ii];
+        float dQ = estQ - levels[qi];
+        candI[nc] = levels[ii];
+        candQ[nc] = levels[qi];
+        cand_d[nc] = dI * dI + dQ * dQ;
+        nc++;
+      }
+    }
+    // partial selection of the L smallest distances to the front
+    for (int a = 0; a < L; a++) {
+      int m = a;
+      for (int b = a + 1; b < 64; b++)
+        if (cand_d[b] < cand_d[m])
+          m = b;
+      if (m != a) {
+        float td = cand_d[a]; cand_d[a] = cand_d[m]; cand_d[m] = td;
+        int ti = candI[a]; candI[a] = candI[m]; candI[m] = ti;
+        int tq = candQ[a]; candQ[a] = candQ[m]; candQ[m] = tq;
+      }
+    }
+
+    // ---- 3+4. metric over candidates, per-bit max-log reduction ----
+    float max0[6] = {-1e30f, -1e30f, -1e30f, -1e30f, -1e30f, -1e30f};
+    float max1[6] = {-1e30f, -1e30f, -1e30f, -1e30f, -1e30f, -1e30f};
+
+    for (int c = 0; c < L; c++) {
+      const int I1 = candI[c], Q1 = candQ[c];
+      const float x1r = I1 * NR_LBEST_NA, x1i = Q1 * NR_LBEST_NA; // normalized x1
+
+      // desired correlation Re{x1_n* z1} and energy 0.5 P0 |x1_n|^2
+      float metric = (x1r * z1r + x1i * z1i) - 0.5f * P0 * (x1r * x1r + x1i * x1i);
+
+      // conditional ML nuisance: x2* = Q_S( (z2 - conj(rho) x1_n) / P1 )
+      // conj(rho)*x1_n = (rr - j ri)(x1r + j x1i)
+      const float cr = rr * x1r + ri * x1i;       // Re{conj(rho) x1_n}
+      const float ci = rr * x1i - ri * x1r;       // Im{conj(rho) x1_n}
+      const float invP1 = P1 != 0.0f ? 1.0f / P1 : 0.0f;
+      const float x2optr = (z2r - cr) * invP1;    // ~ I2-level / sqrt(42)
+      const float x2opti = (z2i - ci) * invP1;
+      const int I2 = nr_lbest_slice_pam8(x2optr * NR_LBEST_SQRT42);
+      const int Q2 = nr_lbest_slice_pam8(x2opti * NR_LBEST_SQRT42);
+      const float x2r = I2 * NR_LBEST_NA, x2i = Q2 * NR_LBEST_NA;
+
+      // add nuisance correlation - energy - cross term
+      metric += (x2r * z2r + x2i * z2i) - 0.5f * P1 * (x2r * x2r + x2i * x2i);
+      // cross = Re{rho * conj(x1_n) * x2_n}
+      const float cxr = x1r * x2r + x1i * x2i; // Re{conj(x1_n) x2_n}
+      const float cxi = x1r * x2i - x1i * x2r; // Im{conj(x1_n) x2_n}
+      metric -= (rr * cxr - ri * cxi);
+
+      // bit labels of this candidate. OAI 64QAM LLR layout interleaves I/Q per
+      // magnitude level: {I0,Q0,I1,Q1,I2,Q2} (matches production SIMD
+      // nr_qam64_llr_2layer output order), NOT grouped {I0,I1,I2,Q0,Q1,Q2}.
+      int bI0, bI1, bI2, bQ0, bQ1, bQ2;
+      nr_lbest_axis_bits(I1, &bI0, &bI1, &bI2);
+      nr_lbest_axis_bits(Q1, &bQ0, &bQ1, &bQ2);
+      const int bit[6] = {bI0, bQ0, bI1, bQ1, bI2, bQ2};
+      for (int p = 0; p < 6; p++) {
+        if (bit[p] == 0) {
+          if (metric > max0[p]) max0[p] = metric;
+        } else {
+          if (metric > max1[p]) max1[p] = metric;
+        }
+      }
+    }
+
+    // emit LLR = max_{bit=0} - max_{bit=1} (positive => bit 0). Empty subset =>
+    // saturate toward the bit value that IS present.
+    for (int p = 0; p < 6; p++) {
+      float llr;
+      if (max0[p] <= -1e29f)
+        llr = -NR_LBEST_LLR_SAT;      // no bit-0 candidate => strongly bit 1
+      else if (max1[p] <= -1e29f)
+        llr = NR_LBEST_LLR_SAT;       // no bit-1 candidate => strongly bit 0
+      else
+        llr = (max0[p] - max1[p]) * NR_LBEST_LLR_SCALE;
+      if (llr > 32767.0f) llr = 32767.0f;
+      if (llr < -32768.0f) llr = -32768.0f;
+      *stream0_out++ = (int16_t)llr;
+    }
+  }
+}
+
+// Drop-in float reference for nr_qam64_llr_2layer (target layer 0): reduced
+// "L-best" search seeded from the linear (ZF/MMSE) estimate. L==64 reproduces
+// the full max-log search; L==8 matches it in BLER at a fraction of the cost
+// (validated via nr_dlsim -E, 2-layer 64QAM). Scalar float reference pending a
+// SIMD port before it can replace the production kernel.
+void nr_qam64_llr_2layer_lbest(c16_t *stream0_in,
+                               c16_t *stream1_in,
+                               c16_t *ch_mag,
+                               c16_t *ch_mag_i,
+                               int16_t *stream0_out,
+                               c16_t *rho01,
+                               uint32_t length,
+                               int L,
+                               float seed_lambda)
+{
+  nr_qam64_llr_2layer_lbest_layer(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, L, seed_lambda);
+}
+
+// ============================================================================
+// Float reference L-best kernel for 2-layer 256QAM (one target layer). Analysis
+// vehicle: L==256 reproduces the full 256-point ML search (no SIMD full-search
+// 256QAM kernel exists); smaller L is the reduced search. Same algorithm/scaling
+// as the 64QAM reference, with PAM-16 levels, 1/sqrt(170) normalization, 8 bits.
+// ============================================================================
+#define NR_LBEST_SQRT170      13.03840481040530f  // sqrt(170)
+#define NR_LBEST_NA256        0.07669649888473f    // 1/sqrt(170), unit-energy 256QAM step
+
+// nearest 256QAM PAM-16 level to v (in level units), O(1) round-to-nearest-odd.
+// = 2*floor(v/2)+1, clamped to [-15,15]. The +16 offset makes the argument
+// non-negative so (int) truncation equals floor (no <math.h> dependency).
+static inline int nr_lbest_slice_pam16(float v)
+{
+  int o = 2 * (int)((v + 16.0f) * 0.5f) - 15;
+  if (o < -15) o = -15; else if (o > 15) o = 15;
+  return o;
+}
+
+// 256QAM Gray bits for one axis level (per nr_gen_mod_table.c 256QAM map):
+//   b0 = sign(level<0); m=|level|: b1=(m>8), b2=(|m-8|>4), b3=(||m-8|-4|>2)
+static inline void nr_lbest_axis_bits256(int level, int *b0, int *b1, int *b2, int *b3)
+{
+  const int m = level < 0 ? -level : level;
+  int m2 = m - 8; if (m2 < 0) m2 = -m2;
+  int m3 = m2 - 4; if (m3 < 0) m3 = -m3;
+  *b0 = level < 0 ? 1 : 0;
+  *b1 = m > 8 ? 1 : 0;
+  *b2 = m2 > 4 ? 1 : 0;
+  *b3 = m3 > 2 ? 1 : 0;
+}
+
+// candidate (constellation point + squared distance to the seed) for the L-nearest sort
+// (members iL/qL, not I/Q: <complex.h> defines I as the imaginary unit)
+struct nr_lbest_cand { float d; int16_t iL, qL; };
+static int nr_lbest_cand_cmp(const void *a, const void *b)
+{
+  const float da = ((const struct nr_lbest_cand *)a)->d, db = ((const struct nr_lbest_cand *)b)->d;
+  return (da > db) - (da < db);
+}
+
+void nr_qam256_llr_2layer_lbest(c16_t *stream0_in,
+                                c16_t *stream1_in,
+                                c16_t *ch_mag,
+                                c16_t *ch_mag_i,
+                                int16_t *stream0_out,
+                                c16_t *rho01,
+                                uint32_t length,
+                                int L,
+                                float seed_lambda)
+{
+  if (L < 1)
+    L = 1;
+  if (L > 256)
+    L = 256;
+  static const int levels[16] = {-15, -13, -11, -9, -7, -5, -3, -1, 1, 3, 5, 7, 9, 11, 13, 15};
+
+  for (uint32_t re = 0; re < length; re++) {
+    const float z1r = stream0_in[re].r, z1i = stream0_in[re].i;
+    const float z2r = stream1_in[re].r, z2i = stream1_in[re].i;
+    const float rr = rho01[re].r, ri = rho01[re].i; // rho = h0^H h1
+    // recover ||h||^2 from the QAM256_n1 (= 8/sqrt(170)) scaled magnitudes
+    const float P0 = (float)ch_mag[re].r * (NR_LBEST_SQRT170 / 8.0f);
+    const float P1 = (float)ch_mag_i[re].r * (NR_LBEST_SQRT170 / 8.0f);
+
+    // ---- ZF/MMSE seed: x_hat1 = ((P1+l) z1 - rho z2) / det ----
+    const float l = seed_lambda;
+    const float det = (P0 + l) * (P1 + l) - (rr * rr + ri * ri);
+    const float invdet = det != 0.0f ? 1.0f / det : 0.0f;
+    const float rz2r = rr * z2r - ri * z2i;
+    const float rz2i = rr * z2i + ri * z2r;
+    const float estI = ((P1 + l) * z1r - rz2r) * invdet * NR_LBEST_SQRT170; // ~ +-1..15
+    const float estQ = ((P1 + l) * z1i - rz2i) * invdet * NR_LBEST_SQRT170;
+
+    // ---- candidate set C1 = L nearest of the 256 constellation points ----
+    // O(256 log 256) sort by distance, take the first L (L==256 == full ML, no sort needed).
+    struct nr_lbest_cand cand[256];
+    int nc = 0;
+    for (int qi = 0; qi < 16; qi++) {
+      for (int ii = 0; ii < 16; ii++) {
+        const float dI = estI - levels[ii];
+        const float dQ = estQ - levels[qi];
+        cand[nc].d = dI * dI + dQ * dQ;
+        cand[nc].iL = (int16_t)levels[ii];
+        cand[nc].qL = (int16_t)levels[qi];
+        nc++;
+      }
+    }
+    if (L < 256)
+      qsort(cand, 256, sizeof(cand[0]), nr_lbest_cand_cmp);
+
+    // ---- metric over candidates, per-bit max-log reduction (8 bits) ----
+    float max0[8], max1[8];
+    for (int p = 0; p < 8; p++) { max0[p] = -1e30f; max1[p] = -1e30f; }
+
+    for (int c = 0; c < L; c++) {
+      const int I1 = cand[c].iL, Q1 = cand[c].qL;
+      const float x1r = I1 * NR_LBEST_NA256, x1i = Q1 * NR_LBEST_NA256;
+      float metric = (x1r * z1r + x1i * z1i) - 0.5f * P0 * (x1r * x1r + x1i * x1i);
+
+      // conditional ML nuisance x2* = Q_S((z2 - conj(rho) x1)/P1)
+      const float cr = rr * x1r + ri * x1i;
+      const float ci = rr * x1i - ri * x1r;
+      const float invP1 = P1 != 0.0f ? 1.0f / P1 : 0.0f;
+      const int I2 = nr_lbest_slice_pam16((z2r - cr) * invP1 * NR_LBEST_SQRT170);
+      const int Q2 = nr_lbest_slice_pam16((z2i - ci) * invP1 * NR_LBEST_SQRT170);
+      const float x2r = I2 * NR_LBEST_NA256, x2i = Q2 * NR_LBEST_NA256;
+
+      metric += (x2r * z2r + x2i * z2i) - 0.5f * P1 * (x2r * x2r + x2i * x2i);
+      const float cxr = x1r * x2r + x1i * x2i;
+      const float cxi = x1r * x2i - x1i * x2r;
+      metric -= (rr * cxr - ri * cxi);
+
+      // interleaved bit order {I0,Q0,I1,Q1,I2,Q2,I3,Q3}
+      int bI0, bI1, bI2, bI3, bQ0, bQ1, bQ2, bQ3;
+      nr_lbest_axis_bits256(I1, &bI0, &bI1, &bI2, &bI3);
+      nr_lbest_axis_bits256(Q1, &bQ0, &bQ1, &bQ2, &bQ3);
+      const int bit[8] = {bI0, bQ0, bI1, bQ1, bI2, bQ2, bI3, bQ3};
+      for (int p = 0; p < 8; p++) {
+        if (bit[p] == 0) { if (metric > max0[p]) max0[p] = metric; }
+        else             { if (metric > max1[p]) max1[p] = metric; }
+      }
+    }
+
+    for (int p = 0; p < 8; p++) {
+      float llr;
+      if (max0[p] <= -1e29f)
+        llr = -NR_LBEST_LLR_SAT;
+      else if (max1[p] <= -1e29f)
+        llr = NR_LBEST_LLR_SAT;
+      else
+        llr = (max0[p] - max1[p]) * NR_LBEST_LLR_SCALE;
+      if (llr > 32767.0f) llr = 32767.0f;
+      if (llr < -32768.0f) llr = -32768.0f;
+      *stream0_out++ = (int16_t)llr;
+    }
+  }
+}
+
+// ============================================================================
+// Float reference L-best kernel for 2-layer 16QAM (one target layer). Mainly a
+// BUILDING BLOCK for the >2-layer hybrid (where 16QAM won't be done by exhaustive
+// search): the deflated 2-layer sub-problem can be any modulation. L==16 == full
+// ML. PAM-4 levels, 1/sqrt(10) norm, 4 bits {I0,Q0,I1,Q1}.
+// ============================================================================
+#define NR_LBEST_SQRT10       3.16227766016838f   // sqrt(10)
+#define NR_LBEST_NA16         0.31622776601684f    // 1/sqrt(10), unit-energy 16QAM step
+
+// nearest 16QAM PAM-4 level to v (level units), O(1) round-to-nearest-odd in [-3,3]
+static inline int nr_lbest_slice_pam4(float v)
+{
+  int o = 2 * (int)((v + 4.0f) * 0.5f) - 3;
+  if (o < -3) o = -3; else if (o > 3) o = 3;
+  return o;
+}
+
+// 16QAM Gray bits for one axis level: b0 = sign(level<0), b1 = (|level|>2)
+static inline void nr_lbest_axis_bits16(int level, int *b0, int *b1)
+{
+  *b0 = level < 0 ? 1 : 0;
+  *b1 = (level < 0 ? -level : level) > 2 ? 1 : 0;
+}
+
+void nr_qam16_llr_2layer_lbest(c16_t *stream0_in,
+                               c16_t *stream1_in,
+                               c16_t *ch_mag,
+                               c16_t *ch_mag_i,
+                               int16_t *stream0_out,
+                               c16_t *rho01,
+                               uint32_t length,
+                               int L,
+                               float seed_lambda)
+{
+  if (L < 1)
+    L = 1;
+  if (L > 16)
+    L = 16;
+  static const int levels[4] = {-3, -1, 1, 3};
+
+  for (uint32_t re = 0; re < length; re++) {
+    const float z1r = stream0_in[re].r, z1i = stream0_in[re].i;
+    const float z2r = stream1_in[re].r, z2i = stream1_in[re].i;
+    const float rr = rho01[re].r, ri = rho01[re].i; // rho = h0^H h1
+    // recover ||h||^2 from the QAM16_n1 (= 2/sqrt(10)) scaled magnitudes
+    const float P0 = (float)ch_mag[re].r * (NR_LBEST_SQRT10 / 2.0f);
+    const float P1 = (float)ch_mag_i[re].r * (NR_LBEST_SQRT10 / 2.0f);
+
+    // ---- ZF/MMSE seed: x_hat1 = ((P1+l) z1 - rho z2) / det ----
+    const float l = seed_lambda;
+    const float det = (P0 + l) * (P1 + l) - (rr * rr + ri * ri);
+    const float invdet = det != 0.0f ? 1.0f / det : 0.0f;
+    const float rz2r = rr * z2r - ri * z2i;
+    const float rz2i = rr * z2i + ri * z2r;
+    const float estI = ((P1 + l) * z1r - rz2r) * invdet * NR_LBEST_SQRT10; // ~ +-1,3
+    const float estQ = ((P1 + l) * z1i - rz2i) * invdet * NR_LBEST_SQRT10;
+
+    // ---- candidate set = L nearest of the 16 points (sort, take first L) ----
+    struct nr_lbest_cand cand[16];
+    int nc = 0;
+    for (int qi = 0; qi < 4; qi++) {
+      for (int ii = 0; ii < 4; ii++) {
+        const float dI = estI - levels[ii];
+        const float dQ = estQ - levels[qi];
+        cand[nc].d = dI * dI + dQ * dQ;
+        cand[nc].iL = (int16_t)levels[ii];
+        cand[nc].qL = (int16_t)levels[qi];
+        nc++;
+      }
+    }
+    if (L < 16)
+      qsort(cand, 16, sizeof(cand[0]), nr_lbest_cand_cmp);
+
+    // ---- metric over candidates, per-bit max-log reduction (4 bits) ----
+    float max0[4], max1[4];
+    for (int p = 0; p < 4; p++) { max0[p] = -1e30f; max1[p] = -1e30f; }
+
+    for (int c = 0; c < L; c++) {
+      const int I1 = cand[c].iL, Q1 = cand[c].qL;
+      const float x1r = I1 * NR_LBEST_NA16, x1i = Q1 * NR_LBEST_NA16;
+      float metric = (x1r * z1r + x1i * z1i) - 0.5f * P0 * (x1r * x1r + x1i * x1i);
+
+      const float cr = rr * x1r + ri * x1i;
+      const float ci = rr * x1i - ri * x1r;
+      const float invP1 = P1 != 0.0f ? 1.0f / P1 : 0.0f;
+      const int I2 = nr_lbest_slice_pam4((z2r - cr) * invP1 * NR_LBEST_SQRT10);
+      const int Q2 = nr_lbest_slice_pam4((z2i - ci) * invP1 * NR_LBEST_SQRT10);
+      const float x2r = I2 * NR_LBEST_NA16, x2i = Q2 * NR_LBEST_NA16;
+
+      metric += (x2r * z2r + x2i * z2i) - 0.5f * P1 * (x2r * x2r + x2i * x2i);
+      const float cxr = x1r * x2r + x1i * x2i;
+      const float cxi = x1r * x2i - x1i * x2r;
+      metric -= (rr * cxr - ri * cxi);
+
+      // interleaved bit order {I0,Q0,I1,Q1}
+      int bI0, bI1, bQ0, bQ1;
+      nr_lbest_axis_bits16(I1, &bI0, &bI1);
+      nr_lbest_axis_bits16(Q1, &bQ0, &bQ1);
+      const int bit[4] = {bI0, bQ0, bI1, bQ1};
+      for (int p = 0; p < 4; p++) {
+        if (bit[p] == 0) { if (metric > max0[p]) max0[p] = metric; }
+        else             { if (metric > max1[p]) max1[p] = metric; }
+      }
+    }
+
+    for (int p = 0; p < 4; p++) {
+      float llr;
+      if (max0[p] <= -1e29f)
+        llr = -NR_LBEST_LLR_SAT;
+      else if (max1[p] <= -1e29f)
+        llr = NR_LBEST_LLR_SAT;
+      else
+        llr = (max0[p] - max1[p]) * NR_LBEST_LLR_SCALE;
+      if (llr > 32767.0f) llr = 32767.0f;
+      if (llr < -32768.0f) llr = -32768.0f;
+      *stream0_out++ = (int16_t)llr;
+    }
+  }
+}
+
+// ============================================================================
+// Generic float L-best machinery (any square QAM) for the >2-layer hybrid.
+// kbits = Qm/2 (2/3/4 -> 16/64/256QAM); per-axis PAM-2^kbits, levels odd in
+// [-(2^kbits-1), 2^kbits-1]. sqrtN = sqrt(norm), norm = 2(4^kbits-1)/3;
+// rf = sqrtN / 2^(kbits-1) recovers ||h||^2 from the n1-scaled ch_mag.
+// ============================================================================
+static const double NR_LBEST_SQRTN[5] = {0, 0, 3.16227766016838, 6.48074069840786, 13.03840481040530};
+static const double NR_LBEST_RF[5]    = {0, 0, 1.58113883008419, 1.62018517460196, 1.62980060130066};
+
+// nearest PAM-2^kbits level to v (level units), O(1) round-to-nearest-odd, clamped.
+static inline int nr_lbest_slice_gen(double v, int kbits)
+{
+  const int nlev = 1 << kbits, maxlev = nlev - 1;
+  int o = 2 * (int)((v + nlev) * 0.5) - maxlev;
+  if (o < -maxlev) o = -maxlev; else if (o > maxlev) o = maxlev;
+  return o;
+}
+
+// Gray bits for one axis level: b[0]=sign, then nested b[i]=( |..| > 2^(kbits-1-i) ).
+static inline void nr_lbest_axis_bits_gen(int level, int kbits, int *b)
+{
+  int v = level < 0 ? -level : level, t = 1 << (kbits - 1);
+  b[0] = level < 0 ? 1 : 0;
+  for (int i = 1; i < kbits; i++) {
+    b[i] = v > t ? 1 : 0;
+    v = v - t < 0 ? t - v : v - t;
+    t >>= 1;
+  }
+}
+
+// Per-RE 2-layer conditional-slice LLR for the target layer (x1), in DOUBLE.
+// Inputs are recovered powers P0=||h1||^2, P1=||h2||^2 (NOT n1-scaled ch_mag),
+// MF outputs z1,z2, cross rho=(rr,ri)=h1^H h2. Writes Qm=2*kbits int16 LLRs.
+static void nr_lbest_2layer_re(double z1r, double z1i, double z2r, double z2i,
+                               double P0, double P1, double rr, double ri,
+                               int kbits, int L, double lambda, int16_t *out)
+{
+  const int nlev = 1 << kbits, M = nlev * nlev, nbits = 2 * kbits;
+  const double sqrtN = NR_LBEST_SQRTN[kbits], NA = 1.0 / sqrtN;
+  if (L < 1) L = 1;
+  if (L > M) L = M;
+
+  const double det = (P0 + lambda) * (P1 + lambda) - (rr * rr + ri * ri);
+  const double invdet = det != 0.0 ? 1.0 / det : 0.0;
+  const double estI = ((P1 + lambda) * z1r - (rr * z2r - ri * z2i)) * invdet * sqrtN;
+  const double estQ = ((P1 + lambda) * z1i - (rr * z2i + ri * z2r)) * invdet * sqrtN;
+
+  struct { double d; int iL, qL; } cand[256];
+  int nc = 0;
+  for (int qi = 0; qi < nlev; qi++) {
+    const int lq = 2 * qi - (nlev - 1);
+    for (int ii = 0; ii < nlev; ii++) {
+      const int li = 2 * ii - (nlev - 1);
+      const double dI = estI - li, dQ = estQ - lq;
+      cand[nc].d = dI * dI + dQ * dQ;
+      cand[nc].iL = li;
+      cand[nc].qL = lq;
+      nc++;
+    }
+  }
+  if (L < M) // selection of the L smallest (M<=256, reference code)
+    for (int a = 0; a < L; a++) {
+      int m = a;
+      for (int b = a + 1; b < M; b++)
+        if (cand[b].d < cand[m].d) m = b;
+      if (m != a) { __typeof__(cand[0]) tmp = cand[a]; cand[a] = cand[m]; cand[m] = tmp; }
+    }
+
+  double max0[8], max1[8];
+  for (int p = 0; p < nbits; p++) { max0[p] = -1e30; max1[p] = -1e30; }
+
+  for (int c = 0; c < L; c++) {
+    const int I1 = cand[c].iL, Q1 = cand[c].qL;
+    const double x1r = I1 * NA, x1i = Q1 * NA;
+    double metric = (x1r * z1r + x1i * z1i) - 0.5 * P0 * (x1r * x1r + x1i * x1i);
+
+    const double cr = rr * x1r + ri * x1i, ci = rr * x1i - ri * x1r;
+    const double invP1 = P1 != 0.0 ? 1.0 / P1 : 0.0;
+    const int I2 = nr_lbest_slice_gen((z2r - cr) * invP1 * sqrtN, kbits);
+    const int Q2 = nr_lbest_slice_gen((z2i - ci) * invP1 * sqrtN, kbits);
+    const double x2r = I2 * NA, x2i = Q2 * NA;
+    metric += (x2r * z2r + x2i * z2i) - 0.5 * P1 * (x2r * x2r + x2i * x2i);
+    metric -= (rr * (x1r * x2r + x1i * x2i) - ri * (x1r * x2i - x1i * x2r));
+
+    int bI[4], bQ[4];
+    nr_lbest_axis_bits_gen(I1, kbits, bI);
+    nr_lbest_axis_bits_gen(Q1, kbits, bQ);
+    for (int j = 0; j < kbits; j++) {
+      const int p0 = 2 * j, p1 = 2 * j + 1; // interleaved {I0,Q0,I1,Q1,...}
+      if (bI[j] == 0) { if (metric > max0[p0]) max0[p0] = metric; } else { if (metric > max1[p0]) max1[p0] = metric; }
+      if (bQ[j] == 0) { if (metric > max0[p1]) max0[p1] = metric; } else { if (metric > max1[p1]) max1[p1] = metric; }
+    }
+  }
+
+  for (int p = 0; p < nbits; p++) {
+    double llr = (max0[p] <= -1e29) ? -NR_LBEST_LLR_SAT : (max1[p] <= -1e29) ? NR_LBEST_LLR_SAT : (max0[p] - max1[p]) * NR_LBEST_LLR_SCALE;
+    if (llr > 32767.0) llr = 32767.0;
+    if (llr < -32768.0) llr = -32768.0;
+    out[p] = (int16_t)llr;
+  }
+}
+
+// 3-layer HYBRID L-best (target layer t, nuisance n1,n2): per RE, project the
+// nuisance layer most orthogonal to the target (smaller |rho|^2/||h||^2), scalar-
+// Schur-deflate it, then run the 2-layer conditional-slice LLR on the deflated
+// (target, kept-nuisance) pair. Inputs: per-layer MF z, n1-scaled ch_mag, and the
+// three cross-Gram arrays rho_ab = h_a^H h_b. Writes Qm LLRs/RE for layer t.
+// Partial-marginalization detector [PM]/[PM-HO]/[BCH] (k=1 enumerated layer); the
+// per-RE orthogonality-based choice of which layer to project is our addition (the
+// cited works order the enumerated subset by SNR). See reference block above.
+void nr_qam_llr_3layer_hybrid(c16_t *zt, c16_t *zn1, c16_t *zn2,
+                              c16_t *cmt, c16_t *cmn1, c16_t *cmn2,
+                              c16_t *rho_tn1, c16_t *rho_tn2, c16_t *rho_n1n2,
+                              int16_t *out, uint32_t length, int Qm, int L, float lambda)
+{
+  const int kbits = Qm / 2;
+  const double rf = NR_LBEST_RF[kbits];
+  for (uint32_t re = 0; re < length; re++) {
+    const double Pt = cmt[re].r * rf, Pn1 = cmn1[re].r * rf, Pn2 = cmn2[re].r * rf;
+    const double t1r = rho_tn1[re].r, t1i = rho_tn1[re].i;     // h_t^H h_n1
+    const double t2r = rho_tn2[re].r, t2i = rho_tn2[re].i;     // h_t^H h_n2
+    const double n12r = rho_n1n2[re].r, n12i = rho_n1n2[re].i; // h_n1^H h_n2
+
+    // keep the more-aligned nuisance discrete, project the other (more orthogonal)
+    const double p1 = (t1r * t1r + t1i * t1i) / Pn1;
+    const double p2 = (t2r * t2r + t2i * t2i) / Pn2;
+    double Pc, Pd, zcr, zci, zdr, zdi, tcr, tci, tdr, tdi, dcr, dci;
+    if (p1 >= p2) { // keep n1 discrete, project n2
+      Pc = Pn2; Pd = Pn1; zcr = zn2[re].r; zci = zn2[re].i; zdr = zn1[re].r; zdi = zn1[re].i;
+      tcr = t2r; tci = t2i; tdr = t1r; tdi = t1i; dcr = n12r; dci = n12i; // rho_dc = h_n1^H h_n2
+    } else {        // keep n2 discrete, project n1
+      Pc = Pn1; Pd = Pn2; zcr = zn1[re].r; zci = zn1[re].i; zdr = zn2[re].r; zdi = zn2[re].i;
+      tcr = t1r; tci = t1i; tdr = t2r; tdi = t2i; dcr = n12r; dci = -n12i; // rho_dc = h_n2^H h_n1 = conj
+    }
+    const double invPc = Pc != 0.0 ? 1.0 / Pc : 0.0;
+    const double Pt2 = Pt - (tcr * tcr + tci * tci) * invPc;
+    const double Pd2 = Pd - (dcr * dcr + dci * dci) * invPc;
+    const double rtdr = tdr - (tcr * dcr + tci * dci) * invPc;          // rho_td - rho_tc conj(rho_dc)/Pc
+    const double rtdi = tdi - (tci * dcr - tcr * dci) * invPc;
+    const double ztr = zt[re].r - (tcr * zcr - tci * zci) * invPc;      // z_t - rho_tc/Pc z_c
+    const double zti = zt[re].i - (tcr * zci + tci * zcr) * invPc;
+    const double zdr2 = zdr - (dcr * zcr - dci * zci) * invPc;
+    const double zdi2 = zdi - (dcr * zci + dci * zcr) * invPc;
+
+    nr_lbest_2layer_re(ztr, zti, zdr2, zdi2, Pt2, Pd2, rtdr, rtdi, kbits, L, lambda, &out[re * Qm]);
+  }
+}
+
+// 3-layer FULL ML reference (target t): per RE, exact max-log over discrete (x_t,x_n1)
+// with the conditional best x_n2 sliced. For BLER comparison against the hybrid.
+void nr_qam_llr_3layer_ml(c16_t *zt, c16_t *zn1, c16_t *zn2,
+                          c16_t *cmt, c16_t *cmn1, c16_t *cmn2,
+                          c16_t *rho_tn1, c16_t *rho_tn2, c16_t *rho_n1n2,
+                          int16_t *out, uint32_t length, int Qm)
+{
+  const int kbits = Qm / 2, nlev = 1 << kbits, nbits = 2 * kbits;
+  const double sqrtN = NR_LBEST_SQRTN[kbits], NA = 1.0 / sqrtN, rf = NR_LBEST_RF[kbits];
+  for (uint32_t re = 0; re < length; re++) {
+    const double Pt = cmt[re].r * rf, Pn1 = cmn1[re].r * rf, Pn2 = cmn2[re].r * rf;
+    const double ztr = zt[re].r, zti = zt[re].i, z1r = zn1[re].r, z1i = zn1[re].i, z2r = zn2[re].r, z2i = zn2[re].i;
+    const double t1r = rho_tn1[re].r, t1i = rho_tn1[re].i, t2r = rho_tn2[re].r, t2i = rho_tn2[re].i, n12r = rho_n1n2[re].r, n12i = rho_n1n2[re].i;
+    const double invPn2 = Pn2 != 0.0 ? 1.0 / Pn2 : 0.0;
+    double max0[8], max1[8];
+    for (int p = 0; p < nbits; p++) { max0[p] = -1e30; max1[p] = -1e30; }
+
+    for (int qit = 0; qit < nlev; qit++) for (int iit = 0; iit < nlev; iit++) {
+      const int It = 2 * iit - (nlev - 1), Qt = 2 * qit - (nlev - 1);
+      const double xtr = It * NA, xti = Qt * NA;
+      for (int q1 = 0; q1 < nlev; q1++) for (int i1 = 0; i1 < nlev; i1++) {
+        const int I1 = 2 * i1 - (nlev - 1), Q1 = 2 * q1 - (nlev - 1);
+        const double x1r = I1 * NA, x1i = Q1 * NA;
+        const double ar = z2r - (t2r * xtr + t2i * xti) - (n12r * x1r + n12i * x1i);
+        const double ai = z2i - (t2r * xti - t2i * xtr) - (n12r * x1i - n12i * x1r);
+        const int I2 = nr_lbest_slice_gen(ar * invPn2 * sqrtN, kbits), Q2 = nr_lbest_slice_gen(ai * invPn2 * sqrtN, kbits);
+        const double x2r = I2 * NA, x2i = Q2 * NA;
+        double m = (xtr * ztr + xti * zti) - 0.5 * Pt * (xtr * xtr + xti * xti)
+                 + (x1r * z1r + x1i * z1i) - 0.5 * Pn1 * (x1r * x1r + x1i * x1i)
+                 + (x2r * z2r + x2i * z2i) - 0.5 * Pn2 * (x2r * x2r + x2i * x2i)
+                 - (t1r * (xtr * x1r + xti * x1i) - t1i * (xtr * x1i - xti * x1r))
+                 - (t2r * (xtr * x2r + xti * x2i) - t2i * (xtr * x2i - xti * x2r))
+                 - (n12r * (x1r * x2r + x1i * x2i) - n12i * (x1r * x2i - x1i * x2r));
+        int bI[4], bQ[4];
+        nr_lbest_axis_bits_gen(It, kbits, bI);
+        nr_lbest_axis_bits_gen(Qt, kbits, bQ);
+        for (int j = 0; j < kbits; j++) {
+          const int p0 = 2 * j, p1 = 2 * j + 1;
+          if (bI[j] == 0) { if (m > max0[p0]) max0[p0] = m; } else { if (m > max1[p0]) max1[p0] = m; }
+          if (bQ[j] == 0) { if (m > max0[p1]) max0[p1] = m; } else { if (m > max1[p1]) max1[p1] = m; }
+        }
+      }
+    }
+    for (int p = 0; p < nbits; p++) {
+      double llr = (max0[p] <= -1e29) ? -NR_LBEST_LLR_SAT : (max1[p] <= -1e29) ? NR_LBEST_LLR_SAT : (max0[p] - max1[p]) * NR_LBEST_LLR_SCALE;
+      if (llr > 32767.0) llr = 32767.0;
+      if (llr < -32768.0) llr = -32768.0;
+      out[re * nbits + p] = (int16_t)llr;
+    }
+  }
+}
+
+// ============================================================================
+// Fixed-point (Q15-input) prototype of the L-best 2-layer 64QAM kernel.
+//
+// Integer twin of nr_qam64_llr_2layer_lbest_layer: same algorithm, but every
+// step uses the int16 demod buffers directly (no float). Two ideas keep it in
+// the existing mulhi/adds Q15 idiom and make it SIMD-portable:
+//
+//  (1) Scale the whole ML metric by 8*sqrt(42). The desired/nuisance
+//      correlation and energy terms then become EXACT integers (no irrational),
+//      and a single 1/sqrt(42) survives only on the cross term:
+//        Mq = 8*(Xr1.z1r+Xi1.z1i) - chmag0*|X1|^2          (desired)
+//           + 8*(Xr2.z2r+Xi2.z2i) - chmag1*|X2|^2          (nuisance)
+//           - 8*Re{rho.conj(X1).X2} / sqrt(42)             (cross)
+//      where X1,X2 are the *integer* level pairs (odd in [-7,7]) and chmag is
+//      the raw ch_mag input (= ||h||^2 * 4/sqrt(42)).
+//
+//  (2) No per-RE reciprocals. The ZF seed level and the conditional nuisance
+//      slice are both decided by comparing a numerator against det- / ||h||^2-
+//      scaled thresholds, never by dividing.
+//
+// Reference/oracle: identical LLRs (within fixed-point rounding) to
+// nr_qam64_llr_2layer_lbest at the same L; L==64 == full search.
+// ============================================================================
+#define NR_LBEST_Q_SQRT42_Q12        26545   // round(sqrt(42)        * 2^12)
+#define NR_LBEST_Q_SQRT42_OVER4_Q14  26545   // round(sqrt(42)/4      * 2^14) (same constant)
+#define NR_LBEST_Q_INVSQRT42_Q15      5057   // round(2^15 / sqrt(42))
+// integer metric is 8*sqrt(42) (~51.8x) larger than the float-ref metric; bring
+// the emitted LLR back onto the float-ref / SIMD scale.
+#define NR_LBEST_Q_LLR_NUM            2533    // round(2^17 / (8*sqrt(42)))
+#define NR_LBEST_Q_LLR_SHIFT            17
+#define NR_LBEST_Q_LLR_SAT           8192
+
+// nearest 64QAM PAM-8 level magnitude for |a|, thresholds at 2/4/6 * step.
+static inline int nr_lbest_q_pam8_abs(int64_t a, int64_t step)
+{
+  if (a < 2 * step) return 1;
+  if (a < 4 * step) return 3;
+  if (a < 6 * step) return 5;
+  return 7;
+}
+
+static void nr_qam64_llr_2layer_lbest_q15_layer(const c16_t *stream0_in,
+                                                const c16_t *stream1_in,
+                                                const c16_t *ch_mag,
+                                                const c16_t *ch_mag_i,
+                                                int16_t *stream0_out,
+                                                const c16_t *rho01,
+                                                uint32_t length,
+                                                int L)
+{
+  if (L < 1)
+    L = 1;
+  if (L > 64)
+    L = 64;
+  static const int levels[8] = {-7, -5, -3, -1, 1, 3, 5, 7};
+
+  for (uint32_t re = 0; re < length; re++) {
+    const int32_t z1r = stream0_in[re].r, z1i = stream0_in[re].i;
+    const int32_t z2r = stream1_in[re].r, z2i = stream1_in[re].i;
+    const int32_t rr = rho01[re].r, ri = rho01[re].i;     // rho = h0^H h1
+    const int32_t cm0 = ch_mag[re].r;                     // ||h0||^2 * 4/sqrt(42)
+    const int32_t cm1 = ch_mag_i[re].r;                   // ||h1||^2 * 4/sqrt(42)
+
+    // recovered channel powers ||h||^2 (for the seed determinant / thresholds)
+    const int64_t Pp0 = ((int64_t)cm0 * NR_LBEST_Q_SQRT42_OVER4_Q14) >> 14;
+    const int64_t Pp1 = ((int64_t)cm1 * NR_LBEST_Q_SQRT42_OVER4_Q14) >> 14;
+
+    // ---- 1. division-free ZF seed: x_hat1 = ((Pp1) z1 - rho z2) / det --------
+    const int64_t det = Pp0 * Pp1 - ((int64_t)rr * rr + (int64_t)ri * ri); // >= 0
+    const int64_t numr = Pp1 * z1r - ((int64_t)rr * z2r - (int64_t)ri * z2i);
+    const int64_t numi = Pp1 * z1i - ((int64_t)rr * z2i + (int64_t)ri * z2r);
+    // soft level estimate in Q6 (level units * 64); clamp to the 64QAM range.
+    int32_t estI_q6 = 0, estQ_q6 = 0;
+    if (det > 0) {
+      estI_q6 = (int32_t)((numr * NR_LBEST_Q_SQRT42_Q12) / (det * 64));
+      estQ_q6 = (int32_t)((numi * NR_LBEST_Q_SQRT42_Q12) / (det * 64));
+      if (estI_q6 < -512) estI_q6 = -512; else if (estI_q6 > 512) estI_q6 = 512;
+      if (estQ_q6 < -512) estQ_q6 = -512; else if (estQ_q6 > 512) estQ_q6 = 512;
+    }
+
+    // ---- 2. candidate set C1 = L nearest constellation points to x_hat1 ------
+    int candI[64], candQ[64];
+    int64_t cand_d[64];
+    int nc = 0;
+    for (int qi = 0; qi < 8; qi++) {
+      for (int ii = 0; ii < 8; ii++) {
+        const int64_t dI = estI_q6 - (levels[ii] << 6);
+        const int64_t dQ = estQ_q6 - (levels[qi] << 6);
+        candI[nc] = levels[ii];
+        candQ[nc] = levels[qi];
+        cand_d[nc] = dI * dI + dQ * dQ;
+        nc++;
+      }
+    }
+    for (int a = 0; a < L; a++) { // partial selection of the L smallest
+      int m = a;
+      for (int b = a + 1; b < 64; b++)
+        if (cand_d[b] < cand_d[m])
+          m = b;
+      if (m != a) {
+        int64_t td = cand_d[a]; cand_d[a] = cand_d[m]; cand_d[m] = td;
+        int ti = candI[a]; candI[a] = candI[m]; candI[m] = ti;
+        int tq = candQ[a]; candQ[a] = candQ[m]; candQ[m] = tq;
+      }
+    }
+
+    // ---- 3+4. metric over candidates (scaled by 8*sqrt(42)), max-log per bit -
+    int64_t max0[6], max1[6];
+    for (int p = 0; p < 6; p++) { max0[p] = INT64_MIN; max1[p] = INT64_MIN; }
+
+    for (int c = 0; c < L; c++) {
+      const int I1 = candI[c], Q1 = candQ[c];
+
+      // conditional ML nuisance x2*: slice (z2*sqrt42 - conj(rho).X1) vs Pp1*thr
+      const int64_t A2I = (((int64_t)z2r * NR_LBEST_Q_SQRT42_Q12) >> 12) - ((int64_t)rr * I1 + (int64_t)ri * Q1);
+      const int64_t A2Q = (((int64_t)z2i * NR_LBEST_Q_SQRT42_Q12) >> 12) - ((int64_t)rr * Q1 - (int64_t)ri * I1);
+      const int I2 = (A2I < 0 ? -1 : 1) * nr_lbest_q_pam8_abs(A2I < 0 ? -A2I : A2I, Pp1);
+      const int Q2 = (A2Q < 0 ? -1 : 1) * nr_lbest_q_pam8_abs(A2Q < 0 ? -A2Q : A2Q, Pp1);
+
+      // metric (units of 8*sqrt(42) * float-ref metric)
+      int64_t metric = 8 * ((int64_t)I1 * z1r + (int64_t)Q1 * z1i) - cm0 * ((int64_t)I1 * I1 + (int64_t)Q1 * Q1);
+      metric += 8 * ((int64_t)I2 * z2r + (int64_t)Q2 * z2i) - cm1 * ((int64_t)I2 * I2 + (int64_t)Q2 * Q2);
+      // cross = 8 * Re{rho.conj(X1).X2} / sqrt(42)
+      const int64_t rec = (int64_t)rr * ((int64_t)I1 * I2 + (int64_t)Q1 * Q2) + (int64_t)ri * ((int64_t)Q1 * I2 - (int64_t)I1 * Q2);
+      metric -= (8 * rec * NR_LBEST_Q_INVSQRT42_Q15) >> 15;
+
+      // bit labels, interleaved {I0,Q0,I1,Q1,I2,Q2} (matches nr_qam64_llr_2layer)
+      int bI0, bI1, bI2, bQ0, bQ1, bQ2;
+      nr_lbest_axis_bits(I1, &bI0, &bI1, &bI2);
+      nr_lbest_axis_bits(Q1, &bQ0, &bQ1, &bQ2);
+      const int bit[6] = {bI0, bQ0, bI1, bQ1, bI2, bQ2};
+      for (int p = 0; p < 6; p++) {
+        if (bit[p] == 0) { if (metric > max0[p]) max0[p] = metric; }
+        else             { if (metric > max1[p]) max1[p] = metric; }
+      }
+    }
+
+    for (int p = 0; p < 6; p++) {
+      int32_t llr;
+      if (max0[p] == INT64_MIN)
+        llr = -NR_LBEST_Q_LLR_SAT;
+      else if (max1[p] == INT64_MIN)
+        llr = NR_LBEST_Q_LLR_SAT;
+      else
+        llr = (int32_t)(((max0[p] - max1[p]) * NR_LBEST_Q_LLR_NUM) >> NR_LBEST_Q_LLR_SHIFT);
+      if (llr > 32767) llr = 32767;
+      if (llr < -32768) llr = -32768;
+      *stream0_out++ = (int16_t)llr;
+    }
+  }
+}
+
+// Public entry for the fixed-point L-best 64QAM kernel (target layer 0, ZF seed).
+void nr_qam64_llr_2layer_lbest_q15(c16_t *stream0_in,
+                                   c16_t *stream1_in,
+                                   c16_t *ch_mag,
+                                   c16_t *ch_mag_i,
+                                   int16_t *stream0_out,
+                                   c16_t *rho01,
+                                   uint32_t length,
+                                   int L)
+{
+  nr_qam64_llr_2layer_lbest_q15_layer(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, L);
+}
+
+// ============================================================================
+// int16/16-lane variant of the AVX2 L-best kernel. The dominant per-candidate
+// work (metric, conditional slice, max-log reduction) runs 16 REs/vector in
+// int16; only the ZF seed and z2*sqrt(42) (which overflow int16) use int32 half-
+// vectors, once per RE-vector. Metric is carried at scale (8*sqrt(42))/512 so all
+// terms fit int16. Single simde-256 source -> NEON on aarch64.
+// ============================================================================
+#define NR_LBEST_Q_INVSQRT42_Q16 10112   // round(1/sqrt(42) * 2^16)
+#define NR_LBEST_Q_PP1_OVER32_Q16 3318   // round(sqrt(42)/4/32 * 2^16) -> ||h||^2/32 via mulhi
+#define NR_LBEST_SIMD16_SENT  (-32768)   // empty-subset sentinel (int16)
+
+static inline simde__m256i nr_lbest_widen(simde__m256i v, int hi)
+{
+  return hi ? simde_mm256_cvtepi16_epi32(simde_mm256_extracti128_si256(v, 1))
+            : simde_mm256_cvtepi16_epi32(simde_mm256_castsi256_si128(v));
+}
+
+// int16 PAM-8 level (sign*mag, mag in {1,3,5,7}) sliced vs {2,4,6}*thunit.
+static inline simde__m256i nr_lbest_simd_level16(simde__m256i num, simde__m256i thunit)
+{
+  const simde__m256i z = simde_mm256_setzero_si256();
+  const simde__m256i a = simde_mm256_abs_epi16(num);
+  const simde__m256i t2 = simde_mm256_slli_epi16(thunit, 1);
+  const simde__m256i t4 = simde_mm256_slli_epi16(thunit, 2);
+  const simde__m256i t6 = simde_mm256_adds_epi16(t2, t4);
+  const simde__m256i g2 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t2));
+  const simde__m256i g4 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t4));
+  const simde__m256i g6 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t6));
+  const simde__m256i mag = simde_mm256_adds_epi16(simde_mm256_set1_epi16(1),
+                                                  simde_mm256_slli_epi16(simde_mm256_adds_epi16(simde_mm256_adds_epi16(g2, g4), g6), 1));
+  const simde__m256i neg = simde_mm256_cmpgt_epi16(z, num);
+  return simde_mm256_blendv_epi8(mag, simde_mm256_sub_epi16(z, mag), neg);
+}
+
+// load 16 complex int16 (c16_t) -> int16 real/imag vectors, lane l == RE l.
+static inline void nr_lbest_simd_load16(const c16_t *p, simde__m256i *re, simde__m256i *im)
+{
+  const simde__m256i sh = simde_mm256_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15,
+                                                0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
+  const simde__m256i v0 = simde_mm256_permute4x64_epi64(simde_mm256_shuffle_epi8(simde_mm256_loadu_si256((const simde__m256i *)p), sh), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+  const simde__m256i v1 = simde_mm256_permute4x64_epi64(simde_mm256_shuffle_epi8(simde_mm256_loadu_si256((const simde__m256i *)(p + 8)), sh), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+  *re = simde_mm256_set_m128i(simde_mm256_castsi256_si128(v1), simde_mm256_castsi256_si128(v0));
+  *im = simde_mm256_set_m128i(simde_mm256_extracti128_si256(v1, 1), simde_mm256_extracti128_si256(v0, 1));
+}
+
+// z * sqrt(42) / 32, packed to int16 (lane l == RE l).
+static inline simde__m256i nr_lbest_z42d32(simde__m256i z16)
+{
+  const simde__m256i C = simde_mm256_set1_epi32(NR_LBEST_Q_SQRT42_Q12);
+  const simde__m256i lo = simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(z16, 0), C), 17); // >>12 (Q12) >>5 (/32)
+  const simde__m256i hi = simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(z16, 1), C), 17);
+  return simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+}
+
+// ZF-seed nearest-level centers for 16 REs (int16 out). The 2x2 solve is done in
+// FLOAT, which is robust to the wide per-RE dynamic range of real channels (TDL
+// deep fades) where any fixed int pre-shift either loses precision or underflows.
+// Also emits dirImask/dirQmask: int16 mask, all-ones where the seed lies on the
+// +2 side of the nearest level (i.e. the toward-seed neighbour is center+2).
+static inline void nr_lbest_simd_seed16(simde__m256i z1r16, simde__m256i z1i16, simde__m256i z2r16, simde__m256i z2i16,
+                                        simde__m256i rr16, simde__m256i ri16, simde__m256i cm0_16, simde__m256i cm1_16,
+                                        simde__m256i *centerI, simde__m256i *centerQ,
+                                        simde__m256i *dirImask, simde__m256i *dirQmask)
+{
+  const simde__m256i SQRT42_OVER4 = simde_mm256_set1_epi32(NR_LBEST_Q_SQRT42_OVER4_Q14);
+  const simde__m256 SQRT42 = simde_mm256_set1_ps(6.48074069840786f);
+  const simde__m256 HALF = simde_mm256_set1_ps(0.5f), ONE = simde_mm256_set1_ps(1.0f), TWO = simde_mm256_set1_ps(2.0f);
+  const simde__m256 P7 = simde_mm256_set1_ps(7.0f), M7 = simde_mm256_set1_ps(-7.0f);
+  simde__m256i cI[2], cQ[2], dI[2], dQ[2];
+  for (int h = 0; h < 2; h++) {
+    const simde__m256 z1r = simde_mm256_cvtepi32_ps(nr_lbest_widen(z1r16, h)), z1i = simde_mm256_cvtepi32_ps(nr_lbest_widen(z1i16, h));
+    const simde__m256 z2r = simde_mm256_cvtepi32_ps(nr_lbest_widen(z2r16, h)), z2i = simde_mm256_cvtepi32_ps(nr_lbest_widen(z2i16, h));
+    const simde__m256 rr = simde_mm256_cvtepi32_ps(nr_lbest_widen(rr16, h)), ri = simde_mm256_cvtepi32_ps(nr_lbest_widen(ri16, h));
+    const simde__m256 Pp0 = simde_mm256_cvtepi32_ps(simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(cm0_16, h), SQRT42_OVER4), 14));
+    const simde__m256 Pp1 = simde_mm256_cvtepi32_ps(simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(cm1_16, h), SQRT42_OVER4), 14));
+    // ZF 2x2 solve (float): x_hat1 = ((Pp1) z1 - rho z2) / det,  det = Pp0 Pp1 - |rho|^2
+    simde__m256 det = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp0, Pp1), simde_mm256_add_ps(simde_mm256_mul_ps(rr, rr), simde_mm256_mul_ps(ri, ri)));
+    det = simde_mm256_max_ps(det, ONE); // guard near-singular (high correlation)
+    const simde__m256 numr = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp1, z1r), simde_mm256_sub_ps(simde_mm256_mul_ps(rr, z2r), simde_mm256_mul_ps(ri, z2i)));
+    const simde__m256 numi = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp1, z1i), simde_mm256_add_ps(simde_mm256_mul_ps(rr, z2i), simde_mm256_mul_ps(ri, z2r)));
+    // soft level estimate est = x_hat1 * sqrt(42)  (~ +-1..7)
+    const simde__m256 estI = simde_mm256_mul_ps(simde_mm256_div_ps(numr, det), SQRT42);
+    const simde__m256 estQ = simde_mm256_mul_ps(simde_mm256_div_ps(numi, det), SQRT42);
+    // nearest odd level: o = 2*round((est-1)/2)+1, clamped to [-7,7]
+    simde__m256 oI = simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps(estI, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    simde__m256 oQ = simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps(estQ, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    oI = simde_mm256_min_ps(simde_mm256_max_ps(oI, M7), P7);
+    oQ = simde_mm256_min_ps(simde_mm256_max_ps(oQ, M7), P7);
+    cI[h] = simde_mm256_cvtps_epi32(oI);
+    cQ[h] = simde_mm256_cvtps_epi32(oQ);
+    dI[h] = simde_mm256_castps_si256(simde_mm256_cmp_ps(estI, oI, SIMDE_CMP_GT_OQ)); // toward-seed = +2 side
+    dQ[h] = simde_mm256_castps_si256(simde_mm256_cmp_ps(estQ, oQ, SIMDE_CMP_GT_OQ));
+  }
+  *centerI = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(cI[0], cI[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+  *centerQ = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(cQ[0], cQ[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+  *dirImask = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(dI[0], dI[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+  *dirQmask = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(dQ[0], dQ[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+}
+
+// Per-candidate evaluation (slice + metric + max-log reduction), updating max0/max1.
+// Captures the per-RE-vector operands from the enclosing scope; the per-candidate
+// I-only/Q-only terms (bits, corr0/energy0 parts, slice operands) are passed in.
+#define NR_LBEST_EVAL16(I1_, Q1_, BI0, BI1, BI2, BQ0, BQ1, BQ2, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
+  do { \
+    const simde__m256i A2I = simde_mm256_subs_epi16(z2r42, simde_mm256_adds_epi16((RRI_), (RIQ_))); \
+    const simde__m256i A2Q = simde_mm256_subs_epi16(z2i42, simde_mm256_subs_epi16((RRQ_), (RII_))); \
+    const simde__m256i I2 = nr_lbest_simd_level16(A2I, Pp1_5); \
+    const simde__m256i Q2 = nr_lbest_simd_level16(A2Q, Pp1_5); \
+    const simde__m256i corr0 = simde_mm256_adds_epi16((C0I_), (C0Q_)); \
+    const simde__m256i energy0 = simde_mm256_adds_epi16((EI_), (EQ_)); \
+    const simde__m256i corr1 = simde_mm256_adds_epi16(simde_mm256_mulhi_epi16(z2r, simde_mm256_mullo_epi16(I2, C13)), simde_mm256_mulhi_epi16(z2i, simde_mm256_mullo_epi16(Q2, C13))); \
+    const simde__m256i energy1 = simde_mm256_mulhi_epi16(cm1, simde_mm256_mullo_epi16(simde_mm256_adds_epi16(simde_mm256_mullo_epi16(I2, I2), simde_mm256_mullo_epi16(Q2, Q2)), CE)); \
+    const simde__m256i aa = simde_mm256_adds_epi16(simde_mm256_mullo_epi16((I1_), I2), simde_mm256_mullo_epi16((Q1_), Q2)); \
+    const simde__m256i bb = simde_mm256_subs_epi16(simde_mm256_mullo_epi16((Q1_), I2), simde_mm256_mullo_epi16((I1_), Q2)); \
+    const simde__m256i cross = simde_mm256_adds_epi16(simde_mm256_mulhi_epi16(rr, simde_mm256_mullo_epi16(aa, CX)), simde_mm256_mulhi_epi16(ri, simde_mm256_mullo_epi16(bb, CX))); \
+    simde__m256i metric = simde_mm256_max_epi16(simde_mm256_subs_epi16(simde_mm256_adds_epi16(simde_mm256_subs_epi16(corr0, energy0), simde_mm256_subs_epi16(corr1, energy1)), cross), FLOORM); \
+    const simde__m256i bm[6] = {(BI0), (BQ0), (BI1), (BQ1), (BI2), (BQ2)}; \
+    for (int p = 0; p < 6; p++) { \
+      max0[p] = simde_mm256_max_epi16(max0[p], simde_mm256_blendv_epi8(metric, SENT, bm[p])); \
+      max1[p] = simde_mm256_max_epi16(max1[p], simde_mm256_blendv_epi8(SENT, metric, bm[p])); \
+    } \
+  } while (0)
+
+// pattern: 0 = 3x3 (9 cand, full BLER), 1 = 6-cand (plus + toward-seed diagonal),
+//          2 = 5-plus (center + +-2 each axis).
+void nr_qam64_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
+                                          c16_t *stream1_in,
+                                          c16_t *ch_mag,
+                                          c16_t *ch_mag_i,
+                                          int16_t *stream0_out,
+                                          c16_t *rho01,
+                                          uint32_t length,
+                                          int pattern)
+{
+  const simde__m256i SENT = simde_mm256_set1_epi16(NR_LBEST_SIMD16_SENT);
+  const simde__m256i FLOORM = simde_mm256_set1_epi16(-32000); // keep real metrics above SENT
+  const simde__m256i V1 = simde_mm256_set1_epi16(1), V4 = simde_mm256_set1_epi16(4);
+  const simde__m256i V7 = simde_mm256_set1_epi16(7), Vm7 = simde_mm256_set1_epi16(-7);
+  const simde__m256i z = simde_mm256_setzero_si256();
+
+  uint32_t re = 0;
+  for (; re + 16 <= length; re += 16) {
+    simde__m256i z1r, z1i, z2r, z2i, rr, ri, cm0, cm1, dummy;
+    nr_lbest_simd_load16(&stream0_in[re], &z1r, &z1i);
+    nr_lbest_simd_load16(&stream1_in[re], &z2r, &z2i);
+    nr_lbest_simd_load16(&rho01[re], &rr, &ri);
+    nr_lbest_simd_load16(&ch_mag[re], &cm0, &dummy);
+    nr_lbest_simd_load16(&ch_mag_i[re], &cm1, &dummy);
+
+    simde__m256i centerI, centerQ, dirImask, dirQmask;
+    nr_lbest_simd_seed16(z1r, z1i, z2r, z2i, rr, ri, cm0, cm1, &centerI, &centerQ, &dirImask, &dirQmask);
+    (void)dirImask; (void)dirQmask;
+
+    // per-RE precompute (int16): conditional-slice operands (/32 scale)
+    const simde__m256i z2r42 = nr_lbest_z42d32(z2r), z2i42 = nr_lbest_z42d32(z2i);
+    const simde__m256i rr5 = simde_mm256_srai_epi16(rr, 5), ri5 = simde_mm256_srai_epi16(ri, 5);
+    const simde__m256i Pp1_5 = simde_mm256_mulhi_epi16(cm1, simde_mm256_set1_epi16(NR_LBEST_Q_PP1_OVER32_Q16));
+    // metric Q-constants (normal/8 scale; precision-preserving via mulhi, not pre-shift)
+    const simde__m256i C13 = simde_mm256_set1_epi16(1264); // 2^13/sqrt(42): mulhi(z, I*C13) = z*I/(8 sqrt42)
+    const simde__m256i CE = simde_mm256_set1_epi16(158);   // 2^16/(64 sqrt42): energy = cm*|X|^2/(64 sqrt42)
+    const simde__m256i CX = simde_mm256_set1_epi16(195);   // 2^16/336: cross = rec/336
+
+    simde__m256i max0[6], max1[6];
+    for (int p = 0; p < 6; p++) { max0[p] = SENT; max1[p] = SENT; }
+
+    // 3x3 candidate block, HOISTED (full BLER). Precompute the I-only / Q-only terms
+    // for the 3 distinct I-levels and 3 Q-levels, then combine in the 9-pair loop.
+    // corr1/energy1/cross + the two level16 slicers stay per-pair (depend on the
+    // conditionally-sliced I2,Q2, which couple I and Q).
+    static const int offs3[3] = {-2, 0, 2};
+    simde__m256i Iv[3], Qv[3];
+    simde__m256i bIv[3][3], bQv[3][3];                       // [level][bit 0..2]
+    simde__m256i c0I[3], c0Q[3], eI[3], eQ[3];               // corr0 / energy0 parts
+    simde__m256i rrI[3], riI[3], rrQ[3], riQ[3];             // slice operands
+    for (int k = 0; k < 3; k++) {
+      const simde__m256i I1 = simde_mm256_min_epi16(simde_mm256_max_epi16(simde_mm256_adds_epi16(centerI, simde_mm256_set1_epi16(offs3[k])), Vm7), V7);
+      const simde__m256i Q1 = simde_mm256_min_epi16(simde_mm256_max_epi16(simde_mm256_adds_epi16(centerQ, simde_mm256_set1_epi16(offs3[k])), Vm7), V7);
+      Iv[k] = I1; Qv[k] = Q1;
+      const simde__m256i aI = simde_mm256_abs_epi16(I1), aQ = simde_mm256_abs_epi16(Q1);
+      bIv[k][0] = simde_mm256_cmpgt_epi16(z, I1);
+      bIv[k][1] = simde_mm256_cmpgt_epi16(aI, V4);
+      bIv[k][2] = simde_mm256_or_si256(simde_mm256_cmpeq_epi16(aI, V1), simde_mm256_cmpeq_epi16(aI, V7));
+      bQv[k][0] = simde_mm256_cmpgt_epi16(z, Q1);
+      bQv[k][1] = simde_mm256_cmpgt_epi16(aQ, V4);
+      bQv[k][2] = simde_mm256_or_si256(simde_mm256_cmpeq_epi16(aQ, V1), simde_mm256_cmpeq_epi16(aQ, V7));
+      c0I[k] = simde_mm256_mulhi_epi16(z1r, simde_mm256_mullo_epi16(I1, C13));
+      c0Q[k] = simde_mm256_mulhi_epi16(z1i, simde_mm256_mullo_epi16(Q1, C13));
+      eI[k] = simde_mm256_mulhi_epi16(cm0, simde_mm256_mullo_epi16(simde_mm256_mullo_epi16(I1, I1), CE));
+      eQ[k] = simde_mm256_mulhi_epi16(cm0, simde_mm256_mullo_epi16(simde_mm256_mullo_epi16(Q1, Q1), CE));
+      rrI[k] = simde_mm256_mullo_epi16(rr5, I1); riI[k] = simde_mm256_mullo_epi16(ri5, I1);
+      rrQ[k] = simde_mm256_mullo_epi16(rr5, Q1); riQ[k] = simde_mm256_mullo_epi16(ri5, Q1);
+    }
+    if (pattern == 0) { // 3x3: all 9 grid pairs
+      for (int iI = 0; iI < 3; iI++)
+        for (int iQ = 0; iQ < 3; iQ++)
+          NR_LBEST_EVAL16(Iv[iI], Qv[iQ], bIv[iI][0], bIv[iI][1], bIv[iI][2], bQv[iQ][0], bQv[iQ][1], bQv[iQ][2],
+                          c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+    } else { // 5-plus: center (1,1) + I+-2 + Q+-2
+      static const int pI[5] = {1, 0, 2, 1, 1}, pQ[5] = {1, 1, 1, 0, 2};
+      for (int c = 0; c < 5; c++) {
+        const int iI = pI[c], iQ = pQ[c];
+        NR_LBEST_EVAL16(Iv[iI], Qv[iQ], bIv[iI][0], bIv[iI][1], bIv[iI][2], bQv[iQ][0], bQv[iQ][1], bQv[iQ][2],
+                        c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+      }
+      if (pattern == 1) { // 6th: toward-seed diagonal, per-lane select corner 0 vs 2
+#define NR_LBEST_SI(a) simde_mm256_blendv_epi8((a)[0], (a)[2], dirImask)
+#define NR_LBEST_SQ(a) simde_mm256_blendv_epi8((a)[0], (a)[2], dirQmask)
+        NR_LBEST_EVAL16(NR_LBEST_SI(Iv), NR_LBEST_SQ(Qv),
+                        simde_mm256_blendv_epi8(bIv[0][0], bIv[2][0], dirImask),
+                        simde_mm256_blendv_epi8(bIv[0][1], bIv[2][1], dirImask),
+                        simde_mm256_blendv_epi8(bIv[0][2], bIv[2][2], dirImask),
+                        simde_mm256_blendv_epi8(bQv[0][0], bQv[2][0], dirQmask),
+                        simde_mm256_blendv_epi8(bQv[0][1], bQv[2][1], dirQmask),
+                        simde_mm256_blendv_epi8(bQv[0][2], bQv[2][2], dirQmask),
+                        NR_LBEST_SI(c0I), NR_LBEST_SQ(c0Q), NR_LBEST_SI(eI), NR_LBEST_SQ(eQ),
+                        NR_LBEST_SI(rrI), NR_LBEST_SI(riI), NR_LBEST_SQ(rrQ), NR_LBEST_SQ(riQ));
+#undef NR_LBEST_SI
+#undef NR_LBEST_SQ
+      }
+    }
+
+    int16_t tmp[6][16];
+    for (int p = 0; p < 6; p++) {
+      const simde__m256i diff = simde_mm256_subs_epi16(max0[p], max1[p]);
+      // metric is normal/8 scale -> LLR = diff*8 (== float-ref / SIMD scale); saturate via int32
+      const simde__m256i lo = simde_mm256_slli_epi32(nr_lbest_widen(diff, 0), 3);
+      const simde__m256i hi = simde_mm256_slli_epi32(nr_lbest_widen(diff, 1), 3);
+      simde__m256i res = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+      res = simde_mm256_blendv_epi8(res, simde_mm256_set1_epi16(-NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max0[p], SENT));
+      res = simde_mm256_blendv_epi8(res, simde_mm256_set1_epi16(NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max1[p], SENT));
+      simde_mm256_storeu_si256((simde__m256i *)tmp[p], res);
+    }
+    for (int r = 0; r < 16; r++)
+      for (int p = 0; p < 6; p++)
+        stream0_out[(re + r) * 6 + p] = tmp[p][r];
+  }
+
+  if (re < length)
+    nr_qam64_llr_2layer_lbest_q15_layer(&stream0_in[re], &stream1_in[re], &ch_mag[re], &ch_mag_i[re],
+                                        &stream0_out[re * 6], &rho01[re], length - re, 9);
+}
+
 void nr_compute_ML_llr(c16_t *rxdataF_comp0,
                        c16_t *rxdataF_comp1,
                        c16_t *ch_mag0,
@@ -2523,8 +3624,40 @@ void nr_compute_ML_llr(c16_t *rxdataF_comp0,
       nr_qam16_llr_2layer(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re);
       break;
     case 6:
-      nr_qam64_llr_2layer(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, llr_layers0, rho0, nb_re);
-      nr_qam64_llr_2layer(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re);
+      // 2-layer 64QAM. Default = full ML search (nr_qam64_llr_2layer), correct on all channels.
+      // The reduced-search L-best kernel (nr_qam64_llr_2layer_lbest_q15_simd16) is GATED OFF by
+      // default: it is only accurate on low-correlation / sparse channels (e.g. mmWave indoor,
+      // LOS-dominated), where the linear (ZF) seed predicts the ML symbol well. On correlated /
+      // selective channels (e.g. 3GPP TDL) it loses several dB and MUST NOT be used.
+      // Enable per-scenario via OAI_LBEST=1; OAI_LBEST_PAT picks the candidate set
+      // (0=3x3 [default], 1=6-cand seed-aware, 2=5-plus). TODO: replace the env gate with a
+      // proper RX-mode/config flag set by the scenario.
+      {
+        static int lbest = -1, pat = 0;
+        if (lbest < 0) {
+          const char *e = getenv("OAI_LBEST");
+          lbest = e ? atoi(e) : 0;
+          const char *ep = getenv("OAI_LBEST_PAT");
+          pat = ep ? atoi(ep) : 0;
+        }
+        if (lbest) {
+          nr_qam64_llr_2layer_lbest_q15_simd16(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, llr_layers0, rho0, nb_re, pat);
+          nr_qam64_llr_2layer_lbest_q15_simd16(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re, pat);
+        } else {
+          nr_qam64_llr_2layer(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, llr_layers0, rho0, nb_re);
+          nr_qam64_llr_2layer(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re);
+        }
+      }
+      break;
+    case 8:
+      // 2-layer 256QAM ML via the float L-best reference (ANALYSIS path; only reached when the
+      // demod L-best gate routes Qm=8 here). L = OAI_LBEST_L256 (default 256 = full ML search).
+      {
+        static int L256 = -1;
+        if (L256 < 0) { const char *e = getenv("OAI_LBEST_L256"); L256 = e ? atoi(e) : 256; }
+        nr_qam256_llr_2layer_lbest(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, llr_layers0, rho0, nb_re, L256, 0.0f);
+        nr_qam256_llr_2layer_lbest(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re, L256, 0.0f);
+      }
       break;
     default:
       AssertFatal(1 == 0, "nr_compute_ML_llr: invalid mod_order, Qm = %d\n", mod_order);

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -2875,6 +2875,20 @@ static void nr_qam64_llr_2layer_lbest_layer(const c16_t *stream0_in,
   }
 }
 
+// ============================================================================
+// L-best 2-layer float reference kernels (nr_qam{64,256,16}_llr_2layer_lbest) —
+// THE ALGORITHMIC CONTRACT for every per-arch SIMD port (AVX2 / AVX-512 / NEON /
+// RISC-V RVV). These double-precision kernels define the exact LLRs; an arch
+// kernel is "correct" iff it matches this reference AT HEAD, verified by the
+// OAI_LBEST_DBG / OAI_LBEST_DBG256 comparators (fitScale ~1.0, residFrac ~0,
+// low sign-disagreement). Port and optimize freely per arch — the DBG check is
+// the contract, so no arch kernel needs to mirror another's optimizations.
+// NB (256QAM): the graded-MSB fallback is part of this contract — an unspanned
+// bit uses the graded per-axis seed LLR (nr_lbest_pam16_axis_llr), NOT the hard
+// +-LLR_SAT. A port still on the old hard fallback shows fitScale ~9 / residFrac
+// ~0.5 and loses the 256QAM ML gain (distorted MSBs); re-diff against HEAD.
+// ============================================================================
+//
 // Drop-in float reference for nr_qam64_llr_2layer (target layer 0): reduced
 // "L-best" search seeded from the linear (ZF/MMSE) estimate. L==64 reproduces
 // the full max-log search; L==8 matches it in BLER at a fraction of the cost
@@ -3736,93 +3750,18 @@ void nr_qam256_llr_2layer_lbest_q15(c16_t *stream0_in,
 #define NR_LBEST_Q_PP1_OVER32_Q16 3318   // round(sqrt(42)/4/32 * 2^16) -> ||h||^2/32 via mulhi
 #define NR_LBEST_SIMD16_SENT  (-32768)   // empty-subset sentinel (int16)
 
-static inline simde__m256i nr_lbest_widen(simde__m256i v, int hi)
-{
-  return hi ? simde_mm256_cvtepi16_epi32(simde_mm256_extracti128_si256(v, 1))
-            : simde_mm256_cvtepi16_epi32(simde_mm256_castsi256_si128(v));
-}
 
 // int16 PAM-8 level (sign*mag, mag in {1,3,5,7}) sliced vs {2,4,6}*thunit.
-static inline simde__m256i nr_lbest_simd_level16(simde__m256i num, simde__m256i thunit)
-{
-  const simde__m256i z = simde_mm256_setzero_si256();
-  const simde__m256i a = simde_mm256_abs_epi16(num);
-  const simde__m256i t2 = simde_mm256_slli_epi16(thunit, 1);
-  const simde__m256i t4 = simde_mm256_slli_epi16(thunit, 2);
-  const simde__m256i t6 = simde_mm256_adds_epi16(t2, t4);
-  const simde__m256i g2 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t2));
-  const simde__m256i g4 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t4));
-  const simde__m256i g6 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t6));
-  const simde__m256i mag = simde_mm256_adds_epi16(simde_mm256_set1_epi16(1),
-                                                  simde_mm256_slli_epi16(simde_mm256_adds_epi16(simde_mm256_adds_epi16(g2, g4), g6), 1));
-  const simde__m256i neg = simde_mm256_cmpgt_epi16(z, num);
-  return simde_mm256_blendv_epi8(mag, simde_mm256_sub_epi16(z, mag), neg);
-}
 
 // load 16 complex int16 (c16_t) -> int16 real/imag vectors, lane l == RE l.
-static inline void nr_lbest_simd_load16(const c16_t *p, simde__m256i *re, simde__m256i *im)
-{
-  const simde__m256i sh = simde_mm256_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15,
-                                                0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
-  const simde__m256i v0 = simde_mm256_permute4x64_epi64(simde_mm256_shuffle_epi8(simde_mm256_loadu_si256((const simde__m256i *)p), sh), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-  const simde__m256i v1 = simde_mm256_permute4x64_epi64(simde_mm256_shuffle_epi8(simde_mm256_loadu_si256((const simde__m256i *)(p + 8)), sh), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-  *re = simde_mm256_set_m128i(simde_mm256_castsi256_si128(v1), simde_mm256_castsi256_si128(v0));
-  *im = simde_mm256_set_m128i(simde_mm256_extracti128_si256(v1, 1), simde_mm256_extracti128_si256(v0, 1));
-}
 
 // z * sqrt(42) / 32, packed to int16 (lane l == RE l).
-static inline simde__m256i nr_lbest_z42d32(simde__m256i z16)
-{
-  const simde__m256i C = simde_mm256_set1_epi32(NR_LBEST_Q_SQRT42_Q12);
-  const simde__m256i lo = simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(z16, 0), C), 17); // >>12 (Q12) >>5 (/32)
-  const simde__m256i hi = simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(z16, 1), C), 17);
-  return simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-}
 
 // ZF-seed nearest-level centers for 16 REs (int16 out). The 2x2 solve is done in
 // FLOAT, which is robust to the wide per-RE dynamic range of real channels (TDL
 // deep fades) where any fixed int pre-shift either loses precision or underflows.
 // Also emits dirImask/dirQmask: int16 mask, all-ones where the seed lies on the
 // +2 side of the nearest level (i.e. the toward-seed neighbour is center+2).
-static inline void nr_lbest_simd_seed16(simde__m256i z1r16, simde__m256i z1i16, simde__m256i z2r16, simde__m256i z2i16,
-                                        simde__m256i rr16, simde__m256i ri16, simde__m256i cm0_16, simde__m256i cm1_16,
-                                        simde__m256i *centerI, simde__m256i *centerQ,
-                                        simde__m256i *dirImask, simde__m256i *dirQmask)
-{
-  const simde__m256i SQRT42_OVER4 = simde_mm256_set1_epi32(NR_LBEST_Q_SQRT42_OVER4_Q14);
-  const simde__m256 SQRT42 = simde_mm256_set1_ps(6.48074069840786f);
-  const simde__m256 HALF = simde_mm256_set1_ps(0.5f), ONE = simde_mm256_set1_ps(1.0f), TWO = simde_mm256_set1_ps(2.0f);
-  const simde__m256 P7 = simde_mm256_set1_ps(7.0f), M7 = simde_mm256_set1_ps(-7.0f);
-  simde__m256i cI[2], cQ[2], dI[2], dQ[2];
-  for (int h = 0; h < 2; h++) {
-    const simde__m256 z1r = simde_mm256_cvtepi32_ps(nr_lbest_widen(z1r16, h)), z1i = simde_mm256_cvtepi32_ps(nr_lbest_widen(z1i16, h));
-    const simde__m256 z2r = simde_mm256_cvtepi32_ps(nr_lbest_widen(z2r16, h)), z2i = simde_mm256_cvtepi32_ps(nr_lbest_widen(z2i16, h));
-    const simde__m256 rr = simde_mm256_cvtepi32_ps(nr_lbest_widen(rr16, h)), ri = simde_mm256_cvtepi32_ps(nr_lbest_widen(ri16, h));
-    const simde__m256 Pp0 = simde_mm256_cvtepi32_ps(simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(cm0_16, h), SQRT42_OVER4), 14));
-    const simde__m256 Pp1 = simde_mm256_cvtepi32_ps(simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(cm1_16, h), SQRT42_OVER4), 14));
-    // ZF 2x2 solve (float): x_hat1 = ((Pp1) z1 - rho z2) / det,  det = Pp0 Pp1 - |rho|^2
-    simde__m256 det = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp0, Pp1), simde_mm256_add_ps(simde_mm256_mul_ps(rr, rr), simde_mm256_mul_ps(ri, ri)));
-    det = simde_mm256_max_ps(det, ONE); // guard near-singular (high correlation)
-    const simde__m256 numr = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp1, z1r), simde_mm256_sub_ps(simde_mm256_mul_ps(rr, z2r), simde_mm256_mul_ps(ri, z2i)));
-    const simde__m256 numi = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp1, z1i), simde_mm256_add_ps(simde_mm256_mul_ps(rr, z2i), simde_mm256_mul_ps(ri, z2r)));
-    // soft level estimate est = x_hat1 * sqrt(42)  (~ +-1..7)
-    const simde__m256 estI = simde_mm256_mul_ps(simde_mm256_div_ps(numr, det), SQRT42);
-    const simde__m256 estQ = simde_mm256_mul_ps(simde_mm256_div_ps(numi, det), SQRT42);
-    // nearest odd level: o = 2*round((est-1)/2)+1, clamped to [-7,7]
-    simde__m256 oI = simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps(estI, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
-    simde__m256 oQ = simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps(estQ, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
-    oI = simde_mm256_min_ps(simde_mm256_max_ps(oI, M7), P7);
-    oQ = simde_mm256_min_ps(simde_mm256_max_ps(oQ, M7), P7);
-    cI[h] = simde_mm256_cvtps_epi32(oI);
-    cQ[h] = simde_mm256_cvtps_epi32(oQ);
-    dI[h] = simde_mm256_castps_si256(simde_mm256_cmp_ps(estI, oI, SIMDE_CMP_GT_OQ)); // toward-seed = +2 side
-    dQ[h] = simde_mm256_castps_si256(simde_mm256_cmp_ps(estQ, oQ, SIMDE_CMP_GT_OQ));
-  }
-  *centerI = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(cI[0], cI[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-  *centerQ = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(cQ[0], cQ[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-  *dirImask = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(dI[0], dI[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-  *dirQmask = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(dQ[0], dQ[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-}
 
 // Per-candidate evaluation (slice + metric + max-log reduction), updating max0/max1.
 // Captures the per-RE-vector operands from the enclosing scope; the per-candidate
@@ -3830,195 +3769,13 @@ static inline void nr_lbest_simd_seed16(simde__m256i z1r16, simde__m256i z1i16, 
 // Store Qm LLR vectors (res[Qm], 16 REs across the lanes) to the interleaved decoder layout
 // stream0_out[(re+r)*Qm + p] via an 8x8 int16 transpose (padded from Qm), replacing the scalar
 // scatter (~24% of the 64QAM kernel). Qm in {6,8}; exactly Qm int16/RE are written (no overflow).
-static inline void nr_lbest_store_llr16(int16_t *stream0_out, uint32_t re, const simde__m256i *res, int Qm)
-{
-  simde__m256i r[8];
-  for (int p = 0; p < Qm; p++) r[p] = res[p];
-  for (int p = Qm; p < 8; p++) r[p] = simde_mm256_setzero_si256();
-  const simde__m256i a0 = simde_mm256_unpacklo_epi16(r[0], r[1]), a1 = simde_mm256_unpackhi_epi16(r[0], r[1]);
-  const simde__m256i a2 = simde_mm256_unpacklo_epi16(r[2], r[3]), a3 = simde_mm256_unpackhi_epi16(r[2], r[3]);
-  const simde__m256i a4 = simde_mm256_unpacklo_epi16(r[4], r[5]), a5 = simde_mm256_unpackhi_epi16(r[4], r[5]);
-  const simde__m256i a6 = simde_mm256_unpacklo_epi16(r[6], r[7]), a7 = simde_mm256_unpackhi_epi16(r[6], r[7]);
-  const simde__m256i b0 = simde_mm256_unpacklo_epi32(a0, a2), b1 = simde_mm256_unpackhi_epi32(a0, a2);
-  const simde__m256i b2 = simde_mm256_unpacklo_epi32(a1, a3), b3 = simde_mm256_unpackhi_epi32(a1, a3);
-  const simde__m256i b4 = simde_mm256_unpacklo_epi32(a4, a6), b5 = simde_mm256_unpackhi_epi32(a4, a6);
-  const simde__m256i b6 = simde_mm256_unpacklo_epi32(a5, a7), b7 = simde_mm256_unpackhi_epi32(a5, a7);
-  simde__m256i c[8];
-  c[0] = simde_mm256_unpacklo_epi64(b0, b4); c[1] = simde_mm256_unpackhi_epi64(b0, b4);
-  c[2] = simde_mm256_unpacklo_epi64(b1, b5); c[3] = simde_mm256_unpackhi_epi64(b1, b5);
-  c[4] = simde_mm256_unpacklo_epi64(b2, b6); c[5] = simde_mm256_unpackhi_epi64(b2, b6);
-  c[6] = simde_mm256_unpacklo_epi64(b3, b7); c[7] = simde_mm256_unpackhi_epi64(b3, b7);
-  for (int j = 0; j < 8; j++) { // c[j] low128 = RE j (bits 0..Qm-1 + pad); high128 = RE j+8
-    const simde__m128i lo = simde_mm256_castsi256_si128(c[j]), hi = simde_mm256_extracti128_si256(c[j], 1);
-    int16_t *o0 = &stream0_out[(re + j) * Qm], *o8 = &stream0_out[(re + j + 8) * Qm];
-    if (Qm == 8) {
-      simde_mm_storeu_si128((simde__m128i *)o0, lo);
-      simde_mm_storeu_si128((simde__m128i *)o8, hi);
-    } else { // Qm == 6: 4 int16 (storel) + 2 int16 (int32 store)
-      simde_mm_storel_epi64((simde__m128i *)o0, lo); *(int32_t *)(o0 + 4) = simde_mm_extract_epi32(lo, 2);
-      simde_mm_storel_epi64((simde__m128i *)o8, hi); *(int32_t *)(o8 + 4) = simde_mm_extract_epi32(hi, 2);
-    }
-  }
-}
 
 // Metric only (slice + corr/energy/cross), result -> (MET_). No max-log reduction.
-#define NR_LBEST_METRIC16(MET_, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
-  do { \
-    const simde__m256i A2I = simde_mm256_subs_epi16(z2r42, simde_mm256_adds_epi16((RRI_), (RIQ_))); \
-    const simde__m256i A2Q = simde_mm256_subs_epi16(z2i42, simde_mm256_subs_epi16((RRQ_), (RII_))); \
-    const simde__m256i I2 = nr_lbest_simd_level16(A2I, Pp1_5); \
-    const simde__m256i Q2 = nr_lbest_simd_level16(A2Q, Pp1_5); \
-    const simde__m256i corr0 = simde_mm256_adds_epi16((C0I_), (C0Q_)); \
-    const simde__m256i energy0 = simde_mm256_adds_epi16((EI_), (EQ_)); \
-    const simde__m256i corr1 = simde_mm256_adds_epi16(simde_mm256_mulhi_epi16(z2r, simde_mm256_mullo_epi16(I2, C13)), simde_mm256_mulhi_epi16(z2i, simde_mm256_mullo_epi16(Q2, C13))); \
-    const simde__m256i energy1 = simde_mm256_mulhi_epi16(cm1, simde_mm256_mullo_epi16(simde_mm256_adds_epi16(simde_mm256_mullo_epi16(I2, I2), simde_mm256_mullo_epi16(Q2, Q2)), CE)); \
-    const simde__m256i aa = simde_mm256_adds_epi16(simde_mm256_mullo_epi16((I1_), I2), simde_mm256_mullo_epi16((Q1_), Q2)); \
-    const simde__m256i bb = simde_mm256_subs_epi16(simde_mm256_mullo_epi16((Q1_), I2), simde_mm256_mullo_epi16((I1_), Q2)); \
-    const simde__m256i cross = simde_mm256_adds_epi16(simde_mm256_mulhi_epi16(rr, simde_mm256_mullo_epi16(aa, CX)), simde_mm256_mulhi_epi16(ri, simde_mm256_mullo_epi16(bb, CX))); \
-    (MET_) = simde_mm256_max_epi16(simde_mm256_subs_epi16(simde_mm256_adds_epi16(simde_mm256_subs_epi16(corr0, energy0), simde_mm256_subs_epi16(corr1, energy1)), cross), FLOORM); \
-  } while (0)
 
 // Per-candidate metric + streaming max-log reduction into max0/max1 (for non-grid patterns).
-#define NR_LBEST_EVAL16(I1_, Q1_, BI0, BI1, BI2, BQ0, BQ1, BQ2, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
-  do { \
-    simde__m256i metric; \
-    NR_LBEST_METRIC16(metric, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_); \
-    const simde__m256i bm[6] = {(BI0), (BQ0), (BI1), (BQ1), (BI2), (BQ2)}; \
-    for (int p = 0; p < 6; p++) { \
-      max0[p] = simde_mm256_max_epi16(max0[p], simde_mm256_blendv_epi8(metric, SENT, bm[p])); \
-      max1[p] = simde_mm256_max_epi16(max1[p], simde_mm256_blendv_epi8(SENT, metric, bm[p])); \
-    } \
-  } while (0)
 
 // pattern: 0 = 3x3 (9 cand, full BLER), 1 = 6-cand (plus + toward-seed diagonal),
 //          2 = 5-plus (center + +-2 each axis).
-void nr_qam64_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
-                                          c16_t *stream1_in,
-                                          c16_t *ch_mag,
-                                          c16_t *ch_mag_i,
-                                          int16_t *stream0_out,
-                                          c16_t *rho01,
-                                          uint32_t length,
-                                          int pattern)
-{
-  const simde__m256i SENT = simde_mm256_set1_epi16(NR_LBEST_SIMD16_SENT);
-  const simde__m256i FLOORM = simde_mm256_set1_epi16(-32000); // keep real metrics above SENT
-  const simde__m256i V1 = simde_mm256_set1_epi16(1), V4 = simde_mm256_set1_epi16(4);
-  const simde__m256i V7 = simde_mm256_set1_epi16(7), Vm7 = simde_mm256_set1_epi16(-7);
-  const simde__m256i z = simde_mm256_setzero_si256();
-
-  uint32_t re = 0;
-  for (; re + 16 <= length; re += 16) {
-    simde__m256i z1r, z1i, z2r, z2i, rr, ri, cm0, cm1, dummy;
-    nr_lbest_simd_load16(&stream0_in[re], &z1r, &z1i);
-    nr_lbest_simd_load16(&stream1_in[re], &z2r, &z2i);
-    nr_lbest_simd_load16(&rho01[re], &rr, &ri);
-    nr_lbest_simd_load16(&ch_mag[re], &cm0, &dummy);
-    nr_lbest_simd_load16(&ch_mag_i[re], &cm1, &dummy);
-
-    simde__m256i centerI, centerQ, dirImask, dirQmask;
-    nr_lbest_simd_seed16(z1r, z1i, z2r, z2i, rr, ri, cm0, cm1, &centerI, &centerQ, &dirImask, &dirQmask);
-    (void)dirImask; (void)dirQmask;
-
-    // per-RE precompute (int16): conditional-slice operands (/32 scale)
-    const simde__m256i z2r42 = nr_lbest_z42d32(z2r), z2i42 = nr_lbest_z42d32(z2i);
-    const simde__m256i rr5 = simde_mm256_srai_epi16(rr, 5), ri5 = simde_mm256_srai_epi16(ri, 5);
-    const simde__m256i Pp1_5 = simde_mm256_mulhi_epi16(cm1, simde_mm256_set1_epi16(NR_LBEST_Q_PP1_OVER32_Q16));
-    // metric Q-constants (normal/8 scale; precision-preserving via mulhi, not pre-shift)
-    const simde__m256i C13 = simde_mm256_set1_epi16(1264); // 2^13/sqrt(42): mulhi(z, I*C13) = z*I/(8 sqrt42)
-    const simde__m256i CE = simde_mm256_set1_epi16(158);   // 2^16/(64 sqrt42): energy = cm*|X|^2/(64 sqrt42)
-    const simde__m256i CX = simde_mm256_set1_epi16(195);   // 2^16/336: cross = rec/336
-
-    simde__m256i max0[6], max1[6];
-    for (int p = 0; p < 6; p++) { max0[p] = SENT; max1[p] = SENT; }
-
-    // 3x3 candidate block, HOISTED (full BLER). Precompute the I-only / Q-only terms
-    // for the 3 distinct I-levels and 3 Q-levels, then combine in the 9-pair loop.
-    // corr1/energy1/cross + the two level16 slicers stay per-pair (depend on the
-    // conditionally-sliced I2,Q2, which couple I and Q).
-    static const int offs3[3] = {-2, 0, 2};
-    simde__m256i Iv[3], Qv[3];
-    simde__m256i bIv[3][3], bQv[3][3];                       // [level][bit 0..2]
-    simde__m256i c0I[3], c0Q[3], eI[3], eQ[3];               // corr0 / energy0 parts
-    simde__m256i rrI[3], riI[3], rrQ[3], riQ[3];             // slice operands
-    for (int k = 0; k < 3; k++) {
-      const simde__m256i I1 = simde_mm256_min_epi16(simde_mm256_max_epi16(simde_mm256_adds_epi16(centerI, simde_mm256_set1_epi16(offs3[k])), Vm7), V7);
-      const simde__m256i Q1 = simde_mm256_min_epi16(simde_mm256_max_epi16(simde_mm256_adds_epi16(centerQ, simde_mm256_set1_epi16(offs3[k])), Vm7), V7);
-      Iv[k] = I1; Qv[k] = Q1;
-      const simde__m256i aI = simde_mm256_abs_epi16(I1), aQ = simde_mm256_abs_epi16(Q1);
-      bIv[k][0] = simde_mm256_cmpgt_epi16(z, I1);
-      bIv[k][1] = simde_mm256_cmpgt_epi16(aI, V4);
-      bIv[k][2] = simde_mm256_or_si256(simde_mm256_cmpeq_epi16(aI, V1), simde_mm256_cmpeq_epi16(aI, V7));
-      bQv[k][0] = simde_mm256_cmpgt_epi16(z, Q1);
-      bQv[k][1] = simde_mm256_cmpgt_epi16(aQ, V4);
-      bQv[k][2] = simde_mm256_or_si256(simde_mm256_cmpeq_epi16(aQ, V1), simde_mm256_cmpeq_epi16(aQ, V7));
-      c0I[k] = simde_mm256_mulhi_epi16(z1r, simde_mm256_mullo_epi16(I1, C13));
-      c0Q[k] = simde_mm256_mulhi_epi16(z1i, simde_mm256_mullo_epi16(Q1, C13));
-      eI[k] = simde_mm256_mulhi_epi16(cm0, simde_mm256_mullo_epi16(simde_mm256_mullo_epi16(I1, I1), CE));
-      eQ[k] = simde_mm256_mulhi_epi16(cm0, simde_mm256_mullo_epi16(simde_mm256_mullo_epi16(Q1, Q1), CE));
-      rrI[k] = simde_mm256_mullo_epi16(rr5, I1); riI[k] = simde_mm256_mullo_epi16(ri5, I1);
-      rrQ[k] = simde_mm256_mullo_epi16(rr5, Q1); riQ[k] = simde_mm256_mullo_epi16(ri5, Q1);
-    }
-    if (pattern == 0) { // 3x3 full grid: reduce per-axis. Bits are per-axis, so the max over a
-      // bit-subset factorises: max over candidates with I-bit=b = max over I-levels-with-b of
-      // (max over Q). Computing maxI[i]=max_Q met[i][.], maxQ[q]=max_I met[.][q] then blending over
-      // 3 values/axis replaces 9*6*2 per-candidate blends with 3*3*4 (~2.6x fewer). Bit-exact.
-      simde__m256i met[3][3];
-      for (int iI = 0; iI < 3; iI++)
-        for (int iQ = 0; iQ < 3; iQ++)
-          NR_LBEST_METRIC16(met[iI][iQ], Iv[iI], Qv[iQ], c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
-      simde__m256i maxI[3], maxQ[3];
-      for (int i = 0; i < 3; i++) maxI[i] = simde_mm256_max_epi16(met[i][0], simde_mm256_max_epi16(met[i][1], met[i][2]));
-      for (int q = 0; q < 3; q++) maxQ[q] = simde_mm256_max_epi16(met[0][q], simde_mm256_max_epi16(met[1][q], met[2][q]));
-      for (int k = 0; k < 3; k++) // I-bit k -> output p=2k ; Q-bit k -> p=2k+1
-        for (int i = 0; i < 3; i++) {
-          max0[2 * k]     = simde_mm256_max_epi16(max0[2 * k],     simde_mm256_blendv_epi8(maxI[i], SENT, bIv[i][k]));
-          max1[2 * k]     = simde_mm256_max_epi16(max1[2 * k],     simde_mm256_blendv_epi8(SENT, maxI[i], bIv[i][k]));
-          max0[2 * k + 1] = simde_mm256_max_epi16(max0[2 * k + 1], simde_mm256_blendv_epi8(maxQ[i], SENT, bQv[i][k]));
-          max1[2 * k + 1] = simde_mm256_max_epi16(max1[2 * k + 1], simde_mm256_blendv_epi8(SENT, maxQ[i], bQv[i][k]));
-        }
-    } else { // 5-plus: center (1,1) + I+-2 + Q+-2
-      static const int pI[5] = {1, 0, 2, 1, 1}, pQ[5] = {1, 1, 1, 0, 2};
-      for (int c = 0; c < 5; c++) {
-        const int iI = pI[c], iQ = pQ[c];
-        NR_LBEST_EVAL16(Iv[iI], Qv[iQ], bIv[iI][0], bIv[iI][1], bIv[iI][2], bQv[iQ][0], bQv[iQ][1], bQv[iQ][2],
-                        c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
-      }
-      if (pattern == 1) { // 6th: toward-seed diagonal, per-lane select corner 0 vs 2
-#define NR_LBEST_SI(a) simde_mm256_blendv_epi8((a)[0], (a)[2], dirImask)
-#define NR_LBEST_SQ(a) simde_mm256_blendv_epi8((a)[0], (a)[2], dirQmask)
-        NR_LBEST_EVAL16(NR_LBEST_SI(Iv), NR_LBEST_SQ(Qv),
-                        simde_mm256_blendv_epi8(bIv[0][0], bIv[2][0], dirImask),
-                        simde_mm256_blendv_epi8(bIv[0][1], bIv[2][1], dirImask),
-                        simde_mm256_blendv_epi8(bIv[0][2], bIv[2][2], dirImask),
-                        simde_mm256_blendv_epi8(bQv[0][0], bQv[2][0], dirQmask),
-                        simde_mm256_blendv_epi8(bQv[0][1], bQv[2][1], dirQmask),
-                        simde_mm256_blendv_epi8(bQv[0][2], bQv[2][2], dirQmask),
-                        NR_LBEST_SI(c0I), NR_LBEST_SQ(c0Q), NR_LBEST_SI(eI), NR_LBEST_SQ(eQ),
-                        NR_LBEST_SI(rrI), NR_LBEST_SI(riI), NR_LBEST_SQ(rrQ), NR_LBEST_SQ(riQ));
-#undef NR_LBEST_SI
-#undef NR_LBEST_SQ
-      }
-    }
-
-    simde__m256i res[6];
-    for (int p = 0; p < 6; p++) {
-      const simde__m256i diff = simde_mm256_subs_epi16(max0[p], max1[p]);
-      // metric is normal/8 scale -> LLR = diff*8 (== float-ref / SIMD scale); saturate via int32
-      const simde__m256i lo = simde_mm256_slli_epi32(nr_lbest_widen(diff, 0), 3);
-      const simde__m256i hi = simde_mm256_slli_epi32(nr_lbest_widen(diff, 1), 3);
-      simde__m256i r = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-      r = simde_mm256_blendv_epi8(r, simde_mm256_set1_epi16(-NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max0[p], SENT));
-      r = simde_mm256_blendv_epi8(r, simde_mm256_set1_epi16(NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max1[p], SENT));
-      res[p] = r;
-    }
-    nr_lbest_store_llr16(stream0_out, re, res, 6);
-  }
-
-  if (re < length)
-    nr_qam64_llr_2layer_lbest_q15_layer(&stream0_in[re], &stream1_in[re], &ch_mag[re], &ch_mag_i[re],
-                                        &stream0_out[re * 6], &rho01[re], length - re, 9);
-}
 
 // ============================================================================
 // int16/16-lane AVX2 L-best kernel for 2-layer 256QAM (PAM-16, 8 bits/RE).
@@ -4033,349 +3790,73 @@ void nr_qam64_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
 #define NR_LBEST_Q_PP1_OVER32_Q16_256       3338  // round(sqrt(170)/8/32 * 2^16)
 
 // int16 PAM-16 level (sign*mag, mag in {1,3,...,15}) sliced vs {2,4,6,8,10,12,14}*thunit.
-static inline simde__m256i nr_lbest_simd_level_pam16(simde__m256i num, simde__m256i thunit)
-{
-  const simde__m256i z   = simde_mm256_setzero_si256();
-  const simde__m256i a   = simde_mm256_abs_epi16(num);
-  const simde__m256i t2  = simde_mm256_slli_epi16(thunit, 1);
-  const simde__m256i t4  = simde_mm256_slli_epi16(thunit, 2);
-  const simde__m256i t8  = simde_mm256_slli_epi16(thunit, 3);
-  const simde__m256i t6  = simde_mm256_adds_epi16(t2, t4);
-  const simde__m256i t10 = simde_mm256_adds_epi16(t2, t8);
-  const simde__m256i t12 = simde_mm256_adds_epi16(t4, t8);
-  const simde__m256i t14 = simde_mm256_adds_epi16(t6, t8);
-  const simde__m256i g2  = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t2));
-  const simde__m256i g4  = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t4));
-  const simde__m256i g6  = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t6));
-  const simde__m256i g8  = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t8));
-  const simde__m256i g10 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t10));
-  const simde__m256i g12 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t12));
-  const simde__m256i g14 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t14));
-  // mag = 1 + 2*(g2+g4+g6+g8+g10+g12+g14)
-  const simde__m256i sum = simde_mm256_adds_epi16(
-      simde_mm256_adds_epi16(simde_mm256_adds_epi16(g2, g4), simde_mm256_adds_epi16(g6, g8)),
-      simde_mm256_adds_epi16(simde_mm256_adds_epi16(g10, g12), g14));
-  const simde__m256i mag = simde_mm256_adds_epi16(simde_mm256_set1_epi16(1),
-                                                  simde_mm256_slli_epi16(sum, 1));
-  const simde__m256i neg = simde_mm256_cmpgt_epi16(z, num);
-  return simde_mm256_blendv_epi8(mag, simde_mm256_sub_epi16(z, mag), neg);
-}
 
 // z * sqrt(170) / 32, packed to int16 (lane l == RE l).
-static inline simde__m256i nr_lbest_z170d32(simde__m256i z16)
-{
-  const simde__m256i C = simde_mm256_set1_epi32(NR_LBEST_Q_SQRT170_Q12);
-  const simde__m256i lo = simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(z16, 0), C), 17);
-  const simde__m256i hi = simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(z16, 1), C), 17);
-  return simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-}
 
 // Graded per-axis PAM-16 LLR (SIMD float, 8 lanes/half): out[b] = g*(min dist^2 with bit b=1 -
 // with b=0), g = 0.5*P0/170, in the kernel's final LLR units. Closed form (no 16-level loop): the
 // nearest PAM-16 level with a given bit value = clamp(round-to-odd(est), subrange), so each bit's
 // min-distance is a couple of clamps. Only b0/b1/b2 are computed — b3 (the finest bit) is ALWAYS
 // spanned by any 3x3/5x5/5-plus window (verified), so its fallback is never used; out[3]=0.
-static inline void nr_lbest_simd_axis_llr256(simde__m256 est, simde__m256 g, simde__m256 out[4])
-{
-  const simde__m256 ONE = simde_mm256_set1_ps(1.0f), TWO = simde_mm256_set1_ps(2.0f), HALF = simde_mm256_set1_ps(0.5f);
-  // o = nearest odd to est; oa = nearest odd to |est|
-  const simde__m256 a = simde_mm256_andnot_ps(simde_mm256_set1_ps(-0.0f), est);
-#define NR_RODD(x) simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps((x), ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE)
-  const simde__m256 o = NR_RODD(est), oa = NR_RODD(a);
-#define NR_CL(x, lo, hi) simde_mm256_min_ps(simde_mm256_max_ps((x), simde_mm256_set1_ps(lo)), simde_mm256_set1_ps(hi))
-#define NR_DSQ(lvl, ref) ({ const simde__m256 _d = simde_mm256_sub_ps((lvl), (ref)); simde_mm256_mul_ps(_d, _d); })
-  // b0 (sign): pos levels [1,15] (bit 0) vs neg [-15,-1] (bit 1)
-  out[0] = simde_mm256_mul_ps(g, simde_mm256_sub_ps(NR_DSQ(NR_CL(o, -15.0f, -1.0f), est), NR_DSQ(NR_CL(o, 1.0f, 15.0f), est)));
-  // b1 (|L|>8): |L| in [1,7] (bit 0) vs [9,15] (bit 1); by symmetry work in a=|est|
-  out[1] = simde_mm256_mul_ps(g, simde_mm256_sub_ps(NR_DSQ(NR_CL(oa, 9.0f, 15.0f), a), NR_DSQ(NR_CL(oa, 1.0f, 7.0f), a)));
-  // b2 (||L|-8|>4): |L| in {5,7,9,11} (bit 0) vs {1,3}U{13,15} (bit 1)
-  const simde__m256 d2_0 = NR_DSQ(NR_CL(oa, 5.0f, 11.0f), a);
-  const simde__m256 d2_1 = simde_mm256_min_ps(NR_DSQ(NR_CL(oa, 1.0f, 3.0f), a), NR_DSQ(NR_CL(oa, 13.0f, 15.0f), a));
-  out[2] = simde_mm256_mul_ps(g, simde_mm256_sub_ps(d2_1, d2_0));
-  out[3] = simde_mm256_setzero_ps(); // b3 always spanned by the search window -> fallback never read
-#undef NR_RODD
-#undef NR_CL
-#undef NR_DSQ
-}
 
 // ZF seed for 256QAM: identical to nr_lbest_simd_seed16 except clamp to [-15,15]
 // and Pp = cm * sqrt(170)/8. Also emits axisLLR[8] = graded per-axis PAM-16 LLRs (interleaved
 // {I0,Q0,I1,Q1,I2,Q2,I3,Q3}, int16) used as the fallback for bits the reduced search cannot span.
-static inline void nr_lbest_simd_seed16_256(simde__m256i z1r16, simde__m256i z1i16,
-                                            simde__m256i z2r16, simde__m256i z2i16,
-                                            simde__m256i rr16,  simde__m256i ri16,
-                                            simde__m256i cm0_16, simde__m256i cm1_16,
-                                            simde__m256i *centerI, simde__m256i *centerQ,
-                                            simde__m256i *dirImask, simde__m256i *dirQmask,
-                                            simde__m256i axisLLR[8])
-{
-  simde__m256 aL[2][8]; // [half][ {I0,Q0,I1,Q1,I2,Q2,I3,Q3} ]
-  const simde__m256i SQRT170_OVER8 = simde_mm256_set1_epi32(NR_LBEST_Q_SQRT170_OVER8_Q14_SIMD);
-  const simde__m256 SQRT170 = simde_mm256_set1_ps(13.038404810405298f);
-  const simde__m256 HALF = simde_mm256_set1_ps(0.5f), ONE = simde_mm256_set1_ps(1.0f), TWO = simde_mm256_set1_ps(2.0f);
-  const simde__m256 P15 = simde_mm256_set1_ps(15.0f), M15 = simde_mm256_set1_ps(-15.0f);
-  simde__m256i cI[2], cQ[2], dI[2], dQ[2];
-  for (int h = 0; h < 2; h++) {
-    const simde__m256 z1r = simde_mm256_cvtepi32_ps(nr_lbest_widen(z1r16, h)), z1i = simde_mm256_cvtepi32_ps(nr_lbest_widen(z1i16, h));
-    const simde__m256 z2r = simde_mm256_cvtepi32_ps(nr_lbest_widen(z2r16, h)), z2i = simde_mm256_cvtepi32_ps(nr_lbest_widen(z2i16, h));
-    const simde__m256 rr  = simde_mm256_cvtepi32_ps(nr_lbest_widen(rr16,  h)), ri  = simde_mm256_cvtepi32_ps(nr_lbest_widen(ri16,  h));
-    const simde__m256 Pp0 = simde_mm256_cvtepi32_ps(simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(cm0_16, h), SQRT170_OVER8), 14));
-    const simde__m256 Pp1 = simde_mm256_cvtepi32_ps(simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(cm1_16, h), SQRT170_OVER8), 14));
-    // ZF 2x2 solve (float): x_hat1 = (Pp1*z1 - rho*z2) / det
-    simde__m256 det = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp0, Pp1),
-                                         simde_mm256_add_ps(simde_mm256_mul_ps(rr, rr), simde_mm256_mul_ps(ri, ri)));
-    det = simde_mm256_max_ps(det, ONE);
-    const simde__m256 numr = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp1, z1r),
-                                                 simde_mm256_sub_ps(simde_mm256_mul_ps(rr, z2r), simde_mm256_mul_ps(ri, z2i)));
-    const simde__m256 numi = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp1, z1i),
-                                                 simde_mm256_add_ps(simde_mm256_mul_ps(rr, z2i), simde_mm256_mul_ps(ri, z2r)));
-    // soft level estimate ~ +-1..15
-    const simde__m256 estI = simde_mm256_mul_ps(simde_mm256_div_ps(numr, det), SQRT170);
-    const simde__m256 estQ = simde_mm256_mul_ps(simde_mm256_div_ps(numi, det), SQRT170);
-    // graded per-axis PAM-16 LLRs from the soft estimate (g = 0.5*P0/170, P0 = Pp0)
-    const simde__m256 glin = simde_mm256_mul_ps(simde_mm256_set1_ps(0.5f / 170.0f), Pp0);
-    simde__m256 aI4[4], aQ4[4];
-    nr_lbest_simd_axis_llr256(estI, glin, aI4);
-    nr_lbest_simd_axis_llr256(estQ, glin, aQ4);
-    for (int b = 0; b < 4; b++) { aL[h][2 * b] = aI4[b]; aL[h][2 * b + 1] = aQ4[b]; }
-    // nearest odd level: o = 2*round((est-1)/2)+1, clamped to [-15,15]
-    simde__m256 oI = simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps(estI, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
-    simde__m256 oQ = simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps(estQ, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
-    oI = simde_mm256_min_ps(simde_mm256_max_ps(oI, M15), P15);
-    oQ = simde_mm256_min_ps(simde_mm256_max_ps(oQ, M15), P15);
-    cI[h] = simde_mm256_cvtps_epi32(oI);
-    cQ[h] = simde_mm256_cvtps_epi32(oQ);
-    dI[h] = simde_mm256_castps_si256(simde_mm256_cmp_ps(estI, oI, SIMDE_CMP_GT_OQ));
-    dQ[h] = simde_mm256_castps_si256(simde_mm256_cmp_ps(estQ, oQ, SIMDE_CMP_GT_OQ));
-  }
-  *centerI  = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(cI[0], cI[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-  *centerQ  = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(cQ[0], cQ[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-  *dirImask = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(dI[0], dI[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-  *dirQmask = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(dQ[0], dQ[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-  for (int p = 0; p < 8; p++) // round to nearest int16, saturating pack (final LLR units)
-    axisLLR[p] = simde_mm256_permute4x64_epi64(
-        simde_mm256_packs_epi32(simde_mm256_cvtps_epi32(aL[0][p]), simde_mm256_cvtps_epi32(aL[1][p])),
-        SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-}
 
 // Per-candidate evaluation for 256QAM (8 bits/RE, PAM-16 slicer).
 // C13_256 = round(2^13/sqrt(170)), CE_256 = round(2^16/(8*8*sqrt(170)*2)),
 // CX_256  = round(2^16/(8*170)).
 // Metric only (256QAM), result -> (MET_). No max-log reduction.
-#define NR_LBEST_METRIC16_256(MET_, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
-  do { \
-    const simde__m256i A2I = simde_mm256_subs_epi16(z2r170, simde_mm256_adds_epi16((RRI_), (RIQ_))); \
-    const simde__m256i A2Q = simde_mm256_subs_epi16(z2i170, simde_mm256_subs_epi16((RRQ_), (RII_))); \
-    const simde__m256i I2  = nr_lbest_simd_level_pam16(A2I, Pp1_5_256); \
-    const simde__m256i Q2  = nr_lbest_simd_level_pam16(A2Q, Pp1_5_256); \
-    const simde__m256i corr0   = simde_mm256_adds_epi16((C0I_), (C0Q_)); \
-    const simde__m256i energy0 = simde_mm256_adds_epi16((EI_), (EQ_)); \
-    const simde__m256i corr1   = simde_mm256_adds_epi16(simde_mm256_mulhi_epi16(z2r, simde_mm256_mullo_epi16(I2, C13_256)), \
-                                                        simde_mm256_mulhi_epi16(z2i, simde_mm256_mullo_epi16(Q2, C13_256))); \
-    const simde__m256i energy1 = simde_mm256_mulhi_epi16(cm1, simde_mm256_mullo_epi16(simde_mm256_adds_epi16(simde_mm256_mullo_epi16(I2, I2), simde_mm256_mullo_epi16(Q2, Q2)), CE_256)); \
-    const simde__m256i aa = simde_mm256_adds_epi16(simde_mm256_mullo_epi16((I1_), I2), simde_mm256_mullo_epi16((Q1_), Q2)); \
-    const simde__m256i bb = simde_mm256_subs_epi16(simde_mm256_mullo_epi16((Q1_), I2), simde_mm256_mullo_epi16((I1_), Q2)); \
-    const simde__m256i cross = simde_mm256_adds_epi16(simde_mm256_mulhi_epi16(rr, simde_mm256_mullo_epi16(aa, CX_256)), \
-                                                      simde_mm256_mulhi_epi16(ri, simde_mm256_mullo_epi16(bb, CX_256))); \
-    (MET_) = simde_mm256_max_epi16(simde_mm256_subs_epi16(simde_mm256_adds_epi16(simde_mm256_subs_epi16(corr0, energy0), simde_mm256_subs_epi16(corr1, energy1)), cross), FLOORM); \
-  } while (0)
 
 // Per-candidate metric + streaming max-log reduction into max0/max1 (for non-grid patterns).
-#define NR_LBEST_EVAL16_256(I1_, Q1_, BI0, BI1, BI2, BI3, BQ0, BQ1, BQ2, BQ3, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
-  do { \
-    simde__m256i metric; \
-    NR_LBEST_METRIC16_256(metric, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_); \
-    const simde__m256i bm[8] = {(BI0), (BQ0), (BI1), (BQ1), (BI2), (BQ2), (BI3), (BQ3)}; \
-    for (int p = 0; p < 8; p++) { \
-      max0[p] = simde_mm256_max_epi16(max0[p], simde_mm256_blendv_epi8(metric, SENT, bm[p])); \
-      max1[p] = simde_mm256_max_epi16(max1[p], simde_mm256_blendv_epi8(SENT, metric, bm[p])); \
-    } \
-  } while (0)
 
 // pattern: 0 = 5x5 (25 cand), 1 = 3x3 (9 cand), 2 = 5-plus (5 cand).
-void nr_qam256_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
-                                           c16_t *stream1_in,
-                                           c16_t *ch_mag,
-                                           c16_t *ch_mag_i,
-                                           int16_t *stream0_out,
-                                           c16_t *rho01,
-                                           uint32_t length,
-                                           int pattern)
+
+// ---- 2-layer 64QAM L-best kernel: width-parameterized (AVX2/NEON/AVX-512) ----
+// Generated once per width from nr_lbest_qam64_simd.c.inc; the public entry dispatches by arch.
+#define NRLB_W 256
+#include "nr_lbest_simd_width.h"
+#include "nr_lbest_qam64_simd.c.inc"
+#include "nr_lbest_qam256_simd.c.inc"
+#undef NRLB_W
+#define NRLB_W 128
+#include "nr_lbest_simd_width.h"
+#include "nr_lbest_qam64_simd.c.inc"
+#include "nr_lbest_qam256_simd.c.inc"
+#undef NRLB_W
+
+// Public entry (name unchanged for callers): pick the arch-native width.
+void nr_qam64_llr_2layer_lbest_q15_simd16(c16_t *stream0_in, c16_t *stream1_in, c16_t *ch_mag,
+                                          c16_t *ch_mag_i, int16_t *stream0_out, c16_t *rho01,
+                                          uint32_t length, int pattern)
 {
-  const simde__m256i SENT   = simde_mm256_set1_epi16(NR_LBEST_SIMD16_SENT);
-  const simde__m256i FLOORM = simde_mm256_set1_epi16(-32000);
-  const simde__m256i V15 = simde_mm256_set1_epi16(15), Vm15 = simde_mm256_set1_epi16(-15);
-  const simde__m256i z   = simde_mm256_setzero_si256();
+  // On aarch64 the 128-bit instantiation runs (SIMDe -> NEON, avoiding the inefficient 256->2x128
+  // cross-lane emulation). On x86 the 256-bit runs; OAI_LBEST_W128=1 forces the 128-bit path so the
+  // NEON code path can be regression-tested on x86 (it is bit-exact to 256 -- verify via the DBG).
+  static int w128 = -1;
+  if (w128 < 0) { const char *e = getenv("OAI_LBEST_W128"); w128 = e ? atoi(e) : 0; }
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE) || defined(__aarch64__)
+  (void)w128;
+  nr_qam64_llr_2layer_lbest_q15_simd_w128(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+#else
+  if (w128) nr_qam64_llr_2layer_lbest_q15_simd_w128(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+  else      nr_qam64_llr_2layer_lbest_q15_simd_w256(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+#endif
+}
 
-  // 256QAM metric Q-constants (metric scale = 1/8, matching 64QAM SIMD kernel):
-  //   C13_256 = round(2^13/sqrt(170))       => mulhi(z, I*C13) = z*I/(8*sqrt(170))
-  //   CE_256  = round(2^16/(8*8*2*sqrt(170)))  => energy = cm*|X|^2/(8*8*2*sqrt(170))
-  //   CX_256  = round(2^16/(8*170))         => cross term
-  const simde__m256i C13_256 = simde_mm256_set1_epi16(628);
-  const simde__m256i CE_256  = simde_mm256_set1_epi16(39);
-  const simde__m256i CX_256  = simde_mm256_set1_epi16(48);
-
-  uint32_t re = 0;
-  for (; re + 16 <= length; re += 16) {
-    simde__m256i z1r, z1i, z2r, z2i, rr, ri, cm0, cm1, dummy;
-    nr_lbest_simd_load16(&stream0_in[re], &z1r, &z1i);
-    nr_lbest_simd_load16(&stream1_in[re], &z2r, &z2i);
-    nr_lbest_simd_load16(&rho01[re],      &rr,  &ri);
-    nr_lbest_simd_load16(&ch_mag[re],     &cm0, &dummy);
-    nr_lbest_simd_load16(&ch_mag_i[re],   &cm1, &dummy);
-
-    simde__m256i centerI, centerQ, dirImask, dirQmask, axisLLR[8];
-    nr_lbest_simd_seed16_256(z1r, z1i, z2r, z2i, rr, ri, cm0, cm1,
-                             &centerI, &centerQ, &dirImask, &dirQmask, axisLLR);
-    (void)dirImask; (void)dirQmask;
-
-    // per-RE-vector precomputed quantities (int16 scale, /32 shift)
-    const simde__m256i z2r170   = nr_lbest_z170d32(z2r), z2i170 = nr_lbest_z170d32(z2i);
-    const simde__m256i rr5      = simde_mm256_srai_epi16(rr, 5), ri5 = simde_mm256_srai_epi16(ri, 5);
-    const simde__m256i Pp1_5_256 = simde_mm256_mulhi_epi16(cm1, simde_mm256_set1_epi16(NR_LBEST_Q_PP1_OVER32_Q16_256));
-
-    simde__m256i max0[8], max1[8];
-    for (int p = 0; p < 8; p++) { max0[p] = SENT; max1[p] = SENT; }
-
-    // ---- 5x5 block (hoisted) ----
-    // Precompute 5 I-levels and 5 Q-levels, then evaluate all or a subset of pairs.
-    // Offsets: {-4,-2,0,+2,+4} around seed center.
-    static const int offs5[5] = {-4, -2, 0, 2, 4};
-    simde__m256i Iv[5], Qv[5];
-    simde__m256i bIv[5][4], bQv[5][4];                // [level][bit 0..3]
-    simde__m256i c0I[5], c0Q[5], eI[5], eQ[5];
-    simde__m256i rrI[5], riI[5], rrQ[5], riQ[5];
-
-    const simde__m256i V8 = simde_mm256_set1_epi16(8), V4 = simde_mm256_set1_epi16(4), V2 = simde_mm256_set1_epi16(2);
-
-    for (int k = 0; k < 5; k++) {
-      const simde__m256i I1 = simde_mm256_min_epi16(simde_mm256_max_epi16(simde_mm256_adds_epi16(centerI, simde_mm256_set1_epi16(offs5[k])), Vm15), V15);
-      const simde__m256i Q1 = simde_mm256_min_epi16(simde_mm256_max_epi16(simde_mm256_adds_epi16(centerQ, simde_mm256_set1_epi16(offs5[k])), Vm15), V15);
-      Iv[k] = I1; Qv[k] = Q1;
-
-      // 256QAM Gray bit labeling per axis (b0..b3):
-      //   b0 = sign (level < 0)
-      //   b1 = |level| > 8
-      //   b2 = ||level|-8| > 4
-      //   b3 = |||level|-8|-4| > 2
-      const simde__m256i aI  = simde_mm256_abs_epi16(I1);
-      const simde__m256i m2I = simde_mm256_abs_epi16(simde_mm256_sub_epi16(aI,  V8));
-      const simde__m256i m3I = simde_mm256_abs_epi16(simde_mm256_sub_epi16(m2I, V4));
-      bIv[k][0] = simde_mm256_cmpgt_epi16(z,   I1);
-      bIv[k][1] = simde_mm256_cmpgt_epi16(aI,  V8);
-      bIv[k][2] = simde_mm256_cmpgt_epi16(m2I, V4);
-      bIv[k][3] = simde_mm256_cmpgt_epi16(m3I, V2);
-
-      const simde__m256i aQ  = simde_mm256_abs_epi16(Q1);
-      const simde__m256i m2Q = simde_mm256_abs_epi16(simde_mm256_sub_epi16(aQ,  V8));
-      const simde__m256i m3Q = simde_mm256_abs_epi16(simde_mm256_sub_epi16(m2Q, V4));
-      bQv[k][0] = simde_mm256_cmpgt_epi16(z,   Q1);
-      bQv[k][1] = simde_mm256_cmpgt_epi16(aQ,  V8);
-      bQv[k][2] = simde_mm256_cmpgt_epi16(m2Q, V4);
-      bQv[k][3] = simde_mm256_cmpgt_epi16(m3Q, V2);
-
-      c0I[k] = simde_mm256_mulhi_epi16(z1r, simde_mm256_mullo_epi16(I1, C13_256));
-      c0Q[k] = simde_mm256_mulhi_epi16(z1i, simde_mm256_mullo_epi16(Q1, C13_256));
-      eI[k]  = simde_mm256_mulhi_epi16(cm0, simde_mm256_mullo_epi16(simde_mm256_mullo_epi16(I1, I1), CE_256));
-      eQ[k]  = simde_mm256_mulhi_epi16(cm0, simde_mm256_mullo_epi16(simde_mm256_mullo_epi16(Q1, Q1), CE_256));
-      rrI[k] = simde_mm256_mullo_epi16(rr5, I1); riI[k] = simde_mm256_mullo_epi16(ri5, I1);
-      rrQ[k] = simde_mm256_mullo_epi16(rr5, Q1); riQ[k] = simde_mm256_mullo_epi16(ri5, Q1);
-    }
-
-    if (pattern == 0) { // 5x5: all 25 grid pairs
-      for (int iI = 0; iI < 5; iI++)
-        for (int iQ = 0; iQ < 5; iQ++)
-          NR_LBEST_EVAL16_256(Iv[iI], Qv[iQ],
-                              bIv[iI][0], bIv[iI][1], bIv[iI][2], bIv[iI][3],
-                              bQv[iQ][0], bQv[iQ][1], bQv[iQ][2], bQv[iQ][3],
-                              c0I[iI], c0Q[iQ], eI[iI], eQ[iQ],
-                              rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
-    } else if (pattern == 1) { // 3x3 full grid (center 3 levels): reduce per-axis (bit-exact, ~2.7x
-      // fewer max-log ops than 9*8*2 per-candidate blends). center indices {1,2,3} = offsets {-2,0,+2}.
-      static const int ci3[3] = {1, 2, 3};
-      simde__m256i met[3][3];
-      for (int a = 0; a < 3; a++)
-        for (int b = 0; b < 3; b++) {
-          const int iI = ci3[a], iQ = ci3[b];
-          NR_LBEST_METRIC16_256(met[a][b], Iv[iI], Qv[iQ], c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
-        }
-      simde__m256i maxI[3], maxQ[3];
-      for (int i = 0; i < 3; i++) maxI[i] = simde_mm256_max_epi16(met[i][0], simde_mm256_max_epi16(met[i][1], met[i][2]));
-      for (int q = 0; q < 3; q++) maxQ[q] = simde_mm256_max_epi16(met[0][q], simde_mm256_max_epi16(met[1][q], met[2][q]));
-      for (int k = 0; k < 4; k++) // I-bit k -> output p=2k ; Q-bit k -> p=2k+1
-        for (int i = 0; i < 3; i++) {
-          const simde__m256i bI = bIv[ci3[i]][k], bQ = bQv[ci3[i]][k];
-          max0[2 * k]     = simde_mm256_max_epi16(max0[2 * k],     simde_mm256_blendv_epi8(maxI[i], SENT, bI));
-          max1[2 * k]     = simde_mm256_max_epi16(max1[2 * k],     simde_mm256_blendv_epi8(SENT, maxI[i], bI));
-          max0[2 * k + 1] = simde_mm256_max_epi16(max0[2 * k + 1], simde_mm256_blendv_epi8(maxQ[i], SENT, bQ));
-          max1[2 * k + 1] = simde_mm256_max_epi16(max1[2 * k + 1], simde_mm256_blendv_epi8(SENT, maxQ[i], bQ));
-        }
-    } else if (pattern == 2) { // 5-plus: center + +-4 each axis (5 cand)
-      // indices: (2,2)=center, (0,2)=I-4, (4,2)=I+4, (2,0)=Q-4, (2,4)=Q+4
-      static const int pI5[5] = {2, 0, 4, 2, 2}, pQ5[5] = {2, 2, 2, 0, 4};
-      for (int c = 0; c < 5; c++) {
-        const int iI = pI5[c], iQ = pQ5[c];
-        NR_LBEST_EVAL16_256(Iv[iI], Qv[iQ],
-                            bIv[iI][0], bIv[iI][1], bIv[iI][2], bIv[iI][3],
-                            bQv[iQ][0], bQv[iQ][1], bQv[iQ][2], bQv[iQ][3],
-                            c0I[iI], c0Q[iQ], eI[iI], eQ[iQ],
-                            rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
-      }
-    } else { // pattern == 3: FULL exact ML — all 256 points (16x16 grid, conditional slice)
-      // Enumerate every PAM-16 level on both axes (no seed centering). Per-level quantities
-      // that depend only on the level (Gray bits, |x|^2 energy, rho5*level) are identical
-      // for the I- and Q-candidate roles; only the correlation term differs (z1r vs z1i).
-      static const int lv16[16] = {-15, -13, -11, -9, -7, -5, -3, -1, 1, 3, 5, 7, 9, 11, 13, 15};
-      simde__m256i fI[16], fbI[16][4], fc0I[16], fc0Q[16], feI[16], frrI[16], friI[16];
-      for (int k = 0; k < 16; k++) {
-        const simde__m256i I1 = simde_mm256_set1_epi16(lv16[k]);
-        fI[k] = I1;
-        const simde__m256i aI  = simde_mm256_abs_epi16(I1);
-        const simde__m256i m2I = simde_mm256_abs_epi16(simde_mm256_sub_epi16(aI,  V8));
-        const simde__m256i m3I = simde_mm256_abs_epi16(simde_mm256_sub_epi16(m2I, V4));
-        fbI[k][0] = simde_mm256_cmpgt_epi16(z,   I1);
-        fbI[k][1] = simde_mm256_cmpgt_epi16(aI,  V8);
-        fbI[k][2] = simde_mm256_cmpgt_epi16(m2I, V4);
-        fbI[k][3] = simde_mm256_cmpgt_epi16(m3I, V2);
-        fc0I[k] = simde_mm256_mulhi_epi16(z1r, simde_mm256_mullo_epi16(I1, C13_256));
-        fc0Q[k] = simde_mm256_mulhi_epi16(z1i, simde_mm256_mullo_epi16(I1, C13_256));
-        feI[k]  = simde_mm256_mulhi_epi16(cm0, simde_mm256_mullo_epi16(simde_mm256_mullo_epi16(I1, I1), CE_256));
-        frrI[k] = simde_mm256_mullo_epi16(rr5, I1);
-        friI[k] = simde_mm256_mullo_epi16(ri5, I1);
-      }
-      for (int iI = 0; iI < 16; iI++)
-        for (int iQ = 0; iQ < 16; iQ++)
-          NR_LBEST_EVAL16_256(fI[iI], fI[iQ],
-                              fbI[iI][0], fbI[iI][1], fbI[iI][2], fbI[iI][3],
-                              fbI[iQ][0], fbI[iQ][1], fbI[iQ][2], fbI[iQ][3],
-                              fc0I[iI], fc0Q[iQ], feI[iI], feI[iQ],
-                              frrI[iI], friI[iI], frrI[iQ], friI[iQ]);
-    }
-
-    // TODO(int8-clip): these (correct, ML-faithful) 256QAM LLRs are hot for the 8-bit LDPC
-    // decoder input — OAI_LBEST_DBG256 measures ~35% of them |.|>=128 (clip int8), which can
-    // add a small high-SNR error floor. Second-order vs the graded-fallback fix above, and
-    // naive log2_maxh cooling made BLER worse (precision loss), so a proper LLR->int8 rescale
-    // (matched to the linear/MMSE path's scale) is needed, not just a shift. Not yet done.
-    simde__m256i res[8];
-    for (int p = 0; p < 8; p++) {
-      const simde__m256i diff = simde_mm256_subs_epi16(max0[p], max1[p]);
-      // metric is at 1/8 scale -> LLR = diff*8; saturate via int32 widening
-      const simde__m256i lo = simde_mm256_slli_epi32(nr_lbest_widen(diff, 0), 3);
-      const simde__m256i hi = simde_mm256_slli_epi32(nr_lbest_widen(diff, 1), 3);
-      simde__m256i r = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-      // unspanned bit (one side has no candidate): use the graded per-axis seed LLR instead of
-      // the hard +-LLR_SAT (which wrecks the coarse/MSB bits a local search cannot span).
-      const simde__m256i unspanned = simde_mm256_or_si256(simde_mm256_cmpeq_epi16(max0[p], SENT),
-                                                          simde_mm256_cmpeq_epi16(max1[p], SENT));
-      res[p] = simde_mm256_blendv_epi8(r, axisLLR[p], unspanned);
-    }
-    nr_lbest_store_llr16(stream0_out, re, res, 8);
-  }
-
-  if (re < length)
-    nr_qam256_llr_2layer_lbest_q15_layer(&stream0_in[re], &stream1_in[re], &ch_mag[re], &ch_mag_i[re],
-                                         &stream0_out[re * 8], &rho01[re], length - re, (pattern == 3) ? 256 : 25);
+// 256QAM public entry (name unchanged for callers): pick the arch-native width.
+void nr_qam256_llr_2layer_lbest_q15_simd16(c16_t *stream0_in, c16_t *stream1_in, c16_t *ch_mag,
+                                           c16_t *ch_mag_i, int16_t *stream0_out, c16_t *rho01,
+                                           uint32_t length, int pattern)
+{
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE) || defined(__aarch64__)
+  nr_qam256_llr_2layer_lbest_q15_simd_w128(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+#else
+  static int w128 = -1;
+  if (w128 < 0) { const char *e = getenv("OAI_LBEST_W128"); w128 = e ? atoi(e) : 0; }
+  if (w128) nr_qam256_llr_2layer_lbest_q15_simd_w128(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+  else      nr_qam256_llr_2layer_lbest_q15_simd_w256(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+#endif
 }
 
 void nr_compute_ML_llr(c16_t *rxdataF_comp0,

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -2769,7 +2769,11 @@ uint8_t nr_mmse_2layers(c16_t **rxdataF_comp,
                         int shift,
                         unsigned char symbol,
                         int length,
-                        uint32_t noise_var)
+                        uint32_t noise_var,
+                        c16_t *rho00,
+                        c16_t *rho01,
+                        c16_t *rho10,
+                        c16_t *rho11)
 {
   uint32_t nb_rb_0 = length / 12 + ((length % 12) ? 1 : 0);
 
@@ -2837,6 +2841,15 @@ uint8_t nr_mmse_2layers(c16_t **rxdataF_comp,
    *
    */
 
+  if (rho01) {
+    // Gram-fed: af_mf = the 2x2 Gram already computed by channel_compensation (rho). Verified
+    // bit-identical to the chFext build below (OAI_MMSE_DBG: max|af_mf-rho|=0 on all elements).
+    const size_t nbytes = (size_t)(12 * nb_rb_0) * sizeof(c16_t);
+    memcpy(af_mf_00, rho00, nbytes);
+    memcpy(af_mf_01, rho01, nbytes);
+    memcpy(af_mf_10, rho10, nbytes);
+    memcpy(af_mf_11, rho11, nbytes);
+  } else {
   if (nb_rx_ant >= 2) {
     // (1/2^log2_maxh)*conj_H_00xH_00: (1/(64*2))conjH_00*H_00*2^15
     nr_conjch0_mult_ch1(ch00, ch00, conjch00_ch00, nb_rb_0, shift);
@@ -2922,6 +2935,8 @@ uint8_t nr_mmse_2layers(c16_t **rxdataF_comp,
                               af_mf_11,
                               nb_rb_0);
   }
+
+  } // end else (legacy chFext Gram build; the if(rho01) branch reads af_mf from rho)
 
   // Add noise_var such that: H^h * H + noise_var * I
   if (noise_var != 0) {
@@ -3068,4 +3083,38 @@ uint8_t nr_mmse_2layers(c16_t **rxdataF_comp,
     after_mf_d_128 += 1;
   }
   return (0);
+}
+
+// Fused 2-layer linear MMSE receiver + scalar LLR (the L=1 case of the unified detector). Does the
+// Gram-fed (rho) 2x2 MMSE equalization (nr_mmse_2layers) followed by the per-layer scalar LLR, in one
+// call. Shared by the UE (pass symbol=0 with pre-offset rxdataF_comp) and the gNB (pass symbol; the
+// symbol*buffer_length offset is applied internally). Replaces the separate {equalize + scalar LLR}.
+uint8_t nr_compute_MMSE_llr(c16_t **rxdataF_comp,
+                            uint32_t buffer_length,
+                            uint32_t pdsch_buf_size_max,
+                            int nb_rx_ant,
+                            int nb_layers,
+                            c16_t ch_mag[nb_layers][pdsch_buf_size_max],
+                            c16_t ch_magb[nb_layers][pdsch_buf_size_max],
+                            c16_t ch_magc[nb_layers][pdsch_buf_size_max],
+                            c16_t ch_estimates_ext[][nb_rx_ant][buffer_length],
+                            unsigned short nb_rb,
+                            unsigned char mod_order,
+                            int shift,
+                            unsigned char symbol,
+                            int length,
+                            uint32_t noise_var,
+                            c16_t *rho00,
+                            c16_t *rho01,
+                            c16_t *rho10,
+                            c16_t *rho11,
+                            int16_t **llr)
+{
+  const uint8_t ret = nr_mmse_2layers(rxdataF_comp, buffer_length, pdsch_buf_size_max, nb_rx_ant, nb_layers,
+                                      ch_mag, ch_magb, ch_magc, ch_estimates_ext, nb_rb, mod_order, shift,
+                                      symbol, length, noise_var, rho00, rho01, rho10, rho11);
+  for (int l = 0; l < nb_layers; l++)
+    nr_compute_llr(&rxdataF_comp[l][symbol * buffer_length], ch_mag[l], ch_magb[l], ch_magc[l],
+                   llr[l], length, symbol, mod_order);
+  return ret;
 }

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -3827,7 +3827,42 @@ static inline void nr_lbest_simd_seed16(simde__m256i z1r16, simde__m256i z1i16, 
 // Per-candidate evaluation (slice + metric + max-log reduction), updating max0/max1.
 // Captures the per-RE-vector operands from the enclosing scope; the per-candidate
 // I-only/Q-only terms (bits, corr0/energy0 parts, slice operands) are passed in.
-#define NR_LBEST_EVAL16(I1_, Q1_, BI0, BI1, BI2, BQ0, BQ1, BQ2, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
+// Store Qm LLR vectors (res[Qm], 16 REs across the lanes) to the interleaved decoder layout
+// stream0_out[(re+r)*Qm + p] via an 8x8 int16 transpose (padded from Qm), replacing the scalar
+// scatter (~24% of the 64QAM kernel). Qm in {6,8}; exactly Qm int16/RE are written (no overflow).
+static inline void nr_lbest_store_llr16(int16_t *stream0_out, uint32_t re, const simde__m256i *res, int Qm)
+{
+  simde__m256i r[8];
+  for (int p = 0; p < Qm; p++) r[p] = res[p];
+  for (int p = Qm; p < 8; p++) r[p] = simde_mm256_setzero_si256();
+  const simde__m256i a0 = simde_mm256_unpacklo_epi16(r[0], r[1]), a1 = simde_mm256_unpackhi_epi16(r[0], r[1]);
+  const simde__m256i a2 = simde_mm256_unpacklo_epi16(r[2], r[3]), a3 = simde_mm256_unpackhi_epi16(r[2], r[3]);
+  const simde__m256i a4 = simde_mm256_unpacklo_epi16(r[4], r[5]), a5 = simde_mm256_unpackhi_epi16(r[4], r[5]);
+  const simde__m256i a6 = simde_mm256_unpacklo_epi16(r[6], r[7]), a7 = simde_mm256_unpackhi_epi16(r[6], r[7]);
+  const simde__m256i b0 = simde_mm256_unpacklo_epi32(a0, a2), b1 = simde_mm256_unpackhi_epi32(a0, a2);
+  const simde__m256i b2 = simde_mm256_unpacklo_epi32(a1, a3), b3 = simde_mm256_unpackhi_epi32(a1, a3);
+  const simde__m256i b4 = simde_mm256_unpacklo_epi32(a4, a6), b5 = simde_mm256_unpackhi_epi32(a4, a6);
+  const simde__m256i b6 = simde_mm256_unpacklo_epi32(a5, a7), b7 = simde_mm256_unpackhi_epi32(a5, a7);
+  simde__m256i c[8];
+  c[0] = simde_mm256_unpacklo_epi64(b0, b4); c[1] = simde_mm256_unpackhi_epi64(b0, b4);
+  c[2] = simde_mm256_unpacklo_epi64(b1, b5); c[3] = simde_mm256_unpackhi_epi64(b1, b5);
+  c[4] = simde_mm256_unpacklo_epi64(b2, b6); c[5] = simde_mm256_unpackhi_epi64(b2, b6);
+  c[6] = simde_mm256_unpacklo_epi64(b3, b7); c[7] = simde_mm256_unpackhi_epi64(b3, b7);
+  for (int j = 0; j < 8; j++) { // c[j] low128 = RE j (bits 0..Qm-1 + pad); high128 = RE j+8
+    const simde__m128i lo = simde_mm256_castsi256_si128(c[j]), hi = simde_mm256_extracti128_si256(c[j], 1);
+    int16_t *o0 = &stream0_out[(re + j) * Qm], *o8 = &stream0_out[(re + j + 8) * Qm];
+    if (Qm == 8) {
+      simde_mm_storeu_si128((simde__m128i *)o0, lo);
+      simde_mm_storeu_si128((simde__m128i *)o8, hi);
+    } else { // Qm == 6: 4 int16 (storel) + 2 int16 (int32 store)
+      simde_mm_storel_epi64((simde__m128i *)o0, lo); *(int32_t *)(o0 + 4) = simde_mm_extract_epi32(lo, 2);
+      simde_mm_storel_epi64((simde__m128i *)o8, hi); *(int32_t *)(o8 + 4) = simde_mm_extract_epi32(hi, 2);
+    }
+  }
+}
+
+// Metric only (slice + corr/energy/cross), result -> (MET_). No max-log reduction.
+#define NR_LBEST_METRIC16(MET_, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
   do { \
     const simde__m256i A2I = simde_mm256_subs_epi16(z2r42, simde_mm256_adds_epi16((RRI_), (RIQ_))); \
     const simde__m256i A2Q = simde_mm256_subs_epi16(z2i42, simde_mm256_subs_epi16((RRQ_), (RII_))); \
@@ -3840,7 +3875,14 @@ static inline void nr_lbest_simd_seed16(simde__m256i z1r16, simde__m256i z1i16, 
     const simde__m256i aa = simde_mm256_adds_epi16(simde_mm256_mullo_epi16((I1_), I2), simde_mm256_mullo_epi16((Q1_), Q2)); \
     const simde__m256i bb = simde_mm256_subs_epi16(simde_mm256_mullo_epi16((Q1_), I2), simde_mm256_mullo_epi16((I1_), Q2)); \
     const simde__m256i cross = simde_mm256_adds_epi16(simde_mm256_mulhi_epi16(rr, simde_mm256_mullo_epi16(aa, CX)), simde_mm256_mulhi_epi16(ri, simde_mm256_mullo_epi16(bb, CX))); \
-    simde__m256i metric = simde_mm256_max_epi16(simde_mm256_subs_epi16(simde_mm256_adds_epi16(simde_mm256_subs_epi16(corr0, energy0), simde_mm256_subs_epi16(corr1, energy1)), cross), FLOORM); \
+    (MET_) = simde_mm256_max_epi16(simde_mm256_subs_epi16(simde_mm256_adds_epi16(simde_mm256_subs_epi16(corr0, energy0), simde_mm256_subs_epi16(corr1, energy1)), cross), FLOORM); \
+  } while (0)
+
+// Per-candidate metric + streaming max-log reduction into max0/max1 (for non-grid patterns).
+#define NR_LBEST_EVAL16(I1_, Q1_, BI0, BI1, BI2, BQ0, BQ1, BQ2, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
+  do { \
+    simde__m256i metric; \
+    NR_LBEST_METRIC16(metric, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_); \
     const simde__m256i bm[6] = {(BI0), (BQ0), (BI1), (BQ1), (BI2), (BQ2)}; \
     for (int p = 0; p < 6; p++) { \
       max0[p] = simde_mm256_max_epi16(max0[p], simde_mm256_blendv_epi8(metric, SENT, bm[p])); \
@@ -3917,11 +3959,24 @@ void nr_qam64_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
       rrI[k] = simde_mm256_mullo_epi16(rr5, I1); riI[k] = simde_mm256_mullo_epi16(ri5, I1);
       rrQ[k] = simde_mm256_mullo_epi16(rr5, Q1); riQ[k] = simde_mm256_mullo_epi16(ri5, Q1);
     }
-    if (pattern == 0) { // 3x3: all 9 grid pairs
+    if (pattern == 0) { // 3x3 full grid: reduce per-axis. Bits are per-axis, so the max over a
+      // bit-subset factorises: max over candidates with I-bit=b = max over I-levels-with-b of
+      // (max over Q). Computing maxI[i]=max_Q met[i][.], maxQ[q]=max_I met[.][q] then blending over
+      // 3 values/axis replaces 9*6*2 per-candidate blends with 3*3*4 (~2.6x fewer). Bit-exact.
+      simde__m256i met[3][3];
       for (int iI = 0; iI < 3; iI++)
         for (int iQ = 0; iQ < 3; iQ++)
-          NR_LBEST_EVAL16(Iv[iI], Qv[iQ], bIv[iI][0], bIv[iI][1], bIv[iI][2], bQv[iQ][0], bQv[iQ][1], bQv[iQ][2],
-                          c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+          NR_LBEST_METRIC16(met[iI][iQ], Iv[iI], Qv[iQ], c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+      simde__m256i maxI[3], maxQ[3];
+      for (int i = 0; i < 3; i++) maxI[i] = simde_mm256_max_epi16(met[i][0], simde_mm256_max_epi16(met[i][1], met[i][2]));
+      for (int q = 0; q < 3; q++) maxQ[q] = simde_mm256_max_epi16(met[0][q], simde_mm256_max_epi16(met[1][q], met[2][q]));
+      for (int k = 0; k < 3; k++) // I-bit k -> output p=2k ; Q-bit k -> p=2k+1
+        for (int i = 0; i < 3; i++) {
+          max0[2 * k]     = simde_mm256_max_epi16(max0[2 * k],     simde_mm256_blendv_epi8(maxI[i], SENT, bIv[i][k]));
+          max1[2 * k]     = simde_mm256_max_epi16(max1[2 * k],     simde_mm256_blendv_epi8(SENT, maxI[i], bIv[i][k]));
+          max0[2 * k + 1] = simde_mm256_max_epi16(max0[2 * k + 1], simde_mm256_blendv_epi8(maxQ[i], SENT, bQv[i][k]));
+          max1[2 * k + 1] = simde_mm256_max_epi16(max1[2 * k + 1], simde_mm256_blendv_epi8(SENT, maxQ[i], bQv[i][k]));
+        }
     } else { // 5-plus: center (1,1) + I+-2 + Q+-2
       static const int pI[5] = {1, 0, 2, 1, 1}, pQ[5] = {1, 1, 1, 0, 2};
       for (int c = 0; c < 5; c++) {
@@ -3946,20 +4001,18 @@ void nr_qam64_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
       }
     }
 
-    int16_t tmp[6][16];
+    simde__m256i res[6];
     for (int p = 0; p < 6; p++) {
       const simde__m256i diff = simde_mm256_subs_epi16(max0[p], max1[p]);
       // metric is normal/8 scale -> LLR = diff*8 (== float-ref / SIMD scale); saturate via int32
       const simde__m256i lo = simde_mm256_slli_epi32(nr_lbest_widen(diff, 0), 3);
       const simde__m256i hi = simde_mm256_slli_epi32(nr_lbest_widen(diff, 1), 3);
-      simde__m256i res = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
-      res = simde_mm256_blendv_epi8(res, simde_mm256_set1_epi16(-NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max0[p], SENT));
-      res = simde_mm256_blendv_epi8(res, simde_mm256_set1_epi16(NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max1[p], SENT));
-      simde_mm256_storeu_si256((simde__m256i *)tmp[p], res);
+      simde__m256i r = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+      r = simde_mm256_blendv_epi8(r, simde_mm256_set1_epi16(-NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max0[p], SENT));
+      r = simde_mm256_blendv_epi8(r, simde_mm256_set1_epi16(NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max1[p], SENT));
+      res[p] = r;
     }
-    for (int r = 0; r < 16; r++)
-      for (int p = 0; p < 6; p++)
-        stream0_out[(re + r) * 6 + p] = tmp[p][r];
+    nr_lbest_store_llr16(stream0_out, re, res, 6);
   }
 
   if (re < length)
@@ -4108,7 +4161,8 @@ static inline void nr_lbest_simd_seed16_256(simde__m256i z1r16, simde__m256i z1i
 // Per-candidate evaluation for 256QAM (8 bits/RE, PAM-16 slicer).
 // C13_256 = round(2^13/sqrt(170)), CE_256 = round(2^16/(8*8*sqrt(170)*2)),
 // CX_256  = round(2^16/(8*170)).
-#define NR_LBEST_EVAL16_256(I1_, Q1_, BI0, BI1, BI2, BI3, BQ0, BQ1, BQ2, BQ3, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
+// Metric only (256QAM), result -> (MET_). No max-log reduction.
+#define NR_LBEST_METRIC16_256(MET_, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
   do { \
     const simde__m256i A2I = simde_mm256_subs_epi16(z2r170, simde_mm256_adds_epi16((RRI_), (RIQ_))); \
     const simde__m256i A2Q = simde_mm256_subs_epi16(z2i170, simde_mm256_subs_epi16((RRQ_), (RII_))); \
@@ -4123,7 +4177,14 @@ static inline void nr_lbest_simd_seed16_256(simde__m256i z1r16, simde__m256i z1i
     const simde__m256i bb = simde_mm256_subs_epi16(simde_mm256_mullo_epi16((Q1_), I2), simde_mm256_mullo_epi16((I1_), Q2)); \
     const simde__m256i cross = simde_mm256_adds_epi16(simde_mm256_mulhi_epi16(rr, simde_mm256_mullo_epi16(aa, CX_256)), \
                                                       simde_mm256_mulhi_epi16(ri, simde_mm256_mullo_epi16(bb, CX_256))); \
-    simde__m256i metric = simde_mm256_max_epi16(simde_mm256_subs_epi16(simde_mm256_adds_epi16(simde_mm256_subs_epi16(corr0, energy0), simde_mm256_subs_epi16(corr1, energy1)), cross), FLOORM); \
+    (MET_) = simde_mm256_max_epi16(simde_mm256_subs_epi16(simde_mm256_adds_epi16(simde_mm256_subs_epi16(corr0, energy0), simde_mm256_subs_epi16(corr1, energy1)), cross), FLOORM); \
+  } while (0)
+
+// Per-candidate metric + streaming max-log reduction into max0/max1 (for non-grid patterns).
+#define NR_LBEST_EVAL16_256(I1_, Q1_, BI0, BI1, BI2, BI3, BQ0, BQ1, BQ2, BQ3, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
+  do { \
+    simde__m256i metric; \
+    NR_LBEST_METRIC16_256(metric, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_); \
     const simde__m256i bm[8] = {(BI0), (BQ0), (BI1), (BQ1), (BI2), (BQ2), (BI3), (BQ3)}; \
     for (int p = 0; p < 8; p++) { \
       max0[p] = simde_mm256_max_epi16(max0[p], simde_mm256_blendv_epi8(metric, SENT, bm[p])); \
@@ -4229,17 +4290,25 @@ void nr_qam256_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
                               bQv[iQ][0], bQv[iQ][1], bQv[iQ][2], bQv[iQ][3],
                               c0I[iI], c0Q[iQ], eI[iI], eQ[iQ],
                               rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
-    } else if (pattern == 1) { // 3x3: center 3 levels, 9 pairs
-      // center indices {1,2,3} map to offsets {-2,0,+2}
+    } else if (pattern == 1) { // 3x3 full grid (center 3 levels): reduce per-axis (bit-exact, ~2.7x
+      // fewer max-log ops than 9*8*2 per-candidate blends). center indices {1,2,3} = offsets {-2,0,+2}.
       static const int ci3[3] = {1, 2, 3};
+      simde__m256i met[3][3];
       for (int a = 0; a < 3; a++)
         for (int b = 0; b < 3; b++) {
           const int iI = ci3[a], iQ = ci3[b];
-          NR_LBEST_EVAL16_256(Iv[iI], Qv[iQ],
-                              bIv[iI][0], bIv[iI][1], bIv[iI][2], bIv[iI][3],
-                              bQv[iQ][0], bQv[iQ][1], bQv[iQ][2], bQv[iQ][3],
-                              c0I[iI], c0Q[iQ], eI[iI], eQ[iQ],
-                              rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+          NR_LBEST_METRIC16_256(met[a][b], Iv[iI], Qv[iQ], c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+        }
+      simde__m256i maxI[3], maxQ[3];
+      for (int i = 0; i < 3; i++) maxI[i] = simde_mm256_max_epi16(met[i][0], simde_mm256_max_epi16(met[i][1], met[i][2]));
+      for (int q = 0; q < 3; q++) maxQ[q] = simde_mm256_max_epi16(met[0][q], simde_mm256_max_epi16(met[1][q], met[2][q]));
+      for (int k = 0; k < 4; k++) // I-bit k -> output p=2k ; Q-bit k -> p=2k+1
+        for (int i = 0; i < 3; i++) {
+          const simde__m256i bI = bIv[ci3[i]][k], bQ = bQv[ci3[i]][k];
+          max0[2 * k]     = simde_mm256_max_epi16(max0[2 * k],     simde_mm256_blendv_epi8(maxI[i], SENT, bI));
+          max1[2 * k]     = simde_mm256_max_epi16(max1[2 * k],     simde_mm256_blendv_epi8(SENT, maxI[i], bI));
+          max0[2 * k + 1] = simde_mm256_max_epi16(max0[2 * k + 1], simde_mm256_blendv_epi8(maxQ[i], SENT, bQ));
+          max1[2 * k + 1] = simde_mm256_max_epi16(max1[2 * k + 1], simde_mm256_blendv_epi8(SENT, maxQ[i], bQ));
         }
     } else if (pattern == 2) { // 5-plus: center + +-4 each axis (5 cand)
       // indices: (2,2)=center, (0,2)=I-4, (4,2)=I+4, (2,0)=Q-4, (2,4)=Q+4
@@ -4283,28 +4352,25 @@ void nr_qam256_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
                               frrI[iI], friI[iI], frrI[iQ], friI[iQ]);
     }
 
-    int16_t tmp[8][16];
+    // TODO(int8-clip): these (correct, ML-faithful) 256QAM LLRs are hot for the 8-bit LDPC
+    // decoder input — OAI_LBEST_DBG256 measures ~35% of them |.|>=128 (clip int8), which can
+    // add a small high-SNR error floor. Second-order vs the graded-fallback fix above, and
+    // naive log2_maxh cooling made BLER worse (precision loss), so a proper LLR->int8 rescale
+    // (matched to the linear/MMSE path's scale) is needed, not just a shift. Not yet done.
+    simde__m256i res[8];
     for (int p = 0; p < 8; p++) {
-      // TODO(int8-clip): these (correct, ML-faithful) 256QAM LLRs are hot for the 8-bit LDPC
-      // decoder input — OAI_LBEST_DBG256 measures ~35% of them |.|>=128 (clip int8), which can
-      // add a small high-SNR error floor. Second-order vs the graded-fallback fix above, and
-      // naive log2_maxh cooling made BLER worse (precision loss), so a proper LLR->int8 rescale
-      // (matched to the linear/MMSE path's scale) is needed, not just a shift. Not yet done.
       const simde__m256i diff = simde_mm256_subs_epi16(max0[p], max1[p]);
       // metric is at 1/8 scale -> LLR = diff*8; saturate via int32 widening
       const simde__m256i lo = simde_mm256_slli_epi32(nr_lbest_widen(diff, 0), 3);
       const simde__m256i hi = simde_mm256_slli_epi32(nr_lbest_widen(diff, 1), 3);
-      simde__m256i res = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+      simde__m256i r = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
       // unspanned bit (one side has no candidate): use the graded per-axis seed LLR instead of
       // the hard +-LLR_SAT (which wrecks the coarse/MSB bits a local search cannot span).
       const simde__m256i unspanned = simde_mm256_or_si256(simde_mm256_cmpeq_epi16(max0[p], SENT),
                                                           simde_mm256_cmpeq_epi16(max1[p], SENT));
-      res = simde_mm256_blendv_epi8(res, axisLLR[p], unspanned);
-      simde_mm256_storeu_si256((simde__m256i *)tmp[p], res);
+      res[p] = simde_mm256_blendv_epi8(r, axisLLR[p], unspanned);
     }
-    for (int r = 0; r < 16; r++)
-      for (int p = 0; p < 8; p++)
-        stream0_out[(re + r) * 8 + p] = tmp[p][r];
+    nr_lbest_store_llr16(stream0_out, re, res, 8);
   }
 
   if (re < length)

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -469,6 +469,73 @@ static inline simde__m128i max_epi16(simde__m128i m0,
   return simde_mm_max_epi16(b0, b1);
 }
 
+// Reduce 16 vectors to 1 via max, for 256QAM LLR computation (128-bit path).
+static inline simde__m128i max16_epi16(simde__m128i v[16])
+{
+  simde__m128i a[8], b[4], c[2];
+  for (int k = 0; k < 8; k++) a[k] = simde_mm_max_epi16(v[2*k], v[2*k+1]);
+  for (int k = 0; k < 4; k++) b[k] = simde_mm_max_epi16(a[2*k], a[2*k+1]);
+  c[0] = simde_mm_max_epi16(b[0], b[1]);
+  c[1] = simde_mm_max_epi16(b[2], b[3]);
+  return simde_mm_max_epi16(c[0], c[1]);
+}
+
+// PAM-16 interference slicer (128-bit). Compares |psi| against 7 thresholds and
+// selects one of 8 interference magnitude levels c1,c3,...,c15.
+static inline simde__m128i interference_abs_256qam_epi16(simde__m128i psi,
+                                                         simde__m128i t2, simde__m128i t4,
+                                                         simde__m128i t6, simde__m128i t8,
+                                                         simde__m128i t10, simde__m128i t12,
+                                                         simde__m128i t14,
+                                                         simde__m128i c1, simde__m128i c3,
+                                                         simde__m128i c5, simde__m128i c7,
+                                                         simde__m128i c9, simde__m128i c11,
+                                                         simde__m128i c13, simde__m128i c15)
+{
+  // Branchless slicer: cmp_k is all-ones where psi < t_k
+  simde__m128i cmp2  = simde_mm_cmpgt_epi16(t2,  psi);
+  simde__m128i cmp4  = simde_mm_cmpgt_epi16(t4,  psi);
+  simde__m128i cmp6  = simde_mm_cmpgt_epi16(t6,  psi);
+  simde__m128i cmp8  = simde_mm_cmpgt_epi16(t8,  psi);
+  simde__m128i cmp10 = simde_mm_cmpgt_epi16(t10, psi);
+  simde__m128i cmp12 = simde_mm_cmpgt_epi16(t12, psi);
+  simde__m128i cmp14 = simde_mm_cmpgt_epi16(t14, psi);
+  // Region mask = XOR of adjacent comparisons (one-hot interval selection)
+  simde__m128i r1  = simde_mm_and_si128(cmp2,                                  c1);
+  simde__m128i r3  = simde_mm_and_si128(simde_mm_xor_si128(cmp4,  cmp2),  c3);
+  simde__m128i r5  = simde_mm_and_si128(simde_mm_xor_si128(cmp6,  cmp4),  c5);
+  simde__m128i r7  = simde_mm_and_si128(simde_mm_xor_si128(cmp8,  cmp6),  c7);
+  simde__m128i r9  = simde_mm_and_si128(simde_mm_xor_si128(cmp10, cmp8),  c9);
+  simde__m128i r11 = simde_mm_and_si128(simde_mm_xor_si128(cmp12, cmp10), c11);
+  simde__m128i r13 = simde_mm_and_si128(simde_mm_xor_si128(cmp14, cmp12), c13);
+  simde__m128i r15 = simde_mm_and_si128(simde_mm_xor_si128(allones128(), cmp14), c15);
+  return simde_mm_or_si128(
+      simde_mm_or_si128(simde_mm_or_si128(r1, r3), simde_mm_or_si128(r5, r7)),
+      simde_mm_or_si128(simde_mm_or_si128(r9, r11), simde_mm_or_si128(r13, r15)));
+}
+
+// a_sq = int_ch_mag * (a_r^2 + a_i^2) * scale_factor for 256QAM (128-bit).
+// Shift 4 instead of 3 because sqrt(170)/8 is half sqrt(42)/4.
+static inline simde__m128i square_a_256qam_epi16(simde__m128i a_r,
+                                                 simde__m128i a_i,
+                                                 simde__m128i int_ch_mag,
+                                                 simde__m128i scale_factor)
+{
+  simde__m128i tmp_result = simde_mm_mulhi_epi16(a_r, a_r);
+  tmp_result = simde_mm_slli_epi16(tmp_result, 1);
+  tmp_result = simde_mm_mulhi_epi16(tmp_result, scale_factor);
+  tmp_result = simde_mm_slli_epi16(tmp_result, 4);
+  tmp_result = simde_mm_mulhi_epi16(tmp_result, int_ch_mag);
+  tmp_result = simde_mm_slli_epi16(tmp_result, 1);
+  simde__m128i tmp_result2 = simde_mm_mulhi_epi16(a_i, a_i);
+  tmp_result2 = simde_mm_slli_epi16(tmp_result2, 1);
+  tmp_result2 = simde_mm_mulhi_epi16(tmp_result2, scale_factor);
+  tmp_result2 = simde_mm_slli_epi16(tmp_result2, 4);
+  tmp_result2 = simde_mm_mulhi_epi16(tmp_result2, int_ch_mag);
+  tmp_result2 = simde_mm_slli_epi16(tmp_result2, 1);
+  return simde_mm_adds_epi16(tmp_result, tmp_result2);
+}
+
 #else
 
 // calculate interference magnitude
@@ -576,6 +643,70 @@ static inline simde__m256i max_epi16_256(simde__m256i m0,
   simde__m256i b0 = simde_mm256_max_epi16(a0, a1);
   simde__m256i b1 = simde_mm256_max_epi16(a2, a3);
   return simde_mm256_max_epi16(b0, b1);
+}
+
+// Reduce 16 vectors to 1 via max, for 256QAM LLR computation (256-bit path).
+static inline simde__m256i max16_epi16_256(simde__m256i v[16])
+{
+  simde__m256i a[8], b[4], c[2];
+  for (int k = 0; k < 8; k++) a[k] = simde_mm256_max_epi16(v[2*k], v[2*k+1]);
+  for (int k = 0; k < 4; k++) b[k] = simde_mm256_max_epi16(a[2*k], a[2*k+1]);
+  c[0] = simde_mm256_max_epi16(b[0], b[1]);
+  c[1] = simde_mm256_max_epi16(b[2], b[3]);
+  return simde_mm256_max_epi16(c[0], c[1]);
+}
+
+// PAM-16 interference slicer (256-bit). Compares |psi| against 7 thresholds and
+// selects one of 8 interference magnitude levels c1,c3,...,c15.
+static inline simde__m256i interference_abs_256qam_epi16_256(simde__m256i psi,
+                                                              simde__m256i t2, simde__m256i t4,
+                                                              simde__m256i t6, simde__m256i t8,
+                                                              simde__m256i t10, simde__m256i t12,
+                                                              simde__m256i t14,
+                                                              simde__m256i c1, simde__m256i c3,
+                                                              simde__m256i c5, simde__m256i c7,
+                                                              simde__m256i c9, simde__m256i c11,
+                                                              simde__m256i c13, simde__m256i c15)
+{
+  simde__m256i cmp2  = simde_mm256_cmpgt_epi16(t2,  psi);
+  simde__m256i cmp4  = simde_mm256_cmpgt_epi16(t4,  psi);
+  simde__m256i cmp6  = simde_mm256_cmpgt_epi16(t6,  psi);
+  simde__m256i cmp8  = simde_mm256_cmpgt_epi16(t8,  psi);
+  simde__m256i cmp10 = simde_mm256_cmpgt_epi16(t10, psi);
+  simde__m256i cmp12 = simde_mm256_cmpgt_epi16(t12, psi);
+  simde__m256i cmp14 = simde_mm256_cmpgt_epi16(t14, psi);
+  simde__m256i r1  = simde_mm256_and_si256(cmp2,                                    c1);
+  simde__m256i r3  = simde_mm256_and_si256(simde_mm256_xor_si256(cmp4,  cmp2),  c3);
+  simde__m256i r5  = simde_mm256_and_si256(simde_mm256_xor_si256(cmp6,  cmp4),  c5);
+  simde__m256i r7  = simde_mm256_and_si256(simde_mm256_xor_si256(cmp8,  cmp6),  c7);
+  simde__m256i r9  = simde_mm256_and_si256(simde_mm256_xor_si256(cmp10, cmp8),  c9);
+  simde__m256i r11 = simde_mm256_and_si256(simde_mm256_xor_si256(cmp12, cmp10), c11);
+  simde__m256i r13 = simde_mm256_and_si256(simde_mm256_xor_si256(cmp14, cmp12), c13);
+  simde__m256i r15 = simde_mm256_and_si256(simde_mm256_xor_si256(allones256(), cmp14), c15);
+  return simde_mm256_or_si256(
+      simde_mm256_or_si256(simde_mm256_or_si256(r1, r3), simde_mm256_or_si256(r5, r7)),
+      simde_mm256_or_si256(simde_mm256_or_si256(r9, r11), simde_mm256_or_si256(r13, r15)));
+}
+
+// a_sq = int_ch_mag * (a_r^2 + a_i^2) * scale_factor for 256QAM (256-bit).
+static inline simde__m256i square_a_256qam_epi16_256(simde__m256i a_r,
+                                                     simde__m256i a_i,
+                                                     simde__m256i int_ch_mag,
+                                                     simde__m256i scale_factor)
+{
+  simde__m256i tmp_result = simde_mm256_mulhi_epi16(a_r, a_r);
+  tmp_result = simde_mm256_slli_epi16(tmp_result, 1);
+  tmp_result = simde_mm256_mulhi_epi16(tmp_result, scale_factor);
+  tmp_result = simde_mm256_slli_epi16(tmp_result, 4);
+  tmp_result = simde_mm256_mulhi_epi16(tmp_result, int_ch_mag);
+  tmp_result = simde_mm256_slli_epi16(tmp_result, 1);
+  simde__m256i tmp_result2 = simde_mm256_mulhi_epi16(a_i, a_i);
+  tmp_result2 = simde_mm256_slli_epi16(tmp_result2, 1);
+  tmp_result2 = simde_mm256_mulhi_epi16(tmp_result2, scale_factor);
+  tmp_result2 = simde_mm256_slli_epi16(tmp_result2, 4);
+  tmp_result2 = simde_mm256_mulhi_epi16(tmp_result2, int_ch_mag);
+  tmp_result2 = simde_mm256_slli_epi16(tmp_result2, 1);
+  return simde_mm256_adds_epi16(tmp_result, tmp_result2);
 }
 
 #endif
@@ -2478,6 +2609,32 @@ void nr_qam64_llr_2layer(c16_t *stream0_in,
 #endif
 }
 
+
+
+/*
+ * This function computes the LLRs of stream 0 (s_0) in presence of the interfering
+ * stream 1 (s_1) assuming that both symbols are 256QAM.
+ * Direct SIMD full ML 2-layer 256QAM (analogous to nr_qam64_llr_2layer for 64QAM).
+ */
+// 2-layer 256QAM direct SIMD full-ML LLR (analogue of nr_qam64_llr_2layer for 64QAM).
+// Exact max-log search over all 256 constellation points, implemented by reusing the
+// verified L-best simd16 machinery on the full 16x16 grid (pattern 3, O(256) per RE via
+// the O(1) conditional slice). Replaces an earlier bespoke unrolled kernel that carried an
+// imaginary-axis / magnitude-threshold bug (OAI_LBEST_DBG256 showed ~46% sign disagreement
+// vs the exact float reference nr_qam256_llr_2layer_lbest).
+void nr_qam256_llr_2layer(c16_t *stream0_in,
+                          c16_t *stream1_in,
+                          c16_t *ch_mag,
+                          c16_t *ch_mag_i,
+                          int16_t *stream0_out,
+                          c16_t *rho01,
+                          uint32_t length)
+{
+  nr_qam256_llr_2layer_lbest_q15_simd16(stream0_in, stream1_in, ch_mag, ch_mag_i,
+                                        stream0_out, rho01, length, 3 /* full 16x16 ML */);
+}
+
+
 static void nr_ml_llr_shift(int16_t *llr_layer0, int16_t *llr_layer1, uint32_t nb_re, int shift)
 {
   simde__m128i *llr_layers0 = (simde__m128i *)llr_layer0;
@@ -3361,6 +3518,179 @@ void nr_qam64_llr_2layer_lbest_q15(c16_t *stream0_in,
 }
 
 // ============================================================================
+// Fixed-point (Q15-input) L-best 2-layer 256QAM kernel.
+//
+// Integer twin of nr_qam256_llr_2layer_lbest: same algorithm and interface,
+// but operates entirely on the int16 demod buffers (no float). Mirrors the
+// 64QAM Q15 design (nr_qam64_llr_2layer_lbest_q15) with PAM-16 levels and
+// 1/sqrt(170) normalization.
+//
+// Metric scale: multiply the float metric by 16*sqrt(170) to make the
+// desired/nuisance correlation and energy terms exact integers:
+//   Mq = 16*(I1*z1r+Q1*z1i) - cm0*(I1^2+Q1^2)  (desired, cm0=||h0||^2*8/sqrt(170))
+//      + 16*(I2*z2r+Q2*z2i) - cm1*(I2^2+Q2^2)  (nuisance)
+//      - 16*Re{rho.conj(X1).X2}/sqrt(170)       (cross; one irrational factor)
+// where I1,Q1,I2,Q2 are integer odd levels in [-15,15].
+//
+// Division-free ZF seed and division-free conditional PAM-16 slice mirror the
+// 64QAM Q15 design. L==256 skips the partial sort (full search, no order needed).
+// ============================================================================
+#define NR_LBEST_Q_SQRT170_Q12       53405  // round(sqrt(170) * 2^12)
+#define NR_LBEST_Q_SQRT170_OVER8_Q14 26690  // round(sqrt(170)/8 * 2^14): ch_mag -> Pp
+#define NR_LBEST_Q_INVSQRT170_Q15     2514  // round(2^15 / sqrt(170))
+// integer metric is 16*sqrt(170) (~208.6x) larger than float; bring LLR back to float scale.
+#define NR_LBEST_Q_LLR256_NUM          628  // round(2^17 / (16*sqrt(170)))
+#define NR_LBEST_Q_LLR256_SHIFT         17
+#define NR_LBEST_Q_LLR256_SAT         8192
+
+// PAM-16 level magnitude for |a|, thresholds at {2,4,...,14}*step (== ||h1||^2).
+static inline int nr_lbest_q_pam16_abs(int64_t a, int64_t step)
+{
+  if (a <  2 * step) return  1;
+  if (a <  4 * step) return  3;
+  if (a <  6 * step) return  5;
+  if (a <  8 * step) return  7;
+  if (a < 10 * step) return  9;
+  if (a < 12 * step) return 11;
+  if (a < 14 * step) return 13;
+  return 15;
+}
+
+static void nr_qam256_llr_2layer_lbest_q15_layer(const c16_t *stream0_in,
+                                                 const c16_t *stream1_in,
+                                                 const c16_t *ch_mag,
+                                                 const c16_t *ch_mag_i,
+                                                 int16_t *stream0_out,
+                                                 const c16_t *rho01,
+                                                 uint32_t length,
+                                                 int L)
+{
+  if (L < 1)   L = 1;
+  if (L > 256) L = 256;
+  static const int levels[16] = {-15,-13,-11,-9,-7,-5,-3,-1,1,3,5,7,9,11,13,15};
+
+  for (uint32_t re = 0; re < length; re++) {
+    const int32_t z1r = stream0_in[re].r,  z1i = stream0_in[re].i;
+    const int32_t z2r = stream1_in[re].r,  z2i = stream1_in[re].i;
+    const int32_t rr  = rho01[re].r,       ri  = rho01[re].i;      // rho = h0^H h1
+    const int32_t cm0 = ch_mag[re].r;      // ||h0||^2 * 8/sqrt(170)
+    const int32_t cm1 = ch_mag_i[re].r;    // ||h1||^2 * 8/sqrt(170)
+
+    // recover channel powers ||h||^2 via cm * sqrt(170)/8
+    const int64_t Pp0 = ((int64_t)cm0 * NR_LBEST_Q_SQRT170_OVER8_Q14) >> 14;
+    const int64_t Pp1 = ((int64_t)cm1 * NR_LBEST_Q_SQRT170_OVER8_Q14) >> 14;
+
+    // ---- 1. division-free ZF seed: x_hat1 = ((Pp1) z1 - rho z2) / det ----
+    const int64_t det  = Pp0 * Pp1 - ((int64_t)rr * rr + (int64_t)ri * ri);
+    const int64_t numr = Pp1 * z1r - ((int64_t)rr * z2r - (int64_t)ri * z2i);
+    const int64_t numi = Pp1 * z1i - ((int64_t)rr * z2i + (int64_t)ri * z2r);
+    // soft level estimate in Q6 (level units * 64); clamp to ±1024 (head-room above ±15*64=±960)
+    int32_t estI_q6 = 0, estQ_q6 = 0;
+    if (det > 0) {
+      estI_q6 = (int32_t)((numr * NR_LBEST_Q_SQRT170_Q12) / (det * 64));
+      estQ_q6 = (int32_t)((numi * NR_LBEST_Q_SQRT170_Q12) / (det * 64));
+      if (estI_q6 < -1024) estI_q6 = -1024; else if (estI_q6 > 1024) estI_q6 = 1024;
+      if (estQ_q6 < -1024) estQ_q6 = -1024; else if (estQ_q6 > 1024) estQ_q6 = 1024;
+    }
+
+    // ---- 2. candidate set: L nearest of 256 points ----
+    int     candI[256], candQ[256];
+    int64_t cand_d[256];
+    int nc = 0;
+    for (int qi = 0; qi < 16; qi++) {
+      for (int ii = 0; ii < 16; ii++) {
+        const int64_t dI = estI_q6 - (levels[ii] << 6);
+        const int64_t dQ = estQ_q6 - (levels[qi] << 6);
+        candI[nc] = levels[ii];
+        candQ[nc] = levels[qi];
+        cand_d[nc] = dI * dI + dQ * dQ;
+        nc++;
+      }
+    }
+    // partial selection sort: bring the L nearest to the front (skipped for full search)
+    if (L < 256) {
+      for (int a = 0; a < L; a++) {
+        int m = a;
+        for (int b = a + 1; b < 256; b++)
+          if (cand_d[b] < cand_d[m])
+            m = b;
+        if (m != a) {
+          int64_t td = cand_d[a]; cand_d[a] = cand_d[m]; cand_d[m] = td;
+          int  ti = candI[a];    candI[a]  = candI[m];  candI[m]  = ti;
+          int  tq = candQ[a];    candQ[a]  = candQ[m];  candQ[m]  = tq;
+        }
+      }
+    }
+
+    // ---- 3+4. metric over candidates (scaled by 16*sqrt(170)), max-log per bit ----
+    int64_t max0[8], max1[8];
+    for (int p = 0; p < 8; p++) { max0[p] = INT64_MIN; max1[p] = INT64_MIN; }
+
+    for (int c = 0; c < L; c++) {
+      const int I1 = candI[c], Q1 = candQ[c];
+
+      // conditional ML nuisance slice: A2 = z2*sqrt(170) - conj(rho)*X1, compare vs Pp1*{2..14}
+      const int64_t A2I = (((int64_t)z2r * NR_LBEST_Q_SQRT170_Q12) >> 12) - ((int64_t)rr * I1 + (int64_t)ri * Q1);
+      const int64_t A2Q = (((int64_t)z2i * NR_LBEST_Q_SQRT170_Q12) >> 12) - ((int64_t)rr * Q1 - (int64_t)ri * I1);
+      const int I2 = (A2I < 0 ? -1 : 1) * nr_lbest_q_pam16_abs(A2I < 0 ? -A2I : A2I, Pp1);
+      const int Q2 = (A2Q < 0 ? -1 : 1) * nr_lbest_q_pam16_abs(A2Q < 0 ? -A2Q : A2Q, Pp1);
+
+      // metric (units of 16*sqrt(170) * float-ref metric)
+      int64_t metric = 16 * ((int64_t)I1 * z1r + (int64_t)Q1 * z1i) - cm0 * ((int64_t)I1 * I1 + (int64_t)Q1 * Q1);
+      metric += 16 * ((int64_t)I2 * z2r + (int64_t)Q2 * z2i) - cm1 * ((int64_t)I2 * I2 + (int64_t)Q2 * Q2);
+      // cross = 16 * Re{rho . conj(X1) . X2} / sqrt(170)
+      const int64_t rec = (int64_t)rr * ((int64_t)I1 * I2 + (int64_t)Q1 * Q2)
+                        + (int64_t)ri * ((int64_t)Q1 * I2 - (int64_t)I1 * Q2);
+      metric -= (16 * rec * NR_LBEST_Q_INVSQRT170_Q15) >> 15;
+
+      // bit labels, interleaved {I0,Q0,I1,Q1,I2,Q2,I3,Q3} (matches nr_qam256_llr_2layer_lbest)
+      int bI0, bI1, bI2, bI3, bQ0, bQ1, bQ2, bQ3;
+      nr_lbest_axis_bits256(I1, &bI0, &bI1, &bI2, &bI3);
+      nr_lbest_axis_bits256(Q1, &bQ0, &bQ1, &bQ2, &bQ3);
+      const int bit[8] = {bI0, bQ0, bI1, bQ1, bI2, bQ2, bI3, bQ3};
+      for (int p = 0; p < 8; p++) {
+        if (bit[p] == 0) { if (metric > max0[p]) max0[p] = metric; }
+        else             { if (metric > max1[p]) max1[p] = metric; }
+      }
+    }
+
+    // emit LLR = max_{bit=0} - max_{bit=1}; empty subset => saturate toward present bit
+    for (int p = 0; p < 8; p++) {
+      int32_t llr;
+      if (max0[p] == INT64_MIN)
+        llr = -NR_LBEST_Q_LLR256_SAT;
+      else if (max1[p] == INT64_MIN)
+        llr = NR_LBEST_Q_LLR256_SAT;
+      else
+        llr = (int32_t)(((max0[p] - max1[p]) * NR_LBEST_Q_LLR256_NUM) >> NR_LBEST_Q_LLR256_SHIFT);
+      if (llr > 32767)  llr =  32767;
+      if (llr < -32768) llr = -32768;
+      *stream0_out++ = (int16_t)llr;
+    }
+  }
+}
+
+// Public entry for the fixed-point L-best 256QAM kernel (target layer 0, ZF seed).
+// pattern: 0 = 5x5 (25 cand, ±{0,2,4} per axis — full-BLER default)
+//          1 = 3x3 ( 9 cand, ±{0,2}   per axis — analogous to 64QAM default)
+//          2 = 5-plus (5 cand, center + ±2 each axis)
+//          other = 256 (full search)
+// Controlled at runtime by OAI_LBEST_PAT256; OAI_LBEST_L256 is for the float ref.
+void nr_qam256_llr_2layer_lbest_q15(c16_t *stream0_in,
+                                    c16_t *stream1_in,
+                                    c16_t *ch_mag,
+                                    c16_t *ch_mag_i,
+                                    int16_t *stream0_out,
+                                    c16_t *rho01,
+                                    uint32_t length,
+                                    int pattern)
+{
+  static const int pat_L[3] = {25, 9, 5};
+  const int L = (pattern >= 0 && pattern <= 2) ? pat_L[pattern] : 256;
+  nr_qam256_llr_2layer_lbest_q15_layer(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, L);
+}
+
+// ============================================================================
 // int16/16-lane variant of the AVX2 L-best kernel. The dominant per-candidate
 // work (metric, conditional slice, max-log reduction) runs 16 REs/vector in
 // int16; only the ZF seed and z2*sqrt(42) (which overflow int16) use int32 half-
@@ -3602,6 +3932,302 @@ void nr_qam64_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
                                         &stream0_out[re * 6], &rho01[re], length - re, 9);
 }
 
+// ============================================================================
+// int16/16-lane AVX2 L-best kernel for 2-layer 256QAM (PAM-16, 8 bits/RE).
+// Mirrors nr_qam64_llr_2layer_lbest_q15_simd16 with:
+//   - sqrt(170) replacing sqrt(42), /8 replacing /4 in Pp
+//   - PAM-16 slicer (7 thresholds) replacing PAM-8 (3 thresholds)
+//   - 4 bits per axis (b0..b3) instead of 3
+//   - 5x5/3x3/5-plus candidate patterns instead of 3x3/6-cand/5-plus
+//   - LLR stride 8 per RE instead of 6
+// ============================================================================
+#define NR_LBEST_Q_SQRT170_OVER8_Q14_SIMD  26705  // round(sqrt(170)/8 * 2^14)
+#define NR_LBEST_Q_PP1_OVER32_Q16_256       3338  // round(sqrt(170)/8/32 * 2^16)
+
+// int16 PAM-16 level (sign*mag, mag in {1,3,...,15}) sliced vs {2,4,6,8,10,12,14}*thunit.
+static inline simde__m256i nr_lbest_simd_level_pam16(simde__m256i num, simde__m256i thunit)
+{
+  const simde__m256i z   = simde_mm256_setzero_si256();
+  const simde__m256i a   = simde_mm256_abs_epi16(num);
+  const simde__m256i t2  = simde_mm256_slli_epi16(thunit, 1);
+  const simde__m256i t4  = simde_mm256_slli_epi16(thunit, 2);
+  const simde__m256i t8  = simde_mm256_slli_epi16(thunit, 3);
+  const simde__m256i t6  = simde_mm256_adds_epi16(t2, t4);
+  const simde__m256i t10 = simde_mm256_adds_epi16(t2, t8);
+  const simde__m256i t12 = simde_mm256_adds_epi16(t4, t8);
+  const simde__m256i t14 = simde_mm256_adds_epi16(t6, t8);
+  const simde__m256i g2  = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t2));
+  const simde__m256i g4  = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t4));
+  const simde__m256i g6  = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t6));
+  const simde__m256i g8  = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t8));
+  const simde__m256i g10 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t10));
+  const simde__m256i g12 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t12));
+  const simde__m256i g14 = simde_mm256_sub_epi16(z, simde_mm256_cmpgt_epi16(a, t14));
+  // mag = 1 + 2*(g2+g4+g6+g8+g10+g12+g14)
+  const simde__m256i sum = simde_mm256_adds_epi16(
+      simde_mm256_adds_epi16(simde_mm256_adds_epi16(g2, g4), simde_mm256_adds_epi16(g6, g8)),
+      simde_mm256_adds_epi16(simde_mm256_adds_epi16(g10, g12), g14));
+  const simde__m256i mag = simde_mm256_adds_epi16(simde_mm256_set1_epi16(1),
+                                                  simde_mm256_slli_epi16(sum, 1));
+  const simde__m256i neg = simde_mm256_cmpgt_epi16(z, num);
+  return simde_mm256_blendv_epi8(mag, simde_mm256_sub_epi16(z, mag), neg);
+}
+
+// z * sqrt(170) / 32, packed to int16 (lane l == RE l).
+static inline simde__m256i nr_lbest_z170d32(simde__m256i z16)
+{
+  const simde__m256i C = simde_mm256_set1_epi32(NR_LBEST_Q_SQRT170_Q12);
+  const simde__m256i lo = simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(z16, 0), C), 17);
+  const simde__m256i hi = simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(z16, 1), C), 17);
+  return simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+}
+
+// ZF seed for 256QAM: identical to nr_lbest_simd_seed16 except clamp to [-15,15]
+// and Pp = cm * sqrt(170)/8.
+static inline void nr_lbest_simd_seed16_256(simde__m256i z1r16, simde__m256i z1i16,
+                                            simde__m256i z2r16, simde__m256i z2i16,
+                                            simde__m256i rr16,  simde__m256i ri16,
+                                            simde__m256i cm0_16, simde__m256i cm1_16,
+                                            simde__m256i *centerI, simde__m256i *centerQ,
+                                            simde__m256i *dirImask, simde__m256i *dirQmask)
+{
+  const simde__m256i SQRT170_OVER8 = simde_mm256_set1_epi32(NR_LBEST_Q_SQRT170_OVER8_Q14_SIMD);
+  const simde__m256 SQRT170 = simde_mm256_set1_ps(13.038404810405298f);
+  const simde__m256 HALF = simde_mm256_set1_ps(0.5f), ONE = simde_mm256_set1_ps(1.0f), TWO = simde_mm256_set1_ps(2.0f);
+  const simde__m256 P15 = simde_mm256_set1_ps(15.0f), M15 = simde_mm256_set1_ps(-15.0f);
+  simde__m256i cI[2], cQ[2], dI[2], dQ[2];
+  for (int h = 0; h < 2; h++) {
+    const simde__m256 z1r = simde_mm256_cvtepi32_ps(nr_lbest_widen(z1r16, h)), z1i = simde_mm256_cvtepi32_ps(nr_lbest_widen(z1i16, h));
+    const simde__m256 z2r = simde_mm256_cvtepi32_ps(nr_lbest_widen(z2r16, h)), z2i = simde_mm256_cvtepi32_ps(nr_lbest_widen(z2i16, h));
+    const simde__m256 rr  = simde_mm256_cvtepi32_ps(nr_lbest_widen(rr16,  h)), ri  = simde_mm256_cvtepi32_ps(nr_lbest_widen(ri16,  h));
+    const simde__m256 Pp0 = simde_mm256_cvtepi32_ps(simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(cm0_16, h), SQRT170_OVER8), 14));
+    const simde__m256 Pp1 = simde_mm256_cvtepi32_ps(simde_mm256_srai_epi32(simde_mm256_mullo_epi32(nr_lbest_widen(cm1_16, h), SQRT170_OVER8), 14));
+    // ZF 2x2 solve (float): x_hat1 = (Pp1*z1 - rho*z2) / det
+    simde__m256 det = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp0, Pp1),
+                                         simde_mm256_add_ps(simde_mm256_mul_ps(rr, rr), simde_mm256_mul_ps(ri, ri)));
+    det = simde_mm256_max_ps(det, ONE);
+    const simde__m256 numr = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp1, z1r),
+                                                 simde_mm256_sub_ps(simde_mm256_mul_ps(rr, z2r), simde_mm256_mul_ps(ri, z2i)));
+    const simde__m256 numi = simde_mm256_sub_ps(simde_mm256_mul_ps(Pp1, z1i),
+                                                 simde_mm256_add_ps(simde_mm256_mul_ps(rr, z2i), simde_mm256_mul_ps(ri, z2r)));
+    // soft level estimate ~ +-1..15
+    const simde__m256 estI = simde_mm256_mul_ps(simde_mm256_div_ps(numr, det), SQRT170);
+    const simde__m256 estQ = simde_mm256_mul_ps(simde_mm256_div_ps(numi, det), SQRT170);
+    // nearest odd level: o = 2*round((est-1)/2)+1, clamped to [-15,15]
+    simde__m256 oI = simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps(estI, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    simde__m256 oQ = simde_mm256_add_ps(simde_mm256_mul_ps(simde_mm256_round_ps(simde_mm256_mul_ps(simde_mm256_sub_ps(estQ, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    oI = simde_mm256_min_ps(simde_mm256_max_ps(oI, M15), P15);
+    oQ = simde_mm256_min_ps(simde_mm256_max_ps(oQ, M15), P15);
+    cI[h] = simde_mm256_cvtps_epi32(oI);
+    cQ[h] = simde_mm256_cvtps_epi32(oQ);
+    dI[h] = simde_mm256_castps_si256(simde_mm256_cmp_ps(estI, oI, SIMDE_CMP_GT_OQ));
+    dQ[h] = simde_mm256_castps_si256(simde_mm256_cmp_ps(estQ, oQ, SIMDE_CMP_GT_OQ));
+  }
+  *centerI  = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(cI[0], cI[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+  *centerQ  = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(cQ[0], cQ[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+  *dirImask = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(dI[0], dI[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+  *dirQmask = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(dQ[0], dQ[1]), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+}
+
+// Per-candidate evaluation for 256QAM (8 bits/RE, PAM-16 slicer).
+// C13_256 = round(2^13/sqrt(170)), CE_256 = round(2^16/(8*8*sqrt(170)*2)),
+// CX_256  = round(2^16/(8*170)).
+#define NR_LBEST_EVAL16_256(I1_, Q1_, BI0, BI1, BI2, BI3, BQ0, BQ1, BQ2, BQ3, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
+  do { \
+    const simde__m256i A2I = simde_mm256_subs_epi16(z2r170, simde_mm256_adds_epi16((RRI_), (RIQ_))); \
+    const simde__m256i A2Q = simde_mm256_subs_epi16(z2i170, simde_mm256_subs_epi16((RRQ_), (RII_))); \
+    const simde__m256i I2  = nr_lbest_simd_level_pam16(A2I, Pp1_5_256); \
+    const simde__m256i Q2  = nr_lbest_simd_level_pam16(A2Q, Pp1_5_256); \
+    const simde__m256i corr0   = simde_mm256_adds_epi16((C0I_), (C0Q_)); \
+    const simde__m256i energy0 = simde_mm256_adds_epi16((EI_), (EQ_)); \
+    const simde__m256i corr1   = simde_mm256_adds_epi16(simde_mm256_mulhi_epi16(z2r, simde_mm256_mullo_epi16(I2, C13_256)), \
+                                                        simde_mm256_mulhi_epi16(z2i, simde_mm256_mullo_epi16(Q2, C13_256))); \
+    const simde__m256i energy1 = simde_mm256_mulhi_epi16(cm1, simde_mm256_mullo_epi16(simde_mm256_adds_epi16(simde_mm256_mullo_epi16(I2, I2), simde_mm256_mullo_epi16(Q2, Q2)), CE_256)); \
+    const simde__m256i aa = simde_mm256_adds_epi16(simde_mm256_mullo_epi16((I1_), I2), simde_mm256_mullo_epi16((Q1_), Q2)); \
+    const simde__m256i bb = simde_mm256_subs_epi16(simde_mm256_mullo_epi16((Q1_), I2), simde_mm256_mullo_epi16((I1_), Q2)); \
+    const simde__m256i cross = simde_mm256_adds_epi16(simde_mm256_mulhi_epi16(rr, simde_mm256_mullo_epi16(aa, CX_256)), \
+                                                      simde_mm256_mulhi_epi16(ri, simde_mm256_mullo_epi16(bb, CX_256))); \
+    simde__m256i metric = simde_mm256_max_epi16(simde_mm256_subs_epi16(simde_mm256_adds_epi16(simde_mm256_subs_epi16(corr0, energy0), simde_mm256_subs_epi16(corr1, energy1)), cross), FLOORM); \
+    const simde__m256i bm[8] = {(BI0), (BQ0), (BI1), (BQ1), (BI2), (BQ2), (BI3), (BQ3)}; \
+    for (int p = 0; p < 8; p++) { \
+      max0[p] = simde_mm256_max_epi16(max0[p], simde_mm256_blendv_epi8(metric, SENT, bm[p])); \
+      max1[p] = simde_mm256_max_epi16(max1[p], simde_mm256_blendv_epi8(SENT, metric, bm[p])); \
+    } \
+  } while (0)
+
+// pattern: 0 = 5x5 (25 cand), 1 = 3x3 (9 cand), 2 = 5-plus (5 cand).
+void nr_qam256_llr_2layer_lbest_q15_simd16(c16_t *stream0_in,
+                                           c16_t *stream1_in,
+                                           c16_t *ch_mag,
+                                           c16_t *ch_mag_i,
+                                           int16_t *stream0_out,
+                                           c16_t *rho01,
+                                           uint32_t length,
+                                           int pattern)
+{
+  const simde__m256i SENT   = simde_mm256_set1_epi16(NR_LBEST_SIMD16_SENT);
+  const simde__m256i FLOORM = simde_mm256_set1_epi16(-32000);
+  const simde__m256i V15 = simde_mm256_set1_epi16(15), Vm15 = simde_mm256_set1_epi16(-15);
+  const simde__m256i z   = simde_mm256_setzero_si256();
+
+  // 256QAM metric Q-constants (metric scale = 1/8, matching 64QAM SIMD kernel):
+  //   C13_256 = round(2^13/sqrt(170))       => mulhi(z, I*C13) = z*I/(8*sqrt(170))
+  //   CE_256  = round(2^16/(8*8*2*sqrt(170)))  => energy = cm*|X|^2/(8*8*2*sqrt(170))
+  //   CX_256  = round(2^16/(8*170))         => cross term
+  const simde__m256i C13_256 = simde_mm256_set1_epi16(628);
+  const simde__m256i CE_256  = simde_mm256_set1_epi16(39);
+  const simde__m256i CX_256  = simde_mm256_set1_epi16(48);
+
+  uint32_t re = 0;
+  for (; re + 16 <= length; re += 16) {
+    simde__m256i z1r, z1i, z2r, z2i, rr, ri, cm0, cm1, dummy;
+    nr_lbest_simd_load16(&stream0_in[re], &z1r, &z1i);
+    nr_lbest_simd_load16(&stream1_in[re], &z2r, &z2i);
+    nr_lbest_simd_load16(&rho01[re],      &rr,  &ri);
+    nr_lbest_simd_load16(&ch_mag[re],     &cm0, &dummy);
+    nr_lbest_simd_load16(&ch_mag_i[re],   &cm1, &dummy);
+
+    simde__m256i centerI, centerQ, dirImask, dirQmask;
+    nr_lbest_simd_seed16_256(z1r, z1i, z2r, z2i, rr, ri, cm0, cm1,
+                             &centerI, &centerQ, &dirImask, &dirQmask);
+    (void)dirImask; (void)dirQmask;
+
+    // per-RE-vector precomputed quantities (int16 scale, /32 shift)
+    const simde__m256i z2r170   = nr_lbest_z170d32(z2r), z2i170 = nr_lbest_z170d32(z2i);
+    const simde__m256i rr5      = simde_mm256_srai_epi16(rr, 5), ri5 = simde_mm256_srai_epi16(ri, 5);
+    const simde__m256i Pp1_5_256 = simde_mm256_mulhi_epi16(cm1, simde_mm256_set1_epi16(NR_LBEST_Q_PP1_OVER32_Q16_256));
+
+    simde__m256i max0[8], max1[8];
+    for (int p = 0; p < 8; p++) { max0[p] = SENT; max1[p] = SENT; }
+
+    // ---- 5x5 block (hoisted) ----
+    // Precompute 5 I-levels and 5 Q-levels, then evaluate all or a subset of pairs.
+    // Offsets: {-4,-2,0,+2,+4} around seed center.
+    static const int offs5[5] = {-4, -2, 0, 2, 4};
+    simde__m256i Iv[5], Qv[5];
+    simde__m256i bIv[5][4], bQv[5][4];                // [level][bit 0..3]
+    simde__m256i c0I[5], c0Q[5], eI[5], eQ[5];
+    simde__m256i rrI[5], riI[5], rrQ[5], riQ[5];
+
+    const simde__m256i V8 = simde_mm256_set1_epi16(8), V4 = simde_mm256_set1_epi16(4), V2 = simde_mm256_set1_epi16(2);
+
+    for (int k = 0; k < 5; k++) {
+      const simde__m256i I1 = simde_mm256_min_epi16(simde_mm256_max_epi16(simde_mm256_adds_epi16(centerI, simde_mm256_set1_epi16(offs5[k])), Vm15), V15);
+      const simde__m256i Q1 = simde_mm256_min_epi16(simde_mm256_max_epi16(simde_mm256_adds_epi16(centerQ, simde_mm256_set1_epi16(offs5[k])), Vm15), V15);
+      Iv[k] = I1; Qv[k] = Q1;
+
+      // 256QAM Gray bit labeling per axis (b0..b3):
+      //   b0 = sign (level < 0)
+      //   b1 = |level| > 8
+      //   b2 = ||level|-8| > 4
+      //   b3 = |||level|-8|-4| > 2
+      const simde__m256i aI  = simde_mm256_abs_epi16(I1);
+      const simde__m256i m2I = simde_mm256_abs_epi16(simde_mm256_sub_epi16(aI,  V8));
+      const simde__m256i m3I = simde_mm256_abs_epi16(simde_mm256_sub_epi16(m2I, V4));
+      bIv[k][0] = simde_mm256_cmpgt_epi16(z,   I1);
+      bIv[k][1] = simde_mm256_cmpgt_epi16(aI,  V8);
+      bIv[k][2] = simde_mm256_cmpgt_epi16(m2I, V4);
+      bIv[k][3] = simde_mm256_cmpgt_epi16(m3I, V2);
+
+      const simde__m256i aQ  = simde_mm256_abs_epi16(Q1);
+      const simde__m256i m2Q = simde_mm256_abs_epi16(simde_mm256_sub_epi16(aQ,  V8));
+      const simde__m256i m3Q = simde_mm256_abs_epi16(simde_mm256_sub_epi16(m2Q, V4));
+      bQv[k][0] = simde_mm256_cmpgt_epi16(z,   Q1);
+      bQv[k][1] = simde_mm256_cmpgt_epi16(aQ,  V8);
+      bQv[k][2] = simde_mm256_cmpgt_epi16(m2Q, V4);
+      bQv[k][3] = simde_mm256_cmpgt_epi16(m3Q, V2);
+
+      c0I[k] = simde_mm256_mulhi_epi16(z1r, simde_mm256_mullo_epi16(I1, C13_256));
+      c0Q[k] = simde_mm256_mulhi_epi16(z1i, simde_mm256_mullo_epi16(Q1, C13_256));
+      eI[k]  = simde_mm256_mulhi_epi16(cm0, simde_mm256_mullo_epi16(simde_mm256_mullo_epi16(I1, I1), CE_256));
+      eQ[k]  = simde_mm256_mulhi_epi16(cm0, simde_mm256_mullo_epi16(simde_mm256_mullo_epi16(Q1, Q1), CE_256));
+      rrI[k] = simde_mm256_mullo_epi16(rr5, I1); riI[k] = simde_mm256_mullo_epi16(ri5, I1);
+      rrQ[k] = simde_mm256_mullo_epi16(rr5, Q1); riQ[k] = simde_mm256_mullo_epi16(ri5, Q1);
+    }
+
+    if (pattern == 0) { // 5x5: all 25 grid pairs
+      for (int iI = 0; iI < 5; iI++)
+        for (int iQ = 0; iQ < 5; iQ++)
+          NR_LBEST_EVAL16_256(Iv[iI], Qv[iQ],
+                              bIv[iI][0], bIv[iI][1], bIv[iI][2], bIv[iI][3],
+                              bQv[iQ][0], bQv[iQ][1], bQv[iQ][2], bQv[iQ][3],
+                              c0I[iI], c0Q[iQ], eI[iI], eQ[iQ],
+                              rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+    } else if (pattern == 1) { // 3x3: center 3 levels, 9 pairs
+      // center indices {1,2,3} map to offsets {-2,0,+2}
+      static const int ci3[3] = {1, 2, 3};
+      for (int a = 0; a < 3; a++)
+        for (int b = 0; b < 3; b++) {
+          const int iI = ci3[a], iQ = ci3[b];
+          NR_LBEST_EVAL16_256(Iv[iI], Qv[iQ],
+                              bIv[iI][0], bIv[iI][1], bIv[iI][2], bIv[iI][3],
+                              bQv[iQ][0], bQv[iQ][1], bQv[iQ][2], bQv[iQ][3],
+                              c0I[iI], c0Q[iQ], eI[iI], eQ[iQ],
+                              rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+        }
+    } else if (pattern == 2) { // 5-plus: center + +-4 each axis (5 cand)
+      // indices: (2,2)=center, (0,2)=I-4, (4,2)=I+4, (2,0)=Q-4, (2,4)=Q+4
+      static const int pI5[5] = {2, 0, 4, 2, 2}, pQ5[5] = {2, 2, 2, 0, 4};
+      for (int c = 0; c < 5; c++) {
+        const int iI = pI5[c], iQ = pQ5[c];
+        NR_LBEST_EVAL16_256(Iv[iI], Qv[iQ],
+                            bIv[iI][0], bIv[iI][1], bIv[iI][2], bIv[iI][3],
+                            bQv[iQ][0], bQv[iQ][1], bQv[iQ][2], bQv[iQ][3],
+                            c0I[iI], c0Q[iQ], eI[iI], eQ[iQ],
+                            rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+      }
+    } else { // pattern == 3: FULL exact ML — all 256 points (16x16 grid, conditional slice)
+      // Enumerate every PAM-16 level on both axes (no seed centering). Per-level quantities
+      // that depend only on the level (Gray bits, |x|^2 energy, rho5*level) are identical
+      // for the I- and Q-candidate roles; only the correlation term differs (z1r vs z1i).
+      static const int lv16[16] = {-15, -13, -11, -9, -7, -5, -3, -1, 1, 3, 5, 7, 9, 11, 13, 15};
+      simde__m256i fI[16], fbI[16][4], fc0I[16], fc0Q[16], feI[16], frrI[16], friI[16];
+      for (int k = 0; k < 16; k++) {
+        const simde__m256i I1 = simde_mm256_set1_epi16(lv16[k]);
+        fI[k] = I1;
+        const simde__m256i aI  = simde_mm256_abs_epi16(I1);
+        const simde__m256i m2I = simde_mm256_abs_epi16(simde_mm256_sub_epi16(aI,  V8));
+        const simde__m256i m3I = simde_mm256_abs_epi16(simde_mm256_sub_epi16(m2I, V4));
+        fbI[k][0] = simde_mm256_cmpgt_epi16(z,   I1);
+        fbI[k][1] = simde_mm256_cmpgt_epi16(aI,  V8);
+        fbI[k][2] = simde_mm256_cmpgt_epi16(m2I, V4);
+        fbI[k][3] = simde_mm256_cmpgt_epi16(m3I, V2);
+        fc0I[k] = simde_mm256_mulhi_epi16(z1r, simde_mm256_mullo_epi16(I1, C13_256));
+        fc0Q[k] = simde_mm256_mulhi_epi16(z1i, simde_mm256_mullo_epi16(I1, C13_256));
+        feI[k]  = simde_mm256_mulhi_epi16(cm0, simde_mm256_mullo_epi16(simde_mm256_mullo_epi16(I1, I1), CE_256));
+        frrI[k] = simde_mm256_mullo_epi16(rr5, I1);
+        friI[k] = simde_mm256_mullo_epi16(ri5, I1);
+      }
+      for (int iI = 0; iI < 16; iI++)
+        for (int iQ = 0; iQ < 16; iQ++)
+          NR_LBEST_EVAL16_256(fI[iI], fI[iQ],
+                              fbI[iI][0], fbI[iI][1], fbI[iI][2], fbI[iI][3],
+                              fbI[iQ][0], fbI[iQ][1], fbI[iQ][2], fbI[iQ][3],
+                              fc0I[iI], fc0Q[iQ], feI[iI], feI[iQ],
+                              frrI[iI], friI[iI], frrI[iQ], friI[iQ]);
+    }
+
+    int16_t tmp[8][16];
+    for (int p = 0; p < 8; p++) {
+      const simde__m256i diff = simde_mm256_subs_epi16(max0[p], max1[p]);
+      // metric is at 1/8 scale -> LLR = diff*8; saturate via int32 widening
+      const simde__m256i lo = simde_mm256_slli_epi32(nr_lbest_widen(diff, 0), 3);
+      const simde__m256i hi = simde_mm256_slli_epi32(nr_lbest_widen(diff, 1), 3);
+      simde__m256i res = simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+      res = simde_mm256_blendv_epi8(res, simde_mm256_set1_epi16(-NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max0[p], SENT));
+      res = simde_mm256_blendv_epi8(res, simde_mm256_set1_epi16( NR_LBEST_Q_LLR_SAT), simde_mm256_cmpeq_epi16(max1[p], SENT));
+      simde_mm256_storeu_si256((simde__m256i *)tmp[p], res);
+    }
+    for (int r = 0; r < 16; r++)
+      for (int p = 0; p < 8; p++)
+        stream0_out[(re + r) * 8 + p] = tmp[p][r];
+  }
+
+  if (re < length)
+    nr_qam256_llr_2layer_lbest_q15_layer(&stream0_in[re], &stream1_in[re], &ch_mag[re], &ch_mag_i[re],
+                                         &stream0_out[re * 8], &rho01[re], length - re, (pattern == 3) ? 256 : 25);
+}
+
 void nr_compute_ML_llr(c16_t *rxdataF_comp0,
                        c16_t *rxdataF_comp1,
                        c16_t *ch_mag0,
@@ -3650,13 +4276,68 @@ void nr_compute_ML_llr(c16_t *rxdataF_comp0,
       }
       break;
     case 8:
-      // 2-layer 256QAM ML via the float L-best reference (ANALYSIS path; only reached when the
-      // demod L-best gate routes Qm=8 here). L = OAI_LBEST_L256 (default 256 = full ML search).
+      // 2-layer 256QAM. Default = direct SIMD full ML (nr_qam256_llr_2layer), correct on all
+      // channels — analogous to nr_qam64_llr_2layer for 64QAM.
+      // The reduced-search L-best kernel is GATED OFF by default; enable via OAI_LBEST_Q15_256=1.
+      // OAI_LBEST_PAT256 picks the candidate set (0=5x5/25 [default], 1=3x3/9, 2=5-plus/5).
       {
-        static int L256 = -1;
-        if (L256 < 0) { const char *e = getenv("OAI_LBEST_L256"); L256 = e ? atoi(e) : 256; }
-        nr_qam256_llr_2layer_lbest(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, llr_layers0, rho0, nb_re, L256, 0.0f);
-        nr_qam256_llr_2layer_lbest(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re, L256, 0.0f);
+        static int lbest256 = -1, pat256 = 0;
+        if (lbest256 < 0) {
+          const char *e = getenv("OAI_LBEST_Q15_256");
+          lbest256 = e ? atoi(e) : 0;
+          const char *ep = getenv("OAI_LBEST_PAT256");
+          pat256 = ep ? atoi(ep) : 0;
+        }
+        if (lbest256) {
+          nr_qam256_llr_2layer_lbest_q15_simd16(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, llr_layers0, rho0, nb_re, pat256);
+          nr_qam256_llr_2layer_lbest_q15_simd16(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re, pat256);
+        } else {
+          nr_qam256_llr_2layer(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, llr_layers0, rho0, nb_re);
+          nr_qam256_llr_2layer(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re);
+        }
+        // --- OAI_LBEST_DBG256: verify the ACTIVE 256QAM kernel (layer 0) vs the FLOAT full-ML
+        // reference (nr_qam256_llr_2layer_lbest, L=256 == exact max-log search) on the SAME
+        // real inputs. Accumulates scale-invariant correctness (sign disagreement), magnitude,
+        // int16 saturation fraction, best-fit scale vs ref, and post-scale residual (distortion).
+        // Analysis-only (dlsim); single-threaded static counters. Set OAI_LBEST_DBG256=1.
+        {
+          static int dbg256 = -1;
+          if (dbg256 < 0) { const char *e = getenv("OAI_LBEST_DBG256"); dbg256 = e ? atoi(e) : 0; }
+          if (dbg256) {
+            static long n = 0, sdis = 0, satN = 0, gtN = 0, pdis[8] = {0};
+            static double sAbsP = 0, sAbsR = 0, sPR = 0, sRR = 0, sPP = 0;
+            int16_t *ref = (int16_t *)malloc((size_t)nb_re * 8 * sizeof(int16_t));
+            nr_qam256_llr_2layer_lbest(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, ref, rho0, nb_re, 256, 0.0f);
+            for (uint32_t k = 0; k < nb_re * 8; k++) {
+              const int p = llr_layers0[k], r = ref[k];
+              const int ap = p < 0 ? -p : p, ar = r < 0 ? -r : r;
+              n++;
+              if ((long)p * r < 0) { sdis++; pdis[k & 7]++; } // k&7 = bit pos {I0,Q0,I1,Q1,I2,Q2,I3,Q3}
+              if (ap >= 30000) satN++;
+              if (ap >= 128) gtN++; // int8 clip point: LDPC narrows int16->int8 (packs, sat +-127)
+              sAbsP += ap; sAbsR += ar;
+              sPR += (double)p * r; sRR += (double)r * r; sPP += (double)p * p;
+            }
+            free(ref);
+            if (n >= 200000) {
+              const double a = sRR > 0 ? sPR / sRR : 0;
+              const double resid = sPP - 2 * a * sPR + a * a * sRR;
+              const double per = n / 8.0; // occurrences per bit position
+              fprintf(stderr,
+                      "### LBEST_DBG256 kernel=%s N=%ld signDisagree=%.3f%% meanAbs prod=%.0f ref=%.0f "
+                      "sat|.|>=30000=%.3f%% int8clip|.|>=128=%.3f%% fitScale=%.3f residFrac=%.3f\n"
+                      "###   per-bit signDisagree{I0,Q0,I1,Q1,I2,Q2,I3,Q3}= "
+                      "%.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f (%%)\n",
+                      lbest256 ? "simd16_256" : "simd_full", n, 100.0 * sdis / n,
+                      sAbsP / n, sAbsR / n, 100.0 * satN / n, 100.0 * gtN / n, a,
+                      sPP > 0 ? resid / sPP : 0,
+                      100.0 * pdis[0] / per, 100.0 * pdis[1] / per, 100.0 * pdis[2] / per, 100.0 * pdis[3] / per,
+                      100.0 * pdis[4] / per, 100.0 * pdis[5] / per, 100.0 * pdis[6] / per, 100.0 * pdis[7] / per);
+              n = sdis = satN = gtN = 0; sAbsP = sAbsR = sPR = sRR = sPP = 0;
+              for (int b = 0; b < 8; b++) pdis[b] = 0;
+            }
+          }
+        }
       }
       break;
     default:

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -3824,23 +3824,63 @@ void nr_qam256_llr_2layer_lbest_q15(c16_t *stream0_in,
 #include "nr_lbest_qam64_simd.c.inc"
 #include "nr_lbest_qam256_simd.c.inc"
 #undef NRLB_W
+// AVX-512 (W=512) instantiation: only when 512 is a real compile target (else SIMDe would
+// emulate it as 2x256/4x128, which is slower than the native w256/w128). Compares yield
+// k-masks and blendv has no 512 form -> the header's NRLB_ wrappers lift both back to the
+// vector-mask model, so this is the same source (bit-exact) at 2x the lanes.
+#if defined(__AVX512BW__) && defined(__AVX512VL__) && defined(__AVX512F__)
+#include <simde/x86/avx512.h>
+#define NRLB_W 512
+#include "nr_lbest_simd_width.h"
+#include "nr_lbest_qam64_simd.c.inc"
+#include "nr_lbest_qam256_simd.c.inc"
+#undef NRLB_W
+#define NRLB_HAVE_W512 1
+#endif
 
 // Public entry (name unchanged for callers): pick the arch-native width.
+// x86 width selection (cached): 1 = w128 (NEON regression), 2 = w512 (AVX-512), 0 = w256 (default).
+// w256 is the safe default: on double-pumped-AVX-512 parts (Zen4/Zen5-mobile, e.g. Strix Halo) the
+// 512 path executes as 2x256 uops with no datapath-width gain, so it is a wash-to-slight-regression
+// there (esp. 256QAM, where the blendv k-mask emulation offsets the fewer-instructions saving).
+// w512 helps on true-512-datapath server CPUs (EPYC Genoa/Turin, Xeon SP) -> opt in with
+// OAI_LBEST_W512=1 (all widths are bit-exact; verified via OAI_LBEST_DBG/DBG256). OAI_LBEST_W128=1
+// selects the NEON-equivalent path for x86 regression testing.
+static int nr_lbest_simd_width_mode(void)
+{
+  static int mode = -1;
+  if (mode < 0) {
+    const char *e;
+    if ((e = getenv("OAI_LBEST_W128")) && atoi(e)) mode = 1;
+#ifdef NRLB_HAVE_W512
+    else if ((e = getenv("OAI_LBEST_W512")) && atoi(e)) mode = 2;
+#endif
+    else mode = 0;
+    // announce once so a measurement run self-documents which kernel ran (and reveals a silent
+    // fallback to w256 when OAI_LBEST_W512=1 but AVX-512 was not a compile target).
+    fprintf(stderr, "### LBEST 2-layer width = %s\n",
+            mode == 1 ? "w128 (SSE->NEON)" : mode == 2 ? "w512 (AVX-512)" : "w256 (AVX2)");
+  }
+  return mode;
+}
+
 void nr_qam64_llr_2layer_lbest_q15_simd16(c16_t *stream0_in, c16_t *stream1_in, c16_t *ch_mag,
                                           c16_t *ch_mag_i, int16_t *stream0_out, c16_t *rho01,
                                           uint32_t length, int pattern)
 {
   // On aarch64 the 128-bit instantiation runs (SIMDe -> NEON, avoiding the inefficient 256->2x128
-  // cross-lane emulation). On x86 the 256-bit runs; OAI_LBEST_W128=1 forces the 128-bit path so the
-  // NEON code path can be regression-tested on x86 (it is bit-exact to 256 -- verify via the DBG).
-  static int w128 = -1;
-  if (w128 < 0) { const char *e = getenv("OAI_LBEST_W128"); w128 = e ? atoi(e) : 0; }
+  // cross-lane emulation). On x86 the 256-bit runs by default; OAI_LBEST_W512=1 opts into AVX-512
+  // (a win only on true-512-datapath server CPUs) and OAI_LBEST_W128=1 selects the NEON-equivalent
+  // path for x86 regression (all widths bit-exact -- see nr_lbest_simd_width_mode()).
 #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) || defined(__aarch64__)
-  (void)w128;
   nr_qam64_llr_2layer_lbest_q15_simd_w128(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
 #else
-  if (w128) nr_qam64_llr_2layer_lbest_q15_simd_w128(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
-  else      nr_qam64_llr_2layer_lbest_q15_simd_w256(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+  const int m = nr_lbest_simd_width_mode();
+  if (m == 1)      nr_qam64_llr_2layer_lbest_q15_simd_w128(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+#ifdef NRLB_HAVE_W512
+  else if (m == 2) nr_qam64_llr_2layer_lbest_q15_simd_w512(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+#endif
+  else             nr_qam64_llr_2layer_lbest_q15_simd_w256(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
 #endif
 }
 
@@ -3852,10 +3892,12 @@ void nr_qam256_llr_2layer_lbest_q15_simd16(c16_t *stream0_in, c16_t *stream1_in,
 #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) || defined(__aarch64__)
   nr_qam256_llr_2layer_lbest_q15_simd_w128(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
 #else
-  static int w128 = -1;
-  if (w128 < 0) { const char *e = getenv("OAI_LBEST_W128"); w128 = e ? atoi(e) : 0; }
-  if (w128) nr_qam256_llr_2layer_lbest_q15_simd_w128(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
-  else      nr_qam256_llr_2layer_lbest_q15_simd_w256(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+  const int m = nr_lbest_simd_width_mode();
+  if (m == 1)      nr_qam256_llr_2layer_lbest_q15_simd_w128(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+#ifdef NRLB_HAVE_W512
+  else if (m == 2) nr_qam256_llr_2layer_lbest_q15_simd_w512(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
+#endif
+  else             nr_qam256_llr_2layer_lbest_q15_simd_w256(stream0_in, stream1_in, ch_mag, ch_mag_i, stream0_out, rho01, length, pattern);
 #endif
 }
 

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -14,6 +14,29 @@
 #define USE_128BIT
 #endif
 
+int nr_ml_llr_maxh_off(int mod_order)
+{
+  // OAI_ML_MAXH_OFF (if set) forces one value across all mod orders (hotness sweep); otherwise the
+  // per-mod-order table below. Values are the empirical optima on TDL, 2-layer, z4, -gA (a uniform
+  // -2, tuned for 256QAM, over-heats QPSK/16/64QAM and loses the ML gain -- QPSK/16QAM ML even fall
+  // below linear MMSE). Retune via the env var; the table is the shipped default.
+  static int env_state = 0, env_val = 0; // 0=unread, 1=env set, 2=env unset
+  if (env_state == 0) {
+    const char *e = getenv("OAI_ML_MAXH_OFF");
+    if (e) { env_val = atoi(e); env_state = 1; }
+    else env_state = 2;
+  }
+  if (env_state == 1)
+    return env_val;
+  switch (mod_order) {
+    case 2:  return 0;  // QPSK
+    case 4:  return 1;  // 16QAM
+    case 6:  return -1; // 64QAM
+    case 8:  return -3; // 256QAM (with the antenna-gain term => effective -2, the prior gNB value)
+    default: return -2;
+  }
+}
+
 void nr_compute_llr(c16_t *rxdataF_comp,
                     c16_t *ch_mag,
                     c16_t *ch_magb,

--- a/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
+++ b/openair1/PHY/nr_phy_common/src/nr_compute_llr.c
@@ -4355,25 +4355,18 @@ void nr_compute_ML_llr(c16_t *rxdataF_comp0,
       }
       break;
     case 8:
-      // 2-layer 256QAM. Default = direct SIMD full ML (nr_qam256_llr_2layer), correct on all
-      // channels — analogous to nr_qam64_llr_2layer for 64QAM.
-      // The reduced-search L-best kernel is GATED OFF by default; enable via OAI_LBEST_Q15_256=1.
-      // OAI_LBEST_PAT256 picks the candidate set (0=5x5/25 [default], 1=3x3/9, 2=5-plus/5).
+      // 2-layer 256QAM. Default = reduced-search L-best with the 3x3/9-candidate pattern, which
+      // matches the full 256-candidate max-log ML in coded BLER (verified on TDL-A, gNB + UE) at a
+      // ~28x candidate reduction. OAI_LBEST_PAT256 overrides the candidate set:
+      //   0 = 5x5/25, 1 = 3x3/9 [default], 2 = 5-plus/5 (degraded), 3 = full 16x16 ML.
       {
-        static int lbest256 = -1, pat256 = 0;
-        if (lbest256 < 0) {
-          const char *e = getenv("OAI_LBEST_Q15_256");
-          lbest256 = e ? atoi(e) : 0;
+        static int pat256 = -1;
+        if (pat256 < 0) {
           const char *ep = getenv("OAI_LBEST_PAT256");
-          pat256 = ep ? atoi(ep) : 0;
+          pat256 = ep ? atoi(ep) : 1; // 3x3/9-candidate L-best is the ML default
         }
-        if (lbest256) {
-          nr_qam256_llr_2layer_lbest_q15_simd16(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, llr_layers0, rho0, nb_re, pat256);
-          nr_qam256_llr_2layer_lbest_q15_simd16(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re, pat256);
-        } else {
-          nr_qam256_llr_2layer(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, llr_layers0, rho0, nb_re);
-          nr_qam256_llr_2layer(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re);
-        }
+        nr_qam256_llr_2layer_lbest_q15_simd16(rxdataF_comp0, rxdataF_comp1, ch_mag0, ch_mag1, llr_layers0, rho0, nb_re, pat256);
+        nr_qam256_llr_2layer_lbest_q15_simd16(rxdataF_comp1, rxdataF_comp0, ch_mag1, ch_mag0, llr_layers1, rho1, nb_re, pat256);
         // --- OAI_LBEST_DBG256: verify the ACTIVE 256QAM kernel (layer 0) vs the FLOAT full-ML
         // reference (nr_qam256_llr_2layer_lbest, L=256 == exact max-log search) on the SAME
         // real inputs. Accumulates scale-invariant correctness (sign disagreement), magnitude,
@@ -4407,7 +4400,7 @@ void nr_compute_ML_llr(c16_t *rxdataF_comp0,
                       "sat|.|>=30000=%.3f%% int8clip|.|>=128=%.3f%% fitScale=%.3f residFrac=%.3f\n"
                       "###   per-bit signDisagree{I0,Q0,I1,Q1,I2,Q2,I3,Q3}= "
                       "%.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f (%%)\n",
-                      lbest256 ? "simd16_256" : "simd_full", n, 100.0 * sdis / n,
+                      "simd16_256", n, 100.0 * sdis / n,
                       sAbsP / n, sAbsR / n, 100.0 * satN / n, 100.0 * gtN / n, a,
                       sPP > 0 ? resid / sPP : 0,
                       100.0 * pdis[0] / per, 100.0 * pdis[1] / per, 100.0 * pdis[2] / per, 100.0 * pdis[3] / per,

--- a/openair1/PHY/nr_phy_common/src/nr_lbest_qam256_simd.c.inc
+++ b/openair1/PHY/nr_phy_common/src/nr_lbest_qam256_simd.c.inc
@@ -16,21 +16,21 @@ static inline NRLB_VI NRLB_NAME(nrlbw_level_pam)(NRLB_VI num, NRLB_VI thunit)
   const NRLB_VI t10 = NRLB_MM(adds_epi16)(t2, t8);
   const NRLB_VI t12 = NRLB_MM(adds_epi16)(t4, t8);
   const NRLB_VI t14 = NRLB_MM(adds_epi16)(t6, t8);
-  const NRLB_VI g2  = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t2));
-  const NRLB_VI g4  = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t4));
-  const NRLB_VI g6  = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t6));
-  const NRLB_VI g8  = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t8));
-  const NRLB_VI g10 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t10));
-  const NRLB_VI g12 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t12));
-  const NRLB_VI g14 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t14));
+  const NRLB_VI g2  = NRLB_MM(sub_epi16)(z, NRLB_CMPGT16(a, t2));
+  const NRLB_VI g4  = NRLB_MM(sub_epi16)(z, NRLB_CMPGT16(a, t4));
+  const NRLB_VI g6  = NRLB_MM(sub_epi16)(z, NRLB_CMPGT16(a, t6));
+  const NRLB_VI g8  = NRLB_MM(sub_epi16)(z, NRLB_CMPGT16(a, t8));
+  const NRLB_VI g10 = NRLB_MM(sub_epi16)(z, NRLB_CMPGT16(a, t10));
+  const NRLB_VI g12 = NRLB_MM(sub_epi16)(z, NRLB_CMPGT16(a, t12));
+  const NRLB_VI g14 = NRLB_MM(sub_epi16)(z, NRLB_CMPGT16(a, t14));
   // mag = 1 + 2*(g2+g4+g6+g8+g10+g12+g14)
   const NRLB_VI sum = NRLB_MM(adds_epi16)(
       NRLB_MM(adds_epi16)(NRLB_MM(adds_epi16)(g2, g4), NRLB_MM(adds_epi16)(g6, g8)),
       NRLB_MM(adds_epi16)(NRLB_MM(adds_epi16)(g10, g12), g14));
   const NRLB_VI mag = NRLB_MM(adds_epi16)(NRLB_MM(set1_epi16)(1),
                                                   NRLB_MM(slli_epi16)(sum, 1));
-  const NRLB_VI neg = NRLB_MM(cmpgt_epi16)(z, num);
-  return NRLB_MM(blendv_epi8)(mag, NRLB_MM(sub_epi16)(z, mag), neg);
+  const NRLB_VI neg = NRLB_CMPGT16(z, num);
+  return NRLB_BLENDV(mag, NRLB_MM(sub_epi16)(z, mag), neg);
 }
 
 static inline NRLB_VI NRLB_NAME(nrlbw_z170d32)(NRLB_VI z16)
@@ -46,7 +46,7 @@ static inline void NRLB_NAME(nrlbw_axis_llr)(NRLB_VF est, NRLB_VF g, NRLB_VF out
   const NRLB_VF ONE = NRLB_MM(set1_ps)(1.0f), TWO = NRLB_MM(set1_ps)(2.0f), HALF = NRLB_MM(set1_ps)(0.5f);
   // o = nearest odd to est; oa = nearest odd to |est|
   const NRLB_VF a = NRLB_MM(andnot_ps)(NRLB_MM(set1_ps)(-0.0f), est);
-#define NR_RODD(x) NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_MM(round_ps)(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)((x), ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE)
+#define NR_RODD(x) NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_ROUNDPS(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)((x), ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE)
   const NRLB_VF o = NR_RODD(est), oa = NR_RODD(a);
 #define NR_CL(x, lo, hi) NRLB_MM(min_ps)(NRLB_MM(max_ps)((x), NRLB_MM(set1_ps)(lo)), NRLB_MM(set1_ps)(hi))
 #define NR_DSQ(lvl, ref) ({ const NRLB_VF _d = NRLB_MM(sub_ps)((lvl), (ref)); NRLB_MM(mul_ps)(_d, _d); })
@@ -102,14 +102,14 @@ static inline void NRLB_NAME(nrlbw_seed256)(NRLB_VI z1r16, NRLB_VI z1i16,
     NRLB_NAME(nrlbw_axis_llr)(estQ, glin, aQ4);
     for (int b = 0; b < 4; b++) { aL[h][2 * b] = aI4[b]; aL[h][2 * b + 1] = aQ4[b]; }
     // nearest odd level: o = 2*round((est-1)/2)+1, clamped to [-15,15]
-    NRLB_VF oI = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_MM(round_ps)(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estI, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
-    NRLB_VF oQ = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_MM(round_ps)(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estQ, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    NRLB_VF oI = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_ROUNDPS(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estI, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    NRLB_VF oQ = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_ROUNDPS(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estQ, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
     oI = NRLB_MM(min_ps)(NRLB_MM(max_ps)(oI, M15), P15);
     oQ = NRLB_MM(min_ps)(NRLB_MM(max_ps)(oQ, M15), P15);
     cI[h] = NRLB_MM(cvtps_epi32)(oI);
     cQ[h] = NRLB_MM(cvtps_epi32)(oQ);
-    dI[h] = NRLB_CASTPS_SI(NRLB_MM(cmp_ps)(estI, oI, SIMDE_CMP_GT_OQ));
-    dQ[h] = NRLB_CASTPS_SI(NRLB_MM(cmp_ps)(estQ, oQ, SIMDE_CMP_GT_OQ));
+    dI[h] = NRLB_CMPPS_SI(estI, oI, SIMDE_CMP_GT_OQ);
+    dQ[h] = NRLB_CMPPS_SI(estQ, oQ, SIMDE_CMP_GT_OQ);
   }
   *centerI  = NRLB_NAME(nrlbw_pack32)(cI[0], cI[1]);
   *centerQ  = NRLB_NAME(nrlbw_pack32)(cQ[0], cQ[1]);
@@ -143,8 +143,8 @@ static inline void NRLB_NAME(nrlbw_seed256)(NRLB_VI z1r16, NRLB_VI z1i16,
     NR_LBEST_METRIC16_256(metric, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_); \
     const NRLB_VI bm[8] = {(BI0), (BQ0), (BI1), (BQ1), (BI2), (BQ2), (BI3), (BQ3)}; \
     for (int p = 0; p < 8; p++) { \
-      max0[p] = NRLB_MM(max_epi16)(max0[p], NRLB_MM(blendv_epi8)(metric, SENT, bm[p])); \
-      max1[p] = NRLB_MM(max_epi16)(max1[p], NRLB_MM(blendv_epi8)(SENT, metric, bm[p])); \
+      max0[p] = NRLB_MM(max_epi16)(max0[p], NRLB_BLENDV(metric, SENT, bm[p])); \
+      max1[p] = NRLB_MM(max_epi16)(max1[p], NRLB_BLENDV(SENT, metric, bm[p])); \
     } \
   } while (0)
 
@@ -216,18 +216,18 @@ void NRLB_NAME(nr_qam256_llr_2layer_lbest_q15_simd)(c16_t *stream0_in,
       const NRLB_VI aI  = NRLB_MM(abs_epi16)(I1);
       const NRLB_VI m2I = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(aI,  V8));
       const NRLB_VI m3I = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(m2I, V4));
-      bIv[k][0] = NRLB_MM(cmpgt_epi16)(z,   I1);
-      bIv[k][1] = NRLB_MM(cmpgt_epi16)(aI,  V8);
-      bIv[k][2] = NRLB_MM(cmpgt_epi16)(m2I, V4);
-      bIv[k][3] = NRLB_MM(cmpgt_epi16)(m3I, V2);
+      bIv[k][0] = NRLB_CMPGT16(z,   I1);
+      bIv[k][1] = NRLB_CMPGT16(aI,  V8);
+      bIv[k][2] = NRLB_CMPGT16(m2I, V4);
+      bIv[k][3] = NRLB_CMPGT16(m3I, V2);
 
       const NRLB_VI aQ  = NRLB_MM(abs_epi16)(Q1);
       const NRLB_VI m2Q = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(aQ,  V8));
       const NRLB_VI m3Q = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(m2Q, V4));
-      bQv[k][0] = NRLB_MM(cmpgt_epi16)(z,   Q1);
-      bQv[k][1] = NRLB_MM(cmpgt_epi16)(aQ,  V8);
-      bQv[k][2] = NRLB_MM(cmpgt_epi16)(m2Q, V4);
-      bQv[k][3] = NRLB_MM(cmpgt_epi16)(m3Q, V2);
+      bQv[k][0] = NRLB_CMPGT16(z,   Q1);
+      bQv[k][1] = NRLB_CMPGT16(aQ,  V8);
+      bQv[k][2] = NRLB_CMPGT16(m2Q, V4);
+      bQv[k][3] = NRLB_CMPGT16(m3Q, V2);
 
       c0I[k] = NRLB_MM(mulhi_epi16)(z1r, NRLB_MM(mullo_epi16)(I1, C13_256));
       c0Q[k] = NRLB_MM(mulhi_epi16)(z1i, NRLB_MM(mullo_epi16)(Q1, C13_256));
@@ -260,10 +260,10 @@ void NRLB_NAME(nr_qam256_llr_2layer_lbest_q15_simd)(c16_t *stream0_in,
       for (int k = 0; k < 4; k++) // I-bit k -> output p=2k ; Q-bit k -> p=2k+1
         for (int i = 0; i < 3; i++) {
           const NRLB_VI bI = bIv[ci3[i]][k], bQ = bQv[ci3[i]][k];
-          max0[2 * k]     = NRLB_MM(max_epi16)(max0[2 * k],     NRLB_MM(blendv_epi8)(maxI[i], SENT, bI));
-          max1[2 * k]     = NRLB_MM(max_epi16)(max1[2 * k],     NRLB_MM(blendv_epi8)(SENT, maxI[i], bI));
-          max0[2 * k + 1] = NRLB_MM(max_epi16)(max0[2 * k + 1], NRLB_MM(blendv_epi8)(maxQ[i], SENT, bQ));
-          max1[2 * k + 1] = NRLB_MM(max_epi16)(max1[2 * k + 1], NRLB_MM(blendv_epi8)(SENT, maxQ[i], bQ));
+          max0[2 * k]     = NRLB_MM(max_epi16)(max0[2 * k],     NRLB_BLENDV(maxI[i], SENT, bI));
+          max1[2 * k]     = NRLB_MM(max_epi16)(max1[2 * k],     NRLB_BLENDV(SENT, maxI[i], bI));
+          max0[2 * k + 1] = NRLB_MM(max_epi16)(max0[2 * k + 1], NRLB_BLENDV(maxQ[i], SENT, bQ));
+          max1[2 * k + 1] = NRLB_MM(max_epi16)(max1[2 * k + 1], NRLB_BLENDV(SENT, maxQ[i], bQ));
         }
     } else if (pattern == 2) { // 5-plus: center + +-4 each axis (5 cand)
       // indices: (2,2)=center, (0,2)=I-4, (4,2)=I+4, (2,0)=Q-4, (2,4)=Q+4
@@ -288,10 +288,10 @@ void NRLB_NAME(nr_qam256_llr_2layer_lbest_q15_simd)(c16_t *stream0_in,
         const NRLB_VI aI  = NRLB_MM(abs_epi16)(I1);
         const NRLB_VI m2I = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(aI,  V8));
         const NRLB_VI m3I = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(m2I, V4));
-        fbI[k][0] = NRLB_MM(cmpgt_epi16)(z,   I1);
-        fbI[k][1] = NRLB_MM(cmpgt_epi16)(aI,  V8);
-        fbI[k][2] = NRLB_MM(cmpgt_epi16)(m2I, V4);
-        fbI[k][3] = NRLB_MM(cmpgt_epi16)(m3I, V2);
+        fbI[k][0] = NRLB_CMPGT16(z,   I1);
+        fbI[k][1] = NRLB_CMPGT16(aI,  V8);
+        fbI[k][2] = NRLB_CMPGT16(m2I, V4);
+        fbI[k][3] = NRLB_CMPGT16(m3I, V2);
         fc0I[k] = NRLB_MM(mulhi_epi16)(z1r, NRLB_MM(mullo_epi16)(I1, C13_256));
         fc0Q[k] = NRLB_MM(mulhi_epi16)(z1i, NRLB_MM(mullo_epi16)(I1, C13_256));
         feI[k]  = NRLB_MM(mulhi_epi16)(cm0, NRLB_MM(mullo_epi16)(NRLB_MM(mullo_epi16)(I1, I1), CE_256));
@@ -321,9 +321,9 @@ void NRLB_NAME(nr_qam256_llr_2layer_lbest_q15_simd)(c16_t *stream0_in,
       NRLB_VI r = NRLB_NAME(nrlbw_pack32)(lo, hi);
       // unspanned bit (one side has no candidate): use the graded per-axis seed LLR instead of
       // the hard +-LLR_SAT (which wrecks the coarse/MSB bits a local search cannot span).
-      const NRLB_VI unspanned = NRLB_OR(NRLB_MM(cmpeq_epi16)(max0[p], SENT),
-                                                          NRLB_MM(cmpeq_epi16)(max1[p], SENT));
-      res[p] = NRLB_MM(blendv_epi8)(r, axisLLR[p], unspanned);
+      const NRLB_VI unspanned = NRLB_OR(NRLB_CMPEQ16(max0[p], SENT),
+                                                          NRLB_CMPEQ16(max1[p], SENT));
+      res[p] = NRLB_BLENDV(r, axisLLR[p], unspanned);
     }
     NRLB_NAME(nrlbw_store_llr)(stream0_out, re, res, 8);
   }

--- a/openair1/PHY/nr_phy_common/src/nr_lbest_qam256_simd.c.inc
+++ b/openair1/PHY/nr_phy_common/src/nr_lbest_qam256_simd.c.inc
@@ -1,0 +1,337 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ * Width-parameterized 2-layer 256QAM L-best SIMD kernel body. Included by
+ * nr_compute_llr.c once per NRLB_W (128/256) after nr_lbest_simd_width.h (which the
+ * 64QAM .inc's include already brought in for this width). Contract: match the float
+ * reference via OAI_LBEST_DBG256.
+ */
+static inline NRLB_VI NRLB_NAME(nrlbw_level_pam)(NRLB_VI num, NRLB_VI thunit)
+{
+  const NRLB_VI z   = NRLB_SETZERO();
+  const NRLB_VI a   = NRLB_MM(abs_epi16)(num);
+  const NRLB_VI t2  = NRLB_MM(slli_epi16)(thunit, 1);
+  const NRLB_VI t4  = NRLB_MM(slli_epi16)(thunit, 2);
+  const NRLB_VI t8  = NRLB_MM(slli_epi16)(thunit, 3);
+  const NRLB_VI t6  = NRLB_MM(adds_epi16)(t2, t4);
+  const NRLB_VI t10 = NRLB_MM(adds_epi16)(t2, t8);
+  const NRLB_VI t12 = NRLB_MM(adds_epi16)(t4, t8);
+  const NRLB_VI t14 = NRLB_MM(adds_epi16)(t6, t8);
+  const NRLB_VI g2  = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t2));
+  const NRLB_VI g4  = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t4));
+  const NRLB_VI g6  = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t6));
+  const NRLB_VI g8  = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t8));
+  const NRLB_VI g10 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t10));
+  const NRLB_VI g12 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t12));
+  const NRLB_VI g14 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t14));
+  // mag = 1 + 2*(g2+g4+g6+g8+g10+g12+g14)
+  const NRLB_VI sum = NRLB_MM(adds_epi16)(
+      NRLB_MM(adds_epi16)(NRLB_MM(adds_epi16)(g2, g4), NRLB_MM(adds_epi16)(g6, g8)),
+      NRLB_MM(adds_epi16)(NRLB_MM(adds_epi16)(g10, g12), g14));
+  const NRLB_VI mag = NRLB_MM(adds_epi16)(NRLB_MM(set1_epi16)(1),
+                                                  NRLB_MM(slli_epi16)(sum, 1));
+  const NRLB_VI neg = NRLB_MM(cmpgt_epi16)(z, num);
+  return NRLB_MM(blendv_epi8)(mag, NRLB_MM(sub_epi16)(z, mag), neg);
+}
+
+static inline NRLB_VI NRLB_NAME(nrlbw_z170d32)(NRLB_VI z16)
+{
+  const NRLB_VI C = NRLB_MM(set1_epi32)(NR_LBEST_Q_SQRT170_Q12);
+  const NRLB_VI lo = NRLB_MM(srai_epi32)(NRLB_MM(mullo_epi32)(NRLB_NAME(nrlbw_widen)(z16, 0), C), 17);
+  const NRLB_VI hi = NRLB_MM(srai_epi32)(NRLB_MM(mullo_epi32)(NRLB_NAME(nrlbw_widen)(z16, 1), C), 17);
+  return NRLB_NAME(nrlbw_pack32)(lo, hi);
+}
+
+static inline void NRLB_NAME(nrlbw_axis_llr)(NRLB_VF est, NRLB_VF g, NRLB_VF out[4])
+{
+  const NRLB_VF ONE = NRLB_MM(set1_ps)(1.0f), TWO = NRLB_MM(set1_ps)(2.0f), HALF = NRLB_MM(set1_ps)(0.5f);
+  // o = nearest odd to est; oa = nearest odd to |est|
+  const NRLB_VF a = NRLB_MM(andnot_ps)(NRLB_MM(set1_ps)(-0.0f), est);
+#define NR_RODD(x) NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_MM(round_ps)(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)((x), ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE)
+  const NRLB_VF o = NR_RODD(est), oa = NR_RODD(a);
+#define NR_CL(x, lo, hi) NRLB_MM(min_ps)(NRLB_MM(max_ps)((x), NRLB_MM(set1_ps)(lo)), NRLB_MM(set1_ps)(hi))
+#define NR_DSQ(lvl, ref) ({ const NRLB_VF _d = NRLB_MM(sub_ps)((lvl), (ref)); NRLB_MM(mul_ps)(_d, _d); })
+  // b0 (sign): pos levels [1,15] (bit 0) vs neg [-15,-1] (bit 1)
+  out[0] = NRLB_MM(mul_ps)(g, NRLB_MM(sub_ps)(NR_DSQ(NR_CL(o, -15.0f, -1.0f), est), NR_DSQ(NR_CL(o, 1.0f, 15.0f), est)));
+  // b1 (|L|>8): |L| in [1,7] (bit 0) vs [9,15] (bit 1); by symmetry work in a=|est|
+  out[1] = NRLB_MM(mul_ps)(g, NRLB_MM(sub_ps)(NR_DSQ(NR_CL(oa, 9.0f, 15.0f), a), NR_DSQ(NR_CL(oa, 1.0f, 7.0f), a)));
+  // b2 (||L|-8|>4): |L| in {5,7,9,11} (bit 0) vs {1,3}U{13,15} (bit 1)
+  const NRLB_VF d2_0 = NR_DSQ(NR_CL(oa, 5.0f, 11.0f), a);
+  const NRLB_VF d2_1 = NRLB_MM(min_ps)(NR_DSQ(NR_CL(oa, 1.0f, 3.0f), a), NR_DSQ(NR_CL(oa, 13.0f, 15.0f), a));
+  out[2] = NRLB_MM(mul_ps)(g, NRLB_MM(sub_ps)(d2_1, d2_0));
+  out[3] = NRLB_MM(setzero_ps)(); // b3 always spanned by the search window -> fallback never read
+#undef NR_RODD
+#undef NR_CL
+#undef NR_DSQ
+}
+
+static inline void NRLB_NAME(nrlbw_seed256)(NRLB_VI z1r16, NRLB_VI z1i16,
+                                            NRLB_VI z2r16, NRLB_VI z2i16,
+                                            NRLB_VI rr16,  NRLB_VI ri16,
+                                            NRLB_VI cm0_16, NRLB_VI cm1_16,
+                                            NRLB_VI *centerI, NRLB_VI *centerQ,
+                                            NRLB_VI *dirImask, NRLB_VI *dirQmask,
+                                            NRLB_VI axisLLR[8])
+{
+  NRLB_VF aL[2][8]; // [half][ {I0,Q0,I1,Q1,I2,Q2,I3,Q3} ]
+  const NRLB_VI SQRT170_OVER8 = NRLB_MM(set1_epi32)(NR_LBEST_Q_SQRT170_OVER8_Q14_SIMD);
+  const NRLB_VF SQRT170 = NRLB_MM(set1_ps)(13.038404810405298f);
+  const NRLB_VF HALF = NRLB_MM(set1_ps)(0.5f), ONE = NRLB_MM(set1_ps)(1.0f), TWO = NRLB_MM(set1_ps)(2.0f);
+  const NRLB_VF P15 = NRLB_MM(set1_ps)(15.0f), M15 = NRLB_MM(set1_ps)(-15.0f);
+  NRLB_VI cI[2], cQ[2], dI[2], dQ[2];
+  for (int h = 0; h < 2; h++) {
+    const NRLB_VF z1r = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(z1r16, h)), z1i = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(z1i16, h));
+    const NRLB_VF z2r = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(z2r16, h)), z2i = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(z2i16, h));
+    const NRLB_VF rr  = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(rr16,  h)), ri  = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(ri16,  h));
+    const NRLB_VF Pp0 = NRLB_MM(cvtepi32_ps)(NRLB_MM(srai_epi32)(NRLB_MM(mullo_epi32)(NRLB_NAME(nrlbw_widen)(cm0_16, h), SQRT170_OVER8), 14));
+    const NRLB_VF Pp1 = NRLB_MM(cvtepi32_ps)(NRLB_MM(srai_epi32)(NRLB_MM(mullo_epi32)(NRLB_NAME(nrlbw_widen)(cm1_16, h), SQRT170_OVER8), 14));
+    // ZF 2x2 solve (float): x_hat1 = (Pp1*z1 - rho*z2) / det
+    NRLB_VF det = NRLB_MM(sub_ps)(NRLB_MM(mul_ps)(Pp0, Pp1),
+                                         NRLB_MM(add_ps)(NRLB_MM(mul_ps)(rr, rr), NRLB_MM(mul_ps)(ri, ri)));
+    det = NRLB_MM(max_ps)(det, ONE);
+    const NRLB_VF numr = NRLB_MM(sub_ps)(NRLB_MM(mul_ps)(Pp1, z1r),
+                                                 NRLB_MM(sub_ps)(NRLB_MM(mul_ps)(rr, z2r), NRLB_MM(mul_ps)(ri, z2i)));
+    const NRLB_VF numi = NRLB_MM(sub_ps)(NRLB_MM(mul_ps)(Pp1, z1i),
+                                                 NRLB_MM(add_ps)(NRLB_MM(mul_ps)(rr, z2i), NRLB_MM(mul_ps)(ri, z2r)));
+    // soft level estimate ~ +-1..15
+    const NRLB_VF estI = NRLB_MM(mul_ps)(NRLB_MM(div_ps)(numr, det), SQRT170);
+    const NRLB_VF estQ = NRLB_MM(mul_ps)(NRLB_MM(div_ps)(numi, det), SQRT170);
+    // graded per-axis PAM-16 LLRs from the soft estimate (g = 0.5*P0/170, P0 = Pp0)
+    const NRLB_VF glin = NRLB_MM(mul_ps)(NRLB_MM(set1_ps)(0.5f / 170.0f), Pp0);
+    NRLB_VF aI4[4], aQ4[4];
+    NRLB_NAME(nrlbw_axis_llr)(estI, glin, aI4);
+    NRLB_NAME(nrlbw_axis_llr)(estQ, glin, aQ4);
+    for (int b = 0; b < 4; b++) { aL[h][2 * b] = aI4[b]; aL[h][2 * b + 1] = aQ4[b]; }
+    // nearest odd level: o = 2*round((est-1)/2)+1, clamped to [-15,15]
+    NRLB_VF oI = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_MM(round_ps)(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estI, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    NRLB_VF oQ = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_MM(round_ps)(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estQ, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    oI = NRLB_MM(min_ps)(NRLB_MM(max_ps)(oI, M15), P15);
+    oQ = NRLB_MM(min_ps)(NRLB_MM(max_ps)(oQ, M15), P15);
+    cI[h] = NRLB_MM(cvtps_epi32)(oI);
+    cQ[h] = NRLB_MM(cvtps_epi32)(oQ);
+    dI[h] = NRLB_CASTPS_SI(NRLB_MM(cmp_ps)(estI, oI, SIMDE_CMP_GT_OQ));
+    dQ[h] = NRLB_CASTPS_SI(NRLB_MM(cmp_ps)(estQ, oQ, SIMDE_CMP_GT_OQ));
+  }
+  *centerI  = NRLB_NAME(nrlbw_pack32)(cI[0], cI[1]);
+  *centerQ  = NRLB_NAME(nrlbw_pack32)(cQ[0], cQ[1]);
+  *dirImask = NRLB_NAME(nrlbw_pack32)(dI[0], dI[1]);
+  *dirQmask = NRLB_NAME(nrlbw_pack32)(dQ[0], dQ[1]);
+  for (int p = 0; p < 8; p++) // round to nearest int16, saturating pack (final LLR units)
+    axisLLR[p] = NRLB_NAME(nrlbw_pack32)(NRLB_MM(cvtps_epi32)(aL[0][p]), NRLB_MM(cvtps_epi32)(aL[1][p]));
+}
+
+#define NR_LBEST_METRIC16_256(MET_, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
+  do { \
+    const NRLB_VI A2I = NRLB_MM(subs_epi16)(z2r170, NRLB_MM(adds_epi16)((RRI_), (RIQ_))); \
+    const NRLB_VI A2Q = NRLB_MM(subs_epi16)(z2i170, NRLB_MM(subs_epi16)((RRQ_), (RII_))); \
+    const NRLB_VI I2  = NRLB_NAME(nrlbw_level_pam)(A2I, Pp1_5_256); \
+    const NRLB_VI Q2  = NRLB_NAME(nrlbw_level_pam)(A2Q, Pp1_5_256); \
+    const NRLB_VI corr0   = NRLB_MM(adds_epi16)((C0I_), (C0Q_)); \
+    const NRLB_VI energy0 = NRLB_MM(adds_epi16)((EI_), (EQ_)); \
+    const NRLB_VI corr1   = NRLB_MM(adds_epi16)(NRLB_MM(mulhi_epi16)(z2r, NRLB_MM(mullo_epi16)(I2, C13_256)), \
+                                                        NRLB_MM(mulhi_epi16)(z2i, NRLB_MM(mullo_epi16)(Q2, C13_256))); \
+    const NRLB_VI energy1 = NRLB_MM(mulhi_epi16)(cm1, NRLB_MM(mullo_epi16)(NRLB_MM(adds_epi16)(NRLB_MM(mullo_epi16)(I2, I2), NRLB_MM(mullo_epi16)(Q2, Q2)), CE_256)); \
+    const NRLB_VI aa = NRLB_MM(adds_epi16)(NRLB_MM(mullo_epi16)((I1_), I2), NRLB_MM(mullo_epi16)((Q1_), Q2)); \
+    const NRLB_VI bb = NRLB_MM(subs_epi16)(NRLB_MM(mullo_epi16)((Q1_), I2), NRLB_MM(mullo_epi16)((I1_), Q2)); \
+    const NRLB_VI cross = NRLB_MM(adds_epi16)(NRLB_MM(mulhi_epi16)(rr, NRLB_MM(mullo_epi16)(aa, CX_256)), \
+                                                      NRLB_MM(mulhi_epi16)(ri, NRLB_MM(mullo_epi16)(bb, CX_256))); \
+    (MET_) = NRLB_MM(max_epi16)(NRLB_MM(subs_epi16)(NRLB_MM(adds_epi16)(NRLB_MM(subs_epi16)(corr0, energy0), NRLB_MM(subs_epi16)(corr1, energy1)), cross), FLOORM); \
+  } while (0)
+
+#define NR_LBEST_EVAL16_256(I1_, Q1_, BI0, BI1, BI2, BI3, BQ0, BQ1, BQ2, BQ3, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
+  do { \
+    NRLB_VI metric; \
+    NR_LBEST_METRIC16_256(metric, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_); \
+    const NRLB_VI bm[8] = {(BI0), (BQ0), (BI1), (BQ1), (BI2), (BQ2), (BI3), (BQ3)}; \
+    for (int p = 0; p < 8; p++) { \
+      max0[p] = NRLB_MM(max_epi16)(max0[p], NRLB_MM(blendv_epi8)(metric, SENT, bm[p])); \
+      max1[p] = NRLB_MM(max_epi16)(max1[p], NRLB_MM(blendv_epi8)(SENT, metric, bm[p])); \
+    } \
+  } while (0)
+
+void NRLB_NAME(nr_qam256_llr_2layer_lbest_q15_simd)(c16_t *stream0_in,
+                                           c16_t *stream1_in,
+                                           c16_t *ch_mag,
+                                           c16_t *ch_mag_i,
+                                           int16_t *stream0_out,
+                                           c16_t *rho01,
+                                           uint32_t length,
+                                           int pattern)
+{
+  const NRLB_VI SENT   = NRLB_MM(set1_epi16)(NR_LBEST_SIMD16_SENT);
+  const NRLB_VI FLOORM = NRLB_MM(set1_epi16)(-32000);
+  const NRLB_VI V15 = NRLB_MM(set1_epi16)(15), Vm15 = NRLB_MM(set1_epi16)(-15);
+  const NRLB_VI z   = NRLB_SETZERO();
+
+  // 256QAM metric Q-constants (metric scale = 1/8, matching 64QAM SIMD kernel):
+  //   C13_256 = round(2^13/sqrt(170))       => mulhi(z, I*C13) = z*I/(8*sqrt(170))
+  //   CE_256  = round(2^16/(8*8*2*sqrt(170)))  => energy = cm*|X|^2/(8*8*2*sqrt(170))
+  //   CX_256  = round(2^16/(8*170))         => cross term
+  const NRLB_VI C13_256 = NRLB_MM(set1_epi16)(628);
+  const NRLB_VI CE_256  = NRLB_MM(set1_epi16)(39);
+  const NRLB_VI CX_256  = NRLB_MM(set1_epi16)(48);
+
+  uint32_t re = 0;
+  for (; re + NRLB_N <= length; re += NRLB_N) {
+    NRLB_VI z1r, z1i, z2r, z2i, rr, ri, cm0, cm1, dummy;
+    NRLB_NAME(nrlbw_load)(&stream0_in[re], &z1r, &z1i);
+    NRLB_NAME(nrlbw_load)(&stream1_in[re], &z2r, &z2i);
+    NRLB_NAME(nrlbw_load)(&rho01[re],      &rr,  &ri);
+    NRLB_NAME(nrlbw_load)(&ch_mag[re],     &cm0, &dummy);
+    NRLB_NAME(nrlbw_load)(&ch_mag_i[re],   &cm1, &dummy);
+
+    NRLB_VI centerI, centerQ, dirImask, dirQmask, axisLLR[8];
+    NRLB_NAME(nrlbw_seed256)(z1r, z1i, z2r, z2i, rr, ri, cm0, cm1,
+                             &centerI, &centerQ, &dirImask, &dirQmask, axisLLR);
+    (void)dirImask; (void)dirQmask;
+
+    // per-RE-vector precomputed quantities (int16 scale, /32 shift)
+    const NRLB_VI z2r170   = NRLB_NAME(nrlbw_z170d32)(z2r), z2i170 = NRLB_NAME(nrlbw_z170d32)(z2i);
+    const NRLB_VI rr5      = NRLB_MM(srai_epi16)(rr, 5), ri5 = NRLB_MM(srai_epi16)(ri, 5);
+    const NRLB_VI Pp1_5_256 = NRLB_MM(mulhi_epi16)(cm1, NRLB_MM(set1_epi16)(NR_LBEST_Q_PP1_OVER32_Q16_256));
+
+    NRLB_VI max0[8], max1[8];
+    for (int p = 0; p < 8; p++) { max0[p] = SENT; max1[p] = SENT; }
+
+    // ---- 5x5 block (hoisted) ----
+    // Precompute 5 I-levels and 5 Q-levels, then evaluate all or a subset of pairs.
+    // Offsets: {-4,-2,0,+2,+4} around seed center.
+    static const int offs5[5] = {-4, -2, 0, 2, 4};
+    NRLB_VI Iv[5], Qv[5];
+    NRLB_VI bIv[5][4], bQv[5][4];                // [level][bit 0..3]
+    NRLB_VI c0I[5], c0Q[5], eI[5], eQ[5];
+    NRLB_VI rrI[5], riI[5], rrQ[5], riQ[5];
+
+    const NRLB_VI V8 = NRLB_MM(set1_epi16)(8), V4 = NRLB_MM(set1_epi16)(4), V2 = NRLB_MM(set1_epi16)(2);
+
+    for (int k = 0; k < 5; k++) {
+      const NRLB_VI I1 = NRLB_MM(min_epi16)(NRLB_MM(max_epi16)(NRLB_MM(adds_epi16)(centerI, NRLB_MM(set1_epi16)(offs5[k])), Vm15), V15);
+      const NRLB_VI Q1 = NRLB_MM(min_epi16)(NRLB_MM(max_epi16)(NRLB_MM(adds_epi16)(centerQ, NRLB_MM(set1_epi16)(offs5[k])), Vm15), V15);
+      Iv[k] = I1; Qv[k] = Q1;
+
+      // 256QAM Gray bit labeling per axis (b0..b3):
+      //   b0 = sign (level < 0)
+      //   b1 = |level| > 8
+      //   b2 = ||level|-8| > 4
+      //   b3 = |||level|-8|-4| > 2
+      const NRLB_VI aI  = NRLB_MM(abs_epi16)(I1);
+      const NRLB_VI m2I = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(aI,  V8));
+      const NRLB_VI m3I = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(m2I, V4));
+      bIv[k][0] = NRLB_MM(cmpgt_epi16)(z,   I1);
+      bIv[k][1] = NRLB_MM(cmpgt_epi16)(aI,  V8);
+      bIv[k][2] = NRLB_MM(cmpgt_epi16)(m2I, V4);
+      bIv[k][3] = NRLB_MM(cmpgt_epi16)(m3I, V2);
+
+      const NRLB_VI aQ  = NRLB_MM(abs_epi16)(Q1);
+      const NRLB_VI m2Q = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(aQ,  V8));
+      const NRLB_VI m3Q = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(m2Q, V4));
+      bQv[k][0] = NRLB_MM(cmpgt_epi16)(z,   Q1);
+      bQv[k][1] = NRLB_MM(cmpgt_epi16)(aQ,  V8);
+      bQv[k][2] = NRLB_MM(cmpgt_epi16)(m2Q, V4);
+      bQv[k][3] = NRLB_MM(cmpgt_epi16)(m3Q, V2);
+
+      c0I[k] = NRLB_MM(mulhi_epi16)(z1r, NRLB_MM(mullo_epi16)(I1, C13_256));
+      c0Q[k] = NRLB_MM(mulhi_epi16)(z1i, NRLB_MM(mullo_epi16)(Q1, C13_256));
+      eI[k]  = NRLB_MM(mulhi_epi16)(cm0, NRLB_MM(mullo_epi16)(NRLB_MM(mullo_epi16)(I1, I1), CE_256));
+      eQ[k]  = NRLB_MM(mulhi_epi16)(cm0, NRLB_MM(mullo_epi16)(NRLB_MM(mullo_epi16)(Q1, Q1), CE_256));
+      rrI[k] = NRLB_MM(mullo_epi16)(rr5, I1); riI[k] = NRLB_MM(mullo_epi16)(ri5, I1);
+      rrQ[k] = NRLB_MM(mullo_epi16)(rr5, Q1); riQ[k] = NRLB_MM(mullo_epi16)(ri5, Q1);
+    }
+
+    if (pattern == 0) { // 5x5: all 25 grid pairs
+      for (int iI = 0; iI < 5; iI++)
+        for (int iQ = 0; iQ < 5; iQ++)
+          NR_LBEST_EVAL16_256(Iv[iI], Qv[iQ],
+                              bIv[iI][0], bIv[iI][1], bIv[iI][2], bIv[iI][3],
+                              bQv[iQ][0], bQv[iQ][1], bQv[iQ][2], bQv[iQ][3],
+                              c0I[iI], c0Q[iQ], eI[iI], eQ[iQ],
+                              rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+    } else if (pattern == 1) { // 3x3 full grid (center 3 levels): reduce per-axis (bit-exact, ~2.7x
+      // fewer max-log ops than 9*8*2 per-candidate blends). center indices {1,2,3} = offsets {-2,0,+2}.
+      static const int ci3[3] = {1, 2, 3};
+      NRLB_VI met[3][3];
+      for (int a = 0; a < 3; a++)
+        for (int b = 0; b < 3; b++) {
+          const int iI = ci3[a], iQ = ci3[b];
+          NR_LBEST_METRIC16_256(met[a][b], Iv[iI], Qv[iQ], c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+        }
+      NRLB_VI maxI[3], maxQ[3];
+      for (int i = 0; i < 3; i++) maxI[i] = NRLB_MM(max_epi16)(met[i][0], NRLB_MM(max_epi16)(met[i][1], met[i][2]));
+      for (int q = 0; q < 3; q++) maxQ[q] = NRLB_MM(max_epi16)(met[0][q], NRLB_MM(max_epi16)(met[1][q], met[2][q]));
+      for (int k = 0; k < 4; k++) // I-bit k -> output p=2k ; Q-bit k -> p=2k+1
+        for (int i = 0; i < 3; i++) {
+          const NRLB_VI bI = bIv[ci3[i]][k], bQ = bQv[ci3[i]][k];
+          max0[2 * k]     = NRLB_MM(max_epi16)(max0[2 * k],     NRLB_MM(blendv_epi8)(maxI[i], SENT, bI));
+          max1[2 * k]     = NRLB_MM(max_epi16)(max1[2 * k],     NRLB_MM(blendv_epi8)(SENT, maxI[i], bI));
+          max0[2 * k + 1] = NRLB_MM(max_epi16)(max0[2 * k + 1], NRLB_MM(blendv_epi8)(maxQ[i], SENT, bQ));
+          max1[2 * k + 1] = NRLB_MM(max_epi16)(max1[2 * k + 1], NRLB_MM(blendv_epi8)(SENT, maxQ[i], bQ));
+        }
+    } else if (pattern == 2) { // 5-plus: center + +-4 each axis (5 cand)
+      // indices: (2,2)=center, (0,2)=I-4, (4,2)=I+4, (2,0)=Q-4, (2,4)=Q+4
+      static const int pI5[5] = {2, 0, 4, 2, 2}, pQ5[5] = {2, 2, 2, 0, 4};
+      for (int c = 0; c < 5; c++) {
+        const int iI = pI5[c], iQ = pQ5[c];
+        NR_LBEST_EVAL16_256(Iv[iI], Qv[iQ],
+                            bIv[iI][0], bIv[iI][1], bIv[iI][2], bIv[iI][3],
+                            bQv[iQ][0], bQv[iQ][1], bQv[iQ][2], bQv[iQ][3],
+                            c0I[iI], c0Q[iQ], eI[iI], eQ[iQ],
+                            rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+      }
+    } else { // pattern == 3: FULL exact ML — all 256 points (16x16 grid, conditional slice)
+      // Enumerate every PAM-16 level on both axes (no seed centering). Per-level quantities
+      // that depend only on the level (Gray bits, |x|^2 energy, rho5*level) are identical
+      // for the I- and Q-candidate roles; only the correlation term differs (z1r vs z1i).
+      static const int lv16[16] = {-15, -13, -11, -9, -7, -5, -3, -1, 1, 3, 5, 7, 9, 11, 13, 15};
+      NRLB_VI fI[16], fbI[16][4], fc0I[16], fc0Q[16], feI[16], frrI[16], friI[16];
+      for (int k = 0; k < 16; k++) {
+        const NRLB_VI I1 = NRLB_MM(set1_epi16)(lv16[k]);
+        fI[k] = I1;
+        const NRLB_VI aI  = NRLB_MM(abs_epi16)(I1);
+        const NRLB_VI m2I = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(aI,  V8));
+        const NRLB_VI m3I = NRLB_MM(abs_epi16)(NRLB_MM(sub_epi16)(m2I, V4));
+        fbI[k][0] = NRLB_MM(cmpgt_epi16)(z,   I1);
+        fbI[k][1] = NRLB_MM(cmpgt_epi16)(aI,  V8);
+        fbI[k][2] = NRLB_MM(cmpgt_epi16)(m2I, V4);
+        fbI[k][3] = NRLB_MM(cmpgt_epi16)(m3I, V2);
+        fc0I[k] = NRLB_MM(mulhi_epi16)(z1r, NRLB_MM(mullo_epi16)(I1, C13_256));
+        fc0Q[k] = NRLB_MM(mulhi_epi16)(z1i, NRLB_MM(mullo_epi16)(I1, C13_256));
+        feI[k]  = NRLB_MM(mulhi_epi16)(cm0, NRLB_MM(mullo_epi16)(NRLB_MM(mullo_epi16)(I1, I1), CE_256));
+        frrI[k] = NRLB_MM(mullo_epi16)(rr5, I1);
+        friI[k] = NRLB_MM(mullo_epi16)(ri5, I1);
+      }
+      for (int iI = 0; iI < 16; iI++)
+        for (int iQ = 0; iQ < 16; iQ++)
+          NR_LBEST_EVAL16_256(fI[iI], fI[iQ],
+                              fbI[iI][0], fbI[iI][1], fbI[iI][2], fbI[iI][3],
+                              fbI[iQ][0], fbI[iQ][1], fbI[iQ][2], fbI[iQ][3],
+                              fc0I[iI], fc0Q[iQ], feI[iI], feI[iQ],
+                              frrI[iI], friI[iI], frrI[iQ], friI[iQ]);
+    }
+
+    // TODO(int8-clip): these (correct, ML-faithful) 256QAM LLRs are hot for the 8-bit LDPC
+    // decoder input — OAI_LBEST_DBG256 measures ~35% of them |.|>=128 (clip int8), which can
+    // add a small high-SNR error floor. Second-order vs the graded-fallback fix above, and
+    // naive log2_maxh cooling made BLER worse (precision loss), so a proper LLR->int8 rescale
+    // (matched to the linear/MMSE path's scale) is needed, not just a shift. Not yet done.
+    NRLB_VI res[8];
+    for (int p = 0; p < 8; p++) {
+      const NRLB_VI diff = NRLB_MM(subs_epi16)(max0[p], max1[p]);
+      // metric is at 1/8 scale -> LLR = diff*8; saturate via int32 widening
+      const NRLB_VI lo = NRLB_MM(slli_epi32)(NRLB_NAME(nrlbw_widen)(diff, 0), 3);
+      const NRLB_VI hi = NRLB_MM(slli_epi32)(NRLB_NAME(nrlbw_widen)(diff, 1), 3);
+      NRLB_VI r = NRLB_NAME(nrlbw_pack32)(lo, hi);
+      // unspanned bit (one side has no candidate): use the graded per-axis seed LLR instead of
+      // the hard +-LLR_SAT (which wrecks the coarse/MSB bits a local search cannot span).
+      const NRLB_VI unspanned = NRLB_OR(NRLB_MM(cmpeq_epi16)(max0[p], SENT),
+                                                          NRLB_MM(cmpeq_epi16)(max1[p], SENT));
+      res[p] = NRLB_MM(blendv_epi8)(r, axisLLR[p], unspanned);
+    }
+    NRLB_NAME(nrlbw_store_llr)(stream0_out, re, res, 8);
+  }
+
+  if (re < length)
+    nr_qam256_llr_2layer_lbest_q15_layer(&stream0_in[re], &stream1_in[re], &ch_mag[re], &ch_mag_i[re],
+                                         &stream0_out[re * 8], &rho01[re], length - re, (pattern == 3) ? 256 : 25);
+}
+
+#undef NR_LBEST_METRIC16_256
+#undef NR_LBEST_EVAL16_256

--- a/openair1/PHY/nr_phy_common/src/nr_lbest_qam64_simd.c.inc
+++ b/openair1/PHY/nr_phy_common/src/nr_lbest_qam64_simd.c.inc
@@ -1,0 +1,244 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ * Width-parameterized 2-layer 64QAM L-best SIMD kernel body. Included by
+ * nr_compute_llr.c once per NRLB_W (128/256) after nr_lbest_simd_width.h.
+ * Elementwise ops via NRLB_MM(); cross-lane via nrlbw_* helpers. Do not edit
+ * per-width copies -- this single source is the contract.
+ */
+static inline NRLB_VI NRLB_NAME(nrlbw_level)(NRLB_VI num, NRLB_VI thunit)
+{
+  const NRLB_VI z = NRLB_SETZERO();
+  const NRLB_VI a = NRLB_MM(abs_epi16)(num);
+  const NRLB_VI t2 = NRLB_MM(slli_epi16)(thunit, 1);
+  const NRLB_VI t4 = NRLB_MM(slli_epi16)(thunit, 2);
+  const NRLB_VI t6 = NRLB_MM(adds_epi16)(t2, t4);
+  const NRLB_VI g2 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t2));
+  const NRLB_VI g4 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t4));
+  const NRLB_VI g6 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t6));
+  const NRLB_VI mag = NRLB_MM(adds_epi16)(NRLB_MM(set1_epi16)(1),
+                                                  NRLB_MM(slli_epi16)(NRLB_MM(adds_epi16)(NRLB_MM(adds_epi16)(g2, g4), g6), 1));
+  const NRLB_VI neg = NRLB_MM(cmpgt_epi16)(z, num);
+  return NRLB_MM(blendv_epi8)(mag, NRLB_MM(sub_epi16)(z, mag), neg);
+}
+
+
+static inline NRLB_VI NRLB_NAME(nrlbw_z42d32)(NRLB_VI z16)
+{
+  const NRLB_VI C = NRLB_MM(set1_epi32)(NR_LBEST_Q_SQRT42_Q12);
+  const NRLB_VI lo = NRLB_MM(srai_epi32)(NRLB_MM(mullo_epi32)(NRLB_NAME(nrlbw_widen)(z16, 0), C), 17); // >>12 (Q12) >>5 (/32)
+  const NRLB_VI hi = NRLB_MM(srai_epi32)(NRLB_MM(mullo_epi32)(NRLB_NAME(nrlbw_widen)(z16, 1), C), 17);
+  return NRLB_NAME(nrlbw_pack32)(lo, hi);
+}
+
+// ZF-seed nearest-level centers for 16 REs (int16 out). The 2x2 solve is done in
+// FLOAT, which is robust to the wide per-RE dynamic range of real channels (TDL
+// deep fades) where any fixed int pre-shift either loses precision or underflows.
+// Also emits dirImask/dirQmask: int16 mask, all-ones where the seed lies on the
+
+static inline void NRLB_NAME(nrlbw_seed)(NRLB_VI z1r16, NRLB_VI z1i16, NRLB_VI z2r16, NRLB_VI z2i16,
+                                        NRLB_VI rr16, NRLB_VI ri16, NRLB_VI cm0_16, NRLB_VI cm1_16,
+                                        NRLB_VI *centerI, NRLB_VI *centerQ,
+                                        NRLB_VI *dirImask, NRLB_VI *dirQmask)
+{
+  const NRLB_VI SQRT42_OVER4 = NRLB_MM(set1_epi32)(NR_LBEST_Q_SQRT42_OVER4_Q14);
+  const NRLB_VF SQRT42 = NRLB_MM(set1_ps)(6.48074069840786f);
+  const NRLB_VF HALF = NRLB_MM(set1_ps)(0.5f), ONE = NRLB_MM(set1_ps)(1.0f), TWO = NRLB_MM(set1_ps)(2.0f);
+  const NRLB_VF P7 = NRLB_MM(set1_ps)(7.0f), M7 = NRLB_MM(set1_ps)(-7.0f);
+  NRLB_VI cI[2], cQ[2], dI[2], dQ[2];
+  for (int h = 0; h < 2; h++) {
+    const NRLB_VF z1r = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(z1r16, h)), z1i = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(z1i16, h));
+    const NRLB_VF z2r = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(z2r16, h)), z2i = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(z2i16, h));
+    const NRLB_VF rr = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(rr16, h)), ri = NRLB_MM(cvtepi32_ps)(NRLB_NAME(nrlbw_widen)(ri16, h));
+    const NRLB_VF Pp0 = NRLB_MM(cvtepi32_ps)(NRLB_MM(srai_epi32)(NRLB_MM(mullo_epi32)(NRLB_NAME(nrlbw_widen)(cm0_16, h), SQRT42_OVER4), 14));
+    const NRLB_VF Pp1 = NRLB_MM(cvtepi32_ps)(NRLB_MM(srai_epi32)(NRLB_MM(mullo_epi32)(NRLB_NAME(nrlbw_widen)(cm1_16, h), SQRT42_OVER4), 14));
+    // ZF 2x2 solve (float): x_hat1 = ((Pp1) z1 - rho z2) / det,  det = Pp0 Pp1 - |rho|^2
+    NRLB_VF det = NRLB_MM(sub_ps)(NRLB_MM(mul_ps)(Pp0, Pp1), NRLB_MM(add_ps)(NRLB_MM(mul_ps)(rr, rr), NRLB_MM(mul_ps)(ri, ri)));
+    det = NRLB_MM(max_ps)(det, ONE); // guard near-singular (high correlation)
+    const NRLB_VF numr = NRLB_MM(sub_ps)(NRLB_MM(mul_ps)(Pp1, z1r), NRLB_MM(sub_ps)(NRLB_MM(mul_ps)(rr, z2r), NRLB_MM(mul_ps)(ri, z2i)));
+    const NRLB_VF numi = NRLB_MM(sub_ps)(NRLB_MM(mul_ps)(Pp1, z1i), NRLB_MM(add_ps)(NRLB_MM(mul_ps)(rr, z2i), NRLB_MM(mul_ps)(ri, z2r)));
+    // soft level estimate est = x_hat1 * sqrt(42)  (~ +-1..7)
+    const NRLB_VF estI = NRLB_MM(mul_ps)(NRLB_MM(div_ps)(numr, det), SQRT42);
+    const NRLB_VF estQ = NRLB_MM(mul_ps)(NRLB_MM(div_ps)(numi, det), SQRT42);
+    // nearest odd level: o = 2*round((est-1)/2)+1, clamped to [-7,7]
+    NRLB_VF oI = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_MM(round_ps)(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estI, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    NRLB_VF oQ = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_MM(round_ps)(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estQ, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    oI = NRLB_MM(min_ps)(NRLB_MM(max_ps)(oI, M7), P7);
+    oQ = NRLB_MM(min_ps)(NRLB_MM(max_ps)(oQ, M7), P7);
+    cI[h] = NRLB_MM(cvtps_epi32)(oI);
+    cQ[h] = NRLB_MM(cvtps_epi32)(oQ);
+    dI[h] = NRLB_CASTPS_SI(NRLB_MM(cmp_ps)(estI, oI, SIMDE_CMP_GT_OQ)); // toward-seed = +2 side
+    dQ[h] = NRLB_CASTPS_SI(NRLB_MM(cmp_ps)(estQ, oQ, SIMDE_CMP_GT_OQ));
+  }
+  *centerI = NRLB_NAME(nrlbw_pack32)(cI[0], cI[1]);
+  *centerQ = NRLB_NAME(nrlbw_pack32)(cQ[0], cQ[1]);
+  *dirImask = NRLB_NAME(nrlbw_pack32)(dI[0], dI[1]);
+  *dirQmask = NRLB_NAME(nrlbw_pack32)(dQ[0], dQ[1]);
+}
+
+// Per-candidate evaluation (slice + metric + max-log reduction), updating max0/max1.
+// Captures the per-RE-vector operands from the enclosing scope; the per-candidate
+// I-only/Q-only terms (bits, corr0/energy0 parts, slice operands) are passed in.
+// Store Qm LLR vectors (res[Qm], 16 REs across the lanes) to the interleaved decoder layout
+// stream0_out[(re+r)*Qm + p] via an 8x8 int16 transpose (padded from Qm), replacing the scalar
+
+#define NR_LBEST_METRIC16(MET_, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
+  do { \
+    const NRLB_VI A2I = NRLB_MM(subs_epi16)(z2r42, NRLB_MM(adds_epi16)((RRI_), (RIQ_))); \
+    const NRLB_VI A2Q = NRLB_MM(subs_epi16)(z2i42, NRLB_MM(subs_epi16)((RRQ_), (RII_))); \
+    const NRLB_VI I2 = NRLB_NAME(nrlbw_level)(A2I, Pp1_5); \
+    const NRLB_VI Q2 = NRLB_NAME(nrlbw_level)(A2Q, Pp1_5); \
+    const NRLB_VI corr0 = NRLB_MM(adds_epi16)((C0I_), (C0Q_)); \
+    const NRLB_VI energy0 = NRLB_MM(adds_epi16)((EI_), (EQ_)); \
+    const NRLB_VI corr1 = NRLB_MM(adds_epi16)(NRLB_MM(mulhi_epi16)(z2r, NRLB_MM(mullo_epi16)(I2, C13)), NRLB_MM(mulhi_epi16)(z2i, NRLB_MM(mullo_epi16)(Q2, C13))); \
+    const NRLB_VI energy1 = NRLB_MM(mulhi_epi16)(cm1, NRLB_MM(mullo_epi16)(NRLB_MM(adds_epi16)(NRLB_MM(mullo_epi16)(I2, I2), NRLB_MM(mullo_epi16)(Q2, Q2)), CE)); \
+    const NRLB_VI aa = NRLB_MM(adds_epi16)(NRLB_MM(mullo_epi16)((I1_), I2), NRLB_MM(mullo_epi16)((Q1_), Q2)); \
+    const NRLB_VI bb = NRLB_MM(subs_epi16)(NRLB_MM(mullo_epi16)((Q1_), I2), NRLB_MM(mullo_epi16)((I1_), Q2)); \
+    const NRLB_VI cross = NRLB_MM(adds_epi16)(NRLB_MM(mulhi_epi16)(rr, NRLB_MM(mullo_epi16)(aa, CX)), NRLB_MM(mulhi_epi16)(ri, NRLB_MM(mullo_epi16)(bb, CX))); \
+    (MET_) = NRLB_MM(max_epi16)(NRLB_MM(subs_epi16)(NRLB_MM(adds_epi16)(NRLB_MM(subs_epi16)(corr0, energy0), NRLB_MM(subs_epi16)(corr1, energy1)), cross), FLOORM); \
+  } while (0)
+
+// Per-candidate metric + streaming max-log reduction into max0/max1 (for non-grid patterns).
+
+#define NR_LBEST_EVAL16(I1_, Q1_, BI0, BI1, BI2, BQ0, BQ1, BQ2, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_) \
+  do { \
+    NRLB_VI metric; \
+    NR_LBEST_METRIC16(metric, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_); \
+    const NRLB_VI bm[6] = {(BI0), (BQ0), (BI1), (BQ1), (BI2), (BQ2)}; \
+    for (int p = 0; p < 6; p++) { \
+      max0[p] = NRLB_MM(max_epi16)(max0[p], NRLB_MM(blendv_epi8)(metric, SENT, bm[p])); \
+      max1[p] = NRLB_MM(max_epi16)(max1[p], NRLB_MM(blendv_epi8)(SENT, metric, bm[p])); \
+    } \
+  } while (0)
+
+// pattern: 0 = 3x3 (9 cand, full BLER), 1 = 6-cand (plus + toward-seed diagonal),
+
+void NRLB_NAME(nr_qam64_llr_2layer_lbest_q15_simd)(c16_t *stream0_in,
+                                          c16_t *stream1_in,
+                                          c16_t *ch_mag,
+                                          c16_t *ch_mag_i,
+                                          int16_t *stream0_out,
+                                          c16_t *rho01,
+                                          uint32_t length,
+                                          int pattern)
+{
+  const NRLB_VI SENT = NRLB_MM(set1_epi16)(NR_LBEST_SIMD16_SENT);
+  const NRLB_VI FLOORM = NRLB_MM(set1_epi16)(-32000); // keep real metrics above SENT
+  const NRLB_VI V1 = NRLB_MM(set1_epi16)(1), V4 = NRLB_MM(set1_epi16)(4);
+  const NRLB_VI V7 = NRLB_MM(set1_epi16)(7), Vm7 = NRLB_MM(set1_epi16)(-7);
+  const NRLB_VI z = NRLB_SETZERO();
+
+  uint32_t re = 0;
+  for (; re + NRLB_N <= length; re += NRLB_N) {
+    NRLB_VI z1r, z1i, z2r, z2i, rr, ri, cm0, cm1, dummy;
+    NRLB_NAME(nrlbw_load)(&stream0_in[re], &z1r, &z1i);
+    NRLB_NAME(nrlbw_load)(&stream1_in[re], &z2r, &z2i);
+    NRLB_NAME(nrlbw_load)(&rho01[re], &rr, &ri);
+    NRLB_NAME(nrlbw_load)(&ch_mag[re], &cm0, &dummy);
+    NRLB_NAME(nrlbw_load)(&ch_mag_i[re], &cm1, &dummy);
+
+    NRLB_VI centerI, centerQ, dirImask, dirQmask;
+    NRLB_NAME(nrlbw_seed)(z1r, z1i, z2r, z2i, rr, ri, cm0, cm1, &centerI, &centerQ, &dirImask, &dirQmask);
+    (void)dirImask; (void)dirQmask;
+
+    // per-RE precompute (int16): conditional-slice operands (/32 scale)
+    const NRLB_VI z2r42 = NRLB_NAME(nrlbw_z42d32)(z2r), z2i42 = NRLB_NAME(nrlbw_z42d32)(z2i);
+    const NRLB_VI rr5 = NRLB_MM(srai_epi16)(rr, 5), ri5 = NRLB_MM(srai_epi16)(ri, 5);
+    const NRLB_VI Pp1_5 = NRLB_MM(mulhi_epi16)(cm1, NRLB_MM(set1_epi16)(NR_LBEST_Q_PP1_OVER32_Q16));
+    // metric Q-constants (normal/8 scale; precision-preserving via mulhi, not pre-shift)
+    const NRLB_VI C13 = NRLB_MM(set1_epi16)(1264); // 2^13/sqrt(42): mulhi(z, I*C13) = z*I/(8 sqrt42)
+    const NRLB_VI CE = NRLB_MM(set1_epi16)(158);   // 2^16/(64 sqrt42): energy = cm*|X|^2/(64 sqrt42)
+    const NRLB_VI CX = NRLB_MM(set1_epi16)(195);   // 2^16/336: cross = rec/336
+
+    NRLB_VI max0[6], max1[6];
+    for (int p = 0; p < 6; p++) { max0[p] = SENT; max1[p] = SENT; }
+
+    // 3x3 candidate block, HOISTED (full BLER). Precompute the I-only / Q-only terms
+    // for the 3 distinct I-levels and 3 Q-levels, then combine in the 9-pair loop.
+    // corr1/energy1/cross + the two level16 slicers stay per-pair (depend on the
+    // conditionally-sliced I2,Q2, which couple I and Q).
+    static const int offs3[3] = {-2, 0, 2};
+    NRLB_VI Iv[3], Qv[3];
+    NRLB_VI bIv[3][3], bQv[3][3];                       // [level][bit 0..2]
+    NRLB_VI c0I[3], c0Q[3], eI[3], eQ[3];               // corr0 / energy0 parts
+    NRLB_VI rrI[3], riI[3], rrQ[3], riQ[3];             // slice operands
+    for (int k = 0; k < 3; k++) {
+      const NRLB_VI I1 = NRLB_MM(min_epi16)(NRLB_MM(max_epi16)(NRLB_MM(adds_epi16)(centerI, NRLB_MM(set1_epi16)(offs3[k])), Vm7), V7);
+      const NRLB_VI Q1 = NRLB_MM(min_epi16)(NRLB_MM(max_epi16)(NRLB_MM(adds_epi16)(centerQ, NRLB_MM(set1_epi16)(offs3[k])), Vm7), V7);
+      Iv[k] = I1; Qv[k] = Q1;
+      const NRLB_VI aI = NRLB_MM(abs_epi16)(I1), aQ = NRLB_MM(abs_epi16)(Q1);
+      bIv[k][0] = NRLB_MM(cmpgt_epi16)(z, I1);
+      bIv[k][1] = NRLB_MM(cmpgt_epi16)(aI, V4);
+      bIv[k][2] = NRLB_OR(NRLB_MM(cmpeq_epi16)(aI, V1), NRLB_MM(cmpeq_epi16)(aI, V7));
+      bQv[k][0] = NRLB_MM(cmpgt_epi16)(z, Q1);
+      bQv[k][1] = NRLB_MM(cmpgt_epi16)(aQ, V4);
+      bQv[k][2] = NRLB_OR(NRLB_MM(cmpeq_epi16)(aQ, V1), NRLB_MM(cmpeq_epi16)(aQ, V7));
+      c0I[k] = NRLB_MM(mulhi_epi16)(z1r, NRLB_MM(mullo_epi16)(I1, C13));
+      c0Q[k] = NRLB_MM(mulhi_epi16)(z1i, NRLB_MM(mullo_epi16)(Q1, C13));
+      eI[k] = NRLB_MM(mulhi_epi16)(cm0, NRLB_MM(mullo_epi16)(NRLB_MM(mullo_epi16)(I1, I1), CE));
+      eQ[k] = NRLB_MM(mulhi_epi16)(cm0, NRLB_MM(mullo_epi16)(NRLB_MM(mullo_epi16)(Q1, Q1), CE));
+      rrI[k] = NRLB_MM(mullo_epi16)(rr5, I1); riI[k] = NRLB_MM(mullo_epi16)(ri5, I1);
+      rrQ[k] = NRLB_MM(mullo_epi16)(rr5, Q1); riQ[k] = NRLB_MM(mullo_epi16)(ri5, Q1);
+    }
+    if (pattern == 0) { // 3x3 full grid: reduce per-axis. Bits are per-axis, so the max over a
+      // bit-subset factorises: max over candidates with I-bit=b = max over I-levels-with-b of
+      // (max over Q). Computing maxI[i]=max_Q met[i][.], maxQ[q]=max_I met[.][q] then blending over
+      // 3 values/axis replaces 9*6*2 per-candidate blends with 3*3*4 (~2.6x fewer). Bit-exact.
+      NRLB_VI met[3][3];
+      for (int iI = 0; iI < 3; iI++)
+        for (int iQ = 0; iQ < 3; iQ++)
+          NR_LBEST_METRIC16(met[iI][iQ], Iv[iI], Qv[iQ], c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+      NRLB_VI maxI[3], maxQ[3];
+      for (int i = 0; i < 3; i++) maxI[i] = NRLB_MM(max_epi16)(met[i][0], NRLB_MM(max_epi16)(met[i][1], met[i][2]));
+      for (int q = 0; q < 3; q++) maxQ[q] = NRLB_MM(max_epi16)(met[0][q], NRLB_MM(max_epi16)(met[1][q], met[2][q]));
+      for (int k = 0; k < 3; k++) // I-bit k -> output p=2k ; Q-bit k -> p=2k+1
+        for (int i = 0; i < 3; i++) {
+          max0[2 * k]     = NRLB_MM(max_epi16)(max0[2 * k],     NRLB_MM(blendv_epi8)(maxI[i], SENT, bIv[i][k]));
+          max1[2 * k]     = NRLB_MM(max_epi16)(max1[2 * k],     NRLB_MM(blendv_epi8)(SENT, maxI[i], bIv[i][k]));
+          max0[2 * k + 1] = NRLB_MM(max_epi16)(max0[2 * k + 1], NRLB_MM(blendv_epi8)(maxQ[i], SENT, bQv[i][k]));
+          max1[2 * k + 1] = NRLB_MM(max_epi16)(max1[2 * k + 1], NRLB_MM(blendv_epi8)(SENT, maxQ[i], bQv[i][k]));
+        }
+    } else { // 5-plus: center (1,1) + I+-2 + Q+-2
+      static const int pI[5] = {1, 0, 2, 1, 1}, pQ[5] = {1, 1, 1, 0, 2};
+      for (int c = 0; c < 5; c++) {
+        const int iI = pI[c], iQ = pQ[c];
+        NR_LBEST_EVAL16(Iv[iI], Qv[iQ], bIv[iI][0], bIv[iI][1], bIv[iI][2], bQv[iQ][0], bQv[iQ][1], bQv[iQ][2],
+                        c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
+      }
+      if (pattern == 1) { // 6th: toward-seed diagonal, per-lane select corner 0 vs 2
+#define NR_LBEST_SI(a) NRLB_MM(blendv_epi8)((a)[0], (a)[2], dirImask)
+#define NR_LBEST_SQ(a) NRLB_MM(blendv_epi8)((a)[0], (a)[2], dirQmask)
+        NR_LBEST_EVAL16(NR_LBEST_SI(Iv), NR_LBEST_SQ(Qv),
+                        NRLB_MM(blendv_epi8)(bIv[0][0], bIv[2][0], dirImask),
+                        NRLB_MM(blendv_epi8)(bIv[0][1], bIv[2][1], dirImask),
+                        NRLB_MM(blendv_epi8)(bIv[0][2], bIv[2][2], dirImask),
+                        NRLB_MM(blendv_epi8)(bQv[0][0], bQv[2][0], dirQmask),
+                        NRLB_MM(blendv_epi8)(bQv[0][1], bQv[2][1], dirQmask),
+                        NRLB_MM(blendv_epi8)(bQv[0][2], bQv[2][2], dirQmask),
+                        NR_LBEST_SI(c0I), NR_LBEST_SQ(c0Q), NR_LBEST_SI(eI), NR_LBEST_SQ(eQ),
+                        NR_LBEST_SI(rrI), NR_LBEST_SI(riI), NR_LBEST_SQ(rrQ), NR_LBEST_SQ(riQ));
+#undef NR_LBEST_SI
+#undef NR_LBEST_SQ
+      }
+    }
+
+    NRLB_VI res[6];
+    for (int p = 0; p < 6; p++) {
+      const NRLB_VI diff = NRLB_MM(subs_epi16)(max0[p], max1[p]);
+      // metric is normal/8 scale -> LLR = diff*8 (== float-ref / SIMD scale); saturate via int32
+      const NRLB_VI lo = NRLB_MM(slli_epi32)(NRLB_NAME(nrlbw_widen)(diff, 0), 3);
+      const NRLB_VI hi = NRLB_MM(slli_epi32)(NRLB_NAME(nrlbw_widen)(diff, 1), 3);
+      NRLB_VI r = NRLB_NAME(nrlbw_pack32)(lo, hi);
+      r = NRLB_MM(blendv_epi8)(r, NRLB_MM(set1_epi16)(-NR_LBEST_Q_LLR_SAT), NRLB_MM(cmpeq_epi16)(max0[p], SENT));
+      r = NRLB_MM(blendv_epi8)(r, NRLB_MM(set1_epi16)(NR_LBEST_Q_LLR_SAT), NRLB_MM(cmpeq_epi16)(max1[p], SENT));
+      res[p] = r;
+    }
+    NRLB_NAME(nrlbw_store_llr)(stream0_out, re, res, 6);
+  }
+
+  if (re < length)
+    nr_qam64_llr_2layer_lbest_q15_layer(&stream0_in[re], &stream1_in[re], &ch_mag[re], &ch_mag_i[re],
+                                        &stream0_out[re * 6], &rho01[re], length - re, 9);
+}
+
+#undef NR_LBEST_METRIC16
+#undef NR_LBEST_EVAL16

--- a/openair1/PHY/nr_phy_common/src/nr_lbest_qam64_simd.c.inc
+++ b/openair1/PHY/nr_phy_common/src/nr_lbest_qam64_simd.c.inc
@@ -12,13 +12,13 @@ static inline NRLB_VI NRLB_NAME(nrlbw_level)(NRLB_VI num, NRLB_VI thunit)
   const NRLB_VI t2 = NRLB_MM(slli_epi16)(thunit, 1);
   const NRLB_VI t4 = NRLB_MM(slli_epi16)(thunit, 2);
   const NRLB_VI t6 = NRLB_MM(adds_epi16)(t2, t4);
-  const NRLB_VI g2 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t2));
-  const NRLB_VI g4 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t4));
-  const NRLB_VI g6 = NRLB_MM(sub_epi16)(z, NRLB_MM(cmpgt_epi16)(a, t6));
+  const NRLB_VI g2 = NRLB_MM(sub_epi16)(z, NRLB_CMPGT16(a, t2));
+  const NRLB_VI g4 = NRLB_MM(sub_epi16)(z, NRLB_CMPGT16(a, t4));
+  const NRLB_VI g6 = NRLB_MM(sub_epi16)(z, NRLB_CMPGT16(a, t6));
   const NRLB_VI mag = NRLB_MM(adds_epi16)(NRLB_MM(set1_epi16)(1),
                                                   NRLB_MM(slli_epi16)(NRLB_MM(adds_epi16)(NRLB_MM(adds_epi16)(g2, g4), g6), 1));
-  const NRLB_VI neg = NRLB_MM(cmpgt_epi16)(z, num);
-  return NRLB_MM(blendv_epi8)(mag, NRLB_MM(sub_epi16)(z, mag), neg);
+  const NRLB_VI neg = NRLB_CMPGT16(z, num);
+  return NRLB_BLENDV(mag, NRLB_MM(sub_epi16)(z, mag), neg);
 }
 
 
@@ -60,14 +60,14 @@ static inline void NRLB_NAME(nrlbw_seed)(NRLB_VI z1r16, NRLB_VI z1i16, NRLB_VI z
     const NRLB_VF estI = NRLB_MM(mul_ps)(NRLB_MM(div_ps)(numr, det), SQRT42);
     const NRLB_VF estQ = NRLB_MM(mul_ps)(NRLB_MM(div_ps)(numi, det), SQRT42);
     // nearest odd level: o = 2*round((est-1)/2)+1, clamped to [-7,7]
-    NRLB_VF oI = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_MM(round_ps)(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estI, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
-    NRLB_VF oQ = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_MM(round_ps)(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estQ, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    NRLB_VF oI = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_ROUNDPS(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estI, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
+    NRLB_VF oQ = NRLB_MM(add_ps)(NRLB_MM(mul_ps)(NRLB_ROUNDPS(NRLB_MM(mul_ps)(NRLB_MM(sub_ps)(estQ, ONE), HALF), SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_NO_EXC), TWO), ONE);
     oI = NRLB_MM(min_ps)(NRLB_MM(max_ps)(oI, M7), P7);
     oQ = NRLB_MM(min_ps)(NRLB_MM(max_ps)(oQ, M7), P7);
     cI[h] = NRLB_MM(cvtps_epi32)(oI);
     cQ[h] = NRLB_MM(cvtps_epi32)(oQ);
-    dI[h] = NRLB_CASTPS_SI(NRLB_MM(cmp_ps)(estI, oI, SIMDE_CMP_GT_OQ)); // toward-seed = +2 side
-    dQ[h] = NRLB_CASTPS_SI(NRLB_MM(cmp_ps)(estQ, oQ, SIMDE_CMP_GT_OQ));
+    dI[h] = NRLB_CMPPS_SI(estI, oI, SIMDE_CMP_GT_OQ); // toward-seed = +2 side
+    dQ[h] = NRLB_CMPPS_SI(estQ, oQ, SIMDE_CMP_GT_OQ);
   }
   *centerI = NRLB_NAME(nrlbw_pack32)(cI[0], cI[1]);
   *centerQ = NRLB_NAME(nrlbw_pack32)(cQ[0], cQ[1]);
@@ -105,8 +105,8 @@ static inline void NRLB_NAME(nrlbw_seed)(NRLB_VI z1r16, NRLB_VI z1i16, NRLB_VI z
     NR_LBEST_METRIC16(metric, I1_, Q1_, C0I_, C0Q_, EI_, EQ_, RRI_, RII_, RRQ_, RIQ_); \
     const NRLB_VI bm[6] = {(BI0), (BQ0), (BI1), (BQ1), (BI2), (BQ2)}; \
     for (int p = 0; p < 6; p++) { \
-      max0[p] = NRLB_MM(max_epi16)(max0[p], NRLB_MM(blendv_epi8)(metric, SENT, bm[p])); \
-      max1[p] = NRLB_MM(max_epi16)(max1[p], NRLB_MM(blendv_epi8)(SENT, metric, bm[p])); \
+      max0[p] = NRLB_MM(max_epi16)(max0[p], NRLB_BLENDV(metric, SENT, bm[p])); \
+      max1[p] = NRLB_MM(max_epi16)(max1[p], NRLB_BLENDV(SENT, metric, bm[p])); \
     } \
   } while (0)
 
@@ -166,12 +166,12 @@ void NRLB_NAME(nr_qam64_llr_2layer_lbest_q15_simd)(c16_t *stream0_in,
       const NRLB_VI Q1 = NRLB_MM(min_epi16)(NRLB_MM(max_epi16)(NRLB_MM(adds_epi16)(centerQ, NRLB_MM(set1_epi16)(offs3[k])), Vm7), V7);
       Iv[k] = I1; Qv[k] = Q1;
       const NRLB_VI aI = NRLB_MM(abs_epi16)(I1), aQ = NRLB_MM(abs_epi16)(Q1);
-      bIv[k][0] = NRLB_MM(cmpgt_epi16)(z, I1);
-      bIv[k][1] = NRLB_MM(cmpgt_epi16)(aI, V4);
-      bIv[k][2] = NRLB_OR(NRLB_MM(cmpeq_epi16)(aI, V1), NRLB_MM(cmpeq_epi16)(aI, V7));
-      bQv[k][0] = NRLB_MM(cmpgt_epi16)(z, Q1);
-      bQv[k][1] = NRLB_MM(cmpgt_epi16)(aQ, V4);
-      bQv[k][2] = NRLB_OR(NRLB_MM(cmpeq_epi16)(aQ, V1), NRLB_MM(cmpeq_epi16)(aQ, V7));
+      bIv[k][0] = NRLB_CMPGT16(z, I1);
+      bIv[k][1] = NRLB_CMPGT16(aI, V4);
+      bIv[k][2] = NRLB_OR(NRLB_CMPEQ16(aI, V1), NRLB_CMPEQ16(aI, V7));
+      bQv[k][0] = NRLB_CMPGT16(z, Q1);
+      bQv[k][1] = NRLB_CMPGT16(aQ, V4);
+      bQv[k][2] = NRLB_OR(NRLB_CMPEQ16(aQ, V1), NRLB_CMPEQ16(aQ, V7));
       c0I[k] = NRLB_MM(mulhi_epi16)(z1r, NRLB_MM(mullo_epi16)(I1, C13));
       c0Q[k] = NRLB_MM(mulhi_epi16)(z1i, NRLB_MM(mullo_epi16)(Q1, C13));
       eI[k] = NRLB_MM(mulhi_epi16)(cm0, NRLB_MM(mullo_epi16)(NRLB_MM(mullo_epi16)(I1, I1), CE));
@@ -192,10 +192,10 @@ void NRLB_NAME(nr_qam64_llr_2layer_lbest_q15_simd)(c16_t *stream0_in,
       for (int q = 0; q < 3; q++) maxQ[q] = NRLB_MM(max_epi16)(met[0][q], NRLB_MM(max_epi16)(met[1][q], met[2][q]));
       for (int k = 0; k < 3; k++) // I-bit k -> output p=2k ; Q-bit k -> p=2k+1
         for (int i = 0; i < 3; i++) {
-          max0[2 * k]     = NRLB_MM(max_epi16)(max0[2 * k],     NRLB_MM(blendv_epi8)(maxI[i], SENT, bIv[i][k]));
-          max1[2 * k]     = NRLB_MM(max_epi16)(max1[2 * k],     NRLB_MM(blendv_epi8)(SENT, maxI[i], bIv[i][k]));
-          max0[2 * k + 1] = NRLB_MM(max_epi16)(max0[2 * k + 1], NRLB_MM(blendv_epi8)(maxQ[i], SENT, bQv[i][k]));
-          max1[2 * k + 1] = NRLB_MM(max_epi16)(max1[2 * k + 1], NRLB_MM(blendv_epi8)(SENT, maxQ[i], bQv[i][k]));
+          max0[2 * k]     = NRLB_MM(max_epi16)(max0[2 * k],     NRLB_BLENDV(maxI[i], SENT, bIv[i][k]));
+          max1[2 * k]     = NRLB_MM(max_epi16)(max1[2 * k],     NRLB_BLENDV(SENT, maxI[i], bIv[i][k]));
+          max0[2 * k + 1] = NRLB_MM(max_epi16)(max0[2 * k + 1], NRLB_BLENDV(maxQ[i], SENT, bQv[i][k]));
+          max1[2 * k + 1] = NRLB_MM(max_epi16)(max1[2 * k + 1], NRLB_BLENDV(SENT, maxQ[i], bQv[i][k]));
         }
     } else { // 5-plus: center (1,1) + I+-2 + Q+-2
       static const int pI[5] = {1, 0, 2, 1, 1}, pQ[5] = {1, 1, 1, 0, 2};
@@ -205,15 +205,15 @@ void NRLB_NAME(nr_qam64_llr_2layer_lbest_q15_simd)(c16_t *stream0_in,
                         c0I[iI], c0Q[iQ], eI[iI], eQ[iQ], rrI[iI], riI[iI], rrQ[iQ], riQ[iQ]);
       }
       if (pattern == 1) { // 6th: toward-seed diagonal, per-lane select corner 0 vs 2
-#define NR_LBEST_SI(a) NRLB_MM(blendv_epi8)((a)[0], (a)[2], dirImask)
-#define NR_LBEST_SQ(a) NRLB_MM(blendv_epi8)((a)[0], (a)[2], dirQmask)
+#define NR_LBEST_SI(a) NRLB_BLENDV((a)[0], (a)[2], dirImask)
+#define NR_LBEST_SQ(a) NRLB_BLENDV((a)[0], (a)[2], dirQmask)
         NR_LBEST_EVAL16(NR_LBEST_SI(Iv), NR_LBEST_SQ(Qv),
-                        NRLB_MM(blendv_epi8)(bIv[0][0], bIv[2][0], dirImask),
-                        NRLB_MM(blendv_epi8)(bIv[0][1], bIv[2][1], dirImask),
-                        NRLB_MM(blendv_epi8)(bIv[0][2], bIv[2][2], dirImask),
-                        NRLB_MM(blendv_epi8)(bQv[0][0], bQv[2][0], dirQmask),
-                        NRLB_MM(blendv_epi8)(bQv[0][1], bQv[2][1], dirQmask),
-                        NRLB_MM(blendv_epi8)(bQv[0][2], bQv[2][2], dirQmask),
+                        NRLB_BLENDV(bIv[0][0], bIv[2][0], dirImask),
+                        NRLB_BLENDV(bIv[0][1], bIv[2][1], dirImask),
+                        NRLB_BLENDV(bIv[0][2], bIv[2][2], dirImask),
+                        NRLB_BLENDV(bQv[0][0], bQv[2][0], dirQmask),
+                        NRLB_BLENDV(bQv[0][1], bQv[2][1], dirQmask),
+                        NRLB_BLENDV(bQv[0][2], bQv[2][2], dirQmask),
                         NR_LBEST_SI(c0I), NR_LBEST_SQ(c0Q), NR_LBEST_SI(eI), NR_LBEST_SQ(eQ),
                         NR_LBEST_SI(rrI), NR_LBEST_SI(riI), NR_LBEST_SQ(rrQ), NR_LBEST_SQ(riQ));
 #undef NR_LBEST_SI
@@ -228,8 +228,8 @@ void NRLB_NAME(nr_qam64_llr_2layer_lbest_q15_simd)(c16_t *stream0_in,
       const NRLB_VI lo = NRLB_MM(slli_epi32)(NRLB_NAME(nrlbw_widen)(diff, 0), 3);
       const NRLB_VI hi = NRLB_MM(slli_epi32)(NRLB_NAME(nrlbw_widen)(diff, 1), 3);
       NRLB_VI r = NRLB_NAME(nrlbw_pack32)(lo, hi);
-      r = NRLB_MM(blendv_epi8)(r, NRLB_MM(set1_epi16)(-NR_LBEST_Q_LLR_SAT), NRLB_MM(cmpeq_epi16)(max0[p], SENT));
-      r = NRLB_MM(blendv_epi8)(r, NRLB_MM(set1_epi16)(NR_LBEST_Q_LLR_SAT), NRLB_MM(cmpeq_epi16)(max1[p], SENT));
+      r = NRLB_BLENDV(r, NRLB_MM(set1_epi16)(-NR_LBEST_Q_LLR_SAT), NRLB_CMPEQ16(max0[p], SENT));
+      r = NRLB_BLENDV(r, NRLB_MM(set1_epi16)(NR_LBEST_Q_LLR_SAT), NRLB_CMPEQ16(max1[p], SENT));
       res[p] = r;
     }
     NRLB_NAME(nrlbw_store_llr)(stream0_out, re, res, 6);

--- a/openair1/PHY/nr_phy_common/src/nr_lbest_simd_width.h
+++ b/openair1/PHY/nr_phy_common/src/nr_lbest_simd_width.h
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ *
+ * Width abstraction for the 2-layer L-best SIMD kernels. Included once per width
+ * (define NRLB_W = 128 or 256 before including). Provides:
+ *   NRLB_VI / NRLB_VF   : int16 / float vector types for this width
+ *   NRLB_N              : int16 lanes (8 for 128, 16 for 256)
+ *   NRLB_MM(op)         : the width's simde intrinsic prefix, e.g. NRLB_MM(mulhi_epi16)
+ *   NRLB_MMF(op)        : same for float ops
+ *   NRLB_NAME(base)     : mangle a function name by lane count (base##_16 / base##_8)
+ *   cross-lane helpers  : nr_lbest_widen_W / load_W / pack32_W / store_llr_W (width-specialised)
+ * The core kernel/slicer/seed use only NRLB_MM(...) + these helpers, so one source
+ * compiles to AVX2 (256), SSE->NEON (128), and later AVX-512 (512).
+ */
+// (no include guard: this header is intentionally re-included per width)
+
+#undef NRLB_VI
+#undef NRLB_VF
+#undef NRLB_N
+#undef NRLB_MM
+#undef NRLB_MMF
+#undef NRLB_NAME
+#undef NRLB_SETZERO
+#undef NRLB_CASTPS_SI
+#undef NRLB_CASTSI_PS
+#undef NRLB_OR
+#undef NRLB_AND
+#undef NRLB_ANDNOT
+#undef NRLB_CC1
+#undef NRLB_CC
+
+#define NRLB_CC1(a, b) a##b
+#define NRLB_CC(a, b) NRLB_CC1(a, b)
+
+#if NRLB_W == 256
+  #define NRLB_VI simde__m256i
+  #define NRLB_VF simde__m256
+  #define NRLB_N 16
+  #define NRLB_MM(op) NRLB_CC(simde_mm256_, op)
+  #define NRLB_MMF(op) NRLB_CC(simde_mm256_, op)
+  #define NRLB_NAME(base) NRLB_CC(base, _w256)
+  #define NRLB_SETZERO() simde_mm256_setzero_si256()
+  #define NRLB_CASTPS_SI(x) simde_mm256_castps_si256(x)
+  #define NRLB_CASTSI_PS(x) simde_mm256_castsi256_ps(x)
+  #define NRLB_OR(a, b) simde_mm256_or_si256(a, b)
+  #define NRLB_AND(a, b) simde_mm256_and_si256(a, b)
+  #define NRLB_ANDNOT(a, b) simde_mm256_andnot_si256(a, b)
+#elif NRLB_W == 128
+  #define NRLB_VI simde__m128i
+  #define NRLB_VF simde__m128
+  #define NRLB_N 8
+  #define NRLB_MM(op) NRLB_CC(simde_mm_, op)
+  #define NRLB_MMF(op) NRLB_CC(simde_mm_, op)
+  #define NRLB_NAME(base) NRLB_CC(base, _w128)
+  #define NRLB_SETZERO() simde_mm_setzero_si128()
+  #define NRLB_CASTPS_SI(x) simde_mm_castps_si128(x)
+  #define NRLB_CASTSI_PS(x) simde_mm_castsi128_ps(x)
+  #define NRLB_OR(a, b) simde_mm_or_si128(a, b)
+  #define NRLB_AND(a, b) simde_mm_and_si128(a, b)
+  #define NRLB_ANDNOT(a, b) simde_mm_andnot_si128(a, b)
+#else
+  #error "NRLB_W must be 128 or 256"
+#endif
+
+// ---- cross-lane helpers (the only structurally width-specific pieces) ----
+
+// widen int16 lane-half `hi` to int32 (N/2 lanes).
+static inline NRLB_VI NRLB_NAME(nrlbw_widen)(NRLB_VI v, int hi)
+{
+#if NRLB_W == 256
+  return hi ? simde_mm256_cvtepi16_epi32(simde_mm256_extracti128_si256(v, 1))
+            : simde_mm256_cvtepi16_epi32(simde_mm256_castsi256_si128(v));
+#else
+  // 128-bit: low half = cvt of low 4 int16; high half = cvt after an 8-byte shift
+  return hi ? simde_mm_cvtepi16_epi32(simde_mm_srli_si128(v, 8))
+            : simde_mm_cvtepi16_epi32(v);
+#endif
+}
+
+// pack two int32 vectors (lo=lanes 0..N/2-1, hi=N/2..N-1) into one int16 vector, lane order preserved.
+static inline NRLB_VI NRLB_NAME(nrlbw_pack32)(NRLB_VI lo, NRLB_VI hi)
+{
+#if NRLB_W == 256
+  return simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+#else
+  return simde_mm_packs_epi32(lo, hi);
+#endif
+}
+
+// deinterleave N complex int16 (re,im) at p into separate re/im vectors, lane l == element l.
+static inline void NRLB_NAME(nrlbw_load)(const c16_t *p, NRLB_VI *re, NRLB_VI *im)
+{
+#if NRLB_W == 256
+  const simde__m256i sh = simde_mm256_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15,
+                                                0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
+  const simde__m256i v0 = simde_mm256_permute4x64_epi64(simde_mm256_shuffle_epi8(simde_mm256_loadu_si256((const simde__m256i *)p), sh), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+  const simde__m256i v1 = simde_mm256_permute4x64_epi64(simde_mm256_shuffle_epi8(simde_mm256_loadu_si256((const simde__m256i *)(p + 8)), sh), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
+  *re = simde_mm256_set_m128i(simde_mm256_castsi256_si128(v1), simde_mm256_castsi256_si128(v0));
+  *im = simde_mm256_set_m128i(simde_mm256_extracti128_si256(v1, 1), simde_mm256_extracti128_si256(v0, 1));
+#else
+  // 128-bit: 8 c16 (re,im) -> shuffle so the low 8 bytes are the 4... need 8 REs: load 8 c16 = 16 int16
+  const simde__m128i sh = simde_mm_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
+  const simde__m128i v0 = simde_mm_shuffle_epi8(simde_mm_loadu_si128((const simde__m128i *)p), sh);       // re0..3 | im0..3
+  const simde__m128i v1 = simde_mm_shuffle_epi8(simde_mm_loadu_si128((const simde__m128i *)(p + 4)), sh); // re4..7 | im4..7
+  *re = simde_mm_unpacklo_epi64(v0, v1); // re0..7
+  *im = simde_mm_unpackhi_epi64(v0, v1); // im0..7
+#endif
+}
+
+// store Qm LLR vectors (res[Qm], N REs across the lanes) to stream0_out[(re+r)*Qm + p].
+static inline void NRLB_NAME(nrlbw_store_llr)(int16_t *stream0_out, uint32_t re, const NRLB_VI *res, int Qm)
+{
+#if NRLB_W == 256
+  simde__m256i r[8];
+  for (int p = 0; p < Qm; p++) r[p] = res[p];
+  for (int p = Qm; p < 8; p++) r[p] = simde_mm256_setzero_si256();
+  const simde__m256i a0 = simde_mm256_unpacklo_epi16(r[0], r[1]), a1 = simde_mm256_unpackhi_epi16(r[0], r[1]);
+  const simde__m256i a2 = simde_mm256_unpacklo_epi16(r[2], r[3]), a3 = simde_mm256_unpackhi_epi16(r[2], r[3]);
+  const simde__m256i a4 = simde_mm256_unpacklo_epi16(r[4], r[5]), a5 = simde_mm256_unpackhi_epi16(r[4], r[5]);
+  const simde__m256i a6 = simde_mm256_unpacklo_epi16(r[6], r[7]), a7 = simde_mm256_unpackhi_epi16(r[6], r[7]);
+  const simde__m256i b0 = simde_mm256_unpacklo_epi32(a0, a2), b1 = simde_mm256_unpackhi_epi32(a0, a2);
+  const simde__m256i b2 = simde_mm256_unpacklo_epi32(a1, a3), b3 = simde_mm256_unpackhi_epi32(a1, a3);
+  const simde__m256i b4 = simde_mm256_unpacklo_epi32(a4, a6), b5 = simde_mm256_unpackhi_epi32(a4, a6);
+  const simde__m256i b6 = simde_mm256_unpacklo_epi32(a5, a7), b7 = simde_mm256_unpackhi_epi32(a5, a7);
+  simde__m256i c[8];
+  c[0] = simde_mm256_unpacklo_epi64(b0, b4); c[1] = simde_mm256_unpackhi_epi64(b0, b4);
+  c[2] = simde_mm256_unpacklo_epi64(b1, b5); c[3] = simde_mm256_unpackhi_epi64(b1, b5);
+  c[4] = simde_mm256_unpacklo_epi64(b2, b6); c[5] = simde_mm256_unpackhi_epi64(b2, b6);
+  c[6] = simde_mm256_unpacklo_epi64(b3, b7); c[7] = simde_mm256_unpackhi_epi64(b3, b7);
+  for (int j = 0; j < 8; j++) {
+    const simde__m128i lo = simde_mm256_castsi256_si128(c[j]), hi = simde_mm256_extracti128_si256(c[j], 1);
+    int16_t *o0 = &stream0_out[(re + j) * Qm], *o8 = &stream0_out[(re + j + 8) * Qm];
+    if (Qm == 8) { simde_mm_storeu_si128((simde__m128i *)o0, lo); simde_mm_storeu_si128((simde__m128i *)o8, hi); }
+    else { simde_mm_storel_epi64((simde__m128i *)o0, lo); *(int32_t *)(o0 + 4) = simde_mm_extract_epi32(lo, 2);
+           simde_mm_storel_epi64((simde__m128i *)o8, hi); *(int32_t *)(o8 + 4) = simde_mm_extract_epi32(hi, 2); }
+  }
+#else
+  // 128-bit: 8 REs in one lane. Transpose 8x8 int16 (padded from Qm) via unpack, store Qm/RE.
+  simde__m128i r[8];
+  for (int p = 0; p < Qm; p++) r[p] = res[p];
+  for (int p = Qm; p < 8; p++) r[p] = simde_mm_setzero_si128();
+  const simde__m128i a0 = simde_mm_unpacklo_epi16(r[0], r[1]), a1 = simde_mm_unpackhi_epi16(r[0], r[1]);
+  const simde__m128i a2 = simde_mm_unpacklo_epi16(r[2], r[3]), a3 = simde_mm_unpackhi_epi16(r[2], r[3]);
+  const simde__m128i a4 = simde_mm_unpacklo_epi16(r[4], r[5]), a5 = simde_mm_unpackhi_epi16(r[4], r[5]);
+  const simde__m128i a6 = simde_mm_unpacklo_epi16(r[6], r[7]), a7 = simde_mm_unpackhi_epi16(r[6], r[7]);
+  const simde__m128i b0 = simde_mm_unpacklo_epi32(a0, a2), b1 = simde_mm_unpackhi_epi32(a0, a2);
+  const simde__m128i b2 = simde_mm_unpacklo_epi32(a1, a3), b3 = simde_mm_unpackhi_epi32(a1, a3);
+  const simde__m128i b4 = simde_mm_unpacklo_epi32(a4, a6), b5 = simde_mm_unpackhi_epi32(a4, a6);
+  const simde__m128i b6 = simde_mm_unpacklo_epi32(a5, a7), b7 = simde_mm_unpackhi_epi32(a5, a7);
+  simde__m128i c[8];
+  c[0] = simde_mm_unpacklo_epi64(b0, b4); c[1] = simde_mm_unpackhi_epi64(b0, b4);
+  c[2] = simde_mm_unpacklo_epi64(b1, b5); c[3] = simde_mm_unpackhi_epi64(b1, b5);
+  c[4] = simde_mm_unpacklo_epi64(b2, b6); c[5] = simde_mm_unpackhi_epi64(b2, b6);
+  c[6] = simde_mm_unpacklo_epi64(b3, b7); c[7] = simde_mm_unpackhi_epi64(b3, b7);
+  for (int j = 0; j < 8; j++) {
+    int16_t *o = &stream0_out[(re + j) * Qm];
+    if (Qm == 8) simde_mm_storeu_si128((simde__m128i *)o, c[j]);
+    else { simde_mm_storel_epi64((simde__m128i *)o, c[j]); *(int32_t *)(o + 4) = simde_mm_extract_epi32(c[j], 2); }
+  }
+#endif
+}

--- a/openair1/PHY/nr_phy_common/src/nr_lbest_simd_width.h
+++ b/openair1/PHY/nr_phy_common/src/nr_lbest_simd_width.h
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: LicenseRef-CSSL-1.0
  *
  * Width abstraction for the 2-layer L-best SIMD kernels. Included once per width
- * (define NRLB_W = 128 or 256 before including). Provides:
+ * (define NRLB_W = 128, 256 or 512 before including). Provides:
  *   NRLB_VI / NRLB_VF   : int16 / float vector types for this width
  *   NRLB_N              : int16 lanes (8 for 128, 16 for 256)
  *   NRLB_MM(op)         : the width's simde intrinsic prefix, e.g. NRLB_MM(mulhi_epi16)
@@ -26,6 +26,11 @@
 #undef NRLB_OR
 #undef NRLB_AND
 #undef NRLB_ANDNOT
+#undef NRLB_BLENDV
+#undef NRLB_CMPGT16
+#undef NRLB_CMPEQ16
+#undef NRLB_CMPPS_SI
+#undef NRLB_ROUNDPS
 #undef NRLB_CC1
 #undef NRLB_CC
 
@@ -45,6 +50,11 @@
   #define NRLB_OR(a, b) simde_mm256_or_si256(a, b)
   #define NRLB_AND(a, b) simde_mm256_and_si256(a, b)
   #define NRLB_ANDNOT(a, b) simde_mm256_andnot_si256(a, b)
+  #define NRLB_BLENDV(a, b, m) simde_mm256_blendv_epi8(a, b, m)
+  #define NRLB_CMPGT16(a, b) simde_mm256_cmpgt_epi16(a, b)
+  #define NRLB_CMPEQ16(a, b) simde_mm256_cmpeq_epi16(a, b)
+  #define NRLB_CMPPS_SI(a, b, imm) simde_mm256_castps_si256(simde_mm256_cmp_ps(a, b, imm))
+  #define NRLB_ROUNDPS(x, imm) simde_mm256_round_ps(x, imm)
 #elif NRLB_W == 128
   #define NRLB_VI simde__m128i
   #define NRLB_VF simde__m128
@@ -58,8 +68,35 @@
   #define NRLB_OR(a, b) simde_mm_or_si128(a, b)
   #define NRLB_AND(a, b) simde_mm_and_si128(a, b)
   #define NRLB_ANDNOT(a, b) simde_mm_andnot_si128(a, b)
+  #define NRLB_BLENDV(a, b, m) simde_mm_blendv_epi8(a, b, m)
+  #define NRLB_CMPGT16(a, b) simde_mm_cmpgt_epi16(a, b)
+  #define NRLB_CMPEQ16(a, b) simde_mm_cmpeq_epi16(a, b)
+  #define NRLB_CMPPS_SI(a, b, imm) simde_mm_castps_si128(simde_mm_cmp_ps(a, b, imm))
+  #define NRLB_ROUNDPS(x, imm) simde_mm_round_ps(x, imm)
+#elif NRLB_W == 512
+  #define NRLB_VI simde__m512i
+  #define NRLB_VF simde__m512
+  #define NRLB_N 32
+  #define NRLB_MM(op) NRLB_CC(simde_mm512_, op)
+  #define NRLB_MMF(op) NRLB_CC(simde_mm512_, op)
+  #define NRLB_NAME(base) NRLB_CC(base, _w512)
+  #define NRLB_SETZERO() simde_mm512_setzero_si512()
+  #define NRLB_CASTPS_SI(x) simde_mm512_castps_si512(x)
+  #define NRLB_CASTSI_PS(x) simde_mm512_castsi512_ps(x)
+  #define NRLB_OR(a, b) simde_mm512_or_si512(a, b)
+  #define NRLB_AND(a, b) simde_mm512_and_si512(a, b)
+  #define NRLB_ANDNOT(a, b) simde_mm512_andnot_si512(a, b)
+  // AVX-512 compares yield k-masks; lift them back to vector (-1/0) via movm so the
+  // vector-mask kernel body is unchanged. blendv_epi8 has no 512 form -> emulate with
+  // movepi8_mask (high bit -> k) + mask_blend_epi8 (2 native insns: vpmovb2m + vpblendmb).
+  #define NRLB_BLENDV(a, b, m) simde_mm512_mask_blend_epi8(simde_mm512_movepi8_mask(m), a, b)
+  #define NRLB_CMPGT16(a, b) simde_mm512_movm_epi16(simde_mm512_cmpgt_epi16_mask(a, b))
+  // equality is sign-agnostic; use the unsigned mask -- some SIMDe versions ship only cmpeq_epu16_mask.
+  #define NRLB_CMPEQ16(a, b) simde_mm512_movm_epi16(simde_mm512_cmpeq_epu16_mask(a, b))
+  #define NRLB_CMPPS_SI(a, b, imm) simde_mm512_movm_epi32(simde_mm512_cmp_ps_mask(a, b, imm))
+  #define NRLB_ROUNDPS(x, imm) simde_mm512_roundscale_ps(x, imm)
 #else
-  #error "NRLB_W must be 128 or 256"
+  #error "NRLB_W must be 128, 256 or 512"
 #endif
 
 // ---- cross-lane helpers (the only structurally width-specific pieces) ----
@@ -67,7 +104,10 @@
 // widen int16 lane-half `hi` to int32 (N/2 lanes).
 static inline NRLB_VI NRLB_NAME(nrlbw_widen)(NRLB_VI v, int hi)
 {
-#if NRLB_W == 256
+#if NRLB_W == 512
+  return hi ? simde_mm512_cvtepi16_epi32(simde_mm512_extracti64x4_epi64(v, 1))
+            : simde_mm512_cvtepi16_epi32(simde_mm512_castsi512_si256(v));
+#elif NRLB_W == 256
   return hi ? simde_mm256_cvtepi16_epi32(simde_mm256_extracti128_si256(v, 1))
             : simde_mm256_cvtepi16_epi32(simde_mm256_castsi256_si128(v));
 #else
@@ -80,7 +120,11 @@ static inline NRLB_VI NRLB_NAME(nrlbw_widen)(NRLB_VI v, int hi)
 // pack two int32 vectors (lo=lanes 0..N/2-1, hi=N/2..N-1) into one int16 vector, lane order preserved.
 static inline NRLB_VI NRLB_NAME(nrlbw_pack32)(NRLB_VI lo, NRLB_VI hi)
 {
-#if NRLB_W == 256
+#if NRLB_W == 512
+  // packs_epi32 packs per-128-lane -> 64-bit words [lo0,hi0,lo1,hi1,lo2,hi2,lo3,hi3];
+  // gather all lo words then all hi words to restore lane order (== 256's permute4x64).
+  return simde_mm512_permutexvar_epi64(simde_mm512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), simde_mm512_packs_epi32(lo, hi));
+#elif NRLB_W == 256
   return simde_mm256_permute4x64_epi64(simde_mm256_packs_epi32(lo, hi), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
 #else
   return simde_mm_packs_epi32(lo, hi);
@@ -90,7 +134,15 @@ static inline NRLB_VI NRLB_NAME(nrlbw_pack32)(NRLB_VI lo, NRLB_VI hi)
 // deinterleave N complex int16 (re,im) at p into separate re/im vectors, lane l == element l.
 static inline void NRLB_NAME(nrlbw_load)(const c16_t *p, NRLB_VI *re, NRLB_VI *im)
 {
-#if NRLB_W == 256
+#if NRLB_W == 512
+  // deinterleave 32 c16: shuffle within each 128-lane groups [re0..3|im0..3] per lane,
+  // then permutex2var gathers the 4 re words (even) / 4 im words (odd) from A(0..15),B(16..31).
+  const simde__m512i sh = simde_mm512_broadcast_i32x4(simde_mm_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15));
+  const simde__m512i A = simde_mm512_shuffle_epi8(simde_mm512_loadu_si512((const void *)p), sh);
+  const simde__m512i B = simde_mm512_shuffle_epi8(simde_mm512_loadu_si512((const void *)(p + 16)), sh);
+  *re = simde_mm512_permutex2var_epi64(A, simde_mm512_set_epi64(14, 12, 10, 8, 6, 4, 2, 0), B);
+  *im = simde_mm512_permutex2var_epi64(A, simde_mm512_set_epi64(15, 13, 11, 9, 7, 5, 3, 1), B);
+#elif NRLB_W == 256
   const simde__m256i sh = simde_mm256_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15,
                                                 0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
   const simde__m256i v0 = simde_mm256_permute4x64_epi64(simde_mm256_shuffle_epi8(simde_mm256_loadu_si256((const simde__m256i *)p), sh), SIMDE_MM_SHUFFLE(3, 1, 2, 0));
@@ -110,7 +162,34 @@ static inline void NRLB_NAME(nrlbw_load)(const c16_t *p, NRLB_VI *re, NRLB_VI *i
 // store Qm LLR vectors (res[Qm], N REs across the lanes) to stream0_out[(re+r)*Qm + p].
 static inline void NRLB_NAME(nrlbw_store_llr)(int16_t *stream0_out, uint32_t re, const NRLB_VI *res, int Qm)
 {
-#if NRLB_W == 256
+#if NRLB_W == 512
+  // 32 REs across the lanes. All unpack ops are per-128-lane, so the 8x8 int16 transpose
+  // runs independently in each of the 4 lanes: 128-lane L holds REs 8L..8L+7, and after the
+  // transpose c[j] lane-L = the Qm LLRs for RE (8L+j).
+  simde__m512i r[8];
+  for (int p = 0; p < Qm; p++) r[p] = res[p];
+  for (int p = Qm; p < 8; p++) r[p] = simde_mm512_setzero_si512();
+  const simde__m512i a0 = simde_mm512_unpacklo_epi16(r[0], r[1]), a1 = simde_mm512_unpackhi_epi16(r[0], r[1]);
+  const simde__m512i a2 = simde_mm512_unpacklo_epi16(r[2], r[3]), a3 = simde_mm512_unpackhi_epi16(r[2], r[3]);
+  const simde__m512i a4 = simde_mm512_unpacklo_epi16(r[4], r[5]), a5 = simde_mm512_unpackhi_epi16(r[4], r[5]);
+  const simde__m512i a6 = simde_mm512_unpacklo_epi16(r[6], r[7]), a7 = simde_mm512_unpackhi_epi16(r[6], r[7]);
+  const simde__m512i b0 = simde_mm512_unpacklo_epi32(a0, a2), b1 = simde_mm512_unpackhi_epi32(a0, a2);
+  const simde__m512i b2 = simde_mm512_unpacklo_epi32(a1, a3), b3 = simde_mm512_unpackhi_epi32(a1, a3);
+  const simde__m512i b4 = simde_mm512_unpacklo_epi32(a4, a6), b5 = simde_mm512_unpackhi_epi32(a4, a6);
+  const simde__m512i b6 = simde_mm512_unpacklo_epi32(a5, a7), b7 = simde_mm512_unpackhi_epi32(a5, a7);
+  simde__m512i c[8];
+  c[0] = simde_mm512_unpacklo_epi64(b0, b4); c[1] = simde_mm512_unpackhi_epi64(b0, b4);
+  c[2] = simde_mm512_unpacklo_epi64(b1, b5); c[3] = simde_mm512_unpackhi_epi64(b1, b5);
+  c[4] = simde_mm512_unpacklo_epi64(b2, b6); c[5] = simde_mm512_unpackhi_epi64(b2, b6);
+  c[6] = simde_mm512_unpacklo_epi64(b3, b7); c[7] = simde_mm512_unpackhi_epi64(b3, b7);
+  for (int L = 0; L < 4; L++)
+    for (int j = 0; j < 8; j++) {
+      const simde__m128i cc = simde_mm512_extracti32x4_epi32(c[j], L);
+      int16_t *o = &stream0_out[(re + (uint32_t)(L * 8 + j)) * Qm];
+      if (Qm == 8) simde_mm_storeu_si128((simde__m128i *)o, cc);
+      else { simde_mm_storel_epi64((simde__m128i *)o, cc); *(int32_t *)(o + 4) = simde_mm_extract_epi32(cc, 2); }
+    }
+#elif NRLB_W == 256
   simde__m256i r[8];
   for (int p = 0; p < Qm; p++) r[p] = res[p];
   for (int p = Qm; p < 8; p++) r[p] = simde_mm256_setzero_si256();

--- a/openair1/PHY/nr_phy_common/src/nr_lbest_simd_width.h
+++ b/openair1/PHY/nr_phy_common/src/nr_lbest_simd_width.h
@@ -182,13 +182,17 @@ static inline void NRLB_NAME(nrlbw_store_llr)(int16_t *stream0_out, uint32_t re,
   c[2] = simde_mm512_unpacklo_epi64(b1, b5); c[3] = simde_mm512_unpackhi_epi64(b1, b5);
   c[4] = simde_mm512_unpacklo_epi64(b2, b6); c[5] = simde_mm512_unpackhi_epi64(b2, b6);
   c[6] = simde_mm512_unpacklo_epi64(b3, b7); c[7] = simde_mm512_unpackhi_epi64(b3, b7);
-  for (int L = 0; L < 4; L++)
-    for (int j = 0; j < 8; j++) {
-      const simde__m128i cc = simde_mm512_extracti32x4_epi32(c[j], L);
+  for (int j = 0; j < 8; j++) {
+    // extracti32x4 needs a compile-time-constant lane -> extract all 4 with literal indices,
+    // then index at runtime (a loop variable in the lane arg fails at -O0, where nothing unrolls).
+    const simde__m128i cc[4] = {simde_mm512_extracti32x4_epi32(c[j], 0), simde_mm512_extracti32x4_epi32(c[j], 1),
+                                simde_mm512_extracti32x4_epi32(c[j], 2), simde_mm512_extracti32x4_epi32(c[j], 3)};
+    for (int L = 0; L < 4; L++) {
       int16_t *o = &stream0_out[(re + (uint32_t)(L * 8 + j)) * Qm];
-      if (Qm == 8) simde_mm_storeu_si128((simde__m128i *)o, cc);
-      else { simde_mm_storel_epi64((simde__m128i *)o, cc); *(int32_t *)(o + 4) = simde_mm_extract_epi32(cc, 2); }
+      if (Qm == 8) simde_mm_storeu_si128((simde__m128i *)o, cc[L]);
+      else { simde_mm_storel_epi64((simde__m128i *)o, cc[L]); *(int32_t *)(o + 4) = simde_mm_extract_epi32(cc[L], 2); }
     }
+  }
 #elif NRLB_W == 256
   simde__m256i r[8];
   for (int p = 0; p < Qm; p++) r[p] = res[p];

--- a/openair1/PHY/nr_phy_common/src/nr_mimo_lbest_detector.md
+++ b/openair1/PHY/nr_phy_common/src/nr_mimo_lbest_detector.md
@@ -1,0 +1,322 @@
+# Reduced-complexity soft-output MIMO detection (L-best / partial marginalization)
+
+Design note for the L-best 2-layer kernels and the >2-layer hybrid detector in
+`nr_compute_llr.c`. Self-contained derivation so the reasoning is version-controlled
+and not dependent on any external notes/session. Sections 1–5 are the algorithm;
+Section 7 is the production implementation (fixed-point, the 128/256/512-bit SIMD
+family, gating, and validation).
+
+## 1. System model and ML metric
+
+Per resource element (RE), after the matched filter / channel compensation:
+
+- Received model `y = H x + n`, with `H = [h_1 ... h_N]` (N transmit layers),
+  `x_i` drawn from a unit-energy square QAM constellation, `n` white (var σ²).
+- Matched-filter (MRC) outputs `z_i = h_i^H y` (these are `rxdataF_comp[layer]`).
+- Gram matrix `R = H^H H`, entries `ρ_ij = h_i^H h_j` (`ρ_ii = ||h_i||²`, real).
+  (These are `rho_dl[i][j]`; the kernels recover `ρ_ii` from the `n1`-scaled `ch_mag`.)
+
+Dropping the constant `||y||²`, the per-hypothesis **max-log metric** (½ convention,
+larger = better) is
+
+```
+M(x) = Σ_i [ Re{x_i* z_i} − ½ ρ_ii |x_i|² ]  −  Σ_{i<j} Re{ ρ_ij x_i* x_j }
+```
+
+The bit LLR of layer `t` is `max_{x_t: bit=0} g(x_t) − max_{x_t: bit=1} g(x_t)`, where
+`g(x_t) = max over the other layers of M`. Everything below is about how to compute
+`g(x_t)` cheaply.
+
+## 2. The conditional slice (2-layer building block)
+
+For two layers (target `x_1`, nuisance `x_2`), the inner `max` over `x_2` is **exact in
+O(1)**: for a fixed `x_1`, the best `x_2` is the nearest constellation point to the
+conditional estimate
+
+```
+x_2*(x_1) = Q_S( (z_2 − conj(ρ_12) x_1) / ρ_22 )          (Q_S = slice to nearest QAM point)
+```
+
+So `g(x_1) = max over candidate x_1 of d(x_1, x_2*(x_1))`. Enumerating all `M` values of
+`x_1` (M = points/layer) gives **exact 2-layer ML at O(M)** (not O(M²)). Taking only the
+`L ≤ M` candidates nearest a linear (ZF/MMSE) seed gives the reduced **L-best** search.
+This is `nr_qam{16,64,256}_llr_2layer_lbest` (float reference) and, for **64QAM and
+256QAM**, the production fixed-point/SIMD kernels `nr_qam{64,256}_llr_2layer_lbest_q15_simd16`
+(§7).
+
+## 3. The continuous approximation collapses to ZF (for any N)
+
+If, instead of slicing the nuisance to the discrete alphabet, we minimize the metric over
+**continuous** nuisance `x_rest`, we get an orthogonal projection:
+
+```
+min_{x_rest ∈ ℂ^{N-1}} ||y − h_1 x_1 − H_rest x_rest||² = ||P⊥ (y − h_1 x_1)||²,
+   P⊥ = I − H_rest (H_rest^H H_rest)^{-1} H_rest^H
+```
+
+which reduces to a **single-stream** metric in `x_1` with
+
+```
+α = ρ_11 − ρ_{1,rest} R_rest^{-1} ρ_{rest,1}     (Schur complement = ||P⊥ h_1||²)
+ζ = z_1  − ρ_{1,rest} R_rest^{-1} z_rest
+x̂_1 = ζ / α      (= the ZF / decorrelator estimate of x_1)
+```
+
+i.e. **the continuous approximation IS zero-forcing, for any number of layers.** It carries
+no gain over a plain linear receiver. The value at N ≥ 3 comes only from keeping *some*
+layers discrete — the hybrid below.
+
+## 4. The N ≥ 3 hybrid: selective deflation
+
+Split the nuisance into a **discrete head** (`k` layers kept and searched/sliced) and a
+**continuous tail** (the rest, projected away). Pure-ZF is `k=0`; exact ML is `k=N−1`.
+The useful middle is small `k`.
+
+**Which layers to project (the selection criterion).** Projecting layer `j` costs only the
+loss of effective channel energy `α`; for a single layer that loss is
+
+```
+Δα_j = |ρ_1j|² / ρ_jj = ρ_11 · cos²θ_1j ,   cos²θ_1j = |ρ_1j|² / (ρ_11 ρ_jj)
+```
+
+— i.e. **the normalized correlation (angle) between the target and layer `j`, NOT its raw
+power.** So **project the layers most ORTHOGONAL to the target** (ZF-nulling them is nearly
+free) and **keep the most ALIGNED ones discrete** (where the finite-alphabet ML gain over ZF
+is largest). This per-RE orthogonality-based selection is the part that appears
+under-documented vs. the SNR-ordered subset selection in the cited literature.
+
+**N=3, k=1 (project one layer `c`, keep `d` discrete).** The projected set is a single layer,
+so the deflation is a **scalar** Schur complement (one real reciprocal `1/ρ_cc`, no matrix
+inverse):
+
+```
+z_i'  = z_i  − (ρ_ic / ρ_cc) z_c                 for i ∈ {t, d}
+ρ_ij' = ρ_ij − ρ_ic conj(ρ_jc) / ρ_cc            for i,j ∈ {t, d}
+```
+
+Then run the 2-layer conditional-slice LLR (Section 2) on the deflated `(t, d)` pair. The
+2-layer kernel's own ZF seed on the deflated inputs equals the **full N-layer ZF** estimate
+of `x_t` (Schur quotient property), so candidate centring is correct automatically.
+This is `nr_qam_llr_3layer_hybrid`; `nr_qam_llr_3layer_ml` is the exact reference
+(`max` over discrete `(x_t, x_n1)` with conditional `x_n2` slice).
+
+**N=4** is the same with **successive scalar deflations** (nested Schur): project two tail
+layers one at a time (each a scalar `1/ρ_cc` on the running-deflated Gram) down to a 2-layer
+problem — never needs an explicit matrix inverse.
+
+## 5. Complexity (per target layer, per RE; M = points/layer)
+
+| scheme | cost | note |
+|---|---|---|
+| MMSE (linear) | ~O(1) | |
+| 2-layer L-best (L candidates) | O(L) | conditional slice keeps it linear |
+| 2-layer exact ML (L = M) | O(M) | |
+| N=3 hybrid, k=1 | O(M) | scalar deflation + 2-layer; **not O(M²)** |
+| N=3 exact ML reference | O(M²) | enumerate two layers jointly |
+| QPSK N=3 / N=4 exact | O(16) / O(64) | small enough to stay exhaustive (M=4) |
+
+The conditional slice is what decouples per-candidate cost from constellation order, so at a
+fixed `L` the hybrid *operation count* is roughly the same for 16/64/256QAM; only the candidate
+count and the output-bit packing differ. These are op-counts, **not wall-clock** — see §7 for
+which kernels are fixed-point/SIMD (production: 2-layer 64QAM and 256QAM) vs scalar `float`
+(analysis-only: the 16QAM 2-layer and all >2-layer references), and §7c for measured wall-clock.
+
+## 6. Measured gains (channel dependence)
+
+**Methodology (important).** ML is enabled by the dlsim `-E` flag (`ue->do_ml`); `OAI_LBEST`
+only selects the *kernel variant*. Both are required — without `-E` the receiver silently runs
+MMSE. Compare at a **well-scaled tx amplitude** (`-Q30`, ~2× the low `-Q36` default): the MMSE
+path is fixed-point (int16) while the ML kernels are float, so at low amplitude MMSE is
+quantization-limited and the comparison is unfair.
+
+**3-layer, TDL-A, 4T4R, `-Q30`, SNR @ 70% throughput** (PRELIMINARY, low-n ~100–300; `-n1000`
+pending):
+
+| Mod. (MCS) | Hybrid | Full-ML | MMSE | Hybrid vs MMSE | Full-ML vs MMSE | Hybrid loss |
+|---|---|---|---|---|---|---|
+| 16QAM (12) | 11.3 dB | 11.1 dB | 12.8 dB | **1.5 dB** | 1.7 dB | 0.2 dB |
+| 64QAM (19) | 16.7 dB | 16.6 dB | 18.6 dB | **1.9 dB** | 2.0 dB | 0.1 dB |
+
+Takeaways: the ML-over-MMSE gain is a real **~1.5–2.0 dB** and grows with constellation order;
+the single continuous ZF deflation in the hybrid costs only **~0.1–0.2 dB** vs exact full-ML, so
+the cheap O(M) hybrid is the right production kernel. (Earlier much-larger figures — e.g. ~5 dB on
+the "fake" channel — were confounded by a missing `-E` and/or the low-amplitude fixed-point-MMSE
+artifact and are retracted; 2-layer and 256QAM gains need re-measuring under `-E`/`-Q30`.)
+
+**Rank/conditioning:** 256QAM with ≥2 layers needs ≥4 RX; below that neither ML nor MMSE converges
+on TDL — physics, not a detector issue.
+
+### 6a. Reduced-search (L-best) viability — resolved
+
+An earlier verdict held that the 2-layer reduced search (`L < M`) loses several dB on correlated
+TDL channels and is usable only on low-correlation / flat channels. **That verdict was an
+LLR-scaling artifact.** Those measurements used *cool* LLR scaling, which depresses BLER regardless
+of the search. With the hot `-2` ML `log2_maxh` (§7a) the reduced search is faithful on 3GPP TDL:
+the float ground-truth comparator measures `<0.35%` sign disagreement (64QAM) between the
+9-candidate (3×3) reduced search and exact full-ML on TDL-A, and the **256QAM 3×3/9-candidate
+L-best matches the full 256-point max-log ML in coded BLER on TDL-A (verified UE + gNB)** — a
+~28× candidate reduction with no BLER loss. So the 3×3 reduced search is the ML default for both
+64QAM and 256QAM (`OAI_LBEST_PAT`=0 / `OAI_LBEST_PAT256`=1), not a flat-channel-only option.
+
+The one real caveat is the empty-subset fallback: when a bit value has no candidate in the searched
+window, the LLR must come from elsewhere. 64QAM uses a saturating `±NR_LBEST_Q_LLR_SAT` (rarely
+fires from a 3×3 window). 256QAM's coarse/MSB bits are *never* spanned by a local 3×3 window, so a
+hard saturation there would be systematically wrong — this is what the **graded-MSB fallback**
+(§7b) fixes.
+
+## 7. Implementation / gating
+
+All gated behind `OAI_LBEST` (default off → production full-search/MMSE, unchanged). Wired into
+**both** RX directions — UE RX (downlink PDSCH: `nr_dlsch_demodulation.c`, `phy_procedures_nr_ue.c`)
+and gNB RX (uplink PUSCH: `nr_ulsch_demodulation.c`) — via the shared kernels in `nr_compute_llr.c`.
+
+- `OAI_LBEST=1` — master switch.
+- `OAI_LBEST_PAT` — 64QAM 2-layer candidate pattern (0=3×3 [ML default], 1=6-cand, 2=5-plus).
+- `OAI_LBEST_PAT256` — 256QAM 2-layer candidate set (0=5×5/25, **1=3×3/9 [ML default]**, 2=5-plus, 3=full 16×16 ML).
+- `OAI_LBEST3` (1=hybrid, 2=full-ML ref) and `OAI_LBEST_L3` — 3-layer.
+- `OAI_LBEST_W512`/`_W256`/`_W128` — x86 SIMD-width override for A/B timing (see §7b).
+- `OAI_LBEST_DBG` / `_DBG256` — float-reference comparator, analysis only (§7a).
+
+**Kernel implementation status.** The **2-layer 64QAM and 256QAM** paths are production-grade
+fixed-point/SIMD: the reduced-search `nr_qam{64,256}_llr_2layer_lbest_q15_simd16` (both with a
+128/256/512-bit SIMD family, §7b) plus the int16 full-search `nr_qam64_llr_2layer`. The
+`nr_qam{16,64,256}_llr_2layer_lbest` **float** kernels are the reference/validation model. The
+2-layer **16QAM** path (`nr_qam16_llr_2layer`) and all **>2-layer** kernels
+(`nr_qam_llr_3layer_hybrid` / `_ml`) remain scalar `float`, analysis-only — SIMD-izing the 3/4-layer
+hybrid is future work (§9).
+
+### 7a. LLR scaling and the analysis knobs
+
+The LDPC decoder is **8-bit**: the int16 demod LLRs are narrowed to int8 by a saturating pack to
+±127 (`nrLDPC_coding_segment_decoder.c`, `simde_mm_packs_epi16`, no down-shift), and every offload
+backend is 8-bit too. So the LLR magnitude that reaches the decoder is set upstream by the output
+shift `log2_maxh` (`nr_dlsch_demodulation.c`), which is **mode-specific**:
+
+```
+nl==1:            (log2_approx(avgs)>>1) + 1 + log2_approx(nbRx>>1)   // single-layer: +1 guard
+nl>1, MMSE:       (log2_approx(avgs)>>1)     + log2_approx(nbRx>>1)   // multi-layer linear: +0
+nl>1, ML (do_ml): (log2_approx(avgs)>>1) - 2 + log2_approx(nbRx>>1)  // multi-layer ML:     -2
+```
+
+A *smaller* `log2_maxh` = less right-shift = larger LLRs. The ML branch's empirical **`-2`** runs
+the ML LLRs hot on purpose, and a dlsim sweep confirms it is near-optimal: colder loses, hotter
+(`-3`) loses, and much hotter (`-4`) **overflows the int16 channel compensation and fails
+completely**. The window is narrow; `-2` sits in it. (All ML modes share this branch, so the L-best
+and full-search kernels get the *same* input scale — differences between them come from the kernels,
+not `log2_maxh`.)
+
+Two **analysis-only** knobs are left in the tree for retuning/verification (both default to the
+current behaviour, so a normal build is unchanged):
+
+- **`OAI_ML_MAXH_OFF=<n>`** (`nr_dlsch_demodulation.c`, default `-2`) — overrides the ML-branch
+  `log2_maxh` offset above, for sweeping ML LLR hotness without a rebuild.
+- **`OAI_LBEST_DBG=1`** / **`OAI_LBEST_DBG256=1`** (`nr_compute_llr.c`, 64QAM / 256QAM 2-layer) —
+  recomputes layer-0 LLRs with the float reference (`nr_qam{64,256}_llr_2layer_lbest`) on the *same*
+  inputs and prints, per ~200k LLRs: sign disagreement, mean |LLR|, int8-clip fraction, best-fit scale
+  vs the reference, and post-scale residual. This is the ground-truth check for the fixed-point kernels
+  (the same statistic the ctest in §7d applies). After the graded-MSB fallback (§7b), 256QAM tracks the
+  reference cleanly (`fitScale≈1.0`, low residual); 64QAM's coarser 3×3 window still runs somewhat hot.
+
+### 7b. Width-parameterized SIMD family (128 / 256 / 512-bit) and the 256QAM fallback
+
+The two production kernels are written **once** and instantiated at three vector widths, so the same
+source compiles to NEON (aarch64), AVX2, and AVX-512:
+
+- `nr_lbest_simd_width.h` — the width abstraction: for `NRLB_W ∈ {128, 256, 512}` it defines the
+  vector types, the `NRLB_MM(op)` intrinsic prefix, the name mangling (`_w128/_w256/_w512`), and the
+  cross-lane helpers (`widen`/`pack32`/`load` deinterleave / `store_llr` transpose).
+- `nr_lbest_qam{64,256}_simd.c.inc` — the kernel bodies, elementwise ops via `NRLB_MM(...)`,
+  cross-lane via the `nrlbw_*` helpers. `nr_compute_llr.c` includes each `.inc` once per width.
+
+**Runtime selection** (`nr_lbest_simd_width_mode`, announced once on stderr): aarch64 runs **w128**
+natively (SIMDe→NEON, avoiding the inefficient 256→2×128 emulation); x86 runs **w256** by default,
+with **`OAI_LBEST_W512=1`** opting into AVX-512 (compiled in only when `__AVX512{F,BW,VL}__` is a build
+target). `OAI_LBEST_W256/_W128` downgrade for A/B timing or NEON regression on x86. **All widths are
+bit-exact** — verified by the ctest (§7d) and the deterministic gNB (identical BER across widths).
+
+**AVX-512 specifics.** AVX-512 breaks the 128/256 vector-mask model: integer/float compares return
+k-masks (lifted back to vectors with `movm`), there is no vector-mask `blendv` (emulated with
+`movepi8_mask` + `mask_blend`, i.e. `vpmovb2m`+`vpblendmb`), and `round_ps`→`roundscale_ps`. These are
+localized in the width header's `NRLB_BLENDV/CMPGT16/CMPEQ16/CMPPS_SI/ROUNDPS` wrappers so the `.inc`
+bodies are unchanged. w512 is **opt-in** because the gain is datapath-dependent (§7c).
+
+**256QAM graded-MSB fallback.** A local 3×3 window around the seed spans the fine (LSB) bits of a
+PAM-16 axis but *never* the coarse/MSB bits. Rather than emit a hard `±sat` for an unspanned bit
+(systematically wrong), the kernel emits a **graded per-axis LLR** `g·[(l1*−e)² − (l0*−e)²]` computed
+in closed form from the soft seed estimate `e` (nearest level with the bit = 0 vs = 1). This is what
+makes the 3×3/9-candidate 256QAM search match full 256-point ML in BLER.
+
+### 7c. Measured performance
+
+Single-thread `RX PUSCH LLR`, 2-layer, 273 PRB, gNB ulsim. **L-best vs full-ML** (the candidate
+reduction; ISA-independent gain — larger on narrower/slower cores):
+
+| Box | ISA | full-ML | L-best | speedup |
+|---|---|---|---|---|
+| EPYC Turin 9575F | AVX2 (w256) | 1192 µs | 837 µs | 1.4× |
+| GH200 (Neoverse V2) | NEON (w128) | 6187 µs | 1966 µs | 3.1× |
+| DGX Spark (GB10) | NEON (w128) | 12648 µs | 3336 µs | 3.8× |
+
+**AVX-512 (w256 → w512)**, single-thread LLR line: the gain is real only on a **true 512-bit
+datapath**, and is capped for 256QAM by the k-mask emulation (§7b):
+
+| Part | datapath | 64QAM | 256QAM |
+|---|---|---|---|
+| EPYC Turin 9575F | true 512 | 1.26× | 1.05× |
+| Ryzen AI MAX+ 395 (Strix Halo) | 2×256 double-pump | 1.13× | ~1.0× (wash) |
+
+At full core load (Turin −C8, whole RX-PUSCH wall) the 64QAM w512 gain dilutes to ~1.14×. Hence w512
+is opt-in, not default. **Real-time:** the gNB is TDD with dominant DL, so the budget per UL slot is
+the UL-slot *period* (≈2.5 ms for DDDSU @30 kHz), not one 500 µs slot — DGX Spark −C8 (RX-PUSCH
+1.8 ms wall) fits, and Turin (−C8 total gNB RX 500 µs) has large margin; LDPC offloads to GPU on
+GPU-equipped boxes.
+
+### 7d. Validation
+
+- **ctest `test_llr_2layer`** (`openair1/PHY/NR_TRANSPORT/tests/`, `-DENABLE_TESTS=ON`): (A) **width
+  equivalence** — `w128 == w256 == w512` bit-identical (memcmp) for 64/256QAM and all patterns; (B)
+  **fidelity vs the float model** — the §7a best-fit-scale / residual / sign-disagreement statistic on
+  clean constellation inputs (observed: 64QAM 0 % sign flips, residFrac 0.29; 256QAM 0 %, residFrac 0).
+- **Deterministic gNB ulsim** (`OAI_RNGSEED`) + `OAI_LBEST_DBG/_DBG256` — the on-real-channel check,
+  used to confirm width bit-exactness and float-model tracking end-to-end.
+
+## 8. References
+
+Partial-marginalization soft MIMO detection lineage (DOIs to re-verify):
+
+- **[PM]** E. G. Larsson, J. Jaldén, "Fixed-Complexity Soft MIMO Detection via Partial
+  Marginalization," IEEE Trans. Signal Process., 56(8):3397–3407, 2008.
+  doi:10.1109/TSP.2008.925260
+- **[PM-HO]** D. Persson, E. G. Larsson, "Partial Marginalization Soft MIMO Detection with
+  Higher-Order Constellations," IEEE Trans. Signal Process., 59(1):453–458, 2011.
+  doi:10.1109/TSP.2010.2068293
+- **[SUMIS]** M. Čirković, E. G. Larsson, "SUMIS: Near-Optimal Soft-In Soft-Out MIMO
+  Detection with Low and Fixed Complexity," IEEE Trans. Signal Process., 2014.
+- **[BCH]** D. W. Waters, J. R. Barry, "The Chase Family of Detection Algorithms for MIMO
+  Channels," IEEE Trans. Signal Process., 56(2):739–747, 2008. doi:10.1109/TSP.2007.911315
+- **[LSD]** B. M. Hochwald, S. ten Brink, "Achieving Near-Capacity on a Multiple-Antenna
+  Channel," IEEE Trans. Commun., 51(3):389–399, 2003. doi:10.1109/TCOMM.2003.809789
+- **[VB]** P. W. Wolniansky, G. J. Foschini, G. D. Golden, R. A. Valenzuela, "V-BLAST...,"
+  Proc. URSI ISSSE, 1998.
+
+Apparently under-documented vs. the above (potential novelty): (i) the per-RE
+orthogonality-based layer-selection criterion (Section 4) and (ii) coded (LDPC) BLER
+evaluation on 3GPP TDL/CDL channels (the literature is mostly uncoded BER on i.i.d. Rayleigh).
+
+## 9. Open items
+
+Done since the first draft: production fixed-point/SIMD **256QAM** 2-layer kernel; the
+**128/256/512-bit** SIMD family incl. **AVX-512**; graded-MSB 256QAM fallback; wiring into the
+**gNB RX (PUSCH)**; the `test_llr_2layer` ctest.
+
+Remaining:
+- **>2-layer SIMD**: the 3/4-layer hybrid is still scalar float — SIMD-ize it (deflate → the existing
+  2-layer SIMD kernel). Then the next PR: 4-layer (nested deflation), QPSK/16QAM 3/4-layer coverage.
+- **Interferer-slice approximation** (2-layer): the one remaining lever to cut per-candidate cost
+  further; backend-agnostic (helps NEON most). Not bit-exact — needs TDL BLER validation before default.
+- **256QAM AVX-512**: only ~1.05× on true-512 (§7c) because compares/blends round-trip through vectors;
+  a native-k-mask reduction would lift it toward the 64QAM ratio (do only if a 256QAM-512 load needs it).
+- **QPSK/16QAM 2-layer**: no float reference exists, so they lack the §7d validation — add float refs
+  first, then the same fidelity test applies.
+- **Eval methodology**: closed-loop PMI in nr_dlsim (and TPMI for nr_ulsim); audit UE PMI and gNB TPMI
+  estimation + usage (both suspected suboptimal) — upstream of the detector work.

--- a/openair1/PHY/nr_phy_common/src/q256_L_sweep.sh
+++ b/openair1/PHY/nr_phy_common/src/q256_L_sweep.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# 256QAM 2-layer reduced-L sweep (analysis; companion to nr_mimo_lbest_detector.md sec 6a).
+#
+# Question: with the hot -2 ML log2_maxh, does the L-best REDUCED search track full-ML (L=256)
+# on TDL-A?  If L256=64/32/16 tracks L256=256 in BLER, that is the 256QAM complexity win
+# (256QAM ML is float/analysis-only today; full search is O(256) per target per RE, no SIMD kernel).
+#
+# Path gate (UE DL 2-layer 256QAM ML) needs BOTH:
+#   -E            -> ue->do_ml (master ML switch)
+#   OAI_LBEST=1   -> ml256 gate routing Qm=8 to nr_qam256_llr_2layer_lbest (float)
+#   OAI_LBEST_L256=<L>  -> candidate count (256 = full ML; smaller = reduced search)
+# 256QAM multi-layer needs >=4 RX to converge -> 4T4R (-y4 -z4).  -q1 = 256QAM MCS table (MCS 20-27).
+# ML log2_maxh offset defaults to -2 (hot); override via OAI_ML_MAXH_OFF.
+#
+# Override from the env, e.g.:  NR_DLSIM=/path/to/nr_dlsim MCS=20 SNR=22 N=1000 CH=C ./q256_L_sweep.sh
+B=${NR_DLSIM:-/home/jovyan/openairinterface5g_x86_A100/build/nr_dlsim}
+OUT=${OUT:-/tmp/q256_sweep}          # logs go here (keeps the source tree clean); override with OUT=
+MCS=${MCS:-22}                       # -q1 256QAM table
+SNR=${SNR:-22}                       # sweep start (256QAM 2-layer 4T4R TDL-A crossing ~ mid/high 20s dB)
+N=${N:-50}                           # trials/SNR (bump to 1000 for citable numbers)
+CH=${CH:-A}                          # TDL model (A/C)
+mkdir -p "$OUT"
+COMMON="-x2 -y4 -z4 -q1 -e${MCS} -Q32 -g${CH} -n${N} -s${SNR}"
+echo "binary: $B"
+echo "COMMON: $COMMON   (ML log2_maxh off = ${OAI_ML_MAXH_OFF:-default -2})   logs -> $OUT"
+
+# full-ML reference (L=256) then reduced L
+for L in 256 64 32 16; do
+  OAI_LBEST=1 OAI_LBEST_L256=$L $B $COMMON -E > "$OUT/q256_L${L}.log" 2>&1
+  echo "L256=$L done"
+done
+# MMSE baseline for context (no -E, no OAI_LBEST)
+$B $COMMON > "$OUT/q256_mmse.log" 2>&1
+echo "MMSE done"
+
+echo "===================== SUMMARY (round-1 BLER / Eff Throughput vs SNR) ====================="
+for tag in 256 64 32 16 mmse; do
+  f="$OUT/q256_L${tag}.log"; [ "$tag" = mmse ] && f="$OUT/q256_mmse.log"
+  label=$([ "$tag" = mmse ] && echo "MMSE" || echo "L256=$tag")
+  echo "----- ${label} -----"
+  grep "Channel BLER" "$f" 2>/dev/null \
+    | sed -E 's/SNR ([0-9.]+).*BLER \(([0-9.e+-]+),.*Eff Throughput ([0-9.]+).*/  SNR \1  BLER1=\2  Thr=\3/'
+done
+echo "ALL DONE"

--- a/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
+++ b/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
@@ -550,6 +550,10 @@ static int nr_ue_pdsch_procedures(PHY_VARS_NR_UE *ue,
                                                          freq_alloc->num_rbs * NR_NB_SC_PER_RB * dlschCfg->number_symbols,
                                                          &mt);
   }
+  // OAI_LBEST analysis gate: also allocate rho for 2-layer 256QAM (Qm=8) so the float
+  // L-best ML path in the demod can use it (off by default).
+  static int lbest256 = -1;
+  if (lbest256 < 0) { const char *e = getenv("OAI_LBEST"); lbest256 = e ? atoi(e) : 0; }
 
   for (int m = dlschCfg->start_symbol; m < (dlschCfg->number_symbols + dlschCfg->start_symbol); m++) {
     bool first_symbol_flag = false;

--- a/openair1/SIMULATION/NR_PHY/ulsim.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim.c
@@ -1039,7 +1039,7 @@ int main(int argc, char *argv[])
 
   ulsch_input_buffer[0] = 0x31;
   for (i = 1; i < TBS/8; i++) {
-    ulsch_input_buffer[i] = (uint8_t)rand();
+    ulsch_input_buffer[i] = (uint8_t)(floor(uniformrandom()*256));
   }
 
   uint8_t ptrs_time_density = get_L_ptrs(ptrs_mcs1, ptrs_mcs2, ptrs_mcs3, Imcs, mcs_table);

--- a/openair1/SIMULATION/tests/CMakeLists.txt
+++ b/openair1/SIMULATION/tests/CMakeLists.txt
@@ -120,6 +120,7 @@ add_physim_test(physim.5g.nr_dlsim.mcs.mimo.test6 "4x4 MIMO, 1 Layer" nr_dlsim -
 add_physim_test(physim.5g.nr_dlsim.mcs.mimo.test7 "4x4 MIMO, 2 Layers" nr_dlsim -P -n30 -s20 -U 3 0 0 2 -gA -x2 -y4 -z4)
 add_physim_test(physim.5g.nr_dlsim.mcs.mimo.test8 "4x4 MIMO, 2 Layers 256 QAM" nr_dlsim -P -n30 -s25 -e22 -q1 -U 3 0 0 2 -gA -x2 -y4 -z4)
 add_physim_test(physim.5g.nr_dlsim.mcs.mimo.test9 "4x4 MIMO, 4 Layers" nr_dlsim -P -n30 -s20 -U 3 0 0 2 -x4 -y4 -z4)
+add_physim_test(physim.5g.nr_dlsim.mcs.mimo.test10 "4x4 MIMO, 3 Layers" nr_dlsim -P -n30 -s20 -U 3 0 0 2 -x3 -y4 -z4)
 add_physim_test(physim.5g.nr_dlsim.dmrs.ptrs.test1 "3 PTRS, 8 Interpolated Symbols" nr_dlsim -P -n300 -s5 -T 2 2 2)
 add_physim_test(physim.5g.nr_dlsim.dmrs.ptrs.test2 "6 PTRS, 5 Interpolated Symbols" nr_dlsim -P -n300 -s5 -T 2 1 2)
 add_physim_test(physim.5g.nr_dlsim.dmrs.ptrs.test3 "11 PTRS, 0 Interpolated Symbols" nr_dlsim -P -n300 -s5 -T 2 0 4)


### PR DESCRIPTION

  Adds a reduced-search ("L-best" / partial-marginalization) near-ML soft-output MIMO
  detector for 2-layer 64QAM and 256QAM, wired into both UE (PDSCH) and gNB (PUSCH) RX,
  gated off by default. For each target layer it fully (max-log) searches a small candidate
  subset around a linear (ZF) seed and slices the interfering layer conditionally in O(1),
  giving near-ML LLRs at a fraction of full-ML cost.

  ### What's included
  - **Algorithm**: conditional-slice 2-layer max-log LLR + reduced (3×3 / 9-candidate) search,
    64QAM and 256QAM. Float reference kernels (`nr_qam{16,64,256}_llr_2layer_lbest`) as the
    cross-arch validation contract.
  - **Production kernels**: fixed-point (Q15) SIMD `nr_qam{64,256}_llr_2layer_lbest_q15_simd16`,
    written once and instantiated at **128 / 256 / 512-bit** (`nr_lbest_simd_width.h` +
    `nr_lbest_qam{64,256}_simd.c.inc`) → NEON (aarch64, native w128), AVX2, AVX-512. Bit-exact
    across widths.
  - **256QAM graded-MSB fallback**: coarse bits a local window can't span get a graded per-axis
    LLR from the soft seed (closed form) — makes the 9-candidate search match full 256-point ML BLER.
  - **MMSE front-end made Gram-based** (UE + gNB), reusing ρ instead of rebuilding it — the linear
    base the L-best builds on.
  - **3-layer hybrid + full-ML float references** (16/64/256QAM), gated, wired in the UE demod
    (`OAI_LBEST3`): Schur-deflate one nuisance layer and keep the other discrete. Float/analysis —
    the algorithmic groundwork for >2-layer; SIMD-ization is a follow-up.
  - **Validation**: `test_llr_2layer` ctest — width equivalence (w128==w256==w512, bit-exact) +
    fidelity vs the float model.
  - **Design note**: `nr_mimo_lbest_detector.md` (algorithm, implementation, gating, measured perf).

  ### Enabling (default OFF — production path unchanged)
  `OAI_LBEST=1`; `OAI_LBEST_PAT`/`_PAT256` pick the candidate set; `OAI_LBEST3` selects the 3-layer
  hybrid/full-ML; `OAI_LBEST_W512=1` opts into AVX-512 on true-512 servers; `OAI_LBEST_DBG/_DBG256`
  are analysis-only comparators.

  ### Performance (2-layer, 273 PRB, single-thread LLR)
  - L-best vs full-ML: **1.4× (Turin/AVX2) … 3.1× (GH200) … 3.8× (DGX Spark/NEON)** — larger on
    narrower cores.
  - AVX-512 (w256→w512), true-512 datapath: **1.26× 64QAM**, 1.05× 256QAM (opt-in; a wash on
    double-pumped-512 parts).

  ### Not in this PR (follow-ups)
  SIMD-ization of the 3/4-layer hybrid; 4-layer nested deflation; the interferer-slice approximation;
  QPSK/16QAM 2-layer float references + tests.