### PR TITLE
ue/gNB: Keep PUCCH on stale UL config; clear all UEs in PUSCH TP group

### DIFF
--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch_demodulation.c
@@ -539,6 +539,20 @@ int nr_rx_pusch_group_tp(PHY_VARS_gNB *gNB,
         frame_parms->first_carrier_offset);
   LOG_D(PHY, "pusch %d.%d : ul_dmrs_symb_pos %x\n", frame, slot, rel15_ul_ref->ul_dmrs_symb_pos);
 
+  // Softscope dumps the whole slot grid; clear unused symbols so they do not keep
+  // stale constellation points. scopeData is set only when nrscope is loaded (--doscope).
+  if (gNB->scopeData) {
+    const int rxdataF_comp_symbol_size = ceil_mod(frame_parms->N_RB_UL * NR_NB_SC_PER_RB, 16);
+    const int rxdataF_comp_slot_size = rxdataF_comp_symbol_size * frame_parms->symbols_per_slot;
+    for (int ue = 0; ue < group_size; ue++) {
+      NR_gNB_PUSCH *pusch_vars = pusch_vars_group[ue];
+      const int n_buf = rel15_ul_group[ue]->nrOfLayers;
+      for (int i = 0; i < n_buf; i++)
+        memset(pusch_vars->rxdataF_comp[i], 0, sizeof(*pusch_vars->rxdataF_comp[i]) * rxdataF_comp_slot_size);
+      memset(pusch_vars->ul_valid_re_per_slot, 0, sizeof(*pusch_vars->ul_valid_re_per_slot) * frame_parms->symbols_per_slot);
+    }
+  }
+
   // Memories to store data for data recording
   int buffer_length_slot = rel15_ul_ref->rb_size * NR_NB_SC_PER_RB * NR_SYMBOLS_PER_SLOT;
   // data recording application supports only a single layer.

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
@@ -2604,6 +2604,7 @@ void nr_ue_ul_scheduler(NR_UE_MAC_INST_t *mac, nr_uplink_indication_t *ul_info)
             && (mac->state == UE_CONNECTED || (ra->ra_state == nrRA_WAIT_RAR && ra->cfra))) {
           if (!nr_timer_is_active(&mac->time_alignment_timer) && mac->state == UE_CONNECTED && !get_softmodem_params()->phy_test) {
             // UL data arrival during RRC_CONNECTED when UL synchronisation status is "non-synchronised"
+            release_ul_config(ulcfg_pdu, false);
             trigger_MAC_UE_RA(mac, NULL);
             return;
           }

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
@@ -2572,93 +2572,101 @@ void nr_ue_ul_scheduler(NR_UE_MAC_INST_t *mac, nr_uplink_indication_t *ul_info)
   uint8_t ulsch_input_buffer_array[FAPI_NR_UL_CONFIG_LIST_NUM][MAX_NUM_NR_ULSCH_SEGMENTS * 1056];
   int number_of_pdus = 0;
 
+  /* Stale ul_config (frame mismatch on a slot-indexed buffer) must not abort the
+   * whole UL scheduler: PUCCH HARQ-ACK/CSI/SR still needs to go out. lockGet_ul_iterator
+   * already cleared the leftover PUSCH grant and released the mutex on that path. */
   fapi_nr_ul_config_request_pdu_t *ulcfg_pdu = lockGet_ul_iterator(mac, frame_tx, slot_tx);
-  if (!ulcfg_pdu)
-    return;
-  LOG_D(NR_MAC, "number of UL PDUs: %d with UL transmission in sfn [%d.%d]\n", *ulcfg_pdu->privateNBpdus, frame_tx, slot_tx);
+  if (ulcfg_pdu) {
+    LOG_D(NR_MAC, "number of UL PDUs: %d with UL transmission in sfn [%d.%d]\n", *ulcfg_pdu->privateNBpdus, frame_tx, slot_tx);
 
-  while (ulcfg_pdu->pdu_type != FAPI_NR_END) {
-    uint8_t *ulsch_input_buffer = ulsch_input_buffer_array[number_of_pdus];
-    if (ulcfg_pdu->pdu_type == FAPI_NR_UL_CONFIG_TYPE_PUSCH) {
-      nfapi_nr_ue_pusch_pdu_t *pdu = &ulcfg_pdu->pusch_config_pdu;
-      uint32_t TBS_bytes = pdu->pusch_data.tb_size;
-      LOG_D(NR_MAC,
-            "harq_id %d, new_data_indicator %d, TBS_bytes %d (ra_state %d)\n",
-            pdu->pusch_data.harq_process_id,
-            pdu->pusch_data.new_data_indicator,
-            TBS_bytes,
-            ra->ra_state);
-      pdu->tx_request_body.fapiTxPdu = NULL;
-      if ((ra->ra_state == nrRA_WAIT_RAR || ra->ra_state == nrRA_WAIT_MSGB) && !ra->cfra) {
-        nr_get_Msg3_MsgA_PUSCH_payload(mac, ulsch_input_buffer, TBS_bytes);
-        for (int k = 0; k < TBS_bytes; k++) {
-          LOG_D(NR_MAC, "(%i): 0x%x\n", k, ulsch_input_buffer[k]);
-        }
-        pdu->tx_request_body.fapiTxPdu = ulsch_input_buffer;
-        pdu->tx_request_body.pdu_length = TBS_bytes;
-        number_of_pdus++;
-        T(T_NRUE_MAC_UL_PDU_WITH_DATA, T_INT(mac->crnti), T_INT(frame_tx), T_INT(slot_tx),
-          T_INT(ulcfg_pdu->pusch_config_pdu.pusch_data.harq_process_id), T_BUFFER(ulsch_input_buffer, TBS_bytes));
-      } else {
-        if (ulcfg_pdu->pusch_config_pdu.pusch_data.new_data_indicator
-            && (mac->state == UE_CONNECTED || (ra->ra_state == nrRA_WAIT_RAR && ra->cfra))) {
-          if (!nr_timer_is_active(&mac->time_alignment_timer) && mac->state == UE_CONNECTED && !get_softmodem_params()->phy_test) {
-            // UL data arrival during RRC_CONNECTED when UL synchronisation status is "non-synchronised"
-            release_ul_config(ulcfg_pdu, false);
-            trigger_MAC_UE_RA(mac, NULL);
-            return;
+    while (ulcfg_pdu->pdu_type != FAPI_NR_END) {
+      uint8_t *ulsch_input_buffer = ulsch_input_buffer_array[number_of_pdus];
+      if (ulcfg_pdu->pdu_type == FAPI_NR_UL_CONFIG_TYPE_PUSCH) {
+        nfapi_nr_ue_pusch_pdu_t *pdu = &ulcfg_pdu->pusch_config_pdu;
+        uint32_t TBS_bytes = pdu->pusch_data.tb_size;
+        LOG_D(NR_MAC,
+              "harq_id %d, new_data_indicator %d, TBS_bytes %d (ra_state %d)\n",
+              pdu->pusch_data.harq_process_id,
+              pdu->pusch_data.new_data_indicator,
+              TBS_bytes,
+              ra->ra_state);
+        pdu->tx_request_body.fapiTxPdu = NULL;
+        if ((ra->ra_state == nrRA_WAIT_RAR || ra->ra_state == nrRA_WAIT_MSGB) && !ra->cfra) {
+          nr_get_Msg3_MsgA_PUSCH_payload(mac, ulsch_input_buffer, TBS_bytes);
+          for (int k = 0; k < TBS_bytes; k++) {
+            LOG_D(NR_MAC, "(%i): 0x%x\n", k, ulsch_input_buffer[k]);
           }
-          // Getting IP traffic to be transmitted
-          int tx_power = pdu->tx_power;
-          bool tp_enabled = pdu->transform_precoding == NR_PUSCH_Config__transformPrecoder_enabled;
-          int P_CMAX = nr_get_Pcmax(mac->p_Max,
-                                    mac->nr_band,
-                                    mac->frame_structure.frame_type,
-                                    mac->frequency_range,
-                                    mac->current_UL_BWP->channel_bandwidth,
-                                    pdu->qam_mod_order,
-                                    false,
-                                    mac->current_UL_BWP->scs,
-                                    mac->current_UL_BWP->BWPSize,
-                                    tp_enabled,
-                                    pdu->rb_size,
-                                    pdu->rb_start);
-          if (nr_ue_get_sdu(mac, frame_tx, slot_tx, ulsch_input_buffer, TBS_bytes, tx_power, P_CMAX, &BSRsent)) {
-            pdu->tx_request_body.fapiTxPdu = ulsch_input_buffer;
-            pdu->tx_request_body.pdu_length = TBS_bytes;
-            number_of_pdus++;
-            T(T_NRUE_MAC_UL_PDU_WITH_DATA,
-              T_INT(mac->crnti),
-              T_INT(frame_tx),
-              T_INT(slot_tx),
-              T_INT(ulcfg_pdu->pusch_config_pdu.pusch_data.harq_process_id),
-              T_BUFFER(ulsch_input_buffer, TBS_bytes));
-          } else
-            LOG_E(MAC, "nr_ue_get_sdu() failed\n");
-          // start or restart dataInactivityTimer  if any MAC entity transmits a MAC SDU for DTCH logical channel,
-          // or DCCH logical channel
-          if (mac->data_inactivity_timer)
-            nr_timer_start(mac->data_inactivity_timer);
+          pdu->tx_request_body.fapiTxPdu = ulsch_input_buffer;
+          pdu->tx_request_body.pdu_length = TBS_bytes;
+          number_of_pdus++;
+          T(T_NRUE_MAC_UL_PDU_WITH_DATA,
+            T_INT(mac->crnti),
+            T_INT(frame_tx),
+            T_INT(slot_tx),
+            T_INT(ulcfg_pdu->pusch_config_pdu.pusch_data.harq_process_id),
+            T_BUFFER(ulsch_input_buffer, TBS_bytes));
+        } else {
+          if (ulcfg_pdu->pusch_config_pdu.pusch_data.new_data_indicator
+              && (mac->state == UE_CONNECTED || (ra->ra_state == nrRA_WAIT_RAR && ra->cfra))) {
+            if (!nr_timer_is_active(&mac->time_alignment_timer) && mac->state == UE_CONNECTED
+                && !get_softmodem_params()->phy_test) {
+              // UL data arrival during RRC_CONNECTED when UL synchronisation status is "non-synchronised"
+              release_ul_config(ulcfg_pdu, false);
+              trigger_MAC_UE_RA(mac, NULL);
+              return;
+            }
+            // Getting IP traffic to be transmitted
+            int tx_power = pdu->tx_power;
+            bool tp_enabled = pdu->transform_precoding == NR_PUSCH_Config__transformPrecoder_enabled;
+            int P_CMAX = nr_get_Pcmax(mac->p_Max,
+                                      mac->nr_band,
+                                      mac->frame_structure.frame_type,
+                                      mac->frequency_range,
+                                      mac->current_UL_BWP->channel_bandwidth,
+                                      pdu->qam_mod_order,
+                                      false,
+                                      mac->current_UL_BWP->scs,
+                                      mac->current_UL_BWP->BWPSize,
+                                      tp_enabled,
+                                      pdu->rb_size,
+                                      pdu->rb_start);
+            if (nr_ue_get_sdu(mac, frame_tx, slot_tx, ulsch_input_buffer, TBS_bytes, tx_power, P_CMAX, &BSRsent)) {
+              pdu->tx_request_body.fapiTxPdu = ulsch_input_buffer;
+              pdu->tx_request_body.pdu_length = TBS_bytes;
+              number_of_pdus++;
+              T(T_NRUE_MAC_UL_PDU_WITH_DATA,
+                T_INT(mac->crnti),
+                T_INT(frame_tx),
+                T_INT(slot_tx),
+                T_INT(ulcfg_pdu->pusch_config_pdu.pusch_data.harq_process_id),
+                T_BUFFER(ulsch_input_buffer, TBS_bytes));
+            } else
+              LOG_E(MAC, "nr_ue_get_sdu() failed\n");
+            // start or restart dataInactivityTimer  if any MAC entity transmits a MAC SDU for DTCH logical channel,
+            // or DCCH logical channel
+            if (mac->data_inactivity_timer)
+              nr_timer_start(mac->data_inactivity_timer);
+          }
+        }
+
+        if (ra->ra_state == nrRA_WAIT_CONTENTION_RESOLUTION && !ra->cfra) {
+          LOG_I(NR_MAC, "[RAPROC][%d.%d] RA-Msg3 retransmitted\n", frame_tx, slot_tx);
+          // 38.321 restart the ra-ContentionResolutionTimer at each HARQ retransmission in the first symbol after the end of the
+          // Msg3 transmission
+          nr_Msg3_transmitted(mac);
+        }
+        if (ra->ra_state == nrRA_WAIT_RAR && !ra->cfra) {
+          LOG_A(NR_MAC, "[RAPROC][%d.%d] RA-Msg3 transmitted\n", frame_tx, slot_tx);
+          nr_Msg3_transmitted(mac);
+        }
+        if (ra->ra_state == nrRA_WAIT_MSGB && !ra->cfra) {
+          LOG_A(NR_MAC, "[RAPROC][%d.%d] RA-MsgA-PUSCH transmitted\n", frame_tx, slot_tx);
         }
       }
-
-      if (ra->ra_state == nrRA_WAIT_CONTENTION_RESOLUTION && !ra->cfra) {
-        LOG_I(NR_MAC, "[RAPROC][%d.%d] RA-Msg3 retransmitted\n", frame_tx, slot_tx);
-        // 38.321 restart the ra-ContentionResolutionTimer at each HARQ retransmission in the first symbol after the end of the Msg3
-        // transmission
-        nr_Msg3_transmitted(mac);
-      }
-      if (ra->ra_state == nrRA_WAIT_RAR && !ra->cfra) {
-        LOG_A(NR_MAC, "[RAPROC][%d.%d] RA-Msg3 transmitted\n", frame_tx, slot_tx);
-        nr_Msg3_transmitted(mac);
-      }
-      if (ra->ra_state == nrRA_WAIT_MSGB && !ra->cfra) {
-        LOG_A(NR_MAC, "[RAPROC][%d.%d] RA-MsgA-PUSCH transmitted\n", frame_tx, slot_tx);
-      }
+      ulcfg_pdu++;
     }
-    ulcfg_pdu++;
+    release_ul_config(ulcfg_pdu, false);
   }
-  release_ul_config(ulcfg_pdu, false);
 
   if(mac->state >= UE_PERFORMING_RA && mac->state < UE_DETACHING)
     nr_ue_pucch_scheduler(mac, frame_tx, slot_tx);

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
@@ -247,7 +247,7 @@ void update_mac_ul_timers(NR_UE_MAC_INST_t *mac)
 
 void remove_ul_config_last_item(fapi_nr_ul_config_request_pdu_t *pdu)
 {
-  pdu->privateNBpdus--;
+  (*pdu->privateNBpdus)--;
 }
 
 void release_ul_config(fapi_nr_ul_config_request_pdu_t *configPerSlot, bool clearIt)


### PR DESCRIPTION
## Summary
- Do not abort the UE UL scheduler when a slot-indexed ul_config is stale, so PUCCH HARQ-ACK/CSI/SR can still go out after leftover PUSCH is cleared.
- Fix privateNBpdus decrementing the pointer instead of the counter, and unlock before the RA path that re-takes the same mutex.
- Zero rxdataF_comp / ul_valid_re_per_slot for every UE in a PUSCH TP group so softscope/demod does not keep stale constellation points.
- Best viewed with whitespace diff off.

## Test plan
- [ ]  Run UE with UL traffic under timing where slot-indexed ul_config can go stale; confirm PUCCH (HARQ-ACK/CSI/SR) still transmits and UL scheduler does not early-return
- [ ]  Exercise Msg3 / connected UL + TA loss RA path; confirm no deadlock on the UL config mutex
- [ ]  Multi-UE PUSCH TP-group demod with softscope: confirm unused symbols/REs do not retain prior-slot constellation points for any UE in the group
- [x] Sanity: connected PUSCH UL and basic RA Msg3 still succeed end-to-end
- [x] PDSCH BLER should show as ~ 0.5% in perfect channel conditions