### PR TITLE
fix(nr-phy): skip decoding undetected PUSCH

### DIFF
--- a/openair1/SCHED_NR/phy_procedures_nr_gNB.c
+++ b/openair1/SCHED_NR/phy_procedures_nr_gNB.c
@@ -1058,7 +1058,7 @@ static bool pusch_signal_detected(PHY_VARS_gNB *gNB, NR_gNB_PUSCH *pusch_vars, N
       stats->ulsch_stats.DTX++;
   }
 
-  return true;
+  return detected;
 }
 
 static bool drop_old_pucch(const void *data, void *user)


### PR DESCRIPTION
The gNB PUSCH detector computes whether received power meets the configured DTX threshold, but returned `true` unconditionally after the RX/DTX helper split. This made the caller's ordinary-runtime DTX branch unreachable, scheduled LDPC decoding for missed receptions, and produced the normal decoder-failure indication instead of the existing explicit DTX indication.

Return the computed `detected` value so a strictly below-threshold PUSCH is omitted from ordinary decoding and uses the existing failed DTX CRC/RX indication. The inclusive `>=` comparison still treats threshold equality as detected, while the caller's PHY-test override still decodes below-threshold input for timing measurements; no interface, threshold, indication structure, or grouped decoder contract changes.

A fixed-seed local regression exercised the real simulator queue, grouped RX, detection, decode scheduling, decoder, and indication path. The exact base reproduced the single-user, all-DTX group, and injected mixed caller-seam failures; all nine focused cases passed after the correction, as did six registered Debug controls, two ASan/UBSan controls, and two TSan controls. ASan/UBSan reported no issue, and the authentic GCC `-fanalyzer` gate completed successfully.