### PR TITLE
fix(ue): clean up per-session policy routing

### DIFF
--- a/common/utils/ocp_itti/intertask_interface.cpp
+++ b/common/utils/ocp_itti/intertask_interface.cpp
@@ -26,6 +26,7 @@ typedef struct timer_elm_s {
     task_info_t admin;
     ittiTask_parms_t task_parms;
     pthread_t thread;
+    bool thread_created = false;
     pthread_mutex_t queue_cond_lock;
     std::vector<MessageDef *> message_queue;
     std::map<long,timer_elm_t> timer_map;
@@ -312,8 +313,26 @@ typedef struct timer_elm_s {
                  (char *)itti_get_task_name(task_id),
                  -1,
                  OAI_PRIORITY_RT);
+    t->thread_created = true;
     LOG_D(ITTI,"Created Posix thread %s\n",  itti_get_task_name(task_id) );
     return 0;
+  }
+
+  int itti_terminate_and_join_task(task_id_t task_id, instance_t instance)
+  {
+    task_list_t *t = tasks[task_id];
+    if (!t->thread_created)
+      return 0;
+
+    MessageDef *msg = itti_alloc_new_message(TASK_UNKNOWN, 0, TERMINATE_MESSAGE);
+    int ret = itti_send_msg_to_task(task_id, instance, msg);
+    if (ret != 0)
+      return ret;
+
+    ret = pthread_join(t->thread, NULL);
+    if (ret == 0)
+      t->thread_created = false;
+    return ret;
   }
 
   void itti_exit_task(void) {

--- a/common/utils/ocp_itti/intertask_interface.h
+++ b/common/utils/ocp_itti/intertask_interface.h
@@ -455,6 +455,16 @@ typedef struct {
 } ittiTask_parms_t;
 int itti_create_task(const task_id_t task_id, void *(*start_routine)(void *), const ittiTask_parms_t *args_p);
 
+/** \brief Send TERMINATE_MESSAGE to a started task and wait for its thread.
+   This is a shutdown-only API; callers must first quiesce the task's producers.
+   Tasks configured as in-place shortcuts have no thread and are assumed to be
+   quiescent; they return directly without receiving TERMINATE_MESSAGE.
+   \param task_id task to terminate
+   \param instance destination instance for TERMINATE_MESSAGE
+   @returns a pthread error number, or 0 on success/no thread
+ **/
+int itti_terminate_and_join_task(task_id_t task_id, instance_t instance);
+
 int itti_create_queue(const task_info_t *task_info);
 
 /** \brief Exit the current task.

--- a/common/utils/system.c
+++ b/common/utils/system.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <signal.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <string.h>
@@ -39,6 +40,11 @@ static int result_pipe_write;
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 
 static int module_initialized = 0;
+
+static void background_system_signal_handler(int sig)
+{
+  (void)sig;
+}
 
 /********************************************************************/
 /* util functions                                                   */
@@ -177,6 +183,12 @@ void start_background_system(void) {
     close(result_pipe_write);
     close(command_pipe_read);
     return;
+  }
+
+  struct sigaction action = {.sa_handler = background_system_signal_handler, .sa_flags = SA_RESTART};
+  if (sigemptyset(&action.sa_mask) == -1 || sigaction(SIGINT, &action, NULL) == -1 || sigaction(SIGTERM, &action, NULL) == -1) {
+    perror("sigaction");
+    _exit(EXIT_FAILURE);
   }
 
   close(result_pipe_read);

--- a/common/utils/tuntap_if.c
+++ b/common/utils/tuntap_if.c
@@ -263,11 +263,16 @@ bool tap_config(const char* ifname)
   return success;
 }
 
-void setup_ue_ipv4_route(const char* ifname, int instance_id, int pdu_session_id, const char *ipv4)
+static int get_ue_ipv4_route_table_id(int instance_id, int pdu_session_id)
 {
   /* This needs to be unique per (instance_id, pdu_session_id) */
   // UE0, PDU1 = 10001, UE1, PDU1 = 10101, UE15, PDU15 = 11515 ...
-  int table_id = 10000 + instance_id * 100 + pdu_session_id;
+  return 10000 + instance_id * 100 + pdu_session_id;
+}
+
+void setup_ue_ipv4_route(const char *ifname, int instance_id, int pdu_session_id, const char *ipv4)
+{
+  int table_id = get_ue_ipv4_route_table_id(instance_id, pdu_session_id);
 
   char command_line[500];
   int res = sprintf(command_line,
@@ -286,6 +291,27 @@ void setup_ue_ipv4_route(const char* ifname, int instance_id, int pdu_session_id
     return;
   }
   background_system(command_line);
+}
+
+bool remove_ue_ipv4_route(int instance_id, int pdu_session_id)
+{
+  const int table_id = get_ue_ipv4_route_table_id(instance_id, pdu_session_id);
+
+  char command_line[500];
+  const int res = snprintf(command_line,
+                           sizeof(command_line),
+                           "ip -4 rule flush table %d; r=$?; ip -4 route flush table %d; s=$?; test $r -eq 0 && test $s -eq 0",
+                           table_id,
+                           table_id);
+  if (res < 0 || res >= (int)sizeof(command_line)) {
+    LOG_E(UTIL, "Could not create ip rule/route cleanup string\n");
+    return false;
+  }
+  if (background_system(command_line) != 0) {
+    LOG_E(UTIL, "Could not remove IPv4 policy routing for table %d\n", table_id);
+    return false;
+  }
+  return true;
 }
 
 int tun_generate_ifname(char *ifname, const char *ifprefix, int instance_id)

--- a/common/utils/tuntap_if.h
+++ b/common/utils/tuntap_if.h
@@ -65,9 +65,9 @@ bool tun_config(const char* ifname, const char *ipv4, const char *ipv6);
 bool tap_config(const char* ifname);
 
 /*!
- * \brief Setup a IPv4 rule in table (interface_id - 1 + 10000) and route to
- * force packets coming into interface back through it, and workaround
- * net.ipv4.conf.all.rp_filter=2 (strict source filtering would filter out
+ * \brief Setup IPv4 rules and a route in a table unique to the UE instance and
+ * PDU session to force packets coming into the interface back through it and
+ * work around net.ipv4.conf.all.rp_filter=2 (strict source filtering would filter out
  * responses of packets going out through interface to another IP address not
  * in same subnet).
  * \param[in] ifname name of the interface
@@ -76,6 +76,14 @@ bool tap_config(const char* ifname);
  * \param[in] ipv4 IPv4 address of the UE
  */
 void setup_ue_ipv4_route(const char* ifname, int instance_id, int pdu_session_id, const char *ipv4);
+
+/*!
+ * \brief Remove IPv4 policy rules and routes for a UE PDU session.
+ * \param[in] instance_id unique UE instance number
+ * \param[in] pdu_session_id PDU session ID
+ * \return true when both rule and route cleanup succeed
+ */
+bool remove_ue_ipv4_route(int instance_id, int pdu_session_id);
 
 /*!
  * \brief This function allocates a TUN or TAP interface

--- a/executables/lte-uesoftmodem.c
+++ b/executables/lte-uesoftmodem.c
@@ -615,6 +615,12 @@ int main( int argc, char **argv ) {
   if (PHY_vars_UE_g[0][0]->rfdevice.trx_end_func)
     PHY_vars_UE_g[0][0]->rfdevice.trx_end_func(&PHY_vars_UE_g[0][0]->rfdevice);
 
+#if defined(NAS_BUILT_IN_UE)
+  if (!IS_SOFTMODEM_NOS1 && NB_UE_INST > 0) {
+    int ret = itti_terminate_and_join_task(TASK_NAS_UE, UE_MODULE_ID_TO_INSTANCE(0));
+    AssertFatal(ret == 0, "Could not terminate TASK_NAS_UE: %s\n", strerror(ret));
+  }
+#endif
   pdcp_module_cleanup();
   terminate_opt();
   logClean();

--- a/executables/nr-uesoftmodem.c
+++ b/executables/nr-uesoftmodem.c
@@ -40,6 +40,7 @@ unsigned short config_frames[4] = {2,9,11,13};
 
 #include "UTIL/OPT/opt.h"
 #include "LAYER2/nr_pdcp/nr_pdcp_oai_api.h"
+#include "openair2/SDAP/nr_sdap/nr_sdap.h"
 
 #include "intertask_interface.h"
 
@@ -522,6 +523,11 @@ int main(int argc, char **argv)
     }
   }
 
+  ret = itti_terminate_and_join_task(TASK_RRC_NRUE, 0);
+  AssertFatal(ret == 0, "Could not terminate TASK_RRC_NRUE: %s\n", strerror(ret));
+  ret = itti_terminate_and_join_task(TASK_NAS_NRUE, 0);
+  AssertFatal(ret == 0, "Could not terminate TASK_NAS_NRUE: %s\n", strerror(ret));
+  nr_sdap_tun_cleanup_ipv4_routes();
   nrue_ru_end();
 
   free_nrLDPC_coding_interface(&nrLDPC_coding_interface);

--- a/openair2/RRC/NR_UE/rrc_UE.c
+++ b/openair2/RRC/NR_UE/rrc_UE.c
@@ -3295,6 +3295,7 @@ void *rrc_nrue(void *notUsed)
   switch (ITTI_MSG_ID(msg_p)) {
   case TERMINATE_MESSAGE:
     RRCLOG_W(" *** Exiting RRC thread\n");
+    itti_free(ITTI_MSG_ORIGIN_ID(msg_p), msg_p);
     itti_exit_task();
     break;
 

--- a/openair2/SDAP/nr_sdap/nr_sdap.c
+++ b/openair2/SDAP/nr_sdap/nr_sdap.c
@@ -24,6 +24,7 @@ typedef struct sdap_tun_iface_s {
   int sock;
   char *ifname;
   int qfi;
+  bool ipv4_route_cleanup_pending;
   struct sdap_tun_iface_s *next;
 } sdap_tun_iface_t;
 
@@ -49,6 +50,18 @@ static sdap_tun_iface_t *sdap_tun_iface_lookup(ue_id_t ue_id, int pdusession_id)
       return it;
   }
   return NULL;
+}
+
+static void cleanup_iface_ipv4_route(sdap_tun_iface_t *iface)
+{
+  if (iface->ipv4_route_cleanup_pending && remove_ue_ipv4_route((int)iface->ue_id, iface->pdusession_id))
+    iface->ipv4_route_cleanup_pending = false;
+}
+
+void nr_sdap_tun_cleanup_ipv4_routes(void)
+{
+  for (sdap_tun_iface_t *iface = sdap_tun_iface_list; iface != NULL; iface = iface->next)
+    cleanup_iface_ipv4_route(iface);
 }
 
 void nr_sdap_tun_store_qfi(ue_id_t ue_id, int pdusession_id, uint8_t qfi)
@@ -271,6 +284,7 @@ void nr_sdap_tun_destroy(ue_id_t ue_id, int pdusession_id)
     LOG_D(SDAP, "nr_sdap_tun_destroy: no iface (ue=%ld, pdu=%d)\n", ue_id, pdusession_id);
     return;
   }
+  cleanup_iface_ipv4_route(iface);
   close(iface->sock);
   tuntap_destroy(iface->ifname);
   LOG_I(SDAP, "Destroyed TUN dataplane for UE %ld PDU session %d (%s)\n", iface->ue_id, iface->pdusession_id, iface->ifname);
@@ -318,6 +332,9 @@ void create_ue_ip_if(const char *ipv4, const char *ipv6, int ue_id, int pdu_sess
 
   tun_config(ifname, ipv4, ipv6);
   if (ipv4) {
+    sdap_tun_iface_t *iface = sdap_tun_iface_lookup(ue_id, pdu_session_id);
+    DevAssert(iface != NULL);
+    iface->ipv4_route_cleanup_pending = true;
     setup_ue_ipv4_route(ifname, ue_id, pdu_session_id, ipv4);
   }
 }

--- a/openair2/SDAP/nr_sdap/nr_sdap.h
+++ b/openair2/SDAP/nr_sdap/nr_sdap.h
@@ -45,6 +45,7 @@ void create_ue_eth_if(int ue_id, int pdu_session_id, bool is_default);
 void nr_sdap_tun_attach(struct nr_sdap_entity_s *entity);
 void nr_sdap_tun_detach(struct nr_sdap_entity_s *entity);
 void nr_sdap_tun_destroy(ue_id_t ue_id, int pdusession_id);
+void nr_sdap_tun_cleanup_ipv4_routes(void);
 void nr_sdap_tun_store_qfi(ue_id_t ue_id, int pdusession_id, uint8_t qfi);
 
 #endif

--- a/openair3/NAS/NR_UE/nr_nas_msg.c
+++ b/openair3/NAS/NR_UE/nr_nas_msg.c
@@ -2248,6 +2248,7 @@ void *nas_nrue(void *args_p)
         break;
 
       case TERMINATE_MESSAGE:
+        itti_free(ITTI_MSG_ORIGIN_ID(msg_p), msg_p);
         itti_exit_task();
         break;
 

--- a/openair3/NAS/UE/ESM/esmData.h
+++ b/openair3/NAS/UE/ESM/esmData.h
@@ -157,6 +157,7 @@ typedef struct esm_data_context_s {
 #define ESM_DATA_PDN_MAX    4
   struct {
     int pid;     /* Identifier of the PDN connection        */
+    bool ipv4_route_cleanup_pending;
     bool is_active;   /* true/false if the PDN connection is active/inactive
               * or the process to activate/deactivate the PDN
               * connection is in progress           */

--- a/openair3/NAS/UE/ESM/esm_ebr_context.c
+++ b/openair3/NAS/UE/ESM/esm_ebr_context.c
@@ -56,6 +56,18 @@ static int _esm_ebr_context_check_precedence(const network_tft_t *,
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
 
+static void cleanup_ipv4_route(esm_data_t *esm_data, int pid)
+{
+  if (esm_data->pdn[pid].ipv4_route_cleanup_pending && remove_ue_ipv4_route(0, pid))
+    esm_data->pdn[pid].ipv4_route_cleanup_pending = false;
+}
+
+void esm_ebr_context_cleanup_ipv4_routes(esm_data_t *esm_data)
+{
+  for (int pid = 0; pid < ESM_DATA_PDN_MAX; ++pid)
+    cleanup_ipv4_route(esm_data, pid);
+}
+
 /****************************************************************************
  **                                                                        **
  ** Name:    esm_ebr_context_create()                                  **
@@ -191,6 +203,7 @@ int esm_ebr_context_create(
               char ifname[IFNAMSIZ];
               tun_generate_ifname(ifname, ifn, 0);
               tun_config(ifname, ip, NULL);
+              esm_ctx->pdn[pid].ipv4_route_cleanup_pending = true;
               setup_ue_ipv4_route(ifname, 0, pid, ip);
             } break;
 
@@ -340,6 +353,8 @@ int esm_ebr_context_release(nas_user_t *user,
     esm_ctx->n_ebrs -= 1;
 
     if (*bid == 0) {
+      cleanup_ipv4_route(esm_ctx, *pid);
+
       /* 3GPP TS 24.301, section 6.4.4.3, 6.4.4.6
        * If the EPS bearer identity is that of the default bearer to a
        * PDN, the UE shall delete all EPS bearer contexts associated to

--- a/openair3/NAS/UE/ESM/esm_ebr_context.h
+++ b/openair3/NAS/UE/ESM/esm_ebr_context.h
@@ -50,6 +50,8 @@ typedef enum {
 int esm_ebr_context_create(esm_data_t *esm_data, int ueid, int pid, int ebi, bool is_default,
                            const network_qos_t *qos, const network_tft_t *tft);
 
+void esm_ebr_context_cleanup_ipv4_routes(esm_data_t *esm_data);
+
 int esm_ebr_context_release(nas_user_t *user, int ebi, int *pid, int *bid);
 
 int esm_ebr_context_get_pid(esm_data_t *esm_data, int ebi);

--- a/openair3/NAS/UE/ESM/esm_main.c
+++ b/openair3/NAS/UE/ESM/esm_main.c
@@ -77,6 +77,7 @@ void esm_main_initialize(nas_user_t *user, esm_indication_callback_t cb)
 
   for (i = 0; i < ESM_DATA_PDN_MAX + 1; i++) {
     esm_data->pdn[i].pid = -1;
+    esm_data->pdn[i].ipv4_route_cleanup_pending = false;
     esm_data->pdn[i].is_active = false;
     esm_data->pdn[i].data = NULL;
   }

--- a/openair3/NAS/UE/nas_ue_task.c
+++ b/openair3/NAS/UE/nas_ue_task.c
@@ -16,6 +16,7 @@
 #include "common/oai_version.h"
 
 #include "nas_user.h"
+#include "ESM/esm_ebr_context.h"
 #include "common/ran_context.h"
 
 // FIXME review these externs
@@ -69,6 +70,7 @@ void *nas_ue_task(void *args_p)
 {
   int                   nb_events;
   MessageDef           *msg_p;
+  bool terminate = false;
   instance_t            instance;
   unsigned int          Mod_id;
   int                   result;
@@ -193,7 +195,7 @@ void *nas_ue_task(void *args_p)
         break;
 
       case TERMINATE_MESSAGE:
-        itti_exit_task ();
+        terminate = true;
         break;
 
       case MESSAGE_TEST:
@@ -279,6 +281,13 @@ void *nas_ue_task(void *args_p)
       AssertFatal (result == EXIT_SUCCESS, "Failed to free memory (%d)!\n", result);
       msg_p = NULL;
     }
+    if (terminate) {
+      for (size_t i = 0; i < users->count; ++i)
+        if (users->item[i].esm_data != NULL)
+          esm_ebr_context_cleanup_ipv4_routes(users->item[i].esm_data);
+      break;
+    }
+
     struct epoll_event events[20];
     nb_events = itti_get_events(TASK_NAS_UE, events, 20);
 


### PR DESCRIPTION
During a normal nrUE Ctrl+C shutdown after an attached session, we noticed that the TUN interface and its route were gone, but the two IPv4 policy rules were still there. Repeating UE runs could therefore accumulate stale selectors, and while validating the cleanup we also found that the same shutdown signal could stop OAI's background command helper before it had a chance to remove them.

Changes:

- Keep setup and cleanup on the same per-`(UE, PDU session)` table identity introduced by PR 399.
- Remove both parts of the policy state: every IPv4 rule selecting the session table and any routes still held in that table.
- Track pending cleanup in the existing NR interface and LTE PDN records, so partial setup or a failed removal stays eligible for retry.
- Preserve temporary NR detach, while final NR teardown and LTE default-bearer release clean their owned tables.
- Wait for the relevant UE ITTI tasks before the final sweep, and keep the background command helper available through handled SIGINT and SIGTERM.