### PR TITLE
Fix ping/iperf failure on second nrUE PDU session

### DIFF
--- a/ci-scripts/xml_files/container_5g_rfsim_u0_25prb.xml
+++ b/ci-scripts/xml_files/container_5g_rfsim_u0_25prb.xml
@@ -50,14 +50,6 @@
 
   <testCase>
     <class>Custom_Command</class>
-    <desc>Configure policy routing for PDU2 source IP</desc>
-    <may_fail>true</may_fail>
-    <node>localhost</node>
-    <command>docker exec rfsim5g-oai-nr-ue sh -c "ip rule add from 12.1.2.2/32 table 1002 prio 1002; ip route replace default dev oaitun_ue1p2 src 12.1.2.2 table 1002"</command>
-  </testCase>
-
-  <testCase>
-    <class>Custom_Command</class>
     <desc>Ping ext-dn from UE PDU session 1 interface</desc>
     <node>localhost</node>
     <command>docker exec rfsim5g-oai-nr-ue ping -I oaitun_ue1 -c 10 192.168.72.135</command>

--- a/common/utils/tuntap_if.c
+++ b/common/utils/tuntap_if.c
@@ -260,9 +260,11 @@ bool tap_config(const char* ifname)
   return success;
 }
 
-void setup_ue_ipv4_route(const char* ifname, int instance_id, const char *ipv4)
+void setup_ue_ipv4_route(const char* ifname, int instance_id, int pdu_session_id, const char *ipv4)
 {
-  int table_id = instance_id - 1 + 10000;
+  /* This needs to be unique per (instance_id, pdu_session_id) */
+  // UE0, PDU1 = 10001, UE1, PDU1 = 10101, UE15, PDU15 = 11515 ...
+  int table_id = 10000 + instance_id * 100 + pdu_session_id;
 
   char command_line[500];
   int res = sprintf(command_line,

--- a/common/utils/tuntap_if.h
+++ b/common/utils/tuntap_if.h
@@ -72,9 +72,10 @@ bool tap_config(const char* ifname);
  * in same subnet).
  * \param[in] ifname name of the interface
  * \param[in] instance_id unique instance number, used to create the table
+ * \param[in] pdu_session_id PDU session ID, used to create the table
  * \param[in] ipv4 IPv4 address of the UE
  */
-void setup_ue_ipv4_route(const char* ifname, int instance_id, const char *ipv4);
+void setup_ue_ipv4_route(const char* ifname, int instance_id, int pdu_session_id, const char *ipv4);
 
 /*!
  * \brief This function allocates a TUN or TAP interface

--- a/openair2/SDAP/nr_sdap/nr_sdap.c
+++ b/openair2/SDAP/nr_sdap/nr_sdap.c
@@ -318,7 +318,7 @@ void create_ue_ip_if(const char *ipv4, const char *ipv6, int ue_id, int pdu_sess
 
   tun_config(ifname, ipv4, ipv6);
   if (ipv4) {
-    setup_ue_ipv4_route(ifname, ue_id, ipv4);
+    setup_ue_ipv4_route(ifname, ue_id, pdu_session_id, ipv4);
   }
 }
 

--- a/openair3/NAS/UE/ESM/esm_ebr_context.c
+++ b/openair3/NAS/UE/ESM/esm_ebr_context.c
@@ -191,7 +191,7 @@ int esm_ebr_context_create(
               char ifname[IFNAMSIZ];
               tun_generate_ifname(ifname, ifn, 0);
               tun_config(ifname, ip, NULL);
-              setup_ue_ipv4_route(ifname, 0, ip);
+              setup_ue_ipv4_route(ifname, 0, pid, ip);
             } break;
 
             case NET_PDN_TYPE_IPV6:


### PR DESCRIPTION
### Observation:
While testing the OAI gNB with the OAI nrUE over RFSIM, the UE can successfully establish two PDU sessions and obtain the corresponding IP addresses, for example:
- PDU Session 1: 12.5.1.2
- PDU Session 2: 12.5.2.2
However, only one of the two PDU session IPs is reachable from the core. For example, if 12.5.1.2 is pinged first, the ping succeeds, while 12.5.2.2 does not respond afterward. Iperf traffic also cannot be established.

The nrUE is started with:
```
sudo ./nr-uesoftmodem -O ue.conf -C 3319680000 -r 106 --numerology 1 --ssb 516 --rfsim --num-ues 1
```
with the following configuration:
```
uicc0 :
{
    imsi = "001010000000001";
    key = "fec86ba6eb707ed08905757b1bb44b8f";
    opc = "C42449363BBAD02B66D16BC975D77CC1";
    pdu_sessions = (
      { dnn = "internet";nssai_sst = 1;},
      { dnn = "iot";nssai_sst = 2;nssai_sd  = 0x000001;}
    );
}
```

### Troubleshooting:
- This behavior was not observed when testing with a Quectel UE.
- The issue depends on which PDU session IP is triggered the traffic first (only the PDU session IP selected first is reachable):
  - If 12.5.1.2 is pinged first, it works, but 12.5.2.2 does not respond afterward.
  - If 12.5.2.2 is pinged first, it works, but 12.5.1.2 does not respond afterward.

### Root Cause:
`setup_ue_ipv4_route()` generates the routing table id using only the UE `instance_id`:
```
int table_id = instance_id - 1 + 10000;
```
Both PDU session IPs therefore reference the same routing table:
```
ip rule
32516: from all to 12.5.1.2 lookup 9999
32517: from 12.5.1.2 lookup 9999
32518: from all to 12.5.2.2 lookup 9999
32519: from 12.5.2.2 lookup 9999
```