### PR TITLE
oru: support UTC/TAI CLOCK_REALTIME mapping in fh_timer

### DIFF
--- a/executables/nr-oru.c
+++ b/executables/nr-oru.c
@@ -87,6 +87,7 @@
 #define CONFIG_STRING_PRACH_EAXC_OFFSET "prach_eaxc_offset"
 #define CONFIG_STRING_PRACH_KBAR "prach_kbar"
 #define CONFIG_STRING_COMP_TYPE         "comp_type"
+#define CONFIG_STRING_CLOCK_TIMEBASE    "clock_timebase"
 
 #define HLP_DPDK_DEVICES "DPDK devices to use for the O-RU."
 #define HLP_RX_CORE "The CPU core to be used to deploy dpdk RX worker for O-RU."
@@ -96,11 +97,19 @@
 #define HLP_PRACH_EAXC_OFFSET "PRACH eAxC offset."
 #define HLP_PRACH_KBAR "PRACH kbar offset."
 #define HLP_COMP_TYPE         "DL U-plane compression method: none, bfp, blkscale, or ulaw."
+#define HLP_CLOCK_TIMEBASE \
+  "Timescale of CLOCK_REALTIME for FH GPS mapping: utc (default, GPS = unix - epoch + 18) or tai (GPS = unix - epoch - 19)."
 
 #define COMP_TYPE_CHECK                                                               \
   &(checkedparam_t)                                                                   \
   {                                                                                   \
     .s3a = { config_checkstr_assign_integer, {"none", "bfp", "blkscale", "ulaw"}, {0, 1, 2, 3}, 4 } \
+  }
+
+#define CLOCK_TIMEBASE_CHECK                                                          \
+  &(checkedparam_t)                                                                   \
+  {                                                                                   \
+    .s3a = { config_checkstr_assign_integer, {"utc", "tai"}, {0, 1}, 2 }               \
   }
 
 // clang-format off
@@ -115,7 +124,8 @@
   {CONFIG_STRING_T2A_CP,                     "",                    0,                      .iptr=NULL,       .defintarrayval=NULL,         TYPE_INTARRAY,     0}, \
   {CONFIG_STRING_PRACH_EAXC_OFFSET,          HLP_PRACH_EAXC_OFFSET, 0,                      .u8ptr=NULL,      .defuintval=0,                TYPE_UINT8,        0}, \
   {CONFIG_STRING_PRACH_KBAR,                 HLP_PRACH_KBAR,        0,                      .uptr=NULL,       .defuintval=4,                TYPE_UINT,         0}, \
-  {CONFIG_STRING_COMP_TYPE,                  HLP_COMP_TYPE,         0,                      .strptr=NULL,     .defstrval="none",           TYPE_STRING,       0, COMP_TYPE_CHECK}  \
+  {CONFIG_STRING_COMP_TYPE,                  HLP_COMP_TYPE,         0,                      .strptr=NULL,     .defstrval="none",           TYPE_STRING,       0, COMP_TYPE_CHECK}, \
+  {CONFIG_STRING_CLOCK_TIMEBASE,             HLP_CLOCK_TIMEBASE,    0,                      .strptr=NULL,     .defstrval="utc",            TYPE_STRING,       0, CLOCK_TIMEBASE_CHECK}  \
 }
 // clang-format on
 
@@ -265,6 +275,9 @@ int get_oru_options(ORU_t *oru)
   int comp_type_idx = config_paramidx_fromname(fh_param, nump, CONFIG_STRING_COMP_TYPE);
   AssertFatal(comp_type_idx >= 0, "Index for %s config option not found!\n", CONFIG_STRING_COMP_TYPE);
   fh_cfg->comp_type = (fh_comp_method_t)config_get_processedint(config_get_if(), &fh_param[comp_type_idx]);
+  int clock_tb_idx = config_paramidx_fromname(fh_param, nump, CONFIG_STRING_CLOCK_TIMEBASE);
+  AssertFatal(clock_tb_idx >= 0, "Index for %s config option not found!\n", CONFIG_STRING_CLOCK_TIMEBASE);
+  fh_cfg->clock_timebase = (fh_clock_timebase_t)config_get_processedint(config_get_if(), &fh_param[clock_tb_idx]);
   fh_cfg->rx_core = *gpd(fh_param, nump, CONFIG_STRING_RX_CORE)->iptr;
   fh_cfg->mtu = *gpd(fh_param, nump, CONFIG_STRING_MTU)->iptr;
   fh_cfg->num_prbs = oru->bw_tx[0];

--- a/fronthaul/core/fh_timer.c
+++ b/fronthaul/core/fh_timer.c
@@ -14,11 +14,36 @@
 #define NS_PER_MS 1000000ULL
 #define NS_PER_FRAME (10 * NS_PER_MS)
 
-static uint64_t get_gps_ns(void)
+static uint64_t get_gps_utc_ns(void)
 {
   struct timespec ts;
   clock_gettime(CLOCK_REALTIME, &ts);
   return ((uint64_t)ts.tv_sec - GPS_EPOCH_OFFSET_UNIX + GPS_LEAP_SECONDS) * NS_PER_SEC + ts.tv_nsec;
+}
+
+static uint64_t get_gps_tai_ns(void)
+{
+  struct timespec ts;
+  clock_gettime(CLOCK_REALTIME, &ts);
+  return ((uint64_t)ts.tv_sec - GPS_EPOCH_OFFSET_UNIX - GPS_TAI_LAG_SECONDS) * NS_PER_SEC + ts.tv_nsec;
+}
+
+static void fh_timer_apply_timebase(fh_timer_t *timer, fh_clock_timebase_t timebase)
+{
+  /* Only TAI is special-cased; anything else uses UTC. */
+  timer->timebase = (timebase == FH_CLOCK_TAI) ? FH_CLOCK_TAI : FH_CLOCK_UTC;
+  timer->get_gps_ns = (timebase == FH_CLOCK_TAI) ? get_gps_tai_ns : get_gps_utc_ns;
+}
+
+static void fh_timer_seed_from_now(fh_timer_t *timer)
+{
+  uint64_t total_syms_per_ms = 14 << timer->numerology;
+  uint64_t gps_now = timer->get_gps_ns();
+  typedef __int128_t int128;
+  uint64_t s_abs = (uint64_t)((int128)gps_now * total_syms_per_ms / NS_PER_MS);
+  rte_atomic64_set(&timer->s_abs, s_abs);
+  timer->next_s_abs = s_abs + 1;
+  timer->target_gps_ns = (uint64_t)((int128)timer->next_s_abs * NS_PER_MS / total_syms_per_ms);
 }
 
 void fh_timer_tick(fh_timer_t *timer)
@@ -26,7 +51,7 @@ void fh_timer_tick(fh_timer_t *timer)
   if (!timer->running)
     return;
 
-  uint64_t now = get_gps_ns();
+  uint64_t now = timer->get_gps_ns();
   if (now >= timer->target_gps_ns) {
     typedef __int128_t int128;
     uint64_t total_syms_per_ms = 14 << timer->numerology;
@@ -67,21 +92,21 @@ int fh_timer_init(fh_timer_t *timer, int numerology)
   timer->numerology = numerology;
   timer->num_cbs = 0;
   timer->running = true;
+  fh_timer_apply_timebase(timer, FH_CLOCK_UTC);
 
   uint64_t total_syms_per_ms = 14 << numerology;
   timer->ns_per_symbol = NS_PER_MS / total_syms_per_ms;
   timer->symbols_per_frame = 10 * total_syms_per_ms;
   timer->slots_per_frame = 10 << numerology;
 
-  // Initial timing state
-  uint64_t gps_now = get_gps_ns();
-  typedef __int128_t int128;
-  uint64_t s_abs = (uint64_t)((int128)gps_now * total_syms_per_ms / NS_PER_MS);
-  rte_atomic64_set(&timer->s_abs, s_abs);
-  timer->next_s_abs = s_abs + 1;
-  timer->target_gps_ns = (uint64_t)((int128)timer->next_s_abs * NS_PER_MS / total_syms_per_ms);
-
+  fh_timer_seed_from_now(timer);
   return 0;
+}
+
+void fh_timer_set_timebase(fh_timer_t *timer, fh_clock_timebase_t timebase)
+{
+  fh_timer_apply_timebase(timer, timebase);
+  fh_timer_seed_from_now(timer);
 }
 
 int fh_timer_register_cb(fh_timer_t *timer, fh_timer_cb cb, void *user_data)
@@ -103,7 +128,7 @@ void fh_timer_stop(fh_timer_t *timer)
 
 uint64_t fh_timer_get_current_symbol(fh_timer_t *timer)
 {
-  uint64_t gps_now = get_gps_ns();
+  uint64_t gps_now = timer->get_gps_ns();
 
   typedef __int128_t int128;
   uint64_t total_syms_per_ms = 14 << timer->numerology;

--- a/fronthaul/core/fh_timer.h
+++ b/fronthaul/core/fh_timer.h
@@ -23,7 +23,23 @@ typedef void (*fh_timer_cb)(uint64_t s_abs, void *user_data);
 
 #define MAX_FH_TIMER_CBS 8
 #define GPS_EPOCH_OFFSET_UNIX 315964800ULL
-#define GPS_LEAP_SECONDS 18
+/* GPS-UTC leap seconds (when CLOCK_REALTIME is UTC). */
+#define GPS_UTC_LEAP_SECONDS 18
+/* TAI-GPS constant lag (when CLOCK_REALTIME is TAI). */
+#define GPS_TAI_LAG_SECONDS 19
+
+/* Compatibility alias for older call sites / tests. */
+#define GPS_LEAP_SECONDS GPS_UTC_LEAP_SECONDS
+
+/**
+ * Timescale of CLOCK_REALTIME used by fh_timer.
+ * - UTC: GPS = unix - epoch + 18
+ * - TAI: GPS = unix - epoch - 19
+ */
+typedef enum {
+  FH_CLOCK_UTC = 0,
+  FH_CLOCK_TAI = 1,
+} fh_clock_timebase_t;
 
 typedef struct {
   fh_timer_cb fn;
@@ -39,6 +55,9 @@ typedef struct fh_timer {
   uint64_t ns_per_symbol;
   uint32_t symbols_per_frame;
   uint32_t slots_per_frame;
+  fh_clock_timebase_t timebase;
+  /* Selected by fh_timer_set_timebase(); defaults to UTC in fh_timer_init(). */
+  uint64_t (*get_gps_ns)(void);
 
   // New state for passive tick
   uint64_t target_gps_ns;
@@ -46,13 +65,19 @@ typedef struct fh_timer {
 } fh_timer_t;
 
 /**
- * @brief Initialize the 5G symbol timer state.
+ * @brief Initialize the 5G symbol timer state (UTC timebase).
  *
  * @param timer Pointer to timer handle to initialize
  * @param numerology 5G NR numerology (0, 1, 2, 3)
  * @return int 0 on success, negative on error
  */
 int fh_timer_init(fh_timer_t *timer, int numerology);
+
+/**
+ * @brief Select CLOCK_REALTIME timescale (UTC default, or TAI).
+ * Reseeds symbol timing from the new clock; call before fh_timer_tick().
+ */
+void fh_timer_set_timebase(fh_timer_t *timer, fh_clock_timebase_t timebase);
 
 /**
  * @brief Register a callback to be executed every symbol.

--- a/fronthaul/oru/oru_fh.c
+++ b/fronthaul/oru/oru_fh.c
@@ -153,6 +153,7 @@ void *oru_fh_init(oru_fh_config_t *cfg)
   memset(fh, 0, sizeof(oru_fh_t));
   fh->cfg = *cfg;
   fh->io_config.numerology = cfg->numerology;
+  fh->io_config.clock_timebase = cfg->clock_timebase;
   fh->io_config.num_ports = cfg->dpdk_conf.num_dpdk_devices;
   for (int i = 0; i < cfg->dpdk_conf.num_dpdk_devices; i++) {
     if (rte_eth_dev_get_port_by_name(cfg->dpdk_conf.dpdk_devices[i], &fh->io_config.port_ids[i]) < 0) {
@@ -181,7 +182,11 @@ void *oru_fh_init(oru_fh_config_t *cfg)
   uint16_t payload_size = cfg->num_prbs * 12 * 4; // 16-bit IQ (4 bytes per sample)
   uint16_t required_mtu = header_size + payload_size;
 
-  printf("ORU_FH: PRBs %u -> Required MTU %u (Limit %u)\n", cfg->num_prbs, required_mtu, cfg->mtu);
+  printf("ORU_FH: PRBs %u -> Required MTU %u (Limit %u); clock_timebase=%s\n",
+         cfg->num_prbs,
+         required_mtu,
+         cfg->mtu,
+         cfg->clock_timebase == FH_CLOCK_TAI ? "tai" : "utc");
 
   fh->io_config.mbuf_data_room = required_mtu + RTE_ETHER_HDR_LEN + RTE_ETHER_CRC_LEN + RTE_PKTMBUF_HEADROOM;
   fh->io_config.mbuf_count = 8192; // Default pool size
@@ -259,7 +264,11 @@ int oru_fh_get_utc_anchor_point(void *handle, uint64_t *hyper_frame, uint32_t *f
   uint64_t total_syms_per_sec = (NR_SYMBOLS_PER_SLOT * 1000) << fh->cfg.numerology;
   uint64_t ns_per_symbol = 1000000000 / total_syms_per_sec;
   uint64_t leftover_syms = absolute_gps_symbol % total_syms_per_sec;
-  ts->tv_sec = (absolute_gps_symbol / total_syms_per_sec) + GPS_EPOCH_OFFSET_UNIX - GPS_LEAP_SECONDS;
+  /* Invert get_gps_ns(): system_sec = gps_sec + epoch - clock_to_gps */
+  int64_t clock_to_gps = (fh->io.timer.timebase == FH_CLOCK_TAI)
+                             ? -(int64_t)GPS_TAI_LAG_SECONDS
+                             : (int64_t)GPS_UTC_LEAP_SECONDS;
+  ts->tv_sec = (absolute_gps_symbol / total_syms_per_sec) + GPS_EPOCH_OFFSET_UNIX - clock_to_gps;
   ts->tv_nsec = leftover_syms * ns_per_symbol;
   return 0;
 }

--- a/fronthaul/oru/oru_fh.h
+++ b/fronthaul/oru/oru_fh.h
@@ -42,6 +42,8 @@ typedef struct {
   uint32_t T2a_up_max_uS;
   uint32_t T2a_cp_min_uS;
   uint32_t T2a_cp_max_uS;
+  /* CLOCK_REALTIME timescale: FH_CLOCK_UTC (default) or FH_CLOCK_TAI. */
+  fh_clock_timebase_t clock_timebase;
   oru_fh_tdd_pattern_t tdd_pattern;
   int prach_eaxc_offset;
   int prach_kbar;

--- a/fronthaul/oru/oru_io.c
+++ b/fronthaul/oru/oru_io.c
@@ -205,6 +205,8 @@ int oru_io_init(oru_io_t *io, oru_io_config_t *conf)
   // 3. Initialize Timer
   if (fh_timer_init(&io->timer, conf->numerology) < 0)
     return -1;
+  if (conf->clock_timebase == FH_CLOCK_TAI)
+    fh_timer_set_timebase(&io->timer, FH_CLOCK_TAI);
   fh_timer_register_cb(&io->timer, conf->timer_cb, conf->timer_user_data);
 
   // 4. Initialize Send (on primary port)

--- a/fronthaul/oru/oru_io.h
+++ b/fronthaul/oru/oru_io.h
@@ -24,6 +24,7 @@ typedef struct {
   struct rte_ether_addr du_macs[MAX_DU_MACS];
   uint16_t num_macs;
   int numerology;
+  fh_clock_timebase_t clock_timebase;
   fh_recv_cb rx_cb;
   void *rx_user_data;
   fh_timer_cb timer_cb;


### PR DESCRIPTION
Select the GPS conversion for FH symbol timing based on whether CLOCK_REALTIME is UTC (default) or TAI, via nr-oru clock_timebase.
This is needed because the ORU assumes GPS time while default aerial configs use TAI, so they end up 37 seconds apart.