### PR TITLE
Ue improvements macstats

### DIFF
--- a/openair1/PHY/NR_UE_TRANSPORT/csi_rx.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/csi_rx.c
@@ -1009,21 +1009,17 @@ void nr_ue_csi_rs_procedures(PHY_VARS_NR_UE *ue,
   switch (csirs_config_pdu->measurement_bitmap) {
     case 0:
       if (do_trs_est)
-        LOG_I(NR_PHY,
-              "%d.%d TRS estimated CFO: %d Hz\n",
-              proc->frame_rx,
-              proc->nr_slot_rx,
-              trs_cfo);
+        LOG_D(NR_PHY, "%d.%d TRS estimated CFO: %d Hz\n", proc->frame_rx, proc->nr_slot_rx, trs_cfo);
       break;
     case 1:
-      LOG_I(NR_PHY, "%d.%d [UE %d] RSRP = %i dBm\n", proc->frame_rx, proc->nr_slot_rx, ue->Mod_id, rsrp_dBm);
+      LOG_D(NR_PHY, "%d.%d [UE %d] RSRP = %i dBm\n", proc->frame_rx, proc->nr_slot_rx, ue->Mod_id, rsrp_dBm);
       break;
     case 26 :
-      LOG_I(NR_PHY, "RI = %i i1 = %i.%i.%i, i2 = %i, SINR = %i dB, CQI = %i\n",
+      LOG_D(NR_PHY, "RI = %i i1 = %i.%i.%i, i2 = %i, SINR = %i dB, CQI = %i\n",
             rank_indicator + 1, i1[0], i1[1], i1[2], i2[0], precoded_sinr_dB, cqi);
       break;
     case 27 :
-      LOG_I(NR_PHY, "RSRP = %i dBm, RI = %i i1 = %i.%i.%i, i2 = %i, SINR = %i dB, CQI = %i\n",
+      LOG_D(NR_PHY, "RSRP = %i dBm, RI = %i i1 = %i.%i.%i, i2 = %i, SINR = %i dB, CQI = %i\n",
             rsrp_dBm, rank_indicator + 1, i1[0], i1[1], i1[2], i2[0], precoded_sinr_dB, cqi);
       break;
     default :

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
@@ -765,6 +765,24 @@ static bool get_cw_info(NR_UE_DL_HARQ_STATUS_t *current_harq,
   return true;
 }
 
+/* Counterpart of the UL accumulation in nr_ue_dl_scheduler(), so that the DL line of
+ * print_ue_mac_stats() can report the same averages. Weighted by TBS like the UL side, and
+ * accumulated on every grant including retransmissions so the per-TB averages divide by the
+ * same round total the print uses. */
+static void accumulate_dl_stats(NR_UE_MAC_INST_t *mac,
+                                const fapi_nr_dl_config_dlsch_pdu_rel15_t *dlsch_pdu,
+                                const fapi_nr_dl_cw_info_t *cw_info,
+                                int number_rbs)
+{
+  int bits = cw_info->TBS;
+  mac->stats.dl.total_bits += bits;
+  mac->stats.dl.target_code_rate += (uint64_t)cw_info->targetCodeRate * bits;
+  if (cw_info->qamModOrder)
+    mac->stats.dl.total_symbols += bits / cw_info->qamModOrder;
+  mac->stats.dl.rb_size += number_rbs;
+  mac->stats.dl.nr_of_symbols += dlsch_pdu->number_symbols;
+}
+
 static int nr_ue_process_dci_dl_10_p_rnti(NR_UE_MAC_INST_t *mac,
                                           frame_t frame,
                                           int slot,
@@ -1475,6 +1493,7 @@ static int nr_ue_process_dci_dl_11(NR_UE_MAC_INST_t *mac,
                     cw_idx)) {
       if (current_harq->round < sizeofArray(mac->stats.dl.rounds))
         mac->stats.dl.rounds[current_harq->round]++;
+      accumulate_dl_stats(mac, dlsch_pdu, &dlsch_pdu->cw_info[0], number_rbs);
       // set the harq status at MAC for feedback
       set_harq_status(mac,
                       dci->pucch_resource_indicator,
@@ -1507,6 +1526,7 @@ static int nr_ue_process_dci_dl_11(NR_UE_MAC_INST_t *mac,
                     cw_idx)) {
       if (current_harq->round < sizeofArray(mac->stats.dl.rounds))
         mac->stats.dl.rounds[current_harq->round]++;
+      accumulate_dl_stats(mac, dlsch_pdu, &dlsch_pdu->cw_info[1], number_rbs);
       // set the harq status at MAC for feedback
       set_harq_status(mac,
                       dci->pucch_resource_indicator,

--- a/openair2/NR_UE_PHY_INTERFACE/NR_IF_Module.c
+++ b/openair2/NR_UE_PHY_INTERFACE/NR_IF_Module.c
@@ -51,6 +51,20 @@ void print_ue_mac_stats(const module_id_t mod, const int frame_rx, const int slo
                   slot_rx,
                   mac->stats.bad_dci);
 
+  const NR_SSB_meas_t *ssb = &mac->ssb_measurements[mac->mib_ssb];
+  const NR_CSIRS_meas_t *csi = &mac->csirs_measurements;
+  cur += snprintf(cur,
+                  end - cur,
+                  "    DL Chan: SSB %d SINR %.01f dB RSRP %d dBm, RI %d ",
+                  mac->mib_ssb,
+                  ssb->ssb_sinr_dB,
+                  ssb->ssb_rsrp_dBm,
+                  csi->ri);
+  if (csi->rsrp_dBm != 0)
+    cur += snprintf(cur, end - cur, "CQI %d CSI-RS RSRP %d dBm\n", csi->cqi, csi->rsrp_dBm);
+  else
+    cur += snprintf(cur, end - cur, "CQI: N/A\n");
+
   cur += snprintf(cur, end - cur, "    DL harq: %lu", mac->stats.dl.rounds[0]);
   int nb;
   for (nb = NR_MAX_HARQ_ROUNDS_FOR_STATS - 1; nb > 1; nb--)
@@ -58,8 +72,17 @@ void print_ue_mac_stats(const module_id_t mod, const int frame_rx, const int slo
       break;
   for (int i = 1; i < nb + 1; i++)
     cur += snprintf(cur, end - cur, "/%lu", mac->stats.dl.rounds[i]);
+  cur += snprintf(cur,
+                  end - cur,
+                  " avg code rate %.01f, avg bit/symbol %.01f, avg per TB: "
+                  "(nb RBs %.01f, nb symbols %.01f)\n",
+                  mac->stats.dl.total_bits ? (double)mac->stats.dl.target_code_rate / (mac->stats.dl.total_bits * 1024 * 10)
+                                           : 0.0, // See const Table_51311 definition
+                  mac->stats.dl.total_symbols ? (double)mac->stats.dl.total_bits / mac->stats.dl.total_symbols : 0.0,
+                  mac->stats.dl.rb_size / nbdl,
+                  mac->stats.dl.nr_of_symbols / nbdl);
 
-  cur += snprintf(cur, end - cur, "\n    UL harq: %lu", mac->stats.ul.rounds[0]);
+  cur += snprintf(cur, end - cur, "    UL harq: %lu", mac->stats.ul.rounds[0]);
   for (nb = NR_MAX_HARQ_ROUNDS_FOR_STATS - 1; nb > 1; nb--)
     if (mac->stats.ul.rounds[nb])
       break;
@@ -69,8 +92,9 @@ void print_ue_mac_stats(const module_id_t mod, const int frame_rx, const int slo
            end - cur,
            " avg code rate %.01f, avg bit/symbol %.01f, avg per TB: "
            "(nb RBs %.01f, nb symbols %.01f)\n",
-           (double)mac->stats.ul.target_code_rate / (mac->stats.ul.total_bits * 1024 * 10), // See const Table_51311 definition
-           (double)mac->stats.ul.total_bits / mac->stats.ul.total_symbols,
+           mac->stats.ul.total_bits ? (double)mac->stats.ul.target_code_rate / (mac->stats.ul.total_bits * 1024 * 10)
+                                    : 0.0, // See const Table_51311 definition
+           mac->stats.ul.total_symbols ? (double)mac->stats.ul.total_bits / mac->stats.ul.total_symbols : 0.0,
            mac->stats.ul.rb_size / nbul,
            mac->stats.ul.nr_of_symbols / nbul);
   LOG_I(NR_MAC, "%s", txt);


### PR DESCRIPTION
## Summary
- Accumulate DL grant stats and extend the UE periodic MAC line with DL averages plus SSB/CSI-RS CQI/RI
- Guard UL averages against divide-by-zero
- Demote per-slot CSI measurement prints to `LOG_D`
- Split out of #375 so that MR stays PDCP-only
## Test plan
- [x] Build `nr-uesoftmodem` and run SA; confirm periodic MAC stats show DL averages and SSB/CSI fields when connected
- [x] Confirm CSI measurement lines are silent at default log level (`LOG_D` only)