### PR TITLE
fix(nr-phy): avoid invalid SRS outputs after detection failure

### DIFF
--- a/openair1/SCHED_NR/phy_procedures_nr_gNB.c
+++ b/openair1/SCHED_NR/phy_procedures_nr_gNB.c
@@ -871,7 +871,9 @@ static void handle_srs(fsn_t now,
                                                 &timing_advance_offset,
                                                 timing_advance_offset_nsec);
 
-  if ((snr * 10) < gNB->srs_thres) {
+  // Measurement outputs are valid on raw success (including 0), before SNR thresholding.
+  const bool estimate_valid = srs_est >= 0;
+  if (estimate_valid && (snr * 10) < gNB->srs_thres) {
     srs_est = -1;
   }
 
@@ -911,6 +913,8 @@ static void handle_srs(fsn_t now,
   start_meas(&gNB->srs_report_tlv_stats);
   switch (srs_indication->srs_usage) {
     case NFAPI_NR_SRS_BEAMMANAGEMENT: {
+      // Keep the existing beam report on failure: wide-band and per-PRG SNR fields
+      // use the invalid value 0xFF without reading unavailable estimates.
       start_meas(&gNB->srs_beam_report_stats);
       nfapi_nr_srs_beamforming_report_t nr_srs_bf_report;
       nr_srs_bf_report.prg_size = srs_pdu->beamforming.prg_size;
@@ -928,6 +932,10 @@ static void handle_srs(fsn_t now,
     }
 
     case NFAPI_NR_SRS_CODEBOOK: {
+      if (!estimate_valid) {
+        srs_indication->report_type = 0;
+        break;
+      }
       start_meas(&gNB->srs_iq_matrix_stats);
       nfapi_nr_srs_normalized_channel_iq_matrix_t nr_srs_channel_iq_matrix;
       fill_srs_channel_matrix(&nr_srs_channel_iq_matrix,
@@ -949,12 +957,15 @@ static void handle_srs(fsn_t now,
 
     case NFAPI_NR_SRS_POSITIONING: {
       nfapi_nr_srs_toa_vendor_ext_indication_t *srs_toa_vendor_ext_ind = srs_toa_v_ext;
-      srs_toa_vendor_ext_ind->sfn = now.f;
-      srs_toa_vendor_ext_ind->slot = now.s;
-      srs_toa_vendor_ext_ind->rnti = srs_pdu->rnti;
-      srs_toa_vendor_ext_ind->num_ta = nb_antennas_rx;
-      for (int ta_idx = 0; ta_idx < nb_antennas_rx; ta_idx++) {
-        srs_toa_vendor_ext_ind->ta_offset_nsec[ta_idx] = timing_advance_offset_nsec[ta_idx];
+      srs_toa_vendor_ext_ind->num_ta = 0;
+      if (estimate_valid) {
+        srs_toa_vendor_ext_ind->sfn = now.f;
+        srs_toa_vendor_ext_ind->slot = now.s;
+        srs_toa_vendor_ext_ind->rnti = srs_pdu->rnti;
+        srs_toa_vendor_ext_ind->num_ta = nb_antennas_rx;
+        for (int ta_idx = 0; ta_idx < nb_antennas_rx; ta_idx++) {
+          srs_toa_vendor_ext_ind->ta_offset_nsec[ta_idx] = timing_advance_offset_nsec[ta_idx];
+        }
       }
       break;
     }

--- a/openair1/SIMULATION/NR_PHY/srssim.c
+++ b/openair1/SIMULATION/NR_PHY/srssim.c
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: LicenseRef-CSSL-1.0
  */
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "common/utils/nr/nr_common.h"
@@ -522,6 +523,7 @@ int main(int argc, char *argv[])
     reset_meas(&gNB->srs_timing_advance_stats);
 
     double sum_srs_snr = 0;
+    int valid_srs_estimates = 0;
     int tao_ns_count = 0;
     for (trial = 0; trial < n_trials && !stop; trial++) {
       // Estimate noise power from the transmitter level and SNR
@@ -573,6 +575,12 @@ int main(int argc, char *argv[])
                            &timing_advance_offset,
                            timing_advance_offset_nsec);
 
+      if (srs_est < 0) {
+        stop_meas(&gNB->rx_srs_stats);
+        continue;
+      }
+
+      valid_srs_estimates++;
       sum_srs_snr += pow(10, (double)snr / 10.0);
 
       int16_t delay_ns = delay * 1e9 / (fp->samples_per_frame * 100);
@@ -588,8 +596,16 @@ int main(int argc, char *argv[])
       stop_meas(&gNB->rx_srs_stats);
     } // trail loop
     float tao_ns_rate = (float)tao_ns_count / (n_trials * n_rx);
-    float SRS_SNR_dB = 10 * log10(sum_srs_snr / n_trials);
-    printf("Actual SNR : %f, Estimated SNR from SRS %f (dB), TA offset success rate %f %%\n", SNR, SRS_SNR_dB, tao_ns_rate * 100);
+    float SRS_SNR_dB = NAN;
+    if (valid_srs_estimates > 0) {
+      SRS_SNR_dB = 10 * log10(sum_srs_snr / valid_srs_estimates);
+      printf("Actual SNR : %f, Estimated SNR from SRS %f (dB), TA offset success rate %f %%\n", SNR, SRS_SNR_dB, tao_ns_rate * 100);
+    } else {
+      printf("Actual SNR : %f, Estimated SNR from SRS unavailable (no valid estimates), TA offset success rate %f %%\n",
+             SNR,
+             tao_ns_rate * 100);
+    }
+    printf("Valid SRS estimates: %d/%d\n", valid_srs_estimates, trial);
 
     if (print_perf == 1) {
       printf("\ngNB RX\n");
@@ -602,12 +618,14 @@ int main(int argc, char *argv[])
     }
 
     int srs_ret = 1;
-    if (SNR > 30 && SRS_SNR_dB > 30) {
-      srs_ret = 0;
-    } else if (SNR >= SRS_SNR_dB) {
-      srs_ret = SRS_SNR_dB >= 0.7 * SNR ? 0 : 1;
-    } else if (SRS_SNR_dB > SNR) {
-      srs_ret = SNR >= 0.7 * SRS_SNR_dB ? 0 : 1;
+    if (valid_srs_estimates > 0) {
+      if (SNR > 30 && SRS_SNR_dB > 30) {
+        srs_ret = 0;
+      } else if (SNR >= SRS_SNR_dB) {
+        srs_ret = SRS_SNR_dB >= 0.7 * SNR ? 0 : 1;
+      } else if (SRS_SNR_dB > SNR) {
+        srs_ret = SNR >= 0.7 * SRS_SNR_dB ? 0 : 1;
+      }
     }
 
     if (tao_ns_rate > 0.9 && srs_ret == 0) {


### PR DESCRIPTION
When gNB SRS detection failed, `nr_srs_rx_procedures()` left measurement outputs unwritten, but downstream handling could still threshold SNR or assemble codebook and positioning data from those outputs. `nr_srssim` also consumed SNR and timing values after failed estimates.

Changes:

- Use raw estimation success (`srs_est >= 0`, including zero) as the measurement-validity boundary, and apply the configured SNR threshold only when the estimate is valid.
- On raw detection failure, return a null report (`report_type = 0`) with an empty report TLV for every SRS usage, before constructing any report payload. For failed positioning measurements, also set `num_ta = 0`.
- In `nr_srssim`, skip unavailable measurement outputs and average linear SNR over valid estimates only. Report an unavailable mean and keep `srs_ret` at failure when no estimates are valid. Failed estimates remain included in the overall timing-advance success-rate denominator.

Valid estimates below the configured SNR threshold retain their existing report behavior, and equality with the threshold remains accepted.