### PR TITLE
fix(thread-pool): validate tasks at queue insertion

### DIFF
--- a/common/utils/threadPool/bounded_notified_fifo.h
+++ b/common/utils/threadPool/bounded_notified_fifo.h
@@ -85,6 +85,7 @@ static void free_seq_ring_task(seq_ring_task_t* r)
 static void push_back_seq_ring_task(seq_ring_task_t* r, task_t t)
 {
   DevAssert(r != NULL);
+  DevAssert(t.func != NULL || t.args == NULL);
 
   if (full(r))
     enlarge_buffer(r);
@@ -166,7 +167,6 @@ static bool try_push_not_q(not_q_t* q, task_t t)
 static void push_not_q(not_q_t* q, task_t t)
 {
   DevAssert(q != NULL);
-  DevAssert(t.func != NULL);
 
   mutexlock(q->mtx);
 


### PR DESCRIPTION
`abortTpool()` and the workers use `{func = NULL, args = NULL}` as the shutdown sentinel. Queue submission first tries nonblocking locks and falls back to a blocking push, but only the blocking path required a non-null function. Under contention, normal shutdown could therefore abort; the try path could also enqueue `{func = NULL, args != NULL}` for a worker to call through a null function pointer.

This change moves the validity assertion to the sole ring-buffer insertion point. Callable tasks remain valid with either null or non-null arguments, the exact all-null shutdown sentinel is accepted through both admission paths, and a null-function task carrying arguments is rejected before enqueue. Queue layout, locking, scheduling, work stealing, task execution, and the public API remain unchanged.

A local-only six-case regression, not included in this submission, produced 4/6 expected outcomes on uncorrected `fb944fbad6`: blocking sentinel admission aborted and malformed try admission returned normally. The identical corrected run produced 6/6. `test_thread-pool` passed 20/20 in Debug and 5/5 under ASan/UBSan with leak detection and no diagnostic; the affected `nr-uesoftmodem` incremental build and final link also passed.