### PR TITLE
NR UE: separate PRACH power from digital amplitude

### DIFF
--- a/nfapi/open-nFAPI/nfapi/public_inc/fapi_nr_ue_interface.h
+++ b/nfapi/open-nFAPI/nfapi/public_inc/fapi_nr_ue_interface.h
@@ -198,7 +198,7 @@ typedef struct {
   uint16_t freq_msg1;
   /// Preamble index for PRACH (0-63)
   uint8_t ra_PreambleIndex;
-  /// PRACH TX power (TODO possibly modify to uint)
+  /// Requested PRACH transmit power in dBm
   int16_t prach_tx_power;
 } fapi_nr_ul_config_prach_pdu;
 

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_prach.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_prach.c
@@ -25,14 +25,13 @@
 // - idft for short sequence assumes we are transmitting starting in symbol 0 of a PRACH slot
 // - Assumes that PRACH SCS is same as PUSCH SCS @ 30 kHz, take values for formats 0-2 and adjust for others below
 // - Preamble index different from 0 is not detected by gNB
-int32_t generate_nr_prach(PHY_VARS_NR_UE *ue, uint8_t gNB_id, int frame, uint8_t slot, c16_t **txData)
+int32_t generate_nr_prach(PHY_VARS_NR_UE *ue, uint8_t gNB_id, int frame, uint8_t slot, int16_t tx_amp, c16_t **txData)
 {
   NR_DL_FRAME_PARMS *fp=&ue->frame_parms;
   fapi_nr_config_request_t *nrUE_config = &ue->nrUE_config;
   fapi_nr_ul_config_prach_pdu *prach_pdu = &ue->prach_vars[gNB_id]->prach_pdu;
 
   const int fd_occasion = prach_pdu->num_ra;
-  const int16_t amp = prach_pdu->prach_tx_power;
   const int prach_sequence_length = nrUE_config->prach_config.prach_sequence_length;
   const int N_ZC = (prach_sequence_length == 0) ? 839 : 139;
   const int mu = nrUE_config->prach_config.prach_sub_c_spacing;
@@ -311,7 +310,7 @@ int32_t generate_nr_prach(PHY_VARS_NR_UE *ue, uint8_t gNB_id, int frame, uint8_t
     for (int offset = 0, offset2 = 0; offset < N_ZC; offset++, offset2 += preamble_shift) {
       if (offset2 >= N_ZC)
         offset2 -= N_ZC;
-      const c16_t Xu_t = c16xmulConstShift(Xu[offset], amp, 15);
+      const c16_t Xu_t = c16xmulConstShift(Xu[offset], tx_amp, 15);
       const double w = 2 * M_PI * (double)offset2 / N_ZC;
       const c16_t ru = {.r = (int16_t)(floor(32767.0 * cos(w))), .i = (int16_t)(floor(32767.0 * sin(w)))};
       const c16_t p = c16mulShift(Xu_t, ru, 15);

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
@@ -259,7 +259,7 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
                 pdsch_scope_req_t *scope_req,
                 c16_t rho_dl[][NR_MAX_NB_LAYERS * NR_MAX_NB_LAYERS][pdsch_buf_size_max]);
 
-int32_t generate_nr_prach(PHY_VARS_NR_UE *ue, uint8_t gNB_id, int frame, uint8_t slot, c16_t **txData);
+int32_t generate_nr_prach(PHY_VARS_NR_UE *ue, uint8_t gNB_id, int frame, uint8_t slot, int16_t tx_amp, c16_t **txData);
 void apply_ntn_config(PHY_VARS_NR_UE *UE,
                       const NR_DL_FRAME_PARMS *fp,
                       int hfn_rx,

--- a/openair1/PHY/defs_nr_UE.h
+++ b/openair1/PHY/defs_nr_UE.h
@@ -211,7 +211,6 @@ typedef struct {
 #define PBCH_A 24
 
 typedef struct {
-  int16_t amp;
   bool active;
   int num_prach_slots;
   fapi_nr_ul_config_prach_pdu prach_pdu;

--- a/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
+++ b/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
@@ -1306,13 +1306,11 @@ void pdsch_processing(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, nr_phy_
   UEscopeCopy(ue, commonRxdataF, rxdataF, sizeof(int32_t), ue->frame_parms.nb_antennas_rx, rxdataF_sz, 0);
 }
 
-
-// todo:
-// - power control as per 38.213 ch 7.4
+// TODO: Actuate the MAC-requested PRACH power after defining a calibrated dBm-to-waveform/radio mapping.
 static void nr_ue_prach_procedures(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, c16_t **txData)
 {
   int gNB_id = proc->gNB_id;
-  int frame_tx = proc->frame_tx, nr_slot_tx = proc->nr_slot_tx, prach_power; // tx_amp
+  int frame_tx = proc->frame_tx, nr_slot_tx = proc->nr_slot_tx, generated_prach_power;
   uint8_t mod_id = ue->Mod_id;
 
   NR_UE_PRACH *prach_var = ue->prach_vars[gNB_id];
@@ -1321,20 +1319,21 @@ static void nr_ue_prach_procedures(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *
     // Generate PRACH in first slot. For L839, the following slots are also filled in this slot.
     if (prach_pdu->prach_slot == nr_slot_tx) {
       ue->tx_power_dBm[nr_slot_tx] = prach_pdu->prach_tx_power;
+      const int16_t tx_amp = AMP;
 
       LOG_D(PHY,
-            "In %s: [UE %d][RAPROC][%d.%d]: Generating PRACH Msg1 (preamble %d, P0_PRACH %d)\n",
+            "In %s: [UE %d][RAPROC][%d.%d]: Generating PRACH Msg1 (preamble %d, requested TX power %d dBm, digital "
+            "amplitude %d)\n",
             __FUNCTION__,
             mod_id,
             frame_tx,
             nr_slot_tx,
             prach_pdu->ra_PreambleIndex,
-            ue->tx_power_dBm[nr_slot_tx]);
-
-      prach_var->amp = AMP;
+            ue->tx_power_dBm[nr_slot_tx],
+            tx_amp);
 
       start_meas_nr_ue_phy(ue, PRACH_GEN_STATS);
-      prach_power = generate_nr_prach(ue, gNB_id, frame_tx, nr_slot_tx, txData);
+      generated_prach_power = generate_nr_prach(ue, gNB_id, frame_tx, nr_slot_tx, tx_amp, txData);
       stop_meas_nr_ue_phy(ue, PRACH_GEN_STATS);
       if (cpumeas(CPUMEAS_GETSTATE)) {
         LOG_D(PHY,
@@ -1345,14 +1344,15 @@ static void nr_ue_prach_procedures(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *
       }
 
       LOG_D(PHY,
-            "In %s: [UE %d][RAPROC][%d.%d]: Generated PRACH Msg1 (TX power PRACH %d dBm, digital power %d dBW (amp %d)\n",
+            "In %s: [UE %d][RAPROC][%d.%d]: Generated PRACH Msg1 (requested TX power %d dBm, digital amplitude %d, "
+            "digital power %d dB)\n",
             __FUNCTION__,
             mod_id,
             frame_tx,
             nr_slot_tx,
             ue->tx_power_dBm[nr_slot_tx],
-            dB_fixed(prach_power),
-            ue->prach_vars[gNB_id]->amp);
+            tx_amp,
+            dB_fixed(generated_prach_power));
 
       // set duration of prach slots so we know when to skip OFDM modulation
       const int prach_format = ue->prach_vars[gNB_id]->prach_pdu.prach_format;

--- a/openair1/SIMULATION/NR_PHY/prachsim.c
+++ b/openair1/SIMULATION/NR_PHY/prachsim.c
@@ -566,7 +566,6 @@ int main(int argc, char **argv){
   ue_prach_config        = &UE->nrUE_config.prach_config;
   txdata = UE->common_vars.txData;
 
-  ue_prach_pdu->prach_tx_power = AMP;
   ue_prach_pdu->root_seq_id     = rootSequenceIndex;
   ue_prach_pdu->num_cs          = get_NCS(NCS_config, format0, restrictedSetConfig);
   ue_prach_pdu->restricted_set  = restrictedSetConfig;
@@ -644,7 +643,7 @@ int main(int argc, char **argv){
   c16_t *tx[frame_parms->nb_antennas_rx];
   for (int i = 0; i < frame_parms->nb_antennas_rx; i++)
     tx[i] = txdata[i] + slot_start;
-  generate_nr_prach(UE, 0, frame, slot, tx);
+  generate_nr_prach(UE, 0, frame, slot, AMP, tx);
 
   /* tx_lev_dB not used later, no need to set */
   //tx_lev_dB = dB_fixed(tx_lev);


### PR DESCRIPTION
The NR UE PRACH PDU carries requested transmit power as signed dBm, but the PHY used that value directly as a Q15 linear waveform-amplitude coefficient.

A deterministic reproduction with requests of -75, -73, and -71 dBm produced energies of 90246, 84750, and 80662 respectively: increasing the requested power reduced the generated waveform energy. A 0 dBm request would also select a zero coefficient and therefore generate a zero waveform.

This change keeps requested dBm as metadata and passes an explicit linear `tx_amp` to `generate_nr_prach()`. The production scheduler and `nr_prachsim` pass their existing `AMP` value through that interface, the redundant stored amplitude is removed, and logs now distinguish requested dBm, digital amplitude, and generator-domain power.