### PR TITLE
ue: fix DL HARQ soft combining under LBRM and protect reused HARQ PIDs

### DIFF
--- a/openair1/PHY/CODING/nrLDPC_coding/nrLDPC_coding_segment/nr_rate_matching.c
+++ b/openair1/PHY/CODING/nrLDPC_coding/nrLDPC_coding_segment/nr_rate_matching.c
@@ -8,8 +8,6 @@
 
 // #define RM_DEBUG 1
 #define USE128BIT
- 
-static const uint8_t index_k0[2][4] = {{0, 17, 33, 56}, {0, 13, 25, 43}};
 
 void nr_interleaving_ldpc(uint32_t E, uint8_t Qm, uint8_t *e, uint8_t *f)
 {
@@ -1046,17 +1044,9 @@ int nr_rate_matching_ldpc(uint32_t Tbslbrm,
     return -1;
   }
 
-  //Bit selection
-  uint32_t N = (BG == 1) ? (66 * Z) : (50 * Z);
-  uint32_t Ncb;
-  if (Tbslbrm == 0)
-    Ncb = N;
-  else {
-    uint32_t Nref = 3 * Tbslbrm / (2 * C); //R_LBRM = 2/3
-    Ncb = min(N, Nref);
-  }
-
-  uint32_t ind = (index_k0[BG - 1][rvidx] * Ncb / N) * Z;
+  const nr_ldpc_geometry_t geo = nr_ldpc_soft_buffer_geometry(Tbslbrm, BG, Z, C, rvidx);
+  const uint32_t Ncb = geo.Ncb;
+  uint32_t ind = geo.k0;
 
 #ifdef RM_DEBUG
   printf("nr_rate_matching_ldpc: E %u, F %u, Foffset %u, k0 %u, Ncb %u, rvidx %d, Tbslbrm %u\n",
@@ -1157,16 +1147,10 @@ int nr_rate_matching_ldpc_rx_simd(uint32_t Tbslbrm,
   }
 
   // Bit selection
-  uint32_t N = (BG == 1) ? (66 * Z) : (50 * Z);
-  uint32_t Ncb;
-  if (Tbslbrm == 0)
-    Ncb = N;
-  else {
-    uint32_t Nref = (3 * Tbslbrm / (2 * C)); // R_LBRM = 2/3
-    Ncb = min(N, Nref);
-  }
-
-  uint32_t ind = (index_k0[BG - 1][rvidx] * Ncb / N) * Z;
+  const nr_ldpc_geometry_t geo = nr_ldpc_soft_buffer_geometry(Tbslbrm, BG, Z, C, rvidx);
+  const uint32_t N = geo.N;
+  const uint32_t Ncb = geo.Ncb;
+  uint32_t ind = geo.k0;
   if (Foffset > E) {
     LOG_E(PHY, "nr_rate_matching: invalid parameters (Foffset %d > E %d)\n", Foffset, E);
     return -1;
@@ -1187,8 +1171,12 @@ int nr_rate_matching_ldpc_rx_simd(uint32_t Tbslbrm,
          Tbslbrm);
 #endif
 
+  /* Clear the whole mother-code extent, not just Ncb: under LBRM the positions in [Ncb, N) are
+   * never transmitted, so they must reach the decoder as erasures. The decoder always reads out
+   * to N, so leaving them at whatever the previous transport block on this HARQ process wrote
+   * feeds it confident parity LLRs for bits that were never sent. */
   if (clear == 1)
-    memset(d, 0, Ncb * sizeof(int16_t));
+    memset(d, 0, N * sizeof(int16_t));
 
   uint32_t k = 0;
   if (ind < Foffset) {
@@ -1232,17 +1220,10 @@ int nr_rate_matching_ldpc_rx(uint32_t Tbslbrm,
     return -1;
   }
 
-  //Bit selection
-  uint32_t N = (BG == 1) ? (66 * Z) : (50 * Z);
-  uint32_t Ncb;
-  if (Tbslbrm == 0)
-    Ncb = N;
-  else {
-    uint32_t Nref = (3 * Tbslbrm / (2 * C)); //R_LBRM = 2/3
-    Ncb = min(N, Nref);
-  }
-
-  uint32_t ind = (index_k0[BG - 1][rvidx] * Ncb / N) * Z;
+  const nr_ldpc_geometry_t geo = nr_ldpc_soft_buffer_geometry(Tbslbrm, BG, Z, C, rvidx);
+  const uint32_t N = geo.N;
+  const uint32_t Ncb = geo.Ncb;
+  uint32_t ind = geo.k0;
   if (Foffset > E) {
     LOG_E(PHY, "nr_rate_matching: invalid parameters (Foffset %d > E %d)\n", Foffset, E);
     return -1;
@@ -1263,8 +1244,12 @@ int nr_rate_matching_ldpc_rx(uint32_t Tbslbrm,
          Tbslbrm);
 #endif
 
+  /* Clear the whole mother-code extent, not just Ncb: under LBRM the positions in [Ncb, N) are
+   * never transmitted, so they must reach the decoder as erasures. The decoder always reads out
+   * to N, so leaving them at whatever the previous transport block on this HARQ process wrote
+   * feeds it confident parity LLRs for bits that were never sent. */
   if (clear == 1)
-    memset(d, 0, Ncb * sizeof(int16_t));
+    memset(d, 0, N * sizeof(int16_t));
 
   uint32_t k = 0;
   if (ind < Foffset)

--- a/openair1/PHY/CODING/nrLDPC_coding/nrLDPC_coding_segment/nr_rate_matching.h
+++ b/openair1/PHY/CODING/nrLDPC_coding/nrLDPC_coding_segment/nr_rate_matching.h
@@ -7,6 +7,24 @@
 
 #include <stdint.h>
 
+/// Mother code extent N, LBRM soft buffer limit Ncb and RV start k0 of a code segment (38.212 5.4.2.1)
+typedef struct {
+  uint32_t N;
+  uint32_t Ncb;
+  uint32_t k0;
+} nr_ldpc_geometry_t;
+
+/* static inline because the rate matching sources link only into the dlopen'd LDPC modules, while the
+ * DLSCH receive path needs the same geometry. Tbslbrm is in bits, despite the FAPI field name. */
+static inline nr_ldpc_geometry_t nr_ldpc_soft_buffer_geometry(uint32_t Tbslbrm, uint8_t BG, uint16_t Z, uint8_t C, uint8_t rvidx)
+{
+  static const uint8_t index_k0[2][4] = {{0, 17, 33, 56}, {0, 13, 25, 43}}; // 38.212 table 5.4.2.1-2, in units of Zc
+  const uint32_t N = (BG == 1) ? 66 * Z : 50 * Z;
+  const uint32_t Nref = (Tbslbrm && C) ? 3 * Tbslbrm / (2 * C) : N; // R_LBRM = 2/3
+  const uint32_t Ncb = Nref < N ? Nref : N;
+  return (nr_ldpc_geometry_t){.N = N, .Ncb = Ncb, .k0 = (index_k0[BG - 1][rvidx & 3] * Ncb / N) * Z};
+}
+
 /**
  * \brief interleave a code segment after encoding and rate matching
  * \param E size of the code segment in bits

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_decoding.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_decoding.c
@@ -6,7 +6,6 @@
  */
 
 #include "PHY/defs_nr_UE.h"
-#include "SCHED_NR_UE/harq_nr.h"
 #include "PHY/CODING/coding_extern.h"
 #include "PHY/CODING/coding_defs.h"
 #include "PHY/CODING/nrLDPC_coding/nrLDPC_coding_interface.h"
@@ -64,6 +63,11 @@ void nr_dlsch_decoding(PHY_VARS_NR_UE *phy_vars_ue,
   AssertFatal(dmrs_Type == 0 || dmrs_Type == 1, "Illegal dmrs_type %d\n", dmrs_Type);
   fapi_nr_dl_cw_info_t *cw_info = &dlsch->cw_info;
   NR_DL_UE_HARQ_t *harq_process = &phy_vars_ue->dl_harq_processes[cw_idx][dlsch_config->harq_process_nbr];
+  if (harq_process->activated_frame != proc->frame_rx || harq_process->activated_slot != proc->nr_slot_rx) {
+    LOG_W(PHY, "%d.%d DLSCH harq %d late decode aborted, re-armed %d.%d\n",
+          proc->frame_rx, proc->nr_slot_rx, harq_pid, harq_process->activated_frame, harq_process->activated_slot);
+    return;
+  }
   LOG_D(PHY, "Round %d RV idx %d\n", harq_process->DLround, cw_info->rv);
   uint8_t nb_re_dmrs;
   if (dmrs_Type == NFAPI_NR_DMRS_TYPE1)
@@ -135,6 +139,12 @@ void nr_dlsch_decoding(PHY_VARS_NR_UE *phy_vars_ue,
   if (LOG_DEBUGFLAG(DEBUG_DLSCH_DECOD))
     LOG_I(PHY, "Segmentation: C %d, K %d\n", harq_process->C, harq_process->K);
 
+  TB_parameters.d_to_be_cleared = harq_process->first_rx == 1;
+  /* Buffer now holds this TB. Clear first_rx only after that, so a skipped decode still re-segments. */
+  harq_process->first_rx = 0;
+  /* Restart llrLen when the buffer is cleared, even if DLround is already non-zero. */
+  const int llr_round = TB_parameters.d_to_be_cleared ? 0 : harq_process->DLround;
+
   TB_parameters.max_ldpc_iterations = dlsch->max_ldpc_iterations;
   TB_parameters.rv_index = cw_info->rv;
   TB_parameters.tbslbrm = dlsch_config->tbslbrm;
@@ -168,8 +178,7 @@ void nr_dlsch_decoding(PHY_VARS_NR_UE *phy_vars_ue,
                                           TB_parameters.BG,
                                           TB_parameters.Z,
                                           &harq_process->llrLen,
-                                          harq_process->DLround);
-  TB_parameters.d_to_be_cleared = harq_process->first_rx == 1;
+                                          llr_round);
   for (int r = 0; r < TB_parameters.C; r++)
     TB_parameters.decodeSuccess[r] = false;
   reset_meas(&TB_parameters.ts_ldpc_decode);
@@ -183,7 +192,7 @@ void nr_dlsch_decoding(PHY_VARS_NR_UE *phy_vars_ue,
                                                TB_parameters.BG,
                                                TB_parameters.Z,
                                                &harq_process->llrLen,
-                                               harq_process->DLround);
+                                               llr_round);
       TB_parameters.first_rE2 = r;
       break;
     }
@@ -214,7 +223,8 @@ void nr_dlsch_decoding(PHY_VARS_NR_UE *phy_vars_ue,
       in += harq_process->K / 8;
     }
   } else {
-    LOG_D(PHY, "frame=%d, slot=%d, first_rx=%d, rv_index=%d\n", proc->frame_rx, proc->nr_slot_rx, harq_process->first_rx, cw_info->rv);
+    LOG_D(PHY, "frame=%d, slot=%d, first_rx=%d, rv_index=%d\n",
+          proc->frame_rx, proc->nr_slot_rx, TB_parameters.d_to_be_cleared, cw_info->rv);
   }
 
   merge_meas(&phy_vars_ue->phy_cpu_stats.cpu_time_stats[DLSCH_LDPC_DECODING_STATS], &TB_parameters.ts_ldpc_decode);
@@ -282,9 +292,22 @@ void nr_dlsch_decoding(PHY_VARS_NR_UE *phy_vars_ue,
     }
   }
 
+  /* LOG_D only: this runs on a SCHED_FIFO thread; LOG_I formatting was enough to miss slot deadlines. */
+  if (harq_process->DLround > 0 || !harq_process->decodeResult)
+    LOG_D(PHY, "%d.%d DL HARQ combine harq %d r%d rv %d %s cleared %d llrLen %d E %d G %d\n",
+          proc->frame_rx, proc->nr_slot_rx, harq_pid, harq_process->DLround, TB_parameters.rv_index,
+          harq_process->decodeResult ? "ok" : "nok", TB_parameters.d_to_be_cleared,
+          harq_process->llrLen, TB_parameters.E, TB_parameters.G);
+
   if (harq_process->decodeResult) {
     LOG_D(PHY, "%d.%d DLSCH received ok \n", proc->frame_rx, proc->nr_slot_rx);
-    harq_process->status = NR_SCH_IDLE;
+    /* Only retire if this decode still owns the PID; a late finish must not idle a newer grant. */
+    if (harq_process->activated_frame == proc->frame_rx && harq_process->activated_slot == proc->nr_slot_rx) {
+      harq_process->status = NR_SCH_IDLE;
+    } else {
+      LOG_W(PHY, "%d.%d DLSCH harq %d decoded ok but re-armed %d.%d, not retiring\n",
+            proc->frame_rx, proc->nr_slot_rx, harq_pid, harq_process->activated_frame, harq_process->activated_slot);
+    }
     dlsch->last_iteration_cnt = dlsch->max_ldpc_iterations - 1;
   } else {
     LOG_D(PHY, "%d.%d DLSCH received nok \n", proc->frame_rx, proc->nr_slot_rx);

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_transport_ue.h
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_transport_ue.h
@@ -64,7 +64,7 @@ typedef struct {
 } NR_UE_ULSCH_t;
 
 typedef struct {
-  /// Indicator of first reception
+  /// Set on new data; cleared after nr_dlsch_decoding() segments the TB. Stays set if decode never ran.
   uint8_t first_rx;
   /// DLSCH status flag indicating
   NR_SCH_status_t status;
@@ -97,6 +97,9 @@ typedef struct {
   /// Number of segments processed so far
   uint32_t processedSegments;
   decode_abort_t abort_decode;
+  /* Slot of the grant that armed this process. A late decode only retires if it still matches. */
+  int activated_frame;
+  int activated_slot;
 } NR_DL_UE_HARQ_t;
 
 typedef struct {

--- a/openair1/SCHED_NR_UE/fapi_nr_ue_l1.c
+++ b/openair1/SCHED_NR_UE/fapi_nr_ue_l1.c
@@ -25,7 +25,8 @@ static void configure_dlsch(NR_UE_DLSCH_t *dlsch,
                             fapi_nr_dl_config_dlsch_pdu_rel15_t *dlsch_config_pdu,
                             NR_UE_MAC_INST_t *mac,
                             int cw_idx,
-                            int rnti)
+                            int rnti,
+                            const fapi_nr_dl_config_request_t *dl_config)
 {
   const uint8_t current_harq_pid = dlsch_config_pdu->harq_process_nbr;
   dlsch->active = true;
@@ -44,14 +45,16 @@ static void configure_dlsch(NR_UE_DLSCH_t *dlsch,
     return;
   }
 
+  /* Do not clear first_rx on a retransmission: decode never ran still needs to re-segment. */
   if (dlsch->cw_info.new_data_indicator) {
     dlsch_harq->first_rx = true;
     dlsch_harq->DLround = 0;
   } else {
-    dlsch_harq->first_rx = false;
     dlsch_harq->DLround++;
   }
   downlink_harq_process(dlsch_harq, current_harq_pid, dlsch->cw_info.new_data_indicator, dlsch->cw_info.rv, dlsch->rnti_type);
+  dlsch_harq->activated_frame = dl_config->sfn;
+  dlsch_harq->activated_slot = dl_config->slot;
   if (dlsch_harq->status != NR_ACTIVE) {
     // dlsch_harq->status not ACTIVE due to false retransmission
     // Reset the following flag to skip PDSCH procedures in that case and retrasmit harq status
@@ -191,7 +194,7 @@ static void nr_ue_scheduled_response_dl(NR_UE_MAC_INST_t *mac,
         for (int c = 0; c < n_codewords; c++) {
           NR_UE_DLSCH_t *dlsch = &phy_data->dlsch[c];
           dlsch->rnti_type = rnti_type;
-          configure_dlsch(dlsch, phy->dl_harq_processes[c], dlsch_config_pdu, mac, c, pdu->dlsch_config_pdu.rnti);
+          configure_dlsch(dlsch, phy->dl_harq_processes[c], dlsch_config_pdu, mac, c, pdu->dlsch_config_pdu.rnti, dl_config);
         }
       } break;
       case FAPI_NR_CONFIG_TA_COMMAND:

--- a/openair1/SCHED_NR_UE/harq_nr.c
+++ b/openair1/SCHED_NR_UE/harq_nr.c
@@ -99,6 +99,8 @@ void init_downlink_harq_status(NR_DL_UE_HARQ_t *dl_harq)
   dl_harq->first_rx = 1;
   dl_harq->DLround  = 0;
   dl_harq->decodeResult = false;
+  dl_harq->activated_frame = -1;
+  dl_harq->activated_slot = -1;
 }
 
 /*******************************************************************

--- a/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
+++ b/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
@@ -681,8 +681,20 @@ static void nr_ue_dlsch_procedures(PHY_VARS_NR_UE *ue,
   // exit dlsch procedures as there are no active dlsch
   NR_DL_UE_HARQ_t *dl_harq = &ue->dl_harq_processes[cw_idx][harq_pid];
   if (dl_harq->status != NR_ACTIVE) {
-    // don't wait anymore
-    LOG_E(NR_PHY, "Internal error  nr_ue_dlsch_procedure() called but no active cw on slot %d, harq %d\n", nr_slot_rx, harq_pid);
+    /* Grant arrived (dlsch active, LLRs demodulated) but the HARQ process is no longer ACTIVE. */
+    LOG_E(NR_PHY, "Internal error nr_ue_dlsch_procedure() no active cw slot %d harq %d (now %d.%d status %d activated %d.%d)\n",
+          nr_slot_rx, harq_pid, frame_rx, nr_slot_rx, dl_harq->status, dl_harq->activated_frame, dl_harq->activated_slot);
+    if (config->k1_feedback) {
+      const int ack_nack_slot_and_frame = (proc->nr_slot_rx + config->k1_feedback) + proc->frame_rx * fp->slots_per_frame;
+      dynamic_barrier_join(&ue->process_slot_tx_barriers[ack_nack_slot_and_frame % NUM_PROCESS_SLOT_TX_BARRIERS]);
+    }
+    return;
+  }
+
+  /* Late finish of a TB that no longer owns the PID: do not decode, ACK, or write HARQ state. */
+  if (dl_harq->activated_frame != frame_rx || dl_harq->activated_slot != nr_slot_rx) {
+    LOG_W(NR_PHY, "%d.%d DLSCH harq %d late decode skipped, re-armed %d.%d first_rx %d\n",
+          frame_rx, nr_slot_rx, harq_pid, dl_harq->activated_frame, dl_harq->activated_slot, dl_harq->first_rx);
     if (config->k1_feedback) {
       const int ack_nack_slot_and_frame = (proc->nr_slot_rx + config->k1_feedback) + proc->frame_rx * fp->slots_per_frame;
       dynamic_barrier_join(&ue->process_slot_tx_barriers[ack_nack_slot_and_frame % NUM_PROCESS_SLOT_TX_BARRIERS]);

--- a/openair1/SIMULATION/NR_PHY/dlschsim.c
+++ b/openair1/SIMULATION/NR_PHY/dlschsim.c
@@ -460,6 +460,8 @@ int main(int argc, char **argv)
 	NR_UE_DLSCH_t *dlsch0_ue = &dlsch_ue[0];
   NR_DL_UE_HARQ_t *harq_process = &UE->dl_harq_processes[0][harq_pid];
   harq_process->first_rx = 1;
+  harq_process->activated_frame = proc.frame_rx;
+  harq_process->activated_slot = proc.nr_slot_rx;
   fapi_nr_dl_config_dlsch_pdu_rel15_t dlsch_config;
   dlsch_config.cw_info[0].mcs = Imcs;
   dlsch_config.mcs_table = mcs_table;

--- a/openair1/SIMULATION/NR_PHY/dlsim.c
+++ b/openair1/SIMULATION/NR_PHY/dlsim.c
@@ -1116,6 +1116,8 @@ int main(int argc, char **argv)
       round = 0;
       UE_harq_process->DLround = round;
       UE_harq_process->first_rx = 1;
+      UE_harq_process->activated_frame = UE_proc.frame_rx;
+      UE_harq_process->activated_slot = UE_proc.nr_slot_rx;
 
       while (round < num_rounds && !UE_harq_process->decodeResult && !stop) {
         reset_sched_response(Sched_INFO, frame, slot, 0, 0);
@@ -1340,6 +1342,9 @@ int main(int argc, char **argv)
 
         pbch_processing(UE, &UE_proc, &phy_data);
         pdcch_processing(UE, &UE_proc, &phy_data);
+        NR_DL_UE_HARQ_t *decode_harq = &UE->dl_harq_processes[0][phy_data.dlsch_config.harq_process_nbr];
+        decode_harq->activated_frame = UE_proc.frame_rx;
+        decode_harq->activated_slot = UE_proc.nr_slot_rx;
         pdsch_processing(UE,
                          &UE_proc,
                          &phy_data);


### PR DESCRIPTION
## Summary
- Clear the full LDPC mother-code soft buffer (`N`, not `Ncb`) on new reception so LBRM-erased positions reach the decoder as erasures instead of stale confident LLRs from a prior TB on the same HARQ process.
- Restart DLSCH segmentation when the cached `C/K/Z/F` layout no longer matches the granted TBS (e.g. missed round-0 PDU), so retransmissions are not combined against the wrong soft-buffer geometry.
- Do not retire a HARQ process after a late decode if a newer grant already re-armed that PID—avoids dropping the in-flight TB with “no active cw”.
- Observed on ASET (Duranta or Aerial) at high SINR (~34 dB): DL HARQ rounds barely recovered (e.g. 349k / 16k / 15.6k / 15.6k with nearly flat r1=r2=r3).

## Test plan
- [ ] ASET DL traffic at high SINR: confirm HARQ retransmissions reduce residual BLER (r1/r2/r3 no longer stall near the first retransmission).
- [ ] With PHY debug enabled, check `DL HARQ combine` logs: `llrLen` grows across rounds and LBRM geometry (`tbslbrm` / `Ncb` / `k0`) looks sane.
- [ ] Exercise delayed DLSCH decode vs rapid HARQ PID reuse: successful late decode must not clear a process already activated for a newer grant (no “no active cw” after re-arm).
- [ ] Sanity: new-data and normal retransmission paths still decode and ACK/NACK as before when layout is consistent.

Assisted-by: Cursor <cursoragent@cursor.com>
