### PR TITLE
fix(itti): report the received shutdown signal

### DIFF
--- a/common/utils/ocp_itti/intertask_interface.cpp
+++ b/common/utils/ocp_itti/intertask_interface.cpp
@@ -436,10 +436,16 @@ typedef struct timer_elm_s {
     AssertFatal(rc == 0, "error in sem_post(): %d %s\n", errno, strerror(errno));
   }
 
-  static void catch_sigterm(int) {
-    static const char msg[] = "\n** Caught SIGTERM, shutting down\n";
-    __attribute__((unused))
-    int unused = write(STDOUT_FILENO, msg, sizeof(msg) - 1);
+  static void catch_signal(int signal_number)
+  {
+    if (signal_number == SIGINT) {
+      static const char msg[] = "\n** Caught SIGINT, shutting down\n";
+      __attribute__((unused)) int unused = write(STDOUT_FILENO, msg, sizeof(msg) - 1);
+    } else if (signal_number == SIGTERM) {
+      static const char msg[] = "\n** Caught SIGTERM, shutting down\n";
+      __attribute__((unused)) int unused = write(STDOUT_FILENO, msg, sizeof(msg) - 1);
+    }
+
     itti_wait_tasks_unblock();
   }
 
@@ -449,7 +455,7 @@ typedef struct timer_elm_s {
     AssertFatal(rc == 0, "error in sem_init(): %d %s\n", errno, strerror(errno));
 
     if (handler == NULL) /* no handler given: install default */
-      handler = catch_sigterm;
+      handler = catch_signal;
     signal(SIGTERM, handler);
     signal(SIGINT, handler);
 


### PR DESCRIPTION
During a normal SIGINT shutdown, the default ITTI wait handler printed `Caught SIGTERM`, which made the shutdown log disagree with the signal actually delivered. The same private handler had originally served only SIGTERM, then was registered for SIGINT as well without starting to use its signal-number argument.

Change:

- Rename the private handler to `catch_signal` and select the fixed `SIGINT` or `SIGTERM` shutdown message from the received signal. Write that message directly before the existing ITTI unblock, without shared signal state or deferred formatting.
