### PR TITLE
nfapi: keep ENABLE_SOCKET private to the socket library

### DIFF
--- a/nfapi/oai_integration/socket/CMakeLists.txt
+++ b/nfapi/oai_integration/socket/CMakeLists.txt
@@ -8,7 +8,11 @@ add_library(nfapi_socket_lib
 
 target_include_directories(nfapi_socket_lib PUBLIC include/)
 
-target_compile_definitions(nfapi_socket_lib PUBLIC ENABLE_SOCKET)
+# Must stay PRIVATE: nfapi_pnf_lib links this library PUBLIC, so a PUBLIC definition would
+# propagate as an INTERFACE usage requirement to nfapi_user_lib in AERIAL builds and compile
+# the socket transport into nfapi_vnf.c alongside the Aerial one. Every consumer that needs
+# ENABLE_SOCKET declares it itself.
+target_compile_definitions(nfapi_socket_lib PRIVATE ENABLE_SOCKET)
 target_link_libraries(nfapi_socket_lib PRIVATE nfapi_nr_lib nfapi_user_lib)
 target_link_libraries(nfapi_socket_lib PRIVATE log_headers)
 target_link_libraries(nfapi_socket_lib PRIVATE asn1_lte_rrc_hdrs asn1_nr_rrc_hdrs)


### PR DESCRIPTION
## Summary
- Make `ENABLE_SOCKET` a `PRIVATE` compile definition on `nfapi_socket_lib`
With PUBLIC ENABLE_SOCKET on develop today, an AERIAL nfapi_vnf.c still builds cleanly with both macros. 
At runtime in configure_nr_nfapi_vnf:

 1. #ifdef ENABLE_SOCKET starts a socket P5 thread (idx ~0)
 2. #ifdef ENABLE_AERIAL then registers a synthetic PNF at p5_idx=1 and overwrites the send hooks

## Test plan
- [x] Build `nr-softmodem` with `-w AERIAL` and confirm `nfapi_vnf.c` is compiled without `ENABLE_SOCKET` (only `ENABLE_AERIAL`)
- [x] Build non-Aerial / socket NFAPI path and confirm socket VNF still works
- [x] Aerial SA: FAPI P5 PARAM/CONFIG/START succeeds without `could not find P5 connection for p5_idx 1`