### PR TITLE
NGAP: simplify PDU encode and use aper_encode

### DIFF
--- a/ci-scripts/conf_files/gnb.sa.band78.51prb.aw2s.ddsuu.2x2.conf
+++ b/ci-scripts/conf_files/gnb.sa.band78.51prb.aw2s.ddsuu.2x2.conf
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LicenseRef-CSSL-1.0
 
-Active_gNBs = ( "gNB-Eurecom-n78_20");
+Active_gNBs = ( "gNB-Eurecom-n78-20");
 # Asn1_verbosity, choice in: none, info, annoying
 Asn1_verbosity = "none";
 
@@ -14,7 +14,7 @@ gNBs =
     ////////// Identification parameters:
     gNB_ID = 0xe00;
 
-    gNB_name  =  "gNB-Eurecom-n78_20";
+    gNB_name  =  "gNB-Eurecom-n78-20";
 
     // Tracking area code, 0x0000 and 0xfffe are reserved values
     tracking_area_code  =  0x1;

--- a/ci-scripts/conf_files/gnb.sa.band78.51prb.aw2s.ddsuu.conf
+++ b/ci-scripts/conf_files/gnb.sa.band78.51prb.aw2s.ddsuu.conf
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LicenseRef-CSSL-1.0
 
-Active_gNBs = ( "gNB-Eurecom-n78_20");
+Active_gNBs = ( "gNB-Eurecom-n78-20");
 # Asn1_verbosity, choice in: none, info, annoying
 Asn1_verbosity = "none";
 
@@ -14,7 +14,7 @@ gNBs =
     ////////// Identification parameters:
     gNB_ID = 0xe00;
 
-    gNB_name  =  "gNB-Eurecom-n78_20";
+    gNB_name  =  "gNB-Eurecom-n78-20";
 
     // Tracking area code, 0x0000 and 0xfffe are reserved values
     tracking_area_code  =  0x1;

--- a/openair3/NGAP/ngap_common.c
+++ b/openair3/NGAP/ngap_common.c
@@ -9,6 +9,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <arpa/inet.h>
+#include "aper_encoder.h"
+#include "assertions.h"
 #include "conversions.h"
 #include "ngap_common.h"
 #include "ngap_msg_includes.h"
@@ -349,15 +351,34 @@ byte_array_t encode_ngap_pdusession_setup_response_transfer(const pdusession_set
     qos_item->qosFlowIdentifier = pdusession->associated_qos_flows[j].qfi;
   }
 
-  // Encode
-  asn_encode_to_new_buffer_result_t res = asn_encode_to_new_buffer(NULL,
-                                                                   ATS_ALIGNED_CANONICAL_PER,
-                                                                   &asn_DEF_NGAP_PDUSessionResourceSetupResponseTransfer,
-                                                                   &pdusessionTransfer);
-  AssertFatal(res.buffer, "ASN1 message encoding failed (%s, %lu)!\n", res.result.failed_type->name, res.result.encoded);
+  void *buf = NULL;
+  ssize_t encoded =
+      aper_encode_to_new_buffer(&asn_DEF_NGAP_PDUSessionResourceSetupResponseTransfer, NULL, &pdusessionTransfer, &buf);
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_PDUSessionResourceSetupResponseTransfer, &pdusessionTransfer);
-  out.buf = res.buffer;
-  out.len = res.result.encoded;
+  if (encoded < 0)
+    return out;
+  out.buf = buf;
+  out.len = encoded;
+  return out;
+}
+
+/** @brief PDU Session Resource Setup Unsuccessful Transfer encoding (9.3.4.16 3GPP TS 38.413) */
+byte_array_t encode_ngap_pdusession_setup_unsuccessful_transfer(const ngap_cause_t *cause)
+{
+  DevAssert(cause != NULL);
+
+  NGAP_PDUSessionResourceSetupUnsuccessfulTransfer_t transfer = {0};
+  byte_array_t out = {0};
+
+  encode_ngap_cause(&transfer.cause, cause);
+
+  void *buf = NULL;
+  ssize_t encoded = aper_encode_to_new_buffer(&asn_DEF_NGAP_PDUSessionResourceSetupUnsuccessfulTransfer, NULL, &transfer, &buf);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_PDUSessionResourceSetupUnsuccessfulTransfer, &transfer);
+  if (encoded < 0)
+    return out;
+  out.buf = buf;
+  out.len = encoded;
   return out;
 }
 

--- a/openair3/NGAP/ngap_common.h
+++ b/openair3/NGAP/ngap_common.h
@@ -41,6 +41,7 @@ pdusession_level_qos_parameter_t fill_qos(uint8_t qfi, const NGAP_QosFlowLevelQo
 void *decode_pdusession_transfer(const asn_TYPE_descriptor_t *td, const OCTET_STRING_t buf);
 bool decodePDUSessionResourceSetup(pdusession_transfer_t *out, const OCTET_STRING_t in);
 byte_array_t encode_ngap_pdusession_setup_response_transfer(const pdusession_setup_t *pdusession);
+byte_array_t encode_ngap_pdusession_setup_unsuccessful_transfer(const ngap_cause_t *cause);
 void encode_ngap_security_capabilities(NGAP_UESecurityCapabilities_t *out, const ngap_security_capabilities_t *in);
 
 bool eq_ngap_plmn(const plmn_id_t *a, const plmn_id_t *b);

--- a/openair3/NGAP/ngap_gNB_encoder.c
+++ b/openair3/NGAP/ngap_gNB_encoder.c
@@ -11,124 +11,39 @@
 #include <stdio.h>
 #include "ngap_msg_includes.h"
 #include "T.h"
+#include "aper_encoder.h"
 #include "asn_application.h"
-#include "asn_codecs.h"
 #include "assertions.h"
 #include "common/utils/T/T.h"
-#include "constr_TYPE.h"
 #include "ngap_common.h"
-#include "utils.h"
 #include "xer_encoder.h"
-
-static inline int ngap_gNB_encode_initiating(NGAP_NGAP_PDU_t *pdu, uint8_t **buffer, uint32_t *len)
-{
-  DevAssert(pdu != NULL);
-
-  const NGAP_ProcedureCode_t tmp[] = {NGAP_ProcedureCode_id_NGSetup,
-                                      NGAP_ProcedureCode_id_UplinkNASTransport,
-                                      NGAP_ProcedureCode_id_UERadioCapabilityInfoIndication,
-                                      NGAP_ProcedureCode_id_InitialUEMessage,
-                                      NGAP_ProcedureCode_id_NASNonDeliveryIndication,
-                                      NGAP_ProcedureCode_id_UEContextReleaseRequest,
-                                      NGAP_ProcedureCode_id_PathSwitchRequest,
-                                      NGAP_ProcedureCode_id_PDUSessionResourceModifyIndication,
-                                      NGAP_ProcedureCode_id_UplinkRANStatusTransfer,
-                                      NGAP_ProcedureCode_id_HandoverPreparation,
-                                      NGAP_ProcedureCode_id_HandoverCancel,
-                                      NGAP_ProcedureCode_id_HandoverNotification,
-                                      NGAP_ProcedureCode_id_UplinkUEAssociatedNRPPaTransport,
-                                      NGAP_ProcedureCode_id_UplinkNonUEAssociatedNRPPaTransport};
-  int i;
-  for (i = 0; i < sizeofArray(tmp); i++)
-    if (pdu->choice.initiatingMessage->procedureCode == tmp[i])
-      break;
-  if (i == sizeofArray(tmp)) {
-    NGAP_DEBUG("Unknown procedure ID (%d) for initiating message\n", (int)pdu->choice.initiatingMessage->procedureCode);
-    return -1;
-  }
-
-  asn_encode_to_new_buffer_result_t res = asn_encode_to_new_buffer(NULL, ATS_ALIGNED_CANONICAL_PER, &asn_DEF_NGAP_NGAP_PDU, pdu);
-  AssertFatal(res.result.encoded > 0, "failed to encode NGAP msg\n");
-  *buffer = res.buffer;
-  *len = res.result.encoded;
-  return 0;
-}
-
-static inline int ngap_gNB_encode_successfull_outcome(NGAP_NGAP_PDU_t *pdu, uint8_t **buffer, uint32_t *len)
-{
-  DevAssert(pdu != NULL);
-  const NGAP_ProcedureCode_t tmp[] = {NGAP_ProcedureCode_id_InitialContextSetup,
-                                      NGAP_ProcedureCode_id_UEContextRelease,
-                                      NGAP_ProcedureCode_id_PDUSessionResourceSetup,
-                                      NGAP_ProcedureCode_id_PDUSessionResourceModify,
-                                      NGAP_ProcedureCode_id_PDUSessionResourceRelease,
-                                      NGAP_ProcedureCode_id_HandoverResourceAllocation};
-  int i;
-  for (i = 0; i < sizeofArray(tmp); i++)
-    if (pdu->choice.successfulOutcome->procedureCode == tmp[i])
-      break;
-  if (i == sizeofArray(tmp)) {
-    NGAP_WARN("Unknown procedure ID (%ld) for successfull outcome message\n", pdu->choice.successfulOutcome->procedureCode);
-    return -1;
-  }
-
-  asn_encode_to_new_buffer_result_t res = asn_encode_to_new_buffer(NULL, ATS_ALIGNED_CANONICAL_PER, &asn_DEF_NGAP_NGAP_PDU, pdu);
-  AssertFatal(res.result.encoded > 0, "failed to encode NGAP msg\n");
-  *buffer = res.buffer;
-  *len = res.result.encoded;
-  return 0;
-}
-
-static inline int ngap_gNB_encode_unsuccessfull_outcome(NGAP_NGAP_PDU_t *pdu, uint8_t **buffer, uint32_t *len)
-{
-  DevAssert(pdu != NULL);
-
-  const NGAP_ProcedureCode_t id[] = {NGAP_ProcedureCode_id_InitialContextSetup, NGAP_ProcedureCode_id_HandoverResourceAllocation};
-
-  int i;
-  for (i = 0; i < sizeofArray(id); i++) {
-    if (pdu->choice.unsuccessfulOutcome->procedureCode == id[i]) {
-      break;
-    }
-  }
-
-  if (i == sizeofArray(id)) {
-    NGAP_WARN("Unknown procedure ID (%ld) for successful outcome message\n", pdu->choice.successfulOutcome->procedureCode);
-    return -1;
-  }
-
-  asn_encode_to_new_buffer_result_t res = asn_encode_to_new_buffer(NULL, ATS_ALIGNED_CANONICAL_PER, &asn_DEF_NGAP_NGAP_PDU, pdu);
-  AssertFatal(res.result.encoded > 0, "failed to encode NGAP msg\n");
-  *buffer = res.buffer;
-  *len = res.result.encoded;
-  return 0;
-}
 
 int ngap_gNB_encode_pdu(NGAP_NGAP_PDU_t *pdu, uint8_t **buffer, uint32_t *len)
 {
-  int ret = -1;
   DevAssert(pdu != NULL);
   DevAssert(buffer != NULL);
   DevAssert(len != NULL);
+
   if (LOG_DEBUGFLAG(DEBUG_ASN1)) {
-    xer_fprint(stdout, &asn_DEF_NGAP_NGAP_PDU, (void *)pdu);
+    xer_fprint(stdout, &asn_DEF_NGAP_NGAP_PDU, pdu);
   }
-  switch (pdu->present) {
-    case NGAP_NGAP_PDU_PR_initiatingMessage:
-      ret = ngap_gNB_encode_initiating(pdu, buffer, len);
-      break;
 
-    case NGAP_NGAP_PDU_PR_successfulOutcome:
-      ret = ngap_gNB_encode_successfull_outcome(pdu, buffer, len);
-      break;
-
-    case NGAP_NGAP_PDU_PR_unsuccessfulOutcome:
-      ret = ngap_gNB_encode_unsuccessfull_outcome(pdu, buffer, len);
-      break;
-
-    default:
-      NGAP_DEBUG("Unknown message outcome (%d) or not implemented", (int)pdu->present);
-      return -1;
+  char errbuf[256];
+  size_t errlen = sizeof(errbuf);
+  if (asn_check_constraints(&asn_DEF_NGAP_NGAP_PDU, pdu, errbuf, &errlen)) {
+    xer_fprint(stdout, &asn_DEF_NGAP_NGAP_PDU, pdu);
+    NGAP_ERROR("Constraint validation failed: %s\n", errbuf);
+    return -1;
   }
-  return ret;
+
+  void *buf = NULL;
+  ssize_t encoded = aper_encode_to_new_buffer(&asn_DEF_NGAP_NGAP_PDU, NULL, pdu, &buf);
+  if (encoded < 0) {
+    NGAP_ERROR("Failed to encode NGAP PDU\n");
+    return -1;
+  }
+
+  *buffer = buf;
+  *len = encoded;
+  return 0;
 }

--- a/openair3/NGAP/ngap_gNB_nas_procedures.c
+++ b/openair3/NGAP/ngap_gNB_nas_procedures.c
@@ -615,6 +615,11 @@ int ngap_gNB_initial_ctxt_resp(instance_t instance, ngap_initial_context_setup_r
       item->pDUSessionID = initial_ctxt_resp_p->pdusessions[i].pdusession_id;
       // PDU Session Resource Setup Response Transfer (Mandatory)
       byte_array_t ba = encode_ngap_pdusession_setup_response_transfer(&initial_ctxt_resp_p->pdusessions[i]);
+      if (ba.buf == NULL) {
+        NGAP_ERROR("Failed to encode PDUSessionResourceSetupResponseTransfer for PDU session %ld\n", item->pDUSessionID);
+        ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
+        return -1;
+      }
       item->pDUSessionResourceSetupResponseTransfer.buf = ba.buf;
       item->pDUSessionResourceSetupResponseTransfer.size = ba.len;
     }
@@ -628,21 +633,18 @@ int ngap_gNB_initial_ctxt_resp(instance_t instance, ngap_initial_context_setup_r
 
     for (i = 0; i < initial_ctxt_resp_p->nb_of_pdusessions_failed; i++) {
       asn1cSequenceAdd(ie->value.choice.PDUSessionResourceFailedToSetupListCxtRes.list, NGAP_PDUSessionResourceFailedToSetupItemCxtRes_t, item);
-      NGAP_PDUSessionResourceSetupUnsuccessfulTransfer_t pdusessionUnTransfer = {0};
-    
       /* pDUSessionID */
       item->pDUSessionID = initial_ctxt_resp_p->pdusessions_failed[i].pdusession_id;
-
-      /* cause */
-      encode_ngap_cause(&pdusessionUnTransfer.cause, &initial_ctxt_resp_p->pdusessions_failed[i].cause);
-
       NGAP_INFO("initial context setup response: failed pdusession ID %ld\n", item->pDUSessionID);
-      asn_encode_to_new_buffer_result_t res = asn_encode_to_new_buffer(NULL, ATS_ALIGNED_CANONICAL_PER, &asn_DEF_NGAP_PDUSessionResourceSetupUnsuccessfulTransfer, &pdusessionUnTransfer);
-      AssertFatal(res.buffer, "ASN1 message encoding failed (%s, %lu)!\n", res.result.failed_type->name, res.result.encoded);
-      item->pDUSessionResourceSetupUnsuccessfulTransfer.buf = res.buffer;
-      item->pDUSessionResourceSetupUnsuccessfulTransfer.size = res.result.encoded;
 
-      ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_PDUSessionResourceSetupUnsuccessfulTransfer, &pdusessionUnTransfer);
+      byte_array_t ba = encode_ngap_pdusession_setup_unsuccessful_transfer(&initial_ctxt_resp_p->pdusessions_failed[i].cause);
+      if (ba.buf == NULL) {
+        NGAP_ERROR("Failed to encode PDUSessionResourceSetupUnsuccessfulTransfer for PDU session %ld\n", item->pDUSessionID);
+        ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
+        return -1;
+      }
+      item->pDUSessionResourceSetupUnsuccessfulTransfer.buf = ba.buf;
+      item->pDUSessionResourceSetupUnsuccessfulTransfer.size = ba.len;
     }
   }
 

--- a/openair3/NGAP/ngap_gNB_pdu_session_management.c
+++ b/openair3/NGAP/ngap_gNB_pdu_session_management.c
@@ -9,7 +9,7 @@
 #include "INTEGER.h"
 #include "ngap_msg_includes.h"
 #include "OCTET_STRING.h"
-#include "asn_application.h"
+#include "aper_encoder.h"
 #include "assertions.h"
 #include "conversions.h"
 #include "ngap_common.h"
@@ -90,6 +90,11 @@ int ngap_gNB_pdusession_setup_resp(instance_t instance, ngap_pdusession_setup_re
 
       // PDU Session Resource Setup Response Transfer (Mandatory)
       byte_array_t ba = encode_ngap_pdusession_setup_response_transfer(pdusession);
+      if (ba.buf == NULL) {
+        NGAP_ERROR("Failed to encode PDUSessionResourceSetupResponseTransfer for PDU session %ld\n", item->pDUSessionID);
+        ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
+        return -1;
+      }
       item->pDUSessionResourceSetupResponseTransfer.buf = ba.buf;
       item->pDUSessionResourceSetupResponseTransfer.size = ba.len;
     }
@@ -107,23 +112,16 @@ int ngap_gNB_pdusession_setup_resp(instance_t instance, ngap_pdusession_setup_re
       asn1cSequenceAdd(ie->value.choice.PDUSessionResourceFailedToSetupListSURes.list,
                        NGAP_PDUSessionResourceFailedToSetupItemSURes_t,
                        item);
-      NGAP_PDUSessionResourceSetupUnsuccessfulTransfer_t pdusessionUnTransfer_p = {0};
-
-      /* pDUSessionID */
       item->pDUSessionID = pdusession_failed->pdusession_id;
 
-      /* cause */
-      encode_ngap_cause(&pdusessionUnTransfer_p.cause, &pdusession_failed->cause);
-      NGAP_INFO("pdusession setup response: failed pdusession ID %ld\n", item->pDUSessionID);
-
-      asn_encode_to_new_buffer_result_t res = asn_encode_to_new_buffer(NULL,
-                                                                       ATS_ALIGNED_CANONICAL_PER,
-                                                                       &asn_DEF_NGAP_PDUSessionResourceSetupUnsuccessfulTransfer,
-                                                                       &pdusessionUnTransfer_p);
-      item->pDUSessionResourceSetupUnsuccessfulTransfer.buf = res.buffer;
-      item->pDUSessionResourceSetupUnsuccessfulTransfer.size = res.result.encoded;
-
-      ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_PDUSessionResourceSetupUnsuccessfulTransfer, &pdusessionUnTransfer_p);
+      byte_array_t ba = encode_ngap_pdusession_setup_unsuccessful_transfer(&pdusession_failed->cause);
+      if (ba.buf == NULL) {
+        NGAP_ERROR("Failed to encode PDUSessionResourceSetupUnsuccessfulTransfer for PDU session %ld\n", item->pDUSessionID);
+        ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
+        return -1;
+      }
+      item->pDUSessionResourceSetupUnsuccessfulTransfer.buf = ba.buf;
+      item->pDUSessionResourceSetupUnsuccessfulTransfer.size = ba.len;
     }
   }
 
@@ -227,19 +225,16 @@ int ngap_gNB_pdusession_modify_resp(instance_t instance, ngap_pdusession_modify_
           qos->qosFlowIdentifier = pdusession_modify_resp_p->pdusessions[i].qos[qos_flow_index].qfi;
         }
       }
-      asn_encode_to_new_buffer_result_t res = {0};
-      res = asn_encode_to_new_buffer(NULL,
-                                     ATS_ALIGNED_CANONICAL_PER,
-                                     &asn_DEF_NGAP_PDUSessionResourceModifyResponseTransfer,
-                                     &transfer);
-      if (res.buffer == NULL || res.result.encoded <= 0) {
+      void *buf = NULL;
+      ssize_t encoded = aper_encode_to_new_buffer(&asn_DEF_NGAP_PDUSessionResourceModifyResponseTransfer, NULL, &transfer, &buf);
+      if (encoded < 0) {
         NGAP_ERROR("Failed to encode PDUSessionResourceModifyResponseTransfer for PDU session %ld\n", item->pDUSessionID);
         ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_PDUSessionResourceModifyResponseTransfer, &transfer);
         ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
         return -1;
       }
-      item->pDUSessionResourceModifyResponseTransfer.buf = res.buffer;
-      item->pDUSessionResourceModifyResponseTransfer.size = res.result.encoded;
+      item->pDUSessionResourceModifyResponseTransfer.buf = buf;
+      item->pDUSessionResourceModifyResponseTransfer.size = encoded;
 
       ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_PDUSessionResourceModifyResponseTransfer, &transfer);
 
@@ -262,15 +257,19 @@ int ngap_gNB_pdusession_modify_resp(instance_t instance, ngap_pdusession_modify_
 
       NGAP_PDUSessionResourceModifyUnsuccessfulTransfer_t pdusessionTransfer = {0};
 
-      // NGAP cause
       encode_ngap_cause(&pdusessionTransfer.cause, &pdusession_modify_resp_p->pdusessions_failed[i].cause);
 
-      asn_encode_to_new_buffer_result_t res = asn_encode_to_new_buffer(NULL,
-                                                                       ATS_ALIGNED_CANONICAL_PER,
-                                                                       &asn_DEF_NGAP_PDUSessionResourceModifyUnsuccessfulTransfer,
-                                                                       &pdusessionTransfer);
-      item->pDUSessionResourceModifyUnsuccessfulTransfer.buf = res.buffer;
-      item->pDUSessionResourceModifyUnsuccessfulTransfer.size = res.result.encoded;
+      void *buf = NULL;
+      ssize_t encoded =
+          aper_encode_to_new_buffer(&asn_DEF_NGAP_PDUSessionResourceModifyUnsuccessfulTransfer, NULL, &pdusessionTransfer, &buf);
+      if (encoded < 0) {
+        NGAP_ERROR("Failed to encode PDUSessionResourceModifyUnsuccessfulTransfer for PDU session %ld\n", item->pDUSessionID);
+        ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_PDUSessionResourceModifyUnsuccessfulTransfer, &pdusessionTransfer);
+        ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
+        return -1;
+      }
+      item->pDUSessionResourceModifyUnsuccessfulTransfer.buf = buf;
+      item->pDUSessionResourceModifyUnsuccessfulTransfer.size = encoded;
 
       ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_PDUSessionResourceModifyUnsuccessfulTransfer, &pdusessionTransfer);
 
@@ -310,15 +309,16 @@ int ngap_gNB_pdusession_modify_resp(instance_t instance, ngap_pdusession_modify_
 static byte_array_t encode_ngap_pdusession_release_response_transfer(void)
 {
   NGAP_PDUSessionResourceReleaseResponseTransfer_t pdusessionTransfer = {0};
+  byte_array_t out = {0};
 
-  // Encode
-  asn_encode_to_new_buffer_result_t res = asn_encode_to_new_buffer(NULL,
-                                                                   ATS_ALIGNED_CANONICAL_PER,
-                                                                   &asn_DEF_NGAP_PDUSessionResourceReleaseResponseTransfer,
-                                                                   &pdusessionTransfer);
-  AssertFatal(res.buffer, "ASN1 message encoding failed (%s, %lu)!\n", res.result.failed_type->name, res.result.encoded);
+  void *buf = NULL;
+  ssize_t encoded =
+      aper_encode_to_new_buffer(&asn_DEF_NGAP_PDUSessionResourceReleaseResponseTransfer, NULL, &pdusessionTransfer, &buf);
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_PDUSessionResourceReleaseResponseTransfer, &pdusessionTransfer);
-  byte_array_t out = {.buf = res.buffer, .len = res.result.encoded};
+  if (encoded < 0)
+    return out;
+  out.buf = buf;
+  out.len = encoded;
   return out;
 }
 
@@ -382,6 +382,11 @@ int ngap_gNB_pdusession_release_resp(instance_t instance, ngap_pdusession_releas
       /* PDU Session Resource Release Response Transfer (mandatory) */
       // Empty transfer is valid since Secondary RAT Usage Information is optional and not used
       byte_array_t transfer = encode_ngap_pdusession_release_response_transfer();
+      if (transfer.buf == NULL) {
+        NGAP_ERROR("Failed to encode PDUSessionResourceReleaseResponseTransfer for PDU session %ld\n", item->pDUSessionID);
+        ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NGAP_NGAP_PDU, &pdu);
+        return -1;
+      }
       OCTET_STRING_fromBuf(&item->pDUSessionResourceReleaseResponseTransfer, (const char *)transfer.buf, transfer.len);
       free_byte_array(transfer);
       NGAP_DEBUG("PDU Session Resource Release Response: pdusession ID %ld\n", item->pDUSessionID);


### PR DESCRIPTION
gNB NGAP transmit encoding required hard-coded procedure-ID list for each allowed PDU outcome and often aborted on ASN.1 encode failure. This branch encodes any constraint-valid NGAP PDU in one path (constraint check, then APER), and applies the same `aper_encode_to_new_buffer` + soft-fail pattern to nested PDU session transfer IEs used in setup/modify/release and Initial Context Setup responses.

Changes:

- Collapse `ngap_gNB_encode_pdu` to a single encode path (no initiating/successful/unsuccessful procedure-ID lists): use `asn_check_constraints` then `aper_encode_to_new_buffer` + soft-fail
- Switch PDU session transfer encodes (setup response, modify, release, and failed-setup unsuccessful transfer) from `asn_encode_to_new_buffer` / `ATS_ALIGNED_CANONICAL_PER` to `aper_encode_to_new_buffer` with soft-fail
- Add shared `encode_ngap_pdusession_setup_unsuccessful_transfer` (TS 38.413 §9.3.4.16) for PDU Session Setup Response and Initial Context Setup Response failed-to-setup lists
