### PR TITLE
Fix RSRP overflow and runtime UB when connecting >32

### DIFF
--- a/common/utils/collection/linear_alloc.h
+++ b/common/utils/collection/linear_alloc.h
@@ -44,7 +44,7 @@ static inline uid_t uid_linear_allocator_new(uid_allocator_t *uia) {
 static inline void uid_linear_allocator_free(uid_allocator_t *uia, uid_t uid) {
   const unsigned int i = uid/sizeof(unsigned int)/8;
   const unsigned int bit = uid % (sizeof(unsigned int) * 8);
-  const unsigned int value = ~(1 << bit);
+  const unsigned int value = ~(1U << bit);
 
   if (i < UID_LINEAR_ALLOCATOR_BITMAP_SIZE) {
     uia->bitmap[i] &= value;

--- a/openair1/PHY/CODING/nrLDPC_coding/nrLDPC_coding_aal/nrLDPC_coding_aal.c
+++ b/openair1/PHY/CODING/nrLDPC_coding/nrLDPC_coding_aal/nrLDPC_coding_aal.c
@@ -784,7 +784,7 @@ static int retrieve_ldpc_enc_op(struct rte_bbdev_enc_op **ops, nrLDPC_slot_encod
           simde__m64 current = *((simde__m64 *)data);
           data += 8;
           current = simde_mm_srli_si64(current, 8 - bit_offset);
-          *(simde__m64 *)&p_out[byte_offset + i] = current;
+          memcpy(&p_out[byte_offset + i], &current, sizeof(simde__m64));
         }
         for (; i < data_len; i++) {
           uint8_t current = *data++;

--- a/openair2/LAYER2/NR_MAC_gNB/main.c
+++ b/openair2/LAYER2/NR_MAC_gNB/main.c
@@ -108,8 +108,8 @@ size_t dump_mac_stats(gNB_MAC_INST *gNB, char *output, size_t strlen, bool reset
   UE_iterator(gNB->UE_info.connected_ue_list, UE) {
     NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
     NR_mac_stats_t *stats = &UE->mac_stats;
-    const int avg_rsrp = stats->num_rsrp_meas > 0 ? stats->cumul_rsrp / stats->num_rsrp_meas : 0;
-    const int avg_sinrx10 = stats->num_sinr_meas > 0 ? stats->cumul_sinrx10 / stats->num_sinr_meas : 0;
+    const int avg_rsrp = stats->num_rsrp_meas > 0 ? stats->cumul_rsrp / (int)stats->num_rsrp_meas : 0;
+    const int avg_sinrx10 = stats->num_sinr_meas > 0 ? stats->cumul_sinrx10 / (int)stats->num_sinr_meas : 0;
 
     output = st_append(output, end, "UE RNTI %04x CU-UE-ID ", UE->rnti);
     if (du_exists_f1_ue_data(UE->rnti)) {
@@ -128,12 +128,12 @@ size_t dump_mac_stats(gNB_MAC_INST *gNB, char *output, size_t strlen, bool reset
                        sched_ctrl->pcmax);
 
     if (stats->num_rsrp_meas)
-      output = st_append(output, end, ", average RSRP %d (%d meas)", avg_rsrp, stats->num_rsrp_meas);
+      output = st_append(output, end, ", average RSRP %d (%u meas)", avg_rsrp, stats->num_rsrp_meas);
 
     if (stats->num_sinr_meas) {
       output = st_append(output,
                          end,
-                         ", average SINR %d.%d (%d meas)",
+                         ", average SINR %d.%d (%u meas)",
                          avg_sinrx10 / 10,
                          avg_sinrx10 % 10,
                          stats->num_sinr_meas);

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -764,9 +764,9 @@ typedef struct NR_mac_stats {
   uint64_t ulsch_total_bytes_scheduled;
   uint32_t pucch0_DTX;
   int cumul_rsrp;
-  uint8_t num_rsrp_meas;
+  uint32_t num_rsrp_meas;
   int cumul_sinrx10;
-  uint8_t num_sinr_meas;
+  uint32_t num_sinr_meas;
   char srs_stats[50]; // Statistics may differ depending on SRS usage
   int deltaMCS;
   int NPRB;


### PR DESCRIPTION
- Fix RSRP report counter overflow: the count was stored in a
uint8_t, which wraps past 255 with many connected UEs, producing
invalid RSRP values.

- Fix undefined behavior detected with UBSan when connecting more
than 32 UEs:

    store to misaligned address for type 'simde__m64' (requires
    8-byte alignment)
    left shift of 1 by 31 places, not representable in type 'int'

