### PR TITLE
ue: add --actor-affinity to pin DL/UL/SYNC actors

### DIFF
--- a/executables/nr-uesoftmodem.c
+++ b/executables/nr-uesoftmodem.c
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <signal.h>
 #include <errno.h>
+#include <string.h>
 
 #include "T.h"
 #include "common/oai_version.h"
@@ -138,6 +139,67 @@ static void get_options(configmodule_interface_t *cfg)
   config_get(cfg, cmdline_params, numparams, NULL);
   AssertFatal(nrUE_params.extra_pdu_id == -1,
               "Add additional PDU sessions in uicc.pdu_sessions array instead\n");
+}
+
+/* Parse --actor-affinity into cores[]. Returns number of cores. Empty/NULL -> 0. */
+static int parse_actor_affinity(const char *params, int *cores, int max_cores)
+{
+  if (params == NULL || params[0] == '\0')
+    return 0;
+
+  char *cpy = strdup(params);
+  AssertFatal(cpy != NULL, "Memory exhausted\n");
+  int n = 0;
+  char *saveptr = NULL;
+  for (char *tok = strtok_r(cpy, ",", &saveptr); tok != NULL; tok = strtok_r(NULL, ",", &saveptr)) {
+    AssertFatal(n < max_cores, "actor-affinity has more than %d entries\n", max_cores);
+    cores[n++] = atoi(tok);
+  }
+  free(cpy);
+  return n;
+}
+
+/* Assign one core from the shared pool to each DL actor, then each UL actor.
+ * If a spare remains, pin SYNC too. Leave everyone at -1 when actor-affinity is unset. */
+static void init_ue_actors(PHY_VARS_NR_UE *UE)
+{
+  const nrUE_params_t *p = get_nrUE_params();
+  const int need = p->num_dl_actors + p->num_ul_actors;
+  int cores[64];
+  const int have = parse_actor_affinity(p->actor_affinity, cores, sizeofArray(cores));
+  AssertFatal(have == 0 || have >= need,
+              "actor-affinity has %d entries but needs at least num-dl-actors (%d) + num-ul-actors (%d) = %d\n",
+              have,
+              p->num_dl_actors,
+              p->num_ul_actors,
+              need);
+
+  int idx = 0;
+  const int sync_core = (have > need) ? cores[need] : -1;
+  init_actor(&UE->sync_actor, "SYNC_", sync_core);
+
+  if (p->num_dl_actors > 0) {
+    UE->dl_actors = calloc_or_fail(p->num_dl_actors, sizeof(*UE->dl_actors));
+    for (int i = 0; i < p->num_dl_actors; i++) {
+      const int core = (have > 0) ? cores[idx++] : -1;
+      init_actor(&UE->dl_actors[i], "DL_", core);
+    }
+  }
+  if (p->num_ul_actors > 0) {
+    UE->ul_actors = calloc_or_fail(p->num_ul_actors, sizeof(*UE->ul_actors));
+    for (int i = 0; i < p->num_ul_actors; i++) {
+      const int core = (have > 0) ? cores[idx++] : -1;
+      init_actor(&UE->ul_actors[i], "UL_", core);
+    }
+  }
+  if (have > 0)
+    LOG_I(PHY,
+          "Pinned actors from actor-affinity=%s (DL %d, UL %d, SYNC %d)%s\n",
+          p->actor_affinity,
+          p->num_dl_actors,
+          p->num_ul_actors,
+          sync_core,
+          have > need + 1 ? " (extra cores unused)" : "");
 }
 
 // set PHY vars from command line
@@ -373,19 +435,7 @@ int main(int argc, char **argv)
       mac->dl_frequency = cell.rf_frequency;
 
       UE_CC->sl_mode = get_softmodem_params()->sl_mode;
-      init_actor(&UE_CC->sync_actor, "SYNC_", -1);
-      if (get_nrUE_params()->num_dl_actors > 0) {
-        UE_CC->dl_actors = calloc_or_fail(get_nrUE_params()->num_dl_actors, sizeof(*UE_CC->dl_actors));
-        for (int i = 0; i < get_nrUE_params()->num_dl_actors; i++) {
-          init_actor(&UE_CC->dl_actors[i], "DL_", -1);
-        }
-      }
-      if (get_nrUE_params()->num_ul_actors > 0) {
-        UE_CC->ul_actors = calloc_or_fail(get_nrUE_params()->num_ul_actors, sizeof(*UE_CC->ul_actors));
-        for (int i = 0; i < get_nrUE_params()->num_ul_actors; i++) {
-          init_actor(&UE_CC->ul_actors[i], "UL_", -1);
-        }
-      }
+      init_ue_actors(UE_CC);
       init_nr_ue_vars(UE_CC, inst);
 
       if (UE_CC->sl_mode) {

--- a/executables/nr-uesoftmodem.h
+++ b/executables/nr-uesoftmodem.h
@@ -29,6 +29,9 @@ extern uint16_t ue_id_g;
 #define  CONFIG_HLP_AGC                    "Rx Gain control used for UE\n"
 #define  CONFIG_HLP_NUM_UL_ACTORS          "Number of UL actors to use. Set to 0 to disable UL actor framework and do processing inline\n"
 #define  CONFIG_HLP_NUM_DL_ACTORS          "Number of DL actors to use. Set to 0 to disable DL actor framework and do processing inline\n"
+#define CONFIG_HLP_ACTOR_AFFINITY                                                                                          \
+  "Comma-separated cores for DL then UL actors (and SYNC if one spare). Must have at least num-dl-actors + num-ul-actors " \
+  "entries; omit for no affinity\n"
 #define  CONFIG_HLP_EXTRA_PDU_ID           "ID of an additional PDU session to configure alongside default PDU session\n"
 
 /***************************************************************************************************************************************/
@@ -78,6 +81,7 @@ extern uint16_t ue_id_g;
   {"agc",                          CONFIG_HLP_AGC,             PARAMFLAG_BOOL,  .iptr=&(nrUE_params.agc),                    .defintval=0,      TYPE_INT,      0}, \
   {"num-ul-actors",                CONFIG_HLP_NUM_UL_ACTORS,   0,               .iptr=&nrUE_params.num_ul_actors,            .defintval=2,      TYPE_INT,      0}, \
   {"num-dl-actors",                CONFIG_HLP_NUM_DL_ACTORS,  0,                .iptr=&nrUE_params.num_dl_actors,            .defintval=4,      TYPE_INT,      0}, \
+  {"actor-affinity",               CONFIG_HLP_ACTOR_AFFINITY,  0,               .strptr=&nrUE_params.actor_affinity,       .defstrval=NULL,   TYPE_STRING,   0}, \
   {"extra-pdu-id",                 CONFIG_HLP_EXTRA_PDU_ID,   0,                .iptr=&nrUE_params.extra_pdu_id,             .defintval=-1,     TYPE_INT,      0}, \
 }
 // clang-format on
@@ -119,6 +123,8 @@ typedef struct {
   int tx_max_power;
   int num_ul_actors;
   int num_dl_actors;
+  /* Shared core pool for actors (see --actor-affinity). NULL means leave them unpinned. */
+  char *actor_affinity;
   int extra_pdu_id;
 } nrUE_params_t;
 extern uint64_t get_nrUE_optmask(void);


### PR DESCRIPTION
## Summary
- Add `--actor-affinity` to pin DL/UL (and optional SYNC) UE actors for RT cpuset layouts
- Part of changes needed for #376

## Rationale
UE DL/UL/SYNC actors were always started with `init_actor(..., -1)`, so they ran unpinned at RT-max (`SCHED_FIFO`). On tuned setups the LDPC thread-pool and radio threads are already pinned to isolated cores at the same priority, so a woken actor cannot preempt them. Under DL-only the UL actors stay idle and this is invisible; under bidirectional traffic they contend for those cores and slot work slips.

The clearest symptom is `Deadline missed for tx slot`, with residual DL BLER clustered on the slots just ahead of UL, when PUSCH prep runs, rather than spread uniformly like a channel impairment. A wider Docker cpuset only reduces the odds; it does not pin threads, so actors can still land on Tpool/radio CPUs.

Use case / gain

Gives the same kind of control that `thread-pool=` already provides, but for the actor threads. Useful for channel saturating bidirectional traffic when those pools share a host with other RT work. Pinning actors onto spare `isolcpus` keeps them off the Tpool/radio set and makes placement deterministic. In bidir runs that cut the deadline misses sharply and brought the  BLER back to roughly ~0.5% at 256QAM MCS 27. Omit --actor-affinity to keep the previous unpinned behaviou

## Test plan
- [x] Build `nr-uesoftmodem` and run SA without `--actor-affinity` (unchanged affinity)
- [x] Run with `--actor-affinity` covering `num-dl-actors + num-ul-actors` (+ optional SYNC) and confirm threads pin as expected