### PR TITLE
Use direct pointer in `tx_data.request`

### DIFF
--- a/nfapi/oai_integration/aerial/fapi_vnf_p7.c
+++ b/nfapi/oai_integration/aerial/fapi_vnf_p7.c
@@ -110,18 +110,19 @@ static int32_t aerial_pack_tx_data_request(void *pMessageBuf,
     // assuming there is only 1 TLV present
     value->PDU_length = value->TLVs[0].length;
     for (uint32_t k = 0; k < value->num_TLV; ++k) {
+      uint32_t *buf = value->TLVs[k].tag == 0 ? value->TLVs[k].value.direct : value->TLVs[k].value.ptr;
       // Ensure tag is 2
       value->TLVs[k].tag = 2;
       uint32_t num_values_to_push = ((value->TLVs[k].length + 3) / 4);
       if (value->TLVs[k].length > 0) {
         if (value->TLVs[k].length % 4 != 0) {
-          if (!pusharray32(value->TLVs[k].value.direct, dataBufLen32, num_values_to_push - 1, ppWriteData, data_end)) {
+          if (!pusharray32(buf, dataBufLen32, num_values_to_push - 1, ppWriteData, data_end)) {
             return 0;
           }
           int bytesToAdd = 4 - (4 - (value->TLVs[k].length % 4)) % 4;
           if (bytesToAdd != 4) {
             for (int j = 0; j < bytesToAdd; j++) {
-              uint8_t toPush = (uint8_t)(value->TLVs[k].value.direct[num_values_to_push - 1] >> (j * 8));
+              uint8_t toPush = (uint8_t)(buf[num_values_to_push - 1] >> (j * 8));
               if (!push8(toPush, ppWriteData, data_end)) {
                 return 0;
               }
@@ -129,7 +130,7 @@ static int32_t aerial_pack_tx_data_request(void *pMessageBuf,
           }
         } else {
           // no padding needed
-          if (!pusharray32(value->TLVs[k].value.direct, dataBufLen32, num_values_to_push, ppWriteData, data_end)) {
+          if (!pusharray32(buf, dataBufLen32, num_values_to_push, ppWriteData, data_end)) {
             return 0;
           }
         }

--- a/nfapi/open-nFAPI/fapi/src/nr_fapi_p7.c
+++ b/nfapi/open-nFAPI/fapi/src/nr_fapi_p7.c
@@ -1643,7 +1643,9 @@ static uint8_t pack_tx_data_pdu_list_value(void *tlv, uint8_t **ppWritePackedMsg
     return 0;
 
   for (int i = 0; i < value->num_TLV; ++i) {
-    if (!push16(value->TLVs[i].tag, ppWritePackedMsg, end))
+    uint16_t tag = value->TLVs[i].tag == 2 ? 2 : 0;
+    // preserve tag == 2 for nvidia, for direct/ptr, convert to pointer
+    if (!push16(tag, ppWritePackedMsg, end))
       return 0;
 #ifdef ENABLE_AERIAL
     if (!push16(value->TLVs[i].length, ppWritePackedMsg, end))
@@ -1725,22 +1727,18 @@ static uint8_t unpack_tx_data_pdu_list_value(uint8_t **ppReadPackedMsg, uint8_t 
       return 0;
     const uint32_t byte_len = (pNfapiMsg->TLVs[i].length + 3) / 4;
     if (pNfapiMsg->TLVs[i].tag == 1) {
-      pNfapiMsg->TLVs[i].value.ptr = calloc(byte_len, sizeof(uint32_t));
+      pNfapiMsg->TLVs[i].tag = 0;
     }
     switch (pNfapiMsg->TLVs[i].tag) {
-      case 0: {
+      case 0:
+      case 1: {
+        // always pull into direct, which simply avoids one (possibly big)
+        // malloc
         if (!pullarray32(ppReadPackedMsg,
                          pNfapiMsg->TLVs[i].value.direct,
                          sizeof(pNfapiMsg->TLVs[i].value.direct) / sizeof(uint32_t),
                          byte_len,
                          end))
-          return 0;
-
-        break;
-      }
-
-      case 1: {
-        if (!pullarray32(ppReadPackedMsg, pNfapiMsg->TLVs[i].value.ptr, byte_len, byte_len, end))
           return 0;
 
         break;

--- a/nfapi/open-nFAPI/fapi/src/nr_fapi_p7_utils.c
+++ b/nfapi/open-nFAPI/fapi/src/nr_fapi_p7_utils.c
@@ -513,24 +513,14 @@ bool eq_tx_data_request_PDU(const nfapi_nr_pdu_t *a, const nfapi_nr_pdu_t *b)
   for (int tlv_idx = 0; tlv_idx < a->num_TLV; ++tlv_idx) {
     const nfapi_nr_tx_data_request_tlv_t *a_tlv = &a->TLVs[tlv_idx];
     const nfapi_nr_tx_data_request_tlv_t *b_tlv = &b->TLVs[tlv_idx];
-    EQ(a_tlv->tag, b_tlv->tag);
     EQ(a_tlv->length, b_tlv->length);
-    switch (a_tlv->tag) {
-      case 0:
-        for (int payload_idx = 0; payload_idx < (a_tlv->length + 3) / 4; ++payload_idx) {
-          // value.direct
-          EQ(a_tlv->value.direct[payload_idx], b_tlv->value.direct[payload_idx]);
-        }
-        break;
-      case 1:
-        for (int payload_idx = 0; payload_idx < (a_tlv->length + 3) / 4; ++payload_idx) {
-          // value.ptr
-          EQ(a_tlv->value.ptr[payload_idx], b_tlv->value.ptr[payload_idx]);
-        }
-        break;
-      default:
-        break;
-    }
+    // it does not matter which tag messages have, the payload must be the same
+    EQ(a_tlv->tag == 0 || a_tlv->tag == 1, true);
+    const uint32_t *abuf = a_tlv->tag == 0 ? a_tlv->value.direct : a_tlv->value.ptr;
+    EQ(b_tlv->tag == 0 || b_tlv->tag == 1, true);
+    const uint32_t *bbuf = b_tlv->tag == 0 ? b_tlv->value.direct : b_tlv->value.ptr;
+    int ret = memcmp(abuf, bbuf, (a_tlv->length + 3) / 4);
+    EQ(ret, 0);
   }
   return true;
 }
@@ -1341,9 +1331,10 @@ void copy_tx_data_request_PDU(const nfapi_nr_pdu_t *src, nfapi_nr_pdu_t *dst)
         memcpy(dst_tlv->value.direct, src_tlv->value.direct, sizeof(src_tlv->value.direct));
         break;
       case 1:
-        // value.ptr
-        dst_tlv->value.ptr = calloc((src_tlv->length + 3) / 4, sizeof(uint32_t));
-        memcpy(dst_tlv->value.ptr, src_tlv->value.ptr, src_tlv->length);
+        // value.ptr: instead of allocating a new pointer, we avoid overhead
+        // and copy into direct
+        memcpy(dst_tlv->value.direct, src_tlv->value.ptr, src_tlv->length);
+        dst_tlv->tag = 0;
         break;
       default:
         AssertFatal(1 == 0, "TX_DATA request TLV tag value unsupported");

--- a/openair1/SCHED_NR/phy_procedures_nr_gNB.c
+++ b/openair1/SCHED_NR/phy_procedures_nr_gNB.c
@@ -277,7 +277,8 @@ void phy_procedures_gNB_TX(PHY_VARS_gNB *gNB,
           // reuse dlsch variables, as there are multiple very large memory
           // buffers
           gNB->dlsch[num_pdsch].pdsch_pdu = &dl_tti_pdu->pdsch_pdu;
-          gNB->dlsch[num_pdsch].pdu = (uint8_t *)TX_req->pdu_list[tx_data_idx].TLVs[0].value.direct;
+          const nfapi_nr_tx_data_request_tlv_t *tlv = &TX_req->pdu_list[tx_data_idx].TLVs[0];
+          gNB->dlsch[num_pdsch].pdu = tlv->tag == 0 ? (uint8_t *)tlv->value.direct : (uint8_t *)tlv->value.ptr;
           DevAssert(num_pdsch < gNB->max_nb_pdsch);
           num_pdsch++;
         } else {

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_RA.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_RA.c
@@ -1768,6 +1768,7 @@ static void nr_generate_Msg2(module_id_t module_idP,
 
   tx_req->PDU_index = pduindex;
   tx_req->num_TLV = 1;
+  tx_req->TLVs[0].tag = 0;
   tx_req->TLVs[0].length = TBS;
   tx_req->PDU_length = compute_PDU_length(tx_req->num_TLV, TBS);
   TX_req->SFN = frameP;
@@ -2050,6 +2051,7 @@ static void nr_generate_Msg4_MsgB(module_id_t module_idP,
 
     // DL TX request
     nfapi_nr_pdu_t *tx_req = &TX_req->pdu_list[TX_req->Number_of_PDUs];
+    tx_req->TLVs[0].tag = 0;
     memcpy(tx_req->TLVs[0].value.direct, harq->transportBlock.buf, sizeof(uint8_t) * harq->tb_size);
     tx_req->PDU_index = pduindex;
     tx_req->num_TLV = 1;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_bch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_bch.c
@@ -500,6 +500,7 @@ void schedule_nr_sib1(module_id_t module_idP,
 
       tx_req->PDU_index  = pdu_index;
       tx_req->num_TLV = 1;
+      tx_req->TLVs[0].tag = 0;
       tx_req->TLVs[0].length = tb_size;
       tx_req->PDU_length = compute_PDU_length(tx_req->num_TLV, tx_req->TLVs[0].length);
       TX_req->Number_of_PDUs++;
@@ -637,6 +638,7 @@ static void other_sib_sched_control(module_id_t module_idP,
 
   tx_req->PDU_index = pdu_index;
   tx_req->num_TLV = 1;
+  tx_req->TLVs[0].tag = 0;
   tx_req->TLVs[0].length = sched_pdsch_otherSI.tb_size;
   tx_req->PDU_length = compute_PDU_length(tx_req->num_TLV, tx_req->TLVs[0].length);
   TX_req->Number_of_PDUs++;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch.c
@@ -1203,7 +1203,9 @@ static void fill_dl_tx_request(post_process_pdsch_t *pdsch,
   tx_req->num_TLV = 1;
   tx_req->TLVs[0].length = TBS;
   tx_req->PDU_length = compute_PDU_length(tx_req->num_TLV, tx_req->TLVs[0].length);
-  memcpy(tx_req->TLVs[0].value.direct, buf, TBS);
+  tx_req->TLVs[0].tag = 1; // means ptr carries for payload
+  DevAssert((uintptr_t) buf % 4 == 0); // check alignment: FAPI uses u32
+  tx_req->TLVs[0].value.ptr = (uint32_t *)buf;
   pdsch->TX_req->Number_of_PDUs++;
   pdsch->TX_req->SFN = frame;
   pdsch->TX_req->Slot = slot;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_pcch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_pcch.c
@@ -624,6 +624,7 @@ void schedule_nr_pcch(gNB_MAC_INST *mac,
   free_byte_array(pcch_sdu);
   tx_req->PDU_index = pdu_index;
   tx_req->num_TLV = 1;
+  tx_req->TLVs[0].tag = 0;
   tx_req->TLVs[0].length = pdsch_pcch.tb_size;
   tx_req->PDU_length = compute_PDU_length(tx_req->num_TLV, tx_req->TLVs[0].length);
   TX_req->Number_of_PDUs++;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -2704,7 +2704,7 @@ uint8_t *allocate_transportBlock_buffer(byte_array_t *tb, uint32_t needed)
     size *= 2;
   LOG_D(NR_MAC, "allocating new TB block of size %d\n", size);
   free(tb->buf);
-  tb->buf = malloc_or_fail(size);
+  tb->buf = aligned_alloc(4, size); // important: FAPI use u32*
   tb->len = size;
   return tb->buf;
 }


### PR DESCRIPTION
For `tx_data.request` use `ptr` to avoid useless `memcpy()`, and modify existing tests/packing/unpacking to always unpack into `direct`, no matter the input.