### PR TITLE
vrtsim: quiet taps sample-path logging and settable timeout for o-ru socket

### DIFF
--- a/radio/vrtsim/taps_client.cpp
+++ b/radio/vrtsim/taps_client.cpp
@@ -44,6 +44,11 @@ struct taps_client_t {
   channel_desc_t channel_descs_[MAX_NUM_IDS];
   struct complexf *ch_ps_storage_[MAX_NUM_IDS][MAX_TX_RX_ANTENNAS * MAX_TX_RX_ANTENNAS];
 
+  // Last geometry announced per ID, so a steady tap stream is not logged on every update
+  uint32_t logged_taps_len_[MAX_NUM_IDS];
+  uint32_t logged_num_rx_[MAX_NUM_IDS];
+  uint32_t logged_num_tx_[MAX_NUM_IDS];
+
   std::mutex mutex_;
   std::thread thread_;
 
@@ -55,6 +60,9 @@ struct taps_client_t {
   {
     memset(current_buffers_, 0, sizeof(current_buffers_));
     memset(channel_descs_, 0, sizeof(channel_descs_));
+    memset(logged_taps_len_, 0, sizeof(logged_taps_len_));
+    memset(logged_num_rx_, 0, sizeof(logged_num_rx_));
+    memset(logged_num_tx_, 0, sizeof(logged_num_tx_));
 
     for (int i = 0; i < MAX_NUM_IDS; i++)
       channel_descs_[i].ch_ps = ch_ps_storage_[i];
@@ -187,7 +195,20 @@ struct taps_client_t {
       current_buffers_[id] = buf;
     }
 
-    LOG_A(HW, "New taps for id %d: channel_length %u, %ux%u antennas\n", id, taps_len, num_rx, num_tx);
+    /* Called from the vrtsim sample path, so this runs once per slot that has taps pending —
+     * 10/s for a 100 ms publisher. An always-printed line here is a blocking write to the
+     * container's stdout pipe, which is enough to overrun the slot deadline and show up as
+     * dropped PDSCH PDUs, stale UL configs and PBCH failures. Announce the geometry only when
+     * it actually changes (that is what catches a publisher/RU antenna mismatch); the steady
+     * stream stays at LOG_D. */
+    if (taps_len != logged_taps_len_[id] || num_rx != logged_num_rx_[id] || num_tx != logged_num_tx_[id]) {
+      logged_taps_len_[id] = taps_len;
+      logged_num_rx_[id] = num_rx;
+      logged_num_tx_[id] = num_tx;
+      LOG_A(HW, "New taps for id %d: channel_length %u, %ux%u antennas\n", id, taps_len, num_rx, num_tx);
+    } else {
+      LOG_D(HW, "New taps for id %d: channel_length %u, %ux%u antennas\n", id, taps_len, num_rx, num_tx);
+    }
 
     return desc;
   }

--- a/radio/vrtsim/vrtsim.c
+++ b/radio/vrtsim/vrtsim.c
@@ -54,14 +54,19 @@ typedef enum { ROLE_SERVER = 1, ROLE_CLIENT } role;
 #define TAPS_SOCKET_HLP "Socket to connect to the channel emulation server\n"
 #define CLIENT_NUM_RX_HLP "Number of RX antennas of the client, specified on the server\n"
 #define CONNECTION_DESCRIPTOR_HLP "Path to the file written by the server that the client can use to connect."
+#define CONNECTION_TIMEOUT_HLP                                                                                                 \
+  "Seconds the client waits for the peer unix socket (0 = wait forever). Useful when the peer starts slowly (e.g. O-RU after " \
+  "DPDK/xRAN init).\n"
 #define DEFAULT_CHANNEL_NAME "vrtsim_channel"
 #define DEFAULT_DESCRIPTOR "/tmp/vrtsim_connection"
+#define DEFAULT_CONNECTION_TIMEOUT 120
 #define TPOOL_HLP "Thread pool for channel modelling. Only used if CUDA support is disabled."
 
 // clang-format off
 #define VRTSIM_PARAMS_DESC \
   { \
      {"connection_descriptor",  CONNECTION_DESCRIPTOR_HLP,   0, .strptr = &vrtsim_state->connection_descriptor,  .defstrval = DEFAULT_DESCRIPTOR, TYPE_STRING, 0}, \
+     {"connection_timeout",     CONNECTION_TIMEOUT_HLP,      0, .uptr = &vrtsim_state->connection_timeout,       .defuintval = DEFAULT_CONNECTION_TIMEOUT, TYPE_UINT, 0}, \
      {"role",                   "either client or server\n", 0, .strptr = &role,                                 .defstrval = ROLE_CLIENT_STRING, TYPE_STRING, 0}, \
      {"timescale",              TIME_SCALE_HLP,              0, .dblptr = &vrtsim_state->timescale,              .defdblval = 1.0,                TYPE_DOUBLE, 0}, \
      {"chanmod",                "Enable channel modelling",  0, .iptr = &vrtsim_state->chanmod,                  .defintval = 0,                  TYPE_INT,    0}, \
@@ -124,6 +129,7 @@ typedef struct client_info_s {
 typedef struct {
   int role;
   char *connection_descriptor;
+  uint32_t connection_timeout;
   ShmTDIQChannel *channel;
   uint64_t last_received_sample;
   pthread_t timing_thread;
@@ -352,7 +358,8 @@ static void server_publish_client_info(vrtsim_state_t *vrtsim_state)
   LOG_A(HW, "VRTSIM: Started IPC server on socket %s\n", socket_path);
 }
 
-static size_t try_read_client_info(int fd, client_info_t *client_info) {
+static size_t try_read_client_info(int fd, client_info_t *client_info)
+{
   size_t total_read = 0;
   char *ptr = (char *)client_info;
   while (total_read < sizeof(*client_info)) {
@@ -371,17 +378,18 @@ static size_t try_read_client_info(int fd, client_info_t *client_info) {
   return total_read;
 }
 
-static client_info_t client_read_info(char *socket_path)
+static client_info_t client_read_info(char *socket_path, uint32_t connection_timeout)
 {
   client_info_t client_info;
-  int tries = 0;
+  uint32_t tries = 0;
   struct sockaddr_un addr;
 
   memset(&addr, 0, sizeof(addr));
   addr.sun_family = AF_UNIX;
   strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
 
-  while (tries < 10) {
+  /* connection_timeout == 0 means wait forever */
+  while (connection_timeout == 0 || tries < connection_timeout) {
     int sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (sock_fd >= 0) {
       if (connect(sock_fd, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
@@ -397,7 +405,7 @@ static client_info_t client_read_info(char *socket_path)
     sleep(1);
     tries++;
   }
-  AssertFatal(0, "Timeout waiting for client info on socket %s\n", socket_path);
+  AssertFatal(0, "Timeout waiting for client info on socket %s after %u s\n", socket_path, connection_timeout);
   return client_info;
 }
 
@@ -534,7 +542,7 @@ static int vrtsim_connect(openair0_device_t *device)
       threadCreate(&vrtsim_state->timing_thread, vrtsim_timing_job, vrtsim_state, "vrtsim_timing", -1, OAI_PRIORITY_RT_MAX);
     }
   } else {
-    client_info_t client_info = client_read_info(vrtsim_state->connection_descriptor);
+    client_info_t client_info = client_read_info(vrtsim_state->connection_descriptor, vrtsim_state->connection_timeout);
     AssertFatal(client_info.num_ues > 0, "Server did not publish valid num_ues\n");
     AssertFatal(vrtsim_state->ue_id < client_info.num_ues, "ue_id %d >= num_ues %d\n", vrtsim_state->ue_id, client_info.num_ues);
 


### PR DESCRIPTION
## Summary
- Increase `client_read_info` connect retries from 10 to 120 (~2 min) so vrtsim can wait for the O-RU unix socket, which only appears after DPDK/xRAN init. Settable via arguments.
- Quiet always-on `LOG_A "New taps ..."` on the vrtsim sample path: announce geometry (`taps_len` / `num_rx` / `num_tx`) at `LOG_A` only when it changes; keep the steady stream at `LOG_D`. Blocking stdout writes were enough to overrun slot deadlines (dropped PDSCH, stale UL configs, PBCH failures).

## Test plan
- [ ] Run ASET/vrtsim with a steady taps publisher: no per-slot `New taps` spam at default log level; one-time `LOG_A` still on geometry change / first update per id
- [ ] With debug logging, confirm per-update taps line still at `LOG_D`
- [ ] Confirm slot-deadline / PDSCH / UL / PBCH symptoms from the old always-on logging no longer appear
- [ ] Bring up ASET when O-RU DPDK/xRAN init is slow; confirm vrtsim connects instead of failing early
- [ ] Confirm connect still succeeds promptly when the socket is already up, and still fails after ~2 min if it never appears

Assisted-by: Cursor <cursoragent@cursor.com>