### PR TITLE
Validate BCCH-DL-SCH constraints and SIB1 hotfix

### DIFF
--- a/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
@@ -2940,6 +2940,8 @@ NR_BCCH_DL_SCH_Message_t *get_SIB1_NR(const NR_ServingCellConfigCommon_t *scc,
   switch (scc->ssb_PositionsInBurst->present) {
     case NR_ServingCellConfigCommon__ssb_PositionsInBurst_PR_shortBitmap:
       ServCellCom->ssb_PositionsInBurst.inOneGroup = bit_string_clone(&scc->ssb_PositionsInBurst->choice.shortBitmap);
+      // ServingCellConfigCommonSIB requires an eight-bit inOneGroup bitmap.
+      ServCellCom->ssb_PositionsInBurst.inOneGroup.bits_unused = 0;
       break;
     case NR_ServingCellConfigCommon__ssb_PositionsInBurst_PR_mediumBitmap:
       ServCellCom->ssb_PositionsInBurst.inOneGroup = bit_string_clone(&scc->ssb_PositionsInBurst->choice.mediumBitmap);
@@ -3073,6 +3075,10 @@ int encode_SIB_NR(NR_BCCH_DL_SCH_Message_t *sib, uint8_t *buffer, int max_buffer
   AssertFatal(max_buffer_size <= NR_MAX_SIB_LENGTH / 8,
               "Maximum buffer size too large: 3GPP TS 38.331 section 5.2.1 - The physical layer imposes a limit to the "
               "maximum size a SIB can take. The maximum SIB1 or SI message size is 2976 bits.\n");
+  char errbuf[256] = {0};
+  size_t errlen = sizeof(errbuf);
+  const int ret = asn_check_constraints(&asn_DEF_NR_BCCH_DL_SCH_Message, sib, errbuf, &errlen);
+  AssertFatal(ret == 0, "BCCH-DL-SCH ASN.1 constraint check failed: %s\n", errbuf);
   asn_enc_rval_t enc_rval = uper_encode_to_buffer(&asn_DEF_NR_BCCH_DL_SCH_Message, NULL, sib, buffer, max_buffer_size);
   AssertFatal(enc_rval.encoded > 0 && enc_rval.encoded <= max_buffer_size * 8, "ASN1 message encoding failed (%s, %lu)!\n", enc_rval.failed_type->name, enc_rval.encoded);
   return (enc_rval.encoded + 7) / 8;


### PR DESCRIPTION
#Summary
Fix BCCH-DL-SCH ASN.1 validation for configurations that use a short SSB position bitmap and NTN SIB19.
The SIB1 construction copied the four-bit shortBitmap directly into ServingCellConfigCommonSIB.ssb-PositionsInBurst.inOneGroup, which is ASN.1 constrained to exactly eight bits. This could produce malformed system information without detection.
#Changes
Normalize short SSB bitmaps to the required 8-bit inOneGroup representation.
Run asn_check_constraints() on BCCH-DL-SCH messages before UPER encoding.
Fail with the ASN.1 constraint diagnostic when an invalid message is constructed.