### PR TITLE
CI: Add RAN-SA-ORU-CN5G testing pipeline

### DIFF
--- a/ci-scripts/Jenkinsfile-GitHub-Container
+++ b/ci-scripts/Jenkinsfile-GitHub-Container
@@ -52,6 +52,7 @@ def saAERIALStatus = ''
 def saMultiAntennaStatus = ''
 def saFHI72Status = ''
 def saFHI72MplaneStatus = ''
+def saORUStatus = ''
 def saHandoverStatus = ''
 def saAERIALOAIUEStatus = ''
 def saOAIUEStatus = ''
@@ -799,6 +800,29 @@ pipeline {
               script {
                 currentBuild.result = 'FAILURE'
                 failingStages += saFHI72MplaneStatus
+              }
+            }
+          }
+        }
+        stage ("SA-ORU-CN5G") {
+          when { expression {do5Gtest} }
+          steps {
+            script {
+              triggerDownstreamJob ('RAN-SA-ORU-CN5G')
+            }
+          }
+          post {
+            always {
+              script {
+                // Using a unique variable name for each test stage to avoid overwriting on a global variable
+                // due to parallel-time concurrency
+                saORUStatus = finalizeDownstreamJob('RAN-SA-ORU-CN5G')
+              }
+            }
+            failure {
+              script {
+                currentBuild.result = 'FAILURE'
+                failingStages += saORUStatus
               }
             }
           }

--- a/ci-scripts/cls_containerize.py
+++ b/ci-scripts/cls_containerize.py
@@ -29,7 +29,7 @@ from cls_ci_helper import archiveArtifact
 # Helper functions used here and in other classes
 # (e.g., cls_cluster.py)
 #-----------------------------------------------------------
-IMAGES = ['oai-enb', 'oai-lte-ru', 'oai-lte-ue', 'oai-gnb', 'oai-nr-cuup', 'oai-gnb-aw2s', 'oai-nr-ue', 'oai-enb-asan', 'oai-gnb-asan', 'oai-lte-ue-asan', 'oai-nr-ue-asan', 'oai-nr-cuup-asan', 'oai-gnb-aerial', 'oai-gnb-fhi72', 'oai-gnb-fhi72-t2']
+IMAGES = ['oai-enb', 'oai-lte-ru', 'oai-lte-ue', 'oai-gnb', 'oai-nr-cuup', 'oai-gnb-aw2s', 'oai-nr-ue', 'oai-enb-asan', 'oai-gnb-asan', 'oai-lte-ue-asan', 'oai-nr-ue-asan', 'oai-nr-cuup-asan', 'oai-gnb-aerial', 'oai-gnb-fhi72', 'oai-gnb-fhi72-t2', 'oai-nr-oru']
 DEFAULT_REGISTRY = "gracehopper3-oai.sboai.cs.eurecom.fr"
 
 def CreateWorkspace(host, sourcePath, repository, branch):

--- a/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru.conf
+++ b/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru.conf
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+Active_gNBs = ( "gNB-OAI");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    =  0xe00;
+    gNB_name  =  "gNB-OAI";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  1;
+    plmn_list = ({ mcc = 208; mnc = 99; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345678L;
+
+    ////////// Physical parameters:
+
+    pdsch_AntennaPorts_XP = 1;
+    pdsch_AntennaPorts_N1 = 1;
+    pusch_AntennaPorts    = 1;
+
+    servingCellConfigCommon = (
+    {
+ #spCellConfigCommon
+
+      physCellId                                                    = 0;
+#  downlinkConfigCommon
+    #frequencyInfoDL
+      # center frequency = 4049.76 MHz
+      # selected SSB frequency = 4049.76 MHz
+      absoluteFrequencySSB                                          = 669984;
+      dl_frequencyBand                                              = 77;
+      # frequency point A = 4030.68 MHz
+      dl_absoluteFrequencyPointA                                    = 668712;
+      #scs-SpecificCarrierList
+        dl_offstToCarrier                                           = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing                                        = 1;
+        dl_carrierBandwidth                                         = 106;
+     #initialDownlinkBWP
+      #genericParameters
+       initialDLBWPlocationAndBandwidth                             = 28875; #38.101-1 Table 5.3.2-1
+       #
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing                               = 1;
+      #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero                          = 11;
+        initialDLBWPsearchSpaceZero                                 = 0;
+
+  #uplinkConfigCommon
+     #frequencyInfoUL
+      ul_frequencyBand                                              = 77;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 106;
+      pMax                                                          = 23;
+     #initialUplinkBWP
+      #genericParameters
+        initialULBWPlocationAndBandwidth                            = 28875;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+        #rach-ConfigGeneric
+          prach_ConfigurationIndex                                  = 152;
+#prach_msg1_FDM
+#0 = one, 1=two, 2=four, 3=eight
+          prach_msg1_FDM                                            = 0;
+          prach_msg1_FrequencyStart                                 = 0;
+          zeroCorrelationZoneConfig                                 = 0;
+          preambleReceivedTargetPower                               = -100;
+#preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+          preambleTransMax                                          = 7;
+#powerRampingStep
+# 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep                                            = 2;
+#ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+#1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+#one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 15;
+#ra_ContentionResolutionTimer
+#(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer                                = 7;
+        rsrp_ThresholdSSB                                           = 19;
+#prach-RootSequenceIndex_PR
+#1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR                                  = 2;
+        prach_RootSequenceIndex                                     = 1;
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        #
+        msg1_SubcarrierSpacing                                      = 1,
+# restrictedSetConfig
+# 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig                                         = 0,
+
+# this is the offset between the last PRACH preamble power and the Msg3 PUSCH, 2 times the field value in dB
+        msg3_DeltaPreamble                                          = 2;
+        p0_NominalWithGrant                                         = -100;
+
+# pucch-ConfigCommon setup :
+# pucchGroupHopping
+# 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping                                           = 0;
+        hoppingId                                                   = 0;
+        p0_nominal                                                  = -96;
+
+      ssb_PositionsInBurst_Bitmap                                   = 0x1;
+
+# ssb_periodicityServingCell
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+# dmrs_TypeA_position
+# 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+  #tdd-UL-DL-ConfigurationCommon
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 5;
+      nrofDownlinkSlots                                             = 3;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 1;
+      nrofUplinkSymbols                                             = 4;
+
+  ssPBCH_BlockPower                                                 = 0;
+  }
+
+  );
+
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+    ////////// AMF parameters:
+    amf_ip_address = ({ ipv4 = "192.168.101.132"; });
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.101.140";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "192.168.101.140";
+        GNB_PORT_FOR_NGU                         = 2152; # Spec 2152
+    };
+  }
+);
+
+MACRLCs = (
+{
+  num_cc                      = 1;
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 200;
+  pucch_TargetSNRx10          = 200;
+  pusch_FailureThres          = 100;
+}
+);
+
+L1s = (
+{
+  num_cc = 1;
+  tr_n_preference = "local_mac";
+  prach_dtx_threshold = 200;
+  pucch0_dtx_threshold = 80;
+  pusch_dtx_threshold = -100;
+ # thread_pool_size = 8;
+  tx_amp_backoff_dB = 36;
+  L1_rx_thread_core = 10;
+  L1_tx_thread_core = 11;
+  phase_compensation = 0; # needs to match O-RU configuration
+}
+);
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 1;
+  nb_rx          = 1;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  ru_thread_core = 12;
+  sl_ahead       = 10;
+  tr_preference  = "raw_if4p5"; # important: activate FHI7.2
+  do_precoding   = 0; # needs to match O-RU configuration
+}
+);
+
+security = {
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms = ( "nea0" );
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms = ( "nia2", "nia0" );
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};
+
+fhi_72 = {
+  dpdk_devices = ("0000:41:11.0"); # one VF can be used as well
+  dpdk_iova_mode = "VA";
+  system_core = 7;
+  io_core = 8;
+  worker_cores = (9);
+  ru_addr = ("00:11:22:33:aa:67");
+  mtu = 9600;
+  fh_config = ({
+    T1a_cp_dl = (285, 470);
+    T1a_cp_ul = (285, 429);
+    T1a_up = (300, 450);
+    Ta4 = (0, 440);
+    ru_config = {
+      iq_width = 16;
+      iq_width_prach = 16;
+    };
+  });
+};

--- a/ci-scripts/conf_files/ru.band77.mu1.106prb.1x1.conf
+++ b/ci-scripts/conf_files/ru.band77.mu1.106prb.1x1.conf
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+ORUs = (
+{
+  tx_bw = [106];
+  rx_bw = [106];
+  carrier_tx = [4049760];
+  carrier_rx = [4049760];
+  prach_config_index = 152;
+  prach_msg1_start = 0;
+  tdd_period = 5;
+  num_dl_slots = 3;
+  num_dl_symbols = 6;
+  num_ul_slots = 1;
+  num_ul_symbols = 4;
+  numerology = 1;
+  fronthaul = {
+    dpdk_devices = ("0000:01:01.0"); # one VF can be used as well
+    rx_core = 2;
+    du_mac_addr = ("00:11:22:33:aa:66");
+    mtu = 9216;
+    T2a_up = (250, 5000);
+    T2a_cp = (250, 5000);
+    prach_eaxc_offset = 1;
+    extra_eal_args = ("--file-prefix", "ru");
+  }
+});
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 1;
+  nb_rx          = 1;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  sl_ahead       = 10;
+  tr_preference  = "raw_if4p5"; # important: activate FHI7.2
+  do_precoding   = 0; # needs to match O-RU configuration
+  # PRACH configuration
+  num_tp_cores = 4;
+  tp_cores = [-1,-1,-1,-1];
+});
+
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};

--- a/ci-scripts/xml_files/container_5g_oai_nr_oru.xml
+++ b/ci-scripts/xml_files/container_5g_oai_nr_oru.xml
@@ -1,0 +1,162 @@
+<!-- SPDX-License-Identifier: LicenseRef-CSSL-1.0 -->
+
+<testCaseList>
+  <htmlTabRef>oai-nr-oru</htmlTabRef>
+  <htmlTabName>O-RU vrtsim 1x1</htmlTabName>
+  <htmlTabIcon>wrench</htmlTabIcon>
+
+  <testCase>
+    <class>Pull_Local_Registry</class>
+    <desc>Pull Images from Local Registry</desc>
+    <node>stonechat</node>
+    <images>oai-gnb-fhi72</images>
+  </testCase>
+
+  <testCase>
+    <class>Pull_Local_Registry</class>
+    <desc>Pull Images from Local Registry</desc>
+    <node>matix</node>
+    <images>oai-nr-ue oai-nr-oru</images>
+  </testCase>
+
+  <testCase>
+    <class>Create_Workspace</class>
+    <desc>Create new Workspace</desc>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Create_Workspace</class>
+    <desc>Create new Workspace</desc>
+    <node>stonechat</node>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G CoreNetwork</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb</yaml_path>
+    <services>mysql oai-amf oai-smf oai-upf oai-ext-dn</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI O-RU</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue</yaml_path>
+    <services>oai-nr-oru</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G gNB 7.2</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb</yaml_path>
+    <services>oai-gnb</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G NR-UE</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue/</yaml_path>
+    <services>oai-nr-ue</services>
+  </testCase>
+
+  <testCase>
+    <class>Attach_UE</class>
+    <desc>Attach OAI UE (Wait for IP)</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Ping</class>
+    <desc>Ping ext-dn from NR-UE</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <ping_args>-c 20 -i 0.25</ping_args>
+    <ping_packetloss_threshold>5</ping_packetloss_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Ping</class>
+    <desc>Ping NR-UE from ext-dn</desc>
+    <id>rfsim5g_ext_dn</id>
+    <node>stonechat</node>
+    <svr_id>rfsim5g_ue</svr_id>
+    <svr_node>matix</svr_node>
+    <ping_args>-c 20 -i 0.25</ping_args>
+    <ping_packetloss_threshold>5</ping_packetloss_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>Iperf (DL/TCP)(20 sec)</desc>
+    <iperf_args>-t 20 -R</iperf_args>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <iperf_tcp_rate_target>90</iperf_tcp_rate_target>
+  </testCase>
+
+    <testCase>
+    <class>Iperf</class>
+    <desc>Iperf (UL/TCP)(20 sec)</desc>
+    <iperf_args>-t 20</iperf_args>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <iperf_tcp_rate_target>25</iperf_tcp_rate_target>
+  </testCase>
+
+  <testCase>
+    <class>Detach_UE</class>
+    <desc>Detach OAI UE</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Undeploy_Object</class>
+    <always_exec>true</always_exec>
+    <desc>Undeploy all OAI 5G stack</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb/</yaml_path>
+    <analysis>
+      <services>oai-gnb=EndsWithBye</services>
+    </analysis>
+  </testCase>
+
+  <testCase>
+    <class>Undeploy_Object</class>
+    <always_exec>true</always_exec>
+    <desc>Undeploy all OAI 5G stack</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue</yaml_path>
+    <analysis>
+      <services>oai-nr-ue oai-nr-oru</services>
+    </analysis>
+  </testCase>
+
+  <testCase>
+    <class>Clean_Test_Server_Images</class>
+    <always_exec>true</always_exec>
+    <desc>Clean Test Images on Test Server</desc>
+    <node>stonechat</node>
+    <images>oai-gnb-fhi72</images>
+  </testCase>
+
+  <testCase>
+    <class>Clean_Test_Server_Images</class>
+    <always_exec>true</always_exec>
+    <desc>Clean Test Images on Test Server</desc>
+    <node>matix</node>
+    <images>oai-nr-ue oai-nr-oru</images>
+  </testCase>
+
+</testCaseList>

--- a/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue/docker-compose.yml
+++ b/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue/docker-compose.yml
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+
+services:
+    dpdk-init-ru:
+        image: docker.io/library/oai-dpdk-init:latest
+        network_mode: host
+        container_name: dpdk-init-ru
+        entrypoint: "/tmp/setup_sriov.sh"
+        privileged: true
+        devices:
+            - /dev/vfio:/dev/vfio/
+        volumes:
+            - ./setup_sriov_ru.sh:/tmp/setup_sriov.sh
+            - /lib/modules:/lib/modules
+            - /usr/lib/modules:/usr/lib/modules
+    oai-nr-oru:
+        image: ${REGISTRY-oaisoftwarealliance/}oai-nr-oru:${TAG:-develop}
+        cap_add:
+            - IPC_LOCK
+            - SYS_NICE
+        cap_drop:
+            - ALL
+        container_name: oai-nr-oru
+        environment:
+            TZ: Europe/Paris
+            USE_ADDITIONAL_OPTIONS: --device.name vrtsim --vrtsim.role server
+        devices:
+            - /dev/vfio:/dev/vfio/
+        volumes:
+            - ../../conf_files/ru.band77.mu1.106prb.1x1.conf:/opt/nr-oru/etc/nr-oru.conf
+            - /dev/hugepages:/dev/hugepages
+            - tmp_data:/tmp/
+        cpuset: "2,3,4,5,6"
+        depends_on:
+           dpdk-init-ru:
+             condition: service_completed_successfully
+        healthcheck:
+           test: /bin/bash -c "ps aux | grep -v grep | grep -c nr-oru"
+           start_period: 15s
+           start_interval: 500ms
+           interval: 5s
+           timeout: 5s
+           retries: 10
+        ipc: host
+    oai-nr-ue:
+        image: ${REGISTRY-oaisoftwarealliance/}${NRUE_IMG:-oai-nr-ue}:${TAG:-develop}
+        container_name: rfsim5g-oai-nr-ue
+        cap_drop:
+            - ALL
+        cap_add:
+            - NET_ADMIN  # for interface bringup
+            - NET_RAW    # for ping
+            - IPC_LOCK   # for memory locking
+        environment:
+            USE_ADDITIONAL_OPTIONS: -r 106 --numerology 1 --band 77 -C 4049760000 --ssb 516 --uicc0.imsi 208990100001100 --log_config.global_log_options level,nocolor,time --device.name vrtsim
+        devices:
+             - /dev/net/tun:/dev/net/tun
+        volumes:
+            - ../../conf_files/nrue.uicc.conf:/opt/oai-nr-ue/etc/nr-ue.conf
+            - tmp_data:/tmp/
+        cpuset: "7,8,9,10,11"
+        healthcheck:
+            test: /bin/bash -c "pgrep nr-uesoftmodem"
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 10s
+            start_interval: 500ms
+        ipc: host
+volumes:
+    tmp_data:

--- a/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue/setup_sriov_ru.sh
+++ b/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue/setup_sriov_ru.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -x
+IF_NAME=enp1s0f0np0
+NUM_VFs=1
+C_U_PLANE_MAC_ADD=00:11:22:33:aa:67
+VLAN=30
+MTU=9000
+C_U_PLANE_PCI=01:01.0
+DPDK_DEVBIND_PREFIX=/usr/local/bin
+ethtool -G $IF_NAME rx 8160 tx 8160
+sh -c "echo 0 > /sys/class/net/$IF_NAME/device/sriov_numvfs"
+sh -c "echo $NUM_VFs > /sys/class/net/$IF_NAME/device/sriov_numvfs"
+modprobe -r iavf
+modprobe iavf
+# this next 1 lines is for C/U planes
+ip link set $IF_NAME vf 0 mac $C_U_PLANE_MAC_ADD vlan $VLAN spoofchk off mtu $MTU
+sleep 1
+${DPDK_DEVBIND_PREFIX}/dpdk-devbind.py --unbind $C_U_PLANE_PCI
+modprobe vfio-pci
+${DPDK_DEVBIND_PREFIX}/dpdk-devbind.py --bind vfio-pci $C_U_PLANE_PCI
+exit 0

--- a/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb/cn.yml
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb/cn.yml
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MIT
+
+services:
+    mysql:
+        container_name: "rfsim5g-mysql"
+        image: mysql:9.6
+        init: true
+        volumes:
+            - ./../5g_rfsimulator/oai_db.sql:/docker-entrypoint-initdb.d/oai_db.sql
+            - ./../5g_rfsimulator/mysql-healthcheck.sh:/tmp/mysql-healthcheck.sh
+        environment:
+            - TZ=Europe/Paris
+            - MYSQL_DATABASE=oai_db
+            - MYSQL_USER=test
+            - MYSQL_PASSWORD=test
+            - MYSQL_ROOT_PASSWORD=linux
+        healthcheck:
+            test: /bin/bash -c "/tmp/mysql-healthcheck.sh"
+            start_period: 10s
+            start_interval: 500ms
+            interval: 10s
+            timeout: 5s
+            retries: 30
+        networks:
+            public_net:
+                ipv4_address: 192.168.101.131
+    oai-amf:
+        container_name: "rfsim5g-oai-amf"
+        image: oaisoftwarealliance/oai-amf:v2.2.1
+        environment:
+            - TZ=Europe/paris
+        volumes:
+            - ./../5g_rfsimulator/mini_nonrf_config.yaml:/openair-amf/etc/config.yaml
+        depends_on:
+            - mysql
+        networks:
+            public_net:
+                ipv4_address: 192.168.101.132
+    oai-smf:
+        container_name: "rfsim5g-oai-smf"
+        image: oaisoftwarealliance/oai-smf:v2.2.1
+        environment:
+            - TZ=Europe/Paris
+        volumes:
+            - ./../5g_rfsimulator/mini_nonrf_config.yaml:/openair-smf/etc/config.yaml
+        depends_on:
+            - oai-amf
+        networks:
+            public_net:
+                ipv4_address: 192.168.101.133
+    oai-upf:
+        container_name: "rfsim5g-oai-upf"
+        image: oaisoftwarealliance/oai-upf:v2.2.1
+        init: true
+        environment:
+            - TZ=Europe/Paris
+        volumes:
+            - ./../5g_rfsimulator/mini_nonrf_config.yaml:/openair-upf/etc/config.yaml
+        depends_on:
+            - oai-smf
+        cap_add:
+            - NET_ADMIN
+            - SYS_ADMIN
+        cap_drop:
+            - ALL
+        privileged: true
+        networks:
+            public_net:
+                ipv4_address: 192.168.101.134
+                interface_name: eth0
+            traffic_net:
+                ipv4_address: 192.168.102.134
+                interface_name: eth1
+    oai-ext-dn:
+        privileged: true
+        container_name: rfsim5g-oai-ext-dn
+        image: oaisoftwarealliance/trf-gen-cn5g:latest
+        init: true
+        entrypoint: /bin/bash -c \
+              "iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE;"\
+              "ip route add 12.1.1.0/24 via 192.168.102.134 dev eth0; sleep infinity"
+        depends_on:
+            - oai-upf
+        networks:
+            traffic_net:
+                ipv4_address: 192.168.102.135
+        healthcheck:
+            test: /bin/bash -c "ping -c 2 192.168.102.134"
+            start_period: 10s
+            start_interval: 500ms
+            interval: 10s
+            timeout: 5s
+            retries: 5
+networks:
+    public_net:
+        driver: bridge
+        name: rfsim5g-oai-public-net
+        ipam:
+            config:
+                - subnet: 192.168.101.128/26
+        driver_opts:
+            com.docker.network.bridge.name: "rfsim5g-public"
+    traffic_net:
+        driver: bridge
+        name: rfsim5g-oai-traffic-net
+        ipam:
+            config:
+                - subnet: 192.168.102.128/26
+        driver_opts:
+            com.docker.network.bridge.name: "rfsim5g-traffic"

--- a/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb/docker-compose.yml
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb/docker-compose.yml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+
+include:
+    - cn.yml
+services:
+    dpdk-init-du:
+        image: docker.io/library/oai-dpdk-init:latest
+        network_mode: host
+        container_name: dpdk-init-du
+        entrypoint: "/tmp/setup_sriov.sh"
+        privileged: true
+        devices:
+            - /dev/vfio:/dev/vfio/
+        volumes:
+            - ./setup_sriov_du.sh:/tmp/setup_sriov.sh
+            - /lib/modules:/lib/modules
+            - /usr/lib/modules:/usr/lib/modules
+    oai-gnb:
+        image: ${REGISTRY-oaisoftwarealliance/}oai-gnb-fhi72:${TAG:-develop}
+        cap_add:
+            - IPC_LOCK
+            - SYS_NICE
+        cap_drop:
+            - ALL
+        container_name: oai-gnb
+        environment:
+            TZ: Europe/Paris
+            USE_ADDITIONAL_OPTIONS: --gNBs.[0].min_rxtxtime 6
+        devices:
+            - /dev/vfio:/dev/vfio/
+        volumes:
+            - ../../conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru.conf:/opt/oai-gnb/etc/gnb.conf
+            - /dev/hugepages:/dev/hugepages
+        cpuset: "7,8,9,10,11,12,13,14,15,16"
+        networks:
+            public_net:
+                ipv4_address: 192.168.101.140
+        depends_on:
+           dpdk-init-du:
+             condition: service_completed_successfully
+        healthcheck:
+           test: /bin/bash -c "ps aux | grep -v grep | grep -c nr-softmodem"
+           start_period: 10s
+           interval: 5s
+           timeout: 5s
+           retries: 10

--- a/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb/setup_sriov_du.sh
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb/setup_sriov_du.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -x
+IF_NAME=ens2f1
+NUM_VFs=1
+C_U_PLANE_MAC_ADD=00:11:22:33:aa:66
+VLAN=30
+MTU=9216
+C_U_PLANE_PCI=41:11.0
+## It will be something like this --> $DPDK_INST/bin
+DPDK_DEVBIND_PREFIX=/usr/local/bin
+ethtool -G $IF_NAME rx 8160 tx 8160
+sh -c "echo 0 > /sys/class/net/$IF_NAME/device/sriov_numvfs"
+sh -c "echo $NUM_VFs > /sys/class/net/$IF_NAME/device/sriov_numvfs"
+modprobe -r iavf
+modprobe iavf
+# this next 2 lines is for C/U planes
+ip link set $IF_NAME vf 0 mac $C_U_PLANE_MAC_ADD vlan $VLAN spoofchk off mtu $MTU
+sleep 1
+${DPDK_DEVBIND_PREFIX}/dpdk-devbind.py --unbind $C_U_PLANE_PCI
+modprobe vfio-pci
+${DPDK_DEVBIND_PREFIX}/dpdk-devbind.py --bind vfio-pci $C_U_PLANE_PCI
+

--- a/docker/Dockerfile.nrORU.fhi72.ubuntu
+++ b/docker/Dockerfile.nrORU.fhi72.ubuntu
@@ -29,7 +29,8 @@ RUN apt-get update && \
         libpcap-dev \
         xz-utils \
         libnuma-dev \
-        libyaml-cpp-dev && \
+        libyaml-cpp-dev \
+        libatomic1 && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/nr-oru/bin
@@ -44,6 +45,7 @@ COPY --from=ran-build \
     /oai-ran/cmake_targets/ran_build/build/libdfts.so \
     /oai-ran/cmake_targets/ran_build/build/libldpc*.so \
     /oai-ran/cmake_targets/ran_build/build/libparams_yaml.so \
+    /oai-ran/cmake_targets/ran_build/build/libvrtsim.so \
     /usr/local/lib/
 
 ## Libxran library


### PR DESCRIPTION
This PR adds a new pipeline for OAI O-RU testing with vrtsim.

TODO: 

- [x] change VLAN tag for O-RU and gNB deployment, @arora-sagar --> changed to 30, to be tested
- [x] add new test, RAN-SA-ORU-CN5G, into parent pipeline
- [x] check DL throughput, gNB/RU logs
- [x] update CN version - or reuse the one from rfsim pipeline

Test:
- https://jenkins-oai.eurecom.fr/job/RAN-SA-ORU-CN5G/