### PR TITLE
Keep the old UE in reestablishment instead of populating the new UE

### DIFF
--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -2854,6 +2854,23 @@ static void create_ul_harq_list(NR_UE_sched_ctrl_t *sched_ctrl, const NR_UE_Serv
   }
 }
 
+void reset_sc_info(NR_UE_ServingCell_Info_t *sc_info)
+{
+  sc_info->csi_MeasConfig = NULL;
+  sc_info->nrofHARQ_ProcessesForPDSCH = NULL;
+  sc_info->maxMIMO_Layers_PDSCH = NULL;
+  sc_info->downlinkHARQ_FeedbackDisabled_r17 = NULL;
+  sc_info->pdsch_CGB_Transmission = NULL;
+  sc_info->nrofHARQ_ProcessesForPDSCH_v1700 = NULL;
+  sc_info->crossCarrierSchedulingConfig = NULL;
+  sc_info->supplementaryUplink = NULL;
+  sc_info->carrierSwitching = NULL;
+  sc_info->maxMIMO_Layers_PUSCH = NULL;
+  sc_info->rateMatching_PUSCH = NULL;
+  sc_info->pusch_CGB_Transmission = NULL;
+  sc_info->nrofHARQ_ProcessesForPUSCH_r17 = NULL;
+}
+
 // main function to configure parameters of current BWP
 void configure_UE_BWP(gNB_MAC_INST *nr_mac,
                       NR_ServingCellConfigCommon_t *scc,
@@ -2930,6 +2947,7 @@ void configure_UE_BWP(gNB_MAC_INST *nr_mac,
     DL_BWP->pdsch_Config = NULL;
     UL_BWP->pusch_Config = NULL;
     UL_BWP->pucch_Config = NULL;
+    UL_BWP->srs_Config = NULL;
     UL_BWP->configuredGrantConfig = NULL;
   }
 
@@ -3037,21 +3055,8 @@ void configure_UE_BWP(gNB_MAC_INST *nr_mac,
             sc_info->nrofHARQ_ProcessesForPUSCH_r17 = pusch_servingcellconfig->ext3->nrofHARQ_ProcessesForPUSCH_r17;
         }
       }
-    } else {
-      sc_info->csi_MeasConfig = NULL;
-      sc_info->nrofHARQ_ProcessesForPDSCH = NULL;
-      sc_info->maxMIMO_Layers_PDSCH = NULL;
-      sc_info->downlinkHARQ_FeedbackDisabled_r17 = NULL;
-      sc_info->pdsch_CGB_Transmission = NULL;
-      sc_info->nrofHARQ_ProcessesForPDSCH_v1700 = NULL;
-      sc_info->crossCarrierSchedulingConfig = NULL;
-      sc_info->supplementaryUplink = NULL;
-      sc_info->carrierSwitching = NULL;
-      sc_info->maxMIMO_Layers_PUSCH = NULL;
-      sc_info->rateMatching_PUSCH = NULL;
-      sc_info->pusch_CGB_Transmission = NULL;
-      sc_info->nrofHARQ_ProcessesForPUSCH_r17 = NULL;
-    }
+    } else
+      reset_sc_info(sc_info);
 
     if (CellGroup && CellGroup->physicalCellGroupConfig)
       UE->pdsch_HARQ_ACK_Codebook = CellGroup->physicalCellGroupConfig->pdsch_HARQ_ACK_Codebook;

--- a/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
@@ -545,7 +545,7 @@ void nr_mac_reset_ul_failure(NR_UE_sched_ctrl_t *sched_ctrl);
 bool nr_mac_check_ul_failure(gNB_MAC_INST *nrmac, int rnti, NR_UE_sched_ctrl_t *sched_ctrl);
 
 void nr_mac_trigger_reconfiguration(const gNB_MAC_INST *nrmac, NR_UE_info_t *UE, int new_bwp_id, int new_beam);
-
+void reset_sc_info(NR_UE_ServingCell_Info_t *sc_info);
 bool nr_mac_add_lcid(NR_UE_sched_ctrl_t *sched_ctrl, const nr_lc_config_t *c);
 nr_lc_config_t *nr_mac_get_lc_config(NR_UE_sched_ctrl_t* sched_ctrl, int lcid);
 bool nr_mac_remove_lcid(NR_UE_sched_ctrl_t *sched_ctrl, long lcid);

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
@@ -1016,17 +1016,6 @@ void dl_rrc_message_transfer(const f1ap_dl_rrc_message_t *dl_rrc)
         dl_rrc->srb_id);
 
   gNB_MAC_INST *mac = RC.nrmac[0];
-  pthread_mutex_lock(&mac->sched_lock);
-  /* check first that the scheduler knows such UE */
-  NR_UE_info_t *UE = find_nr_UE(&mac->UE_info, dl_rrc->gNB_DU_ue_id);
-  UE = UE ? UE : find_ra_UE(&mac->UE_info, dl_rrc->gNB_DU_ue_id);
-  if (UE == NULL) {
-    LOG_E(MAC, "ERROR: unknown UE with RNTI %04x, ignoring DL RRC Message Transfer\n", dl_rrc->gNB_DU_ue_id);
-    pthread_mutex_unlock(&mac->sched_lock);
-    return;
-  }
-  pthread_mutex_unlock(&mac->sched_lock);
-
   if (!du_exists_f1_ue_data(dl_rrc->gNB_DU_ue_id)) {
     LOG_D(NR_MAC, "No CU UE ID stored for UE RNTI %04x, adding CU UE ID %d\n", dl_rrc->gNB_DU_ue_id, dl_rrc->gNB_CU_ue_id);
     f1_ue_data_t new_ue_data = {.secondary_ue = dl_rrc->gNB_CU_ue_id};
@@ -1045,6 +1034,14 @@ void dl_rrc_message_transfer(const f1ap_dl_rrc_message_t *dl_rrc)
   if (dl_rrc->old_gNB_DU_ue_id != NULL) {
     AssertFatal(*dl_rrc->old_gNB_DU_ue_id != dl_rrc->gNB_DU_ue_id,
                 "logic bug: current and old gNB DU UE ID cannot be the same\n");
+    /* check first that the scheduler knows such UE among the ones doing RA */
+    NR_UE_info_t *UE = find_ra_UE(&mac->UE_info, dl_rrc->gNB_DU_ue_id);
+    if (UE == NULL) {
+      LOG_E(MAC, "ERROR: unknown UE with RNTI %04x, ignoring DL RRC Message Transfer\n", dl_rrc->gNB_DU_ue_id);
+      pthread_mutex_unlock(&mac->sched_lock);
+      return;
+    }
+    pthread_mutex_unlock(&mac->sched_lock);
     NR_UE_info_t *oldUE = find_nr_UE(&mac->UE_info, *dl_rrc->old_gNB_DU_ue_id);
     if (oldUE == NULL) {
       /* No matching UE-associated logical F1-connection for the old gNB-DU UE F1AP ID.
@@ -1058,11 +1055,11 @@ void dl_rrc_message_transfer(const f1ap_dl_rrc_message_t *dl_rrc)
         du_remove_f1_ue_data(*dl_rrc->old_gNB_DU_ue_id);
       }
     } else {
+      pthread_mutex_lock(&mac->sched_lock);
       /* Per TS 38.401: "Find UE context based on old gNB-DU UE F1AP ID, replace
        * old C-RNTI/PCI with new C-RNTI/PCI". Below, we do the inverse: we keep
        * the new UE context (with new C-RNTI), but set up everything to reuse the
        * old config. */
-      pthread_mutex_lock(&mac->sched_lock);
       uid_t temp_uid = UE->uid;
       UE->uid = oldUE->uid;
       oldUE->uid = temp_uid;

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
@@ -1002,6 +1002,93 @@ void ue_context_release_command(const f1ap_ue_context_rel_cmd_t *cmd)
   NR_SCHED_UNLOCK(&mac->sched_lock);
 }
 
+static void process_reestablishment(gNB_MAC_INST *mac, uint32_t new_dl_rrc_id, uint32_t old_dl_rrc_id)
+{
+  /* check first that the scheduler knows such UE */
+  NR_UE_info_t *UE = find_ra_UE(&mac->UE_info, new_dl_rrc_id);
+  if (!UE) {
+    LOG_E(MAC, "ERROR: couldn't find UE with RNTI %04x, ignoring DL RRC Message Transfer\n", new_dl_rrc_id);
+    return;
+  }
+
+  NR_UE_info_t *oldUE = find_nr_UE(&mac->UE_info, old_dl_rrc_id);
+  if (!oldUE) {
+    /* No matching UE-associated logical F1-connection for the old gNB-DU UE F1AP ID.
+     * Per TS 38.473, if there's no matching connection, there's nothing to release. */
+    LOG_W(NR_MAC,
+          "DL RRC Message Transfer: old gNB-DU UE F1AP ID %04x has no matching UE-associated F1-connection, nothing to relese\n",
+          old_dl_rrc_id);
+    /* Clean up any F1 UE data associated with the old gNB-DU UE F1AP ID */
+    if (du_exists_f1_ue_data(old_dl_rrc_id))
+      du_remove_f1_ue_data(old_dl_rrc_id);
+    return;
+  }
+
+  // Per TS 38.401: "Find UE context based on old gNB-DU UE F1AP ID, replace old C-RNTI/PCI with new C-RNTI/PCI"
+  rnti_t new_rnti = UE->rnti;
+  // assigning the old RNTI to the new UE so that mac_remove_nr_ue prints correct RNTI when removing
+  UE->rnti = oldUE->rnti;
+  oldUE->rnti = new_rnti;
+  for (int i = 1; i < seq_arr_size(&oldUE->UE_sched_ctrl.lc_config); ++i) {
+    const nr_lc_config_t *c = seq_arr_at(&oldUE->UE_sched_ctrl.lc_config, i);
+    nr_lc_config_t new = *c;
+    new.suspended = true;
+    nr_mac_add_lcid(&UE->UE_sched_ctrl, &new);
+  }
+  // need to move the oldUE to RA list because it still needs to transmit MSG4
+  NR_RA_t *temp_ra = UE->ra;
+  oldUE->ra = temp_ra;
+  UE->ra = NULL;
+  NR_UE_sched_ctrl_t temp_sc;
+  memcpy(&temp_sc, &UE->UE_sched_ctrl, sizeof(NR_UE_sched_ctrl_t));
+  memcpy(&UE->UE_sched_ctrl, &oldUE->UE_sched_ctrl, sizeof(NR_UE_sched_ctrl_t));
+  memcpy(&oldUE->UE_sched_ctrl, &temp_sc, sizeof(NR_UE_sched_ctrl_t));
+  mac_remove_nr_ue(mac, UE->rnti);
+  NR_UE_info_t *r = remove_UE_from_list(MAX_MOBILES_PER_GNB + 1, mac->UE_info.connected_ue_list, oldUE->rnti);
+  DevAssert(r == oldUE);
+  add_UE_to_list(NR_NB_RA_PROC_MAX, mac->UE_info.access_ue_list, oldUE);
+  nr_rlc_remove_ue(new_dl_rrc_id);
+  nr_rlc_update_id(old_dl_rrc_id, new_dl_rrc_id);
+  instance_t f1inst = get_f1_gtp_instance();
+  if (f1inst >= 0) // we actually use F1-U
+    gtpv1u_update_ue_id(f1inst, old_dl_rrc_id, new_dl_rrc_id);
+
+  /* Per TS 38.331 5.3.7.2: the UE releases the spCellConfig, so we drop it
+   * from the current configuration. It will be reapplied when the
+   * reconfiguration has succeeded (indicated by the CU).
+   * Guard against double reestablishment: if reestablish_rlc is already set,
+   * reconfigCellGroup was saved by the first reestablishment and
+   * CellGroup.spCellConfig is already NULL — don't overwrite. */
+  if (!oldUE->reestablish_rlc) {
+    asn_copy(&asn_DEF_NR_CellGroupConfig, (void **)&oldUE->reconfigCellGroup, oldUE->CellGroup);
+    ASN_STRUCT_FREE(asn_DEF_NR_SpCellConfig, oldUE->CellGroup->spCellConfig);
+    oldUE->CellGroup->spCellConfig = NULL;
+    reset_sc_info(&oldUE->sc_info);
+    configure_UE_BWP(mac,
+                     mac->common_channels[0].ServingCellConfigCommon,
+                     oldUE,
+                     true,
+                     NR_SearchSpace__searchSpaceType_PR_common,
+                     -1,
+                     -1);
+  } else {
+    LOG_W(NR_MAC,
+          "UE %04x: reestablishment while other reestablishment still pending keeping saved reconfigCellGroup with spCellConfig\n",
+          oldUE->rnti);
+  }
+  oldUE->reestablish_rlc = true;
+  /* Per TS 38.331 clause 5.3.7.4: apply gNB RLC configuration for SRB1 to match the UE RLC configuration defined in 9.2.1.
+   * Use configuration file values for timers t_poll_retransmit, t_reassembly and t_status_prohibit */
+  nr_rlc_configuration_t rlc_configuration = mac->rlc_config;
+  rlc_configuration.srb.poll_pdu = -1;
+  rlc_configuration.srb.poll_byte = -1;
+  rlc_configuration.srb.max_retx_threshold = 8;
+  rlc_configuration.srb.sn_field_length = 12;
+  NR_RLC_Config_t *rlc_Config = nr_srb_config(&rlc_configuration);
+  nr_rlc_reconfigure_entity(new_dl_rrc_id, 1, rlc_Config);
+  ASN_STRUCT_FREE(asn_DEF_NR_RLC_Config, rlc_Config);
+}
+
 /** @brief Process a DL RRC MESSAGE TRANSFER. Handles delivery of an RRC message to a UE
  * via the F1AP DL RRC MESSAGE TRANSFER procedure, as specified in TS 38.473. This procedure
  * is also responsible for re-establishing UE context when required (e.g., during RRC connection
@@ -1032,99 +1119,13 @@ void dl_rrc_message_transfer(const f1ap_dl_rrc_message_t *dl_rrc)
    * it shall release the old gNB-DU UE F1AP ID and the related configurations associated
    * with the old gNB-DU UE F1AP ID." */
   if (dl_rrc->old_gNB_DU_ue_id != NULL) {
-    AssertFatal(*dl_rrc->old_gNB_DU_ue_id != dl_rrc->gNB_DU_ue_id,
-                "logic bug: current and old gNB DU UE ID cannot be the same\n");
-    /* check first that the scheduler knows such UE among the ones doing RA */
-    NR_UE_info_t *UE = find_ra_UE(&mac->UE_info, dl_rrc->gNB_DU_ue_id);
-    if (UE == NULL) {
-      LOG_E(MAC, "ERROR: unknown UE with RNTI %04x, ignoring DL RRC Message Transfer\n", dl_rrc->gNB_DU_ue_id);
-      pthread_mutex_unlock(&mac->sched_lock);
-      return;
-    }
-    pthread_mutex_unlock(&mac->sched_lock);
-    NR_UE_info_t *oldUE = find_nr_UE(&mac->UE_info, *dl_rrc->old_gNB_DU_ue_id);
-    if (oldUE == NULL) {
-      /* No matching UE-associated logical F1-connection for the old gNB-DU UE F1AP ID.
-       * Per TS 38.473, if there's no matching connection, there's nothing to release. */
-      LOG_I(NR_MAC,
-           "DL RRC Message Transfer: old gNB-DU UE F1AP ID %04x has no matching UE-associated logical F1-connection, nothing to "
-           "release\n",
-           *dl_rrc->old_gNB_DU_ue_id);
-      /* Clean up any F1 UE data associated with the old gNB-DU UE F1AP ID */
-      if (du_exists_f1_ue_data(*dl_rrc->old_gNB_DU_ue_id)) {
-        du_remove_f1_ue_data(*dl_rrc->old_gNB_DU_ue_id);
-      }
-    } else {
-      // Per TS 38.401: "Find UE context based on old gNB-DU UE F1AP ID, replace old C-RNTI/PCI with new C-RNTI/PCI"
-      pthread_mutex_lock(&mac->sched_lock);
-      rnti_t new_rnti = UE->rnti;
-      // assigning the old RNTI to the new RNTI so that mac_remove_nr_ue prints correct RNTI when removing
-      UE->rnti = oldUE->rnti;
-      oldUE->rnti = new_rnti;
-      // if the new UE was performing RA we need to move the old UE to RA procedures
-      // otherwise we just remove the new UE
-      for (int i = 1; i < seq_arr_size(&oldUE->UE_sched_ctrl.lc_config); ++i) {
-        const nr_lc_config_t *c = seq_arr_at(&oldUE->UE_sched_ctrl.lc_config, i);
-        nr_lc_config_t new = *c;
-        new.suspended = true;
-        nr_mac_add_lcid(&UE->UE_sched_ctrl, &new);
-      }
-      // need to move the oldUE to RA list because it still needs to transmit MSG4
-      NR_RA_t *temp_ra = UE->ra;
-      oldUE->ra = temp_ra;
-      UE->ra = NULL;
-      NR_UE_sched_ctrl_t temp_sc;
-      memcpy(&temp_sc, &UE->UE_sched_ctrl, sizeof(NR_UE_sched_ctrl_t));
-      memcpy(&UE->UE_sched_ctrl, &oldUE->UE_sched_ctrl, sizeof(NR_UE_sched_ctrl_t));
-      memcpy(&oldUE->UE_sched_ctrl, &temp_sc, sizeof(NR_UE_sched_ctrl_t));
-      mac_remove_nr_ue(mac, UE->rnti);
-      NR_UE_info_t *r = remove_UE_from_list(MAX_MOBILES_PER_GNB + 1, mac->UE_info.connected_ue_list, oldUE->rnti);
-      DevAssert(r == oldUE);
-      add_UE_to_list(NR_NB_RA_PROC_MAX, mac->UE_info.access_ue_list, oldUE);
-      pthread_mutex_unlock(&mac->sched_lock);
-      nr_rlc_remove_ue(dl_rrc->gNB_DU_ue_id);
-      nr_rlc_update_id(*dl_rrc->old_gNB_DU_ue_id, dl_rrc->gNB_DU_ue_id);
-      instance_t f1inst = get_f1_gtp_instance();
-      if (f1inst >= 0) // we actually use F1-U
-        gtpv1u_update_ue_id(f1inst, *dl_rrc->old_gNB_DU_ue_id, dl_rrc->gNB_DU_ue_id);
-    }
-    /* Per TS 38.331 5.3.7.2: the UE releases the spCellConfig, so we drop it
-     * from the current configuration. It will be reapplied when the
-     * reconfiguration has succeeded (indicated by the CU).
-     * Guard against double reestablishment: if reestablish_rlc is already set,
-     * reconfigCellGroup was saved by the first reestablishment and
-     * CellGroup.spCellConfig is already NULL — don't overwrite. */
-    if (!oldUE->reestablish_rlc) {
-      pthread_mutex_lock(&mac->sched_lock);
-      asn_copy(&asn_DEF_NR_CellGroupConfig, (void **)&oldUE->reconfigCellGroup, oldUE->CellGroup);
-      ASN_STRUCT_FREE(asn_DEF_NR_SpCellConfig, oldUE->CellGroup->spCellConfig);
-      oldUE->CellGroup->spCellConfig = NULL;
-      reset_sc_info(&oldUE->sc_info);
-      configure_UE_BWP(mac,
-                       mac->common_channels[0].ServingCellConfigCommon,
-                       oldUE,
-                       true,
-                       NR_SearchSpace__searchSpaceType_PR_common,
-                       -1,
-                       -1);
-     pthread_mutex_unlock(&mac->sched_lock);
-    } else {
-      LOG_W(NR_MAC, "UE %04x: reestablishment while previous reestablishment still pending, "
-            "keeping saved reconfigCellGroup with spCellConfig\n", oldUE->rnti);
-    }
-    oldUE->reestablish_rlc = true;
-    /* Per TS 38.331 clause 5.3.7.4: apply gNB RLC configuration for SRB1 to match the UE RLC configuration defined in 9.2.1.
-     * Use configuration file values for timers t_poll_retransmit, t_reassembly and t_status_prohibit */
-    nr_rlc_configuration_t rlc_configuration = mac->rlc_config;
-    rlc_configuration.srb.poll_pdu = -1;
-    rlc_configuration.srb.poll_byte = -1;
-    rlc_configuration.srb.max_retx_threshold = 8;
-    rlc_configuration.srb.sn_field_length = 12;
-    NR_RLC_Config_t *rlc_Config = nr_srb_config(&rlc_configuration);
-    nr_rlc_reconfigure_entity(dl_rrc->gNB_DU_ue_id, 1, rlc_Config);
-    ASN_STRUCT_FREE(asn_DEF_NR_RLC_Config, rlc_Config);
+    if (*dl_rrc->old_gNB_DU_ue_id != dl_rrc->gNB_DU_ue_id) {
+      NR_SCHED_LOCK(&mac->sched_lock);
+      process_reestablishment(mac, dl_rrc->gNB_DU_ue_id, *dl_rrc->old_gNB_DU_ue_id);
+      NR_SCHED_UNLOCK(&mac->sched_lock);
+    } else
+      LOG_E(NR_MAC, "Current and old gNB DU UE ID are the same (%04x), cannot do reestablishment\n", dl_rrc->gNB_DU_ue_id);
   }
-
   /* the DU ue id is the RNTI */
   nr_rlc_srb_recv_sdu(dl_rrc->gNB_DU_ue_id, dl_rrc->srb_id, dl_rrc->rrc_container, dl_rrc->rrc_container_length);
 }

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
@@ -1055,34 +1055,32 @@ void dl_rrc_message_transfer(const f1ap_dl_rrc_message_t *dl_rrc)
         du_remove_f1_ue_data(*dl_rrc->old_gNB_DU_ue_id);
       }
     } else {
+      // Per TS 38.401: "Find UE context based on old gNB-DU UE F1AP ID, replace old C-RNTI/PCI with new C-RNTI/PCI"
       pthread_mutex_lock(&mac->sched_lock);
-      /* Per TS 38.401: "Find UE context based on old gNB-DU UE F1AP ID, replace
-       * old C-RNTI/PCI with new C-RNTI/PCI". Below, we do the inverse: we keep
-       * the new UE context (with new C-RNTI), but set up everything to reuse the
-       * old config. */
-      uid_t temp_uid = UE->uid;
-      UE->uid = oldUE->uid;
-      oldUE->uid = temp_uid;
+      rnti_t new_rnti = UE->rnti;
+      // assigning the old RNTI to the new RNTI so that mac_remove_nr_ue prints correct RNTI when removing
+      UE->rnti = oldUE->rnti;
+      oldUE->rnti = new_rnti;
+      // if the new UE was performing RA we need to move the old UE to RA procedures
+      // otherwise we just remove the new UE
       for (int i = 1; i < seq_arr_size(&oldUE->UE_sched_ctrl.lc_config); ++i) {
         const nr_lc_config_t *c = seq_arr_at(&oldUE->UE_sched_ctrl.lc_config, i);
         nr_lc_config_t new = *c;
         new.suspended = true;
         nr_mac_add_lcid(&UE->UE_sched_ctrl, &new);
       }
-      ASN_STRUCT_FREE(asn_DEF_NR_CellGroupConfig, UE->CellGroup);
-      UE->CellGroup = oldUE->CellGroup;
-      oldUE->CellGroup = NULL;
-      ASN_STRUCT_FREE(asn_DEF_NR_CellGroupConfig, UE->reconfigCellGroup);
-      UE->reconfigCellGroup = oldUE->reconfigCellGroup;
-      oldUE->reconfigCellGroup = NULL;
-      UE->reestablish_rlc = oldUE->reestablish_rlc;
-      ASN_STRUCT_FREE(asn_DEF_NR_UE_NR_Capability, UE->capability);
-      UE->capability = oldUE->capability;
-      oldUE->capability = NULL;
-      UE->mac_stats = oldUE->mac_stats;
-      UE->measgap_config = oldUE->measgap_config;
-      UE->local_bwp_id = oldUE->local_bwp_id;
-      mac_remove_nr_ue(mac, *dl_rrc->old_gNB_DU_ue_id);
+      // need to move the oldUE to RA list because it still needs to transmit MSG4
+      NR_RA_t *temp_ra = UE->ra;
+      oldUE->ra = temp_ra;
+      UE->ra = NULL;
+      NR_UE_sched_ctrl_t temp_sc;
+      memcpy(&temp_sc, &UE->UE_sched_ctrl, sizeof(NR_UE_sched_ctrl_t));
+      memcpy(&UE->UE_sched_ctrl, &oldUE->UE_sched_ctrl, sizeof(NR_UE_sched_ctrl_t));
+      memcpy(&oldUE->UE_sched_ctrl, &temp_sc, sizeof(NR_UE_sched_ctrl_t));
+      mac_remove_nr_ue(mac, UE->rnti);
+      NR_UE_info_t *r = remove_UE_from_list(MAX_MOBILES_PER_GNB + 1, mac->UE_info.connected_ue_list, oldUE->rnti);
+      DevAssert(r == oldUE);
+      add_UE_to_list(NR_NB_RA_PROC_MAX, mac->UE_info.access_ue_list, oldUE);
       pthread_mutex_unlock(&mac->sched_lock);
       nr_rlc_remove_ue(dl_rrc->gNB_DU_ue_id);
       nr_rlc_update_id(*dl_rrc->old_gNB_DU_ue_id, dl_rrc->gNB_DU_ue_id);
@@ -1096,15 +1094,25 @@ void dl_rrc_message_transfer(const f1ap_dl_rrc_message_t *dl_rrc)
      * Guard against double reestablishment: if reestablish_rlc is already set,
      * reconfigCellGroup was saved by the first reestablishment and
      * CellGroup.spCellConfig is already NULL — don't overwrite. */
-    if (!UE->reestablish_rlc) {
-      asn_copy(&asn_DEF_NR_CellGroupConfig, (void **)&UE->reconfigCellGroup, UE->CellGroup);
-      ASN_STRUCT_FREE(asn_DEF_NR_SpCellConfig, UE->CellGroup->spCellConfig);
-      UE->CellGroup->spCellConfig = NULL;
+    if (!oldUE->reestablish_rlc) {
+      pthread_mutex_lock(&mac->sched_lock);
+      asn_copy(&asn_DEF_NR_CellGroupConfig, (void **)&oldUE->reconfigCellGroup, oldUE->CellGroup);
+      ASN_STRUCT_FREE(asn_DEF_NR_SpCellConfig, oldUE->CellGroup->spCellConfig);
+      oldUE->CellGroup->spCellConfig = NULL;
+      reset_sc_info(&oldUE->sc_info);
+      configure_UE_BWP(mac,
+                       mac->common_channels[0].ServingCellConfigCommon,
+                       oldUE,
+                       true,
+                       NR_SearchSpace__searchSpaceType_PR_common,
+                       -1,
+                       -1);
+     pthread_mutex_unlock(&mac->sched_lock);
     } else {
       LOG_W(NR_MAC, "UE %04x: reestablishment while previous reestablishment still pending, "
-            "keeping saved reconfigCellGroup with spCellConfig\n", UE->rnti);
+            "keeping saved reconfigCellGroup with spCellConfig\n", oldUE->rnti);
     }
-    UE->reestablish_rlc = true;
+    oldUE->reestablish_rlc = true;
     /* Per TS 38.331 clause 5.3.7.4: apply gNB RLC configuration for SRB1 to match the UE RLC configuration defined in 9.2.1.
      * Use configuration file values for timers t_poll_retransmit, t_reassembly and t_status_prohibit */
     nr_rlc_configuration_t rlc_configuration = mac->rlc_config;


### PR DESCRIPTION
Standard prescribes to find UE to be reestablished using information received and replace old C-RNTI/PCI with new C-RNTI/PCI. Before this PR we were instead transferring the old UE information to the UE created for the RA triggering the re-establishment.