### PR TITLE
Settable ORU core affinity

### DIFF
--- a/common/utils/system.c
+++ b/common/utils/system.c
@@ -263,6 +263,15 @@ void threadCreate(pthread_t* t, void * (*func)(void*), void * param, char* name,
     LOG_I(UTIL, "%s() for %s: creating thread (no affinity, default priority)\n", __func__, name);
   }
 
+  if (affinity != -1) {
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(affinity, &cpuset);
+    /* Pin before create; post-create setaffinity can hang on a busy RT thread. */
+    ret = pthread_attr_setaffinity_np(&attr, sizeof(cpu_set_t), &cpuset);
+    AssertFatal(ret == 0, "Error in pthread_attr_setaffinity_np(): ret: %d, errno: %d\n", ret, errno);
+  }
+
   ret=pthread_create(t, &attr, func, param);
   AssertFatal(ret == 0, "Error in pthread_create(): ret: %d, errno: %d\n", ret, errno);
 
@@ -272,13 +281,6 @@ void threadCreate(pthread_t* t, void * (*func)(void*), void * param, char* name,
   ret = pthread_setname_np(*t, short_name);
   AssertFatal(ret == 0, "Error in pthread_setname_np(): ret: %d, errno: %d\n", ret, errno);
 
-  if (affinity != -1 ) {
-    cpu_set_t cpuset;
-    CPU_ZERO(&cpuset);
-    CPU_SET(affinity, &cpuset);
-    ret = pthread_setaffinity_np(*t, sizeof(cpu_set_t), &cpuset);
-    AssertFatal(ret == 0, "Error in pthread_getaffinity_np(): ret: %d, errno: %d", ret, errno);
-  }
   pthread_attr_destroy(&attr);
 }
 

--- a/doc/ORAN_FHI7.2_ORU_Tutorial.md
+++ b/doc/ORAN_FHI7.2_ORU_Tutorial.md
@@ -64,7 +64,6 @@ An example configuration file can be found at
 | `num_dl_symbols` | Integer | Number of DL symbols in the mixed slot | `7` |
 | `num_ul_symbols` | Integer | Number of UL symbols in the mixed slot | `3` |
 | `tx_core` | Integer | CPU core for the South (Split 8) write thread | `-1` |
-| `num_dl_threads` | Integer | Number of parallel DL reader threads (max `8`) | `1` |
 
 ### `ORUs.[0].fronthaul` parameters
 
@@ -72,6 +71,9 @@ An example configuration file can be found at
 | :--- | :--- | :--- | :--- |
 | `dpdk_devices` | String List | PCIe address list of DPDK interfaces | **Mandatory** |
 | `rx_core` | Integer | CPU core for the DPDK RX worker thread | **Mandatory** |
+| `north_cores` | Integer Array | CPU affinity per DL north reader (`-1` = unpinned). **List length is the number of DL readers** (max `8`) | `[-1]` (one unpinned reader) |
+| `south_core` | Integer | CPU core for the south (UL) reader thread (`-1` = unpinned) | `-1` |
+| `ul_worker_cores` | Integer Array | CPU cores for UL Tpool workers; empty falls back to `RUs.tp_cores` | `[]` |
 | `du_mac_addr` | String List | Destination MAC addresses of the DU | **Mandatory** |
 | `T2a_up` | Int Array (2) | Timing window bounds `(T2a_up_min, T2a_up_max)` | **Mandatory** |
 | `T2a_cp` | Int Array (2) | Timing window bounds `(T2a_cp_min, T2a_cp_max)` | **Mandatory** |
@@ -161,9 +163,10 @@ rotation), and contiguous format packing.
 For transmitted DL symbols, the O-RU must perform phase rotation, an
 FFT-shift, and cyclic prefix (CP) insertion before handing samples to the
 South (Split 8) write thread.
-* Instead of a single DL reader thread, `num_dl_threads` independent
-  `oru_north_read_worker` threads run concurrently, each executing the
-  full read/process/publish loop for a symbol.
+* One `oru_north_read_worker` runs per `north_cores` entry, each executing
+  the full read/process/publish loop for a symbol (e.g. `north_cores =
+  [-1, -1, -1, -1]` starts four unpinned readers; `north_cores = [21, 22]`
+  starts two pinned ones).
 * Because several threads complete symbols concurrently, completions can
   arrive out of order. A generic reorder buffer
   (`common/utils/symbol_reorder`) tracks completions by absolute symbol
@@ -196,7 +199,7 @@ The report includes, per direction (DL/UL):
 * Number of symbols (or antenna-symbols) processed in the window.
 * Per-thread processing time (Avg/Max).
 * **Effective** processing time — the per-thread time scaled by how many
-  worker threads (`num_dl_threads` for DL, `num_tp_cores` for UL) actually
+  worker threads (`north_cores` length for DL, `num_tp_cores` for UL) actually
   run concurrently on the available CPU cores.
 * A safety margin relative to the physical symbol duration, with a
   `PASS` / `WARNING` (margin < 20%) / `CRITICAL` (budget exceeded)

--- a/executables/main_nr_ru.c
+++ b/executables/main_nr_ru.c
@@ -241,23 +241,44 @@ int main(int argc, char **argv)
   AssertFatal(rc == 0, "pthread_cond_init() failed: %d, %s\n", rc, strerror(rc));
   oru.tx_write.initialized = false;
 
-  AssertFatal(ru->num_tpcores > 0, "RU %u: num_tp_cores must be > 0\n", ru->idx);
-  char pool[80];
-  int s_offset = sprintf(pool, "%d", ru->tpcores[0]);
-  for (int icpu = 1; icpu < ru->num_tpcores; icpu++) {
-    s_offset += sprintf(pool + s_offset, ",%d", ru->tpcores[icpu]);
+  /* Prefer fronthaul.ul_worker_cores when set so north/south pins stay exclusive of the UL Tpool. */
+  int num_pool_cores;
+  const int *pool_cores;
+  if (oru.num_ul_worker_cores > 0) {
+    num_pool_cores = oru.num_ul_worker_cores;
+    pool_cores = oru.ul_worker_cores;
+  } else {
+    AssertFatal(ru->num_tpcores > 0, "RU %u: num_tp_cores must be > 0 (or set fronthaul.ul_worker_cores)\n", ru->idx);
+    num_pool_cores = ru->num_tpcores;
+    pool_cores = ru->tpcores;
   }
-  LOG_I(PHY, "O-RU thread-pool core string %s (size %d)\n", pool, ru->num_tpcores);
+  char pool[80];
+  int s_offset = sprintf(pool, "%d", pool_cores[0]);
+  for (int icpu = 1; icpu < num_pool_cores; icpu++) {
+    s_offset += sprintf(pool + s_offset, ",%d", pool_cores[icpu]);
+  }
+  LOG_I(PHY, "O-RU thread-pool core string %s (size %d)\n", pool, num_pool_cores);
   ru->threadPool = malloc(sizeof(tpool_t));
   initNamedTpool(pool, ru->threadPool, false, "ul_worker");
 
+  /* Create south before north so TX/RX start even if a north reader stalls. */
+  threadCreate(&oru.south_read_thread,
+               oru_south_read_thread,
+               (void *)&oru,
+               "south_read_thread",
+               oru.south_core,
+               OAI_PRIORITY_RT_MAX);
+  threadCreate(&oru.south_write_thread,
+               oru_south_write_thread,
+               (void *)&oru,
+               "south_write_thread",
+               oru.tx_write.core,
+               OAI_PRIORITY_RT_MAX);
   for (int i = 0; i < oru.num_dl_read_threads; i++) {
     char thread_name[32];
     snprintf(thread_name, sizeof(thread_name), "north_read_%d", i);
-    threadCreate(&oru.dl_read_threads[i], oru_north_read_worker, (void *)&oru, thread_name, -1, OAI_PRIORITY_RT_MAX);
+    threadCreate(&oru.dl_read_threads[i], oru_north_read_worker, (void *)&oru, thread_name, oru.north_cores[i], OAI_PRIORITY_RT_MAX);
   }
-  threadCreate(&oru.south_read_thread, oru_south_read_thread, (void *)&oru, "south_read_thread", -1, OAI_PRIORITY_RT_MAX);
-  threadCreate(&oru.south_write_thread, oru_south_write_thread, (void *)&oru, "south_write_thread", oru.tx_write.core, OAI_PRIORITY_RT_MAX);
 
   while (oai_exit == 0) {
     oru_fh_print_stats(oru.fronthaul);

--- a/executables/nr-oru.c
+++ b/executables/nr-oru.c
@@ -32,7 +32,6 @@
 #define CONFIG_STRING_ORU_NUM_DL_SYMBOLS "num_dl_symbols"
 #define CONFIG_STRING_ORU_NUM_UL_SYMBOLS "num_ul_symbols"
 #define CONFIG_STRING_ORU_TX_CORE "tx_core"
-#define CONFIG_STRING_ORU_NUM_DL_THREADS "num_dl_threads"
 
 #define HLP_ORU_TX_BW "set the TX bandwidth list per component carrier"
 #define HLP_ORU_RX_BW "set the RX bandwidth list per component carrier"
@@ -66,7 +65,6 @@
   {CONFIG_STRING_ORU_NUM_DL_SYMBOLS,            HLP_ORU_NUM_DL_SYMBOLS,             0,    .uptr=NULL,       .defintval=7,                 TYPE_UINT,         0}, \
   {CONFIG_STRING_ORU_NUM_UL_SYMBOLS,            HLP_ORU_NUM_UL_SYMBOLS,             0,    .uptr=NULL,       .defintval=3,                 TYPE_UINT,         0}, \
   {CONFIG_STRING_ORU_TX_CORE,                   "The CPU core to be used to deploy south write thread for O-RU.", 0, .iptr=NULL, .defintval=-1, TYPE_INT, 0}, \
-  {CONFIG_STRING_ORU_NUM_DL_THREADS,            "Number of parallel DL reader threads for O-RU.", 0, .iptr=NULL, .defintval=1, TYPE_INT, 0}, \
 }
 
 #define CMDLINE_PARAMS_DESC_ORU_COMMON \
@@ -79,6 +77,9 @@
 
 #define CONFIG_STRING_ORU_DPDK_DEVICES "dpdk_devices"
 #define CONFIG_STRING_RX_CORE "rx_core"
+#define CONFIG_STRING_NORTH_CORES "north_cores"
+#define CONFIG_STRING_SOUTH_CORE "south_core"
+#define CONFIG_STRING_UL_WORKER_CORES "ul_worker_cores"
 #define CONFIG_STRING_EXTRA_EAL_ARGS "extra_eal_args"
 #define CONFIG_STRING_DU_MAC_ADDRESSES "du_mac_addr"
 #define CONFIG_STRING_MTU "mtu"
@@ -90,6 +91,12 @@
 
 #define HLP_DPDK_DEVICES "DPDK devices to use for the O-RU."
 #define HLP_RX_CORE "The CPU core to be used to deploy dpdk RX worker for O-RU."
+/* North/south/UL workers are RT-max; pin them or they roam into vrtsim cores. */
+#define HLP_NORTH_CORES                                                                                                       \
+  "CPU cores for O-RU north reader threads (one entry per thread, -1 = unpinned). List length sets the number of DL readers " \
+  "(default [-1] = one unpinned reader)."
+#define HLP_SOUTH_CORE "CPU core for the O-RU south (UL) reader thread; -1 for no pinning."
+#define HLP_UL_WORKER_CORES "CPU cores for the UL Tpool workers; empty falls back to RUs.tp_cores."
 #define HLP_EXTRA_EAL_ARGS "Extra arguments passed to RTE_EAL_INIT."
 #define HLP_DU_MAC_ADDRESSES "DU MAC addreses, used to prepare Ethernet headers."
 #define HLP_MTU "MTU for RX and TX."
@@ -108,6 +115,9 @@
 { \
   {CONFIG_STRING_ORU_DPDK_DEVICES,           HLP_DPDK_DEVICES,      PARAMFLAG_MANDATORY,    .strptr=NULL,     .defstrval=NULL,              TYPE_STRINGLIST,   0}, \
   {CONFIG_STRING_RX_CORE,                    HLP_RX_CORE,           PARAMFLAG_MANDATORY,    .iptr=NULL,       .defintval=-1,                TYPE_INT,          0}, \
+  {CONFIG_STRING_NORTH_CORES,                HLP_NORTH_CORES,       0,                      .iptr=NULL,       .defintarrayval=NULL,         TYPE_INTARRAY,     0}, \
+  {CONFIG_STRING_SOUTH_CORE,                 HLP_SOUTH_CORE,        0,                      .iptr=NULL,       .defintval=-1,                TYPE_INT,          0}, \
+  {CONFIG_STRING_UL_WORKER_CORES,            HLP_UL_WORKER_CORES,   0,                      .iptr=NULL,       .defintarrayval=NULL,         TYPE_INTARRAY,     0}, \
   {CONFIG_STRING_EXTRA_EAL_ARGS,             HLP_EXTRA_EAL_ARGS,    0,                      .strptr=NULL,     .defstrval=NULL,              TYPE_STRINGLIST,   0}, \
   {CONFIG_STRING_DU_MAC_ADDRESSES,           HLP_DU_MAC_ADDRESSES,  PARAMFLAG_MANDATORY,    .strptr=NULL,     .defstrval=NULL,              TYPE_STRINGLIST,   0}, \
   {CONFIG_STRING_MTU,                        HLP_MTU,               0,                      .iptr=NULL,       .defintval=9600,              TYPE_INT,          0}, \
@@ -230,11 +240,6 @@ int get_oru_options(ORU_t *oru)
   oru->num_DL_symbols = *gpd(param, nump, CONFIG_STRING_ORU_NUM_DL_SYMBOLS)->iptr;
   oru->num_UL_symbols = *gpd(param, nump, CONFIG_STRING_ORU_NUM_UL_SYMBOLS)->iptr;
   oru->tx_write.core = *gpd(param, nump, CONFIG_STRING_ORU_TX_CORE)->iptr;
-  oru->num_dl_read_threads = *gpd(param, nump, CONFIG_STRING_ORU_NUM_DL_THREADS)->iptr;
-  AssertFatal(oru->num_dl_read_threads > 0 && oru->num_dl_read_threads <= MAX_DL_READ_THREADS,
-              "Invalid number of DL read threads (%d), must be in [1, %d]\n",
-              oru->num_dl_read_threads,
-              MAX_DL_READ_THREADS);
 
   paramdef_t fh_param[] = CMDLINE_PARAMS_DESC_ORU_FH;
   nump = sizeofArray(fh_param);
@@ -266,6 +271,28 @@ int get_oru_options(ORU_t *oru)
   AssertFatal(comp_type_idx >= 0, "Index for %s config option not found!\n", CONFIG_STRING_COMP_TYPE);
   fh_cfg->comp_type = (fh_comp_method_t)config_get_processedint(config_get_if(), &fh_param[comp_type_idx]);
   fh_cfg->rx_core = *gpd(fh_param, nump, CONFIG_STRING_RX_CORE)->iptr;
+  oru->num_dl_read_threads = gpd(fh_param, nump, CONFIG_STRING_NORTH_CORES)->numelt;
+  if (oru->num_dl_read_threads == 0) {
+    oru->num_dl_read_threads = 1;
+    oru->north_cores[0] = -1;
+  } else {
+    AssertFatal(oru->num_dl_read_threads <= MAX_DL_READ_THREADS,
+                "%s has %d entries; need [1, %d] (one core per DL reader, -1 to leave unpinned)\n",
+                CONFIG_STRING_NORTH_CORES,
+                oru->num_dl_read_threads,
+                MAX_DL_READ_THREADS);
+    for (int i = 0; i < oru->num_dl_read_threads; i++)
+      oru->north_cores[i] = gpd(fh_param, nump, CONFIG_STRING_NORTH_CORES)->iptr[i];
+  }
+  oru->south_core = *gpd(fh_param, nump, CONFIG_STRING_SOUTH_CORE)->iptr;
+  oru->num_ul_worker_cores = gpd(fh_param, nump, CONFIG_STRING_UL_WORKER_CORES)->numelt;
+  AssertFatal(oru->num_ul_worker_cores <= MAX_ORU_UL_WORKERS,
+              "%s has %d entries, at most %d supported\n",
+              CONFIG_STRING_UL_WORKER_CORES,
+              oru->num_ul_worker_cores,
+              MAX_ORU_UL_WORKERS);
+  for (int i = 0; i < oru->num_ul_worker_cores; i++)
+    oru->ul_worker_cores[i] = gpd(fh_param, nump, CONFIG_STRING_UL_WORKER_CORES)->iptr[i];
   fh_cfg->mtu = *gpd(fh_param, nump, CONFIG_STRING_MTU)->iptr;
   fh_cfg->num_prbs = oru->bw_tx[0];
   fh_cfg->numerology = oru->numerology;
@@ -491,11 +518,7 @@ void wait_for_south_read(uint64_t *hyper_frame, uint32_t *start_frame, uint32_t 
   pthread_mutex_unlock(&south_read_mutex);
 }
 
-// Runs concurrently as several DL reader threads (see oru.num_dl_read_threads). Each thread
-// independently derives the same start_timestamp/start_hyper_frame/start_symbol_index from the
-// deterministic HW UTC anchor (or the shared wait_for_south_read() notification), then only the
-// first thread to arrive actually publishes them to ORU_t and creates the shared dl_reorder -
-// later threads see tx_write.initialized already set and just use their own local values below.
+// Parallel DL readers share one TX timing anchor under tx_write.mutex.
 void *oru_north_read_worker(void *arg)
 {
   ORU_t *oru = (ORU_t *)arg;
@@ -512,31 +535,46 @@ void *oru_north_read_worker(void *arg)
   uint32_t start_frame, start_slot;
   uint64_t start_hyper_frame;
   int64_t start_timestamp;
-  if (ru->rfdevice.get_timestamp) {
-    struct timespec utc_anchor_point;
-    oru_fh_get_utc_anchor_point(oru->fronthaul, &start_hyper_frame, &start_frame, &start_slot, &utc_anchor_point);
-    start_timestamp = ru->rfdevice.get_timestamp(&ru->rfdevice, &utc_anchor_point);
-  } else {
-    wait_for_south_read(&start_hyper_frame, &start_frame, &start_slot, &start_timestamp);
-  }
-    // subtract the start_frame and start_slot from the timestamp simplify calculation below.
-  start_timestamp -= (start_frame * fp->samples_per_frame + get_samples_slot_timestamp(fp, start_slot));
-  // Now start_timestamp points to the start sample of the frame 0 slot 0 symbol 0 of hyperframe 0
-  LOG_A(PHY, "DL thread started: start_timestamp %ld, start_frame %d, start_slot %d\n", start_timestamp, start_frame, start_slot);
 
   pthread_mutex_lock(&oru->tx_write.mutex);
   if (!oru->tx_write.initialized) {
+    if (ru->rfdevice.get_timestamp) {
+      struct timespec utc_anchor_point;
+      oru_fh_get_utc_anchor_point(oru->fronthaul, &start_hyper_frame, &start_frame, &start_slot, &utc_anchor_point);
+      start_timestamp = ru->rfdevice.get_timestamp(&ru->rfdevice, &utc_anchor_point);
+    } else {
+      pthread_mutex_unlock(&oru->tx_write.mutex);
+      wait_for_south_read(&start_hyper_frame, &start_frame, &start_slot, &start_timestamp);
+      pthread_mutex_lock(&oru->tx_write.mutex);
+      if (oru->tx_write.initialized) {
+        start_timestamp = oru->tx_write.start_timestamp;
+        start_hyper_frame = oru->tx_write.start_hyper_frame;
+        goto anchor_ready;
+      }
+    }
+    start_timestamp -= (start_frame * fp->samples_per_frame + get_samples_slot_timestamp(fp, start_slot));
     oru->tx_write.start_timestamp = start_timestamp;
     oru->tx_write.start_hyper_frame = start_hyper_frame;
-    oru->tx_write.start_symbol_index = start_frame * (fp->slots_per_frame * fp->symbols_per_slot) + start_slot * fp->symbols_per_slot;
+    oru->tx_write.start_symbol_index =
+        start_frame * (fp->slots_per_frame * fp->symbols_per_slot) + start_slot * fp->symbols_per_slot;
     const uint8_t *dl_symbol_bitmask;
     uint16_t bitmask_bit_length;
     oru_fh_get_dl_symbol_bitmask(oru->fronthaul, &dl_symbol_bitmask, &bitmask_bit_length);
     oru->dl_reorder = symbol_reorder_create(oru->tx_write.start_symbol_index, dl_symbol_bitmask, bitmask_bit_length);
     oru->tx_write.initialized = true;
     pthread_cond_broadcast(&oru->tx_write.cond);
+  } else {
+    start_timestamp = oru->tx_write.start_timestamp;
+    start_hyper_frame = oru->tx_write.start_hyper_frame;
   }
+anchor_ready:
   pthread_mutex_unlock(&oru->tx_write.mutex);
+
+  LOG_A(PHY,
+        "DL thread started: start_timestamp %ld, start_hyper_frame %lu, start_symbol_index %lu\n",
+        start_timestamp,
+        (unsigned long)start_hyper_frame,
+        (unsigned long)oru->tx_write.start_symbol_index);
 
   while (!oai_exit) {
     int frame = -1, slot = -1, symbol = -1;

--- a/executables/nr-oru.h
+++ b/executables/nr-oru.h
@@ -12,6 +12,7 @@
 #include "openair1/PHY/defs_gNB.h"
 
 #define MAX_DL_READ_THREADS 8
+#define MAX_ORU_UL_WORKERS 8
 
 typedef struct {
   RU_t *ru;
@@ -40,6 +41,11 @@ typedef struct {
   /// number of UL symbols
   int num_UL_symbols;
   int numerology;
+
+  int north_cores[MAX_DL_READ_THREADS]; ///< affinity for DL reader i (-1 = unpinned); length sets num_dl_read_threads
+  int south_core;
+  int ul_worker_cores[MAX_ORU_UL_WORKERS];
+  int num_ul_worker_cores;
 
   int num_dl_read_threads;
   pthread_t dl_read_threads[MAX_DL_READ_THREADS];


### PR DESCRIPTION
## Summary
- Pin north/south readers and UL Tpool via `fronthaul` cores (`north_core` INTARRAY 0/1/N)
- Share one TX timing anchor across dual north readers; create south before north
- Pin via `pthread_attr_setaffinity_np` before create (avoids post-create hang on busy RT threads)
## Test plan
- [x] Build `nr-oru` and run ASET aerial path with `num_dl_threads = 2` and dual `north_core`
- [x] Confirm south TX/RX start and DL reorder stays contiguous under load