### PR TITLE
[FHI72] Fix multi-RU and delete assertion for PRACH nRxPkt > 1

### DIFF
--- a/radio/fhi_72/oaioran.c
+++ b/radio/fhi_72/oaioran.c
@@ -238,7 +238,6 @@ void oai_xran_fh_rx_prach_callback(void *pCallbackTag, xran_status_t status, uin
             struct xran_prb_map *pRbMap = (struct xran_prb_map *)bufs->prachdstdecomp[ant_id][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
             AssertFatal(pRbMap != NULL, "(%d:%d:%d)pRbMapPrach == NULL. Aborting.\n", cc_id, tti % XRAN_N_FE_BUF_LEN, ant_id);
             for (uint32_t sym_id = 0; sym_id < XRAN_NUM_OF_SYMBOL_PER_SLOT; sym_id++) {
-              AssertFatal(pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt <= 1, "PRACH segmentation is not supported\n");
               info->nRxPkt[cc_id][ant_id + ru_idx * fh_config->neAxc][sym_id] = pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt;
               pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt = 0;
             }
@@ -360,22 +359,18 @@ int xran_fh_rx_prach_read_slot(PHY_VARS_gNB *gNB, ru_info_t *ru, int *frame, int
         struct xran_prb_map * pPrbMap = (struct xran_prb_map *)bufs->prachdstdecomp[aa % nb_rx_per_ru][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
         struct xran_rx_packet_ctl *p_rx_packet_ctl = &pPrbMap->sFrontHaulRxPacketCtrl[sym_idx];
         int32_t nRxPkt = info->nRxPkt[cc_id][aa][sym_idx];
-        if (nRxPkt == 0) {
-          LOG_D(HW, "read_prach %d.%d.%d saa = %d: nRxPkt = 0!\n", *frame, *slot, sym_idx, aa);
-          memset(&dst[sym_idx], 0, N_ZC * 2 * sizeof(*dst));
+        /* known issue: for aa = 2, the packet (one per symbol) is not received/stored on time */
+        if (nRxPkt != 1) {
+          LOG_D(HW, "[%d.%d] tti %d aa %d sym_idx %d nRxPkt %d (expected 1 packet)\n", *frame, *slot, tti, aa, sym_idx, nRxPkt);
           continue;
-        } else if (nRxPkt > 1) { // protection
-          LOG_E(HW, "read_prach %d.%d.%d saa = %d: nRxPkt = %d!\n", *frame, *slot, sym_idx, aa, nRxPkt);
-          memset(&dst[sym_idx], 0, N_ZC * 2 * sizeof(*dst));
-          continue;
-        } else {
-          src = (int16_t *)p_rx_packet_ctl->pData[0];
-          if (src == NULL) { // protection
-            LOG_E(HW, "read_prach %d.%d.%d saa = %d:  src = NULL!!\n", *frame, *slot, sym_idx, aa);
-            memset(&dst[sym_idx], 0, N_ZC * 2 * sizeof(*dst));
-            continue;
-          }
         }
+
+        src = (int16_t *)p_rx_packet_ctl->pData[0];
+        if (src == NULL) { // protection
+          LOG_E(HW, "[%d.%d] tti %d aa %d sym_idx %d src = NULL\n", *frame, *slot, tti, aa, sym_idx);
+          continue;
+        }
+
         num_prbu = p_rx_packet_ctl->nRBSize[0];
         /* convert Network order to host order */
         if (ru_conf->compMeth_PRACH == XRAN_COMPMETHOD_NONE) {

--- a/radio/fhi_72/oaioran.c
+++ b/radio/fhi_72/oaioran.c
@@ -162,7 +162,7 @@ void oai_xran_fh_rx_callback(void *pCallbackTag, xran_status_t status, uint8_t m
             struct xran_prb_map *pRbMap = (struct xran_prb_map *)bufs->dstcp[ant_id][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
             AssertFatal(pRbMap != NULL, "(%d:%d:%d)pRbMap == NULL. Aborting.\n", cc_id, tti % XRAN_N_FE_BUF_LEN, ant_id);
             for (uint32_t sym_id = 0; sym_id < XRAN_NUM_OF_SYMBOL_PER_SLOT; sym_id++) {
-              info->nRxPkt[cc_id][ant_id][sym_id] = pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt;
+              info->nRxPkt[cc_id][ant_id + ru_idx * fh_config->neAxc][sym_id] = pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt;
               pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt = 0;
             }
           }
@@ -239,7 +239,7 @@ void oai_xran_fh_rx_prach_callback(void *pCallbackTag, xran_status_t status, uin
             AssertFatal(pRbMap != NULL, "(%d:%d:%d)pRbMapPrach == NULL. Aborting.\n", cc_id, tti % XRAN_N_FE_BUF_LEN, ant_id);
             for (uint32_t sym_id = 0; sym_id < XRAN_NUM_OF_SYMBOL_PER_SLOT; sym_id++) {
               AssertFatal(pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt <= 1, "PRACH segmentation is not supported\n");
-              info->nRxPkt[cc_id][ant_id][sym_id] = pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt;
+              info->nRxPkt[cc_id][ant_id + ru_idx * fh_config->neAxc][sym_id] = pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt;
               pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt = 0;
             }
           }


### PR DESCRIPTION
In the MR https://gitlab.eurecom.fr/oai/openairinterface5g/-/merge_requests/3444:
- 8x8 testbed was tested but `nrL1_stats` was not checked which shows the signal strength per antenna port. It indicated that only the IQ samples from one RU were taken.
- if PRACH nRxPkt > 1, the gNB asserted. The fragmentation can only occur when long PRACH with MTU 1500 bytes is considered. Since we haven't tested this setup, we process only 1 packet per symbol. The assertion was achieved sometimes when a packet wasn't received on time for current slot, it was taken into consideration for the next (slot + `XRAN_N_FE_BUF_LEN`)

=> This PR fixes both issues.