### PR TITLE
NR PHY simulators: release owned state at exit

### DIFF
--- a/openair1/PHY/INIT/nr_init_ue.c
+++ b/openair1/PHY/INIT/nr_init_ue.c
@@ -281,6 +281,9 @@ void term_nr_ue_signal(PHY_VARS_NR_UE *ue)
   const NR_DL_FRAME_PARMS* fp = &ue->frame_parms;
   phy_term_nr_top();
 
+  free_and_zero(ue->measurements.rx_spatial_power);
+  free_and_zero(ue->measurements.rx_spatial_power_dB);
+
   NR_UE_COMMON* common_vars = &ue->common_vars;
 
   for (int i = 0; i < fp->nb_antennas_tx; i++) {
@@ -311,6 +314,8 @@ void term_nr_ue_signal(PHY_VARS_NR_UE *ue)
     {
       for (int j=0; j<fp->nb_antennas_rx; j++)
       {
+        int ret = pthread_mutex_destroy(&ue->prs_vars[idx]->prs_resource[k].prs_meas[j]->dl_toa_mtx);
+        AssertFatal(ret == 0, "mutex destroy failed with %d\n", ret);
         free_and_zero(ue->prs_vars[idx]->prs_resource[k].prs_meas[j]);
       }
       free_and_zero(ue->prs_vars[idx]->prs_resource[k].prs_meas);
@@ -338,6 +343,8 @@ void free_nr_ue_dl_harq(NR_DL_UE_HARQ_t harq_list[2][NR_MAX_HARQ_PROCESSES], int
       free_and_zero(harq_list[j][i].c);
 #endif
       free_and_zero(harq_list[j][i].d);
+      int ret = pthread_mutex_destroy(&harq_list[j][i].abort_decode.mutex_failure);
+      AssertFatal(ret == 0, "mutex destroy failed with %d\n", ret);
     }
   }
 }

--- a/openair1/PHY/INIT/nr_phy_init.h
+++ b/openair1/PHY/INIT/nr_phy_init.h
@@ -13,6 +13,7 @@ int nr_get_ssb_start_symbol(const NR_DL_FRAME_PARMS *fp, uint8_t i_ssb);
 int init_nr_ue_signal(PHY_VARS_NR_UE *ue,int nb_connected_eNB);
 void term_nr_ue_signal(PHY_VARS_NR_UE *ue);
 void init_nr_ue_transport(PHY_VARS_NR_UE *ue);
+void term_nr_ue_transport(PHY_VARS_NR_UE *ue);
 void init_phy_nr_measurements(PHY_VARS_NR_UE *ue);
 void phy_init_nr_gNB(PHY_VARS_gNB *gNB);
 int init_codebook_gNB(PHY_VARS_gNB *gNB);

--- a/openair1/PHY/nr_phy_common/inc/nr_ue_phy_meas.h
+++ b/openair1/PHY/nr_phy_common/inc/nr_ue_phy_meas.h
@@ -46,5 +46,6 @@ typedef struct nr_ue_phy_cpu_stat_t {
 
 void init_nr_ue_phy_cpu_stats(nr_ue_phy_cpu_stat_t *ue_phy_cpu_stats);
 void reset_nr_ue_phy_cpu_stats(nr_ue_phy_cpu_stat_t *ue_phy_cpu_stats);
+void free_nr_ue_phy_cpu_stats(nr_ue_phy_cpu_stat_t *ue_phy_cpu_stats);
 
 #endif

--- a/openair1/PHY/nr_phy_common/src/nr_ue_phy_meas.c
+++ b/openair1/PHY/nr_phy_common/src/nr_ue_phy_meas.c
@@ -21,3 +21,9 @@ void reset_nr_ue_phy_cpu_stats(nr_ue_phy_cpu_stat_t *ue_phy_cpu_stats) {
     reset_meas(&ue_phy_cpu_stats->cpu_time_stats[i]);
   }
 }
+
+void free_nr_ue_phy_cpu_stats(nr_ue_phy_cpu_stat_t *ue_phy_cpu_stats)
+{
+  for (int i = 0; i < MAX_CPU_STAT_TYPE; i++)
+    free_and_zero(ue_phy_cpu_stats->cpu_time_stats[i].meas_name);
+}

--- a/openair1/SIMULATION/NR_PHY/dlsim.c
+++ b/openair1/SIMULATION/NR_PHY/dlsim.c
@@ -1679,6 +1679,8 @@ void update_dmrs_config(NR_BWP_Downlink_t *bwp, int8_t* dmrs_arg)
   AssertFatal((bwp->bwp_Dedicated->pdsch_Config != NULL && bwp->bwp_Dedicated->pdsch_Config->choice.setup != NULL), "Base RRC reconfig structures are not allocated.\n");
 
   if(mapping_type == typeA) {
+    asn1cFreeStruc(asn_DEF_NR_SetupRelease_DMRS_DownlinkConfig,
+                   bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeA);
     bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeA = calloc(1,sizeof(*bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeA));
     bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeA->present= NR_SetupRelease_DMRS_DownlinkConfig_PR_setup;
     bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeA->choice.setup = calloc(1,sizeof(*bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeA->choice.setup));
@@ -1695,6 +1697,8 @@ void update_dmrs_config(NR_BWP_Downlink_t *bwp, int8_t* dmrs_arg)
   }
 
   if(mapping_type == typeB) {
+    asn1cFreeStruc(asn_DEF_NR_SetupRelease_DMRS_DownlinkConfig,
+                   bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeB);
     bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeB = calloc(1,sizeof(*bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeB));
     bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeB->present= NR_SetupRelease_DMRS_DownlinkConfig_PR_setup;
     bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeB->choice.setup = calloc(1,sizeof(*bwp->bwp_Dedicated->pdsch_Config->choice.setup->dmrs_DownlinkForPDSCH_MappingTypeB->choice.setup));

--- a/openair1/SIMULATION/NR_PHY/dlsim.c
+++ b/openair1/SIMULATION/NR_PHY/dlsim.c
@@ -1015,7 +1015,6 @@ int main(int argc, char **argv)
   //NR_COMMON_channels_t *cc = RC.nrmac[0]->common_channels;
   int ret = 1;
   initNamedTpool(gNBthreads, &gNB->threadPool, true, "gNB-tpool");
-  initNotifiedFIFO(&gNB->L1_tx_out);
 
   // Buffers to store internal memory of slot process
   int rx_size = (((14 * UE->frame_parms.N_RB_DL * 12 * sizeof(int32_t)) + 15) >> 4) << 4;
@@ -1480,7 +1479,6 @@ int main(int argc, char **argv)
         printStatIndent(&UE->phy_cpu_stats.cpu_time_stats[i], UE->phy_cpu_stats.cpu_time_stats[i].meas_name);
       }
     }
-
     if (n_trials == 1) {
       unsigned int op_format = 1;
       unsigned int dec = 1;
@@ -1540,6 +1538,9 @@ int main(int argc, char **argv)
 
   } // NSR
 
+  abortTpool(&nrUE_params.Tpool);
+  abortTpool(&gNB->threadPool);
+
   free_sorted_list_meas(&gNB->phy_proc_tx);
   free(Sched_INFO);
 
@@ -1564,6 +1565,8 @@ int main(int argc, char **argv)
                           &h_final_output_pinned,
                           &h_channel_coeffs,
                           &d_channel_coeffs_gpu);
+#else
+  free_and_zero(h_tx_sig_pinned);
 #endif
 
   free(s_interleaved);
@@ -1579,10 +1582,15 @@ int main(int argc, char **argv)
   free(UE->phy_sim_pdsch_dl_ch_estimates);
   free(UE->phy_sim_pdsch_dl_ch_estimates_ext);
   free(UE->phy_sim_dlsch_b);
+  term_nr_ue_transport(UE);
+  free_nr_ue_phy_cpu_stats(&UE->phy_cpu_stats);
+  term_nr_ue_signal(UE);
   free(UE);
   free(nrPHY_vars_UE_g[0]);
   free(nrPHY_vars_UE_g);
 
+  free_MIB_NR(mib);
+  ASN_STRUCT_FREE(asn_DEF_NR_UE_NR_Capability, UE_Capability_nr);
   free_nrLDPC_coding_interface(&gNB->nrLDPC_coding_interface);
 
   if (output_fd)

--- a/openair1/SIMULATION/NR_PHY/srssim.c
+++ b/openair1/SIMULATION/NR_PHY/srssim.c
@@ -25,6 +25,7 @@
 #include "common/ran_context.h"
 #include "time_meas.h"
 #include "SCHED_NR/phy_frame_config_nr.h"
+#include "nfapi/open-nFAPI/fapi/inc/nr_fapi_p5_utils.h"
 
 PHY_VARS_gNB *gNB;
 PHY_VARS_NR_UE *UE;
@@ -647,8 +648,11 @@ int main(int argc, char *argv[])
   free(rxdata);
 
   phy_free_nr_gNB(gNB);
+  free_config_request(&gNB->gNB_config);
   free_channel_desc_scm(UE2gNB);
   free(gNB->RU_list[0]);
+  free(gNB);
+  gNB = NULL;
   free(UE);
 
   return ret;

--- a/openair1/SIMULATION/NR_PHY/ulschsim.c
+++ b/openair1/SIMULATION/NR_PHY/ulschsim.c
@@ -589,6 +589,8 @@ int main(int argc, char **argv)
     printf("\n");
   }
 
+  abortTpool(&nrUE_params.Tpool);
+
   free_nr_ue_ul_harq(UE->ul_harq_processes, NR_MAX_HARQ_PROCESSES, UE->frame_parms.N_RB_UL, UE->frame_parms.nb_antennas_tx);
 
   int nb_slots_to_set = (1 << mu) * NR_NUMBER_OF_SUBFRAMES_PER_FRAME;
@@ -617,4 +619,3 @@ int main(int argc, char **argv)
 
   return (n_errors);
 }
-

--- a/openair1/SIMULATION/NR_PHY/ulsim.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim.c
@@ -62,6 +62,7 @@
 #include "fapi_nr_ue_interface.h"
 #include "nfapi_interface.h"
 #include "nfapi_nr_interface_scf.h"
+#include "nfapi/open-nFAPI/fapi/inc/nr_fapi_p5_utils.h"
 #include "nr_ue_phy_meas.h"
 #include "openair1/SIMULATION/NR_PHY/nr_unitary_defs.h"
 #include "openair1/SIMULATION/TOOLS/sim.h"
@@ -826,6 +827,7 @@ int main(int argc, char *argv[])
   int uid = 0;
   int ssb_index = 0;
   NR_CellGroupConfig_t *secondaryCellGroup = get_default_secondaryCellGroup(scc, UE_Capability_nr, 0, 1, &conf, cell, uid, ssb_index);
+  ASN_STRUCT_FREE(asn_DEF_NR_UE_NR_Capability, UE_Capability_nr);
   secondaryCellGroup->spCellConfig->reconfigurationWithSync = get_reconfiguration_with_sync(rnti, uid, scc, frame);
 
   NR_BCCH_BCH_Message_t *mib = get_new_MIB_NR(scc);
@@ -922,6 +924,7 @@ int main(int argc, char *argv[])
   }
 
   init_nr_ue_transport(UE);
+  init_nr_ue_phy_cpu_stats(&UE->phy_cpu_stats);
 
   //Configure UE
   NR_UE_MAC_INST_t* UE_mac = nr_l2_init_ue(0, mu);
@@ -959,6 +962,8 @@ int main(int argc, char *argv[])
   uint32_t errors_decoding = 0;
 
   fapi_nr_ul_config_request_t ul_config = {0};
+  nfapi_nr_ptrs_ports_t gnb_ptrs_ports[2] = {0};
+  nfapi_nr_ue_ptrs_ports_t ue_ptrs_ports[2] = {0};
 
   uint8_t ptrs_mcs1 = 2;
   uint8_t ptrs_mcs2 = 4;
@@ -1192,7 +1197,7 @@ int main(int argc, char *argv[])
     reset_meas(&gNB->srs_report_tlv_stats);
     reset_meas(&gNB->srs_beam_report_stats);
     reset_meas(&gNB->srs_iq_matrix_stats);
-    init_nr_ue_phy_cpu_stats(&UE->phy_cpu_stats);
+    reset_nr_ue_phy_cpu_stats(&UE->phy_cpu_stats);
 
     uint32_t errors_scrambling[16] = {0};
     int n_errors[16] = {0};
@@ -1281,7 +1286,7 @@ int main(int argc, char *argv[])
         pusch_pdu->pusch_data.num_cb = 0;
         pusch_pdu->pusch_ptrs.ptrs_time_density = ptrs_time_density;
         pusch_pdu->pusch_ptrs.ptrs_freq_density = ptrs_freq_density;
-        pusch_pdu->pusch_ptrs.ptrs_ports_list = (nfapi_nr_ptrs_ports_t *)malloc_or_fail(2 * sizeof(nfapi_nr_ptrs_ports_t));
+        pusch_pdu->pusch_ptrs.ptrs_ports_list = gnb_ptrs_ports;
         pusch_pdu->pusch_ptrs.ptrs_ports_list[0].ptrs_re_offset = 0;
         pusch_pdu->pusch_ptrs.num_ptrs_ports = 1;
         pusch_pdu->maintenance_parms_v3.ldpcBaseGraph = get_BG(TBS, code_rate);
@@ -1377,8 +1382,7 @@ int main(int argc, char *argv[])
         pusch_config_pdu->pusch_data.harq_process_id = harq_pid;
         pusch_config_pdu->pusch_ptrs.ptrs_time_density = ptrs_time_density;
         pusch_config_pdu->pusch_ptrs.ptrs_freq_density = ptrs_freq_density;
-        pusch_config_pdu->pusch_ptrs.ptrs_ports_list =
-            (nfapi_nr_ue_ptrs_ports_t *)malloc_or_fail(2 * sizeof(nfapi_nr_ue_ptrs_ports_t));
+        pusch_config_pdu->pusch_ptrs.ptrs_ports_list = ue_ptrs_ports;
         pusch_config_pdu->pusch_ptrs.ptrs_ports_list[0].ptrs_re_offset = 0;
         pusch_config_pdu->pusch_ptrs.num_ptrs_ports = 1;
         pusch_config_pdu->transform_precoding = transform_precoding;
@@ -1901,10 +1905,12 @@ int main(int argc, char *argv[])
           length_dmrs,
           num_dmrs_cdm_grps_no_data);
 
+  abortTpool(&nrUE_params.Tpool);
+  abortTpool(&gNB->threadPool);
+
   free_sorted_list_meas(&gNB->phy_proc_rx);
   free_MIB_NR(mib);
-
-  free_nrLDPC_coding_interface(&gNB->nrLDPC_coding_interface);
+  free(Sched_INFO);
 
   if (output_fd)
     fclose(output_fd);
@@ -1921,11 +1927,28 @@ int main(int argc, char *argv[])
   if (uci_ulsch_matlab_vec)
     fclose(uci_ulsch_matlab_vec);
 
+  term_nr_ue_transport(UE);
+  free_nr_ue_phy_cpu_stats(&UE->phy_cpu_stats);
+  term_nr_ue_signal(UE);
   free_and_zero(UE->phy_sim_test_buf);
 
   free(nrPHY_vars_UE_g[0][0]);
   free(nrPHY_vars_UE_g[0]);
   free(nrPHY_vars_UE_g);
+
+  for (int i = 0; i < n_tx; i++)
+    free_and_zero(s_interleaved[i]);
+  free_and_zero(s_interleaved);
+  for (int i = 0; i < n_rx; i++) {
+    free_and_zero(r_re[i]);
+    free_and_zero(r_im[i]);
+    free_and_zero(rxdata[i]);
+    free_and_zero(gNB->common_vars.rxdataF[i]);
+  }
+  free_and_zero(r_re);
+  free_and_zero(r_im);
+  free_and_zero(rxdata);
+  free_channel_desc_scm(UE2gNB);
 
 #ifdef CHANNEL_SIM_CUDA
   free_cuda_chsim_buffers(use_cuda,
@@ -1937,7 +1960,16 @@ int main(int argc, char *argv[])
                           &h_final_output_pinned,
                           &h_channel_coeffs,
                           &d_channel_coeffs_gpu);
+#else
+  free_and_zero(h_tx_sig_pinned);
 #endif
+
+  phy_free_nr_gNB(gNB);
+  free_config_request(&gNB->gNB_config);
+  free_and_zero(gNB->RU_list[0]);
+  free_and_zero(RC.gNB[0]);
+  free_and_zero(RC.gNB);
+  gNB = NULL;
 
   return ret;
 }

--- a/openair1/SIMULATION/NR_PHY/ulsim.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim.c
@@ -1909,6 +1909,7 @@ int main(int argc, char *argv[])
   abortTpool(&gNB->threadPool);
 
   free_sorted_list_meas(&gNB->phy_proc_rx);
+  free_sorted_list_meas(&gNB->phy_proc_tx);
   free_MIB_NR(mib);
   free(Sched_INFO);
 

--- a/openair1/SIMULATION/NR_PHY/ulsim_mu_mimo.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim_mu_mimo.c
@@ -59,6 +59,7 @@
 #include "fapi_nr_ue_interface.h"
 #include "nfapi_interface.h"
 #include "nfapi_nr_interface_scf.h"
+#include "nfapi/open-nFAPI/fapi/inc/nr_fapi_p5_utils.h"
 #include "nr_ue_phy_meas.h"
 #include "openair1/SIMULATION/NR_PHY/nr_unitary_defs.h"
 #include "openair1/SIMULATION/TOOLS/sim.h"
@@ -642,6 +643,7 @@ int main(int argc, char *argv[])
   int uid = 0;
   int ssb_index = 0;
   NR_CellGroupConfig_t *secondaryCellGroup = get_default_secondaryCellGroup(scc, UE_Capability_nr, 0, 1, &conf, cell, uid, ssb_index);
+  ASN_STRUCT_FREE(asn_DEF_NR_UE_NR_Capability, UE_Capability_nr);
   secondaryCellGroup->spCellConfig->reconfigurationWithSync = get_reconfiguration_with_sync(rnti, uid, scc, frame);
 
   NR_BCCH_BCH_Message_t *mib = get_new_MIB_NR(scc);
@@ -728,6 +730,7 @@ int main(int argc, char *argv[])
     }
 
     init_nr_ue_transport(UE[u]);
+    init_nr_ue_phy_cpu_stats(&UE[u]->phy_cpu_stats);
 
     UE_mac[u] = nr_l2_init_ue(u, mu);
     ue_init_config_request(UE_mac[u], get_slots_per_frame_from_scs(mu));
@@ -884,7 +887,7 @@ int main(int argc, char *argv[])
     reset_meas(&gNB->ulsch_channel_estimation_stats);
     reset_meas(&gNB->pusch_channel_estimation_antenna_processing_stats);
     for (int u = 0; u < NUM_UE; u++)
-      init_nr_ue_phy_cpu_stats(&UE[u]->phy_cpu_stats);
+      reset_nr_ue_phy_cpu_stats(&UE[u]->phy_cpu_stats);
 
     uint32_t errors_scrambling[MAX_NUM_UE][16] = {0};
     int n_errors[MAX_NUM_UE][16] = {0};
@@ -1477,10 +1480,12 @@ int main(int argc, char *argv[])
       length_dmrs,
       num_dmrs_cdm_grps_no_data);
 
+  abortTpool(&nrUE_params.Tpool);
+  abortTpool(&gNB->threadPool);
+
   free_sorted_list_meas(&gNB->phy_proc_rx);
   free_MIB_NR(mib);
-
-  free_nrLDPC_coding_interface(&gNB->nrLDPC_coding_interface);
+  free(Sched_INFO);
 
   for (int u = 0; u < NUM_UE; u++) {
     free_and_zero(UE[u]->phy_sim_test_buf);
@@ -1507,8 +1512,16 @@ int main(int argc, char *argv[])
 
   for (int i = 0; i < n_rx; ++i) {
     free_and_zero(rxdata[i]);
+    free_and_zero(gNB->common_vars.rxdataF[i]);
   }
   free_and_zero(rxdata);
+
+  for (int u = 0; u < NUM_UE; u++) {
+    term_nr_ue_transport(UE[u]);
+    free_nr_ue_phy_cpu_stats(&UE[u]->phy_cpu_stats);
+  }
+  for (int u = 0; u < NUM_UE; u++)
+    term_nr_ue_signal(UE[u]);
 
   for (int u = 0; u < NUM_UE; u++) {
     free_and_zero(UE[u]);
@@ -1516,6 +1529,13 @@ int main(int argc, char *argv[])
   }
   free_and_zero(nrPHY_vars_UE_g);
   free_and_zero(h_tx_sig_pinned);
+
+  phy_free_nr_gNB(gNB);
+  free_config_request(&gNB->gNB_config);
+  free_and_zero(gNB->RU_list[0]);
+  free_and_zero(RC.gNB[0]);
+  free_and_zero(RC.gNB);
+  gNB = NULL;
 
   return ret;
 }

--- a/openair1/SIMULATION/TOOLS/random_channel.c
+++ b/openair1/SIMULATION/TOOLS/random_channel.c
@@ -348,6 +348,7 @@ void tdlModel(int  tdl_paths, double *tdl_delays, double *tdl_amps_dB, double DS
   printf("TDL : %f Ms/s, nb_taps %d, Td %e, channel_length %d\n",chan_desc->sampling_rate,tdl_paths,chan_desc->Td,chan_desc->channel_length);
   double sum_amps = 0;
   chan_desc->amps           = calloc(chan_desc->nb_taps, sizeof(double));
+  chan_desc->free_flags |= CHANMODEL_FREE_AMPS;
 
   for (int i = 0; i<chan_desc->nb_taps; i++) {
     chan_desc->amps[i]      = pow(10,.1*tdl_amps_dB[i]);
@@ -427,6 +428,7 @@ void tdlModel(int  tdl_paths, double *tdl_delays, double *tdl_amps_dB, double DS
   }
 
   chan_desc->R_sqrt = calloc(matrix_size, sizeof(*chan_desc->R_sqrt));
+  chan_desc->free_flags |= CHANMODEL_FREE_RSQRT_NTXRX;
   for (int row = 0; row < matrix_size; row++) {
     chan_desc->R_sqrt[row] = calloc(matrix_size, sizeof(**chan_desc->R_sqrt));
     if (correlation_matrix[row] == NULL) {
@@ -1716,6 +1718,10 @@ void free_channel_desc_scm(channel_desc_t *ch) {
 
   if(ch->free_flags&CHANMODEL_FREE_RSQRT_NTAPS)
     for (int i = 0; i<ch->nb_taps; i++)
+      free(ch->R_sqrt[i]);
+
+  if (ch->free_flags & CHANMODEL_FREE_RSQRT_NTXRX)
+    for (int i = 0; i < ch->nb_tx * ch->nb_rx; i++)
       free(ch->R_sqrt[i]);
 
   free(ch->R_sqrt);

--- a/openair1/SIMULATION/TOOLS/sim.h
+++ b/openair1/SIMULATION/TOOLS/sim.h
@@ -34,6 +34,7 @@ typedef enum {
 #define CHANMODEL_FREE_RSQRT_6     1<<1
 #define CHANMODEL_FREE_RSQRT_NTAPS 1<<2
 #define CHANMODEL_FREE_AMPS        1<<3
+#define CHANMODEL_FREE_RSQRT_NTXRX 1 << 4
 #define SHR3 (jz = jsr, jsr ^= (jsr << 13), jsr ^= (jsr >> 17), jsr ^= (jsr << 5), jz + jsr)
 
 typedef enum {


### PR DESCRIPTION
While running the NR PHY simulators with LeakSanitizer enabled, `nr_dlsim`, `nr_ulsim`, and `nr_ulsim_mu_mimo` all reached their normal PDSCH or PUSCH success markers and then failed at process exit with large retained object graphs. Following the allocations showed that UE and gNB workers, transport state, channel models, and per-run configuration did not always reach their matching owners during shutdown. The same teardown pass also found a live UE LDPC worker in `nr_ulschsim` and simulator-owned gNB/TDD configuration still reachable after a successful `nr_srssim` run.

Changes:

- Finish the shared nrUE shutdown path by releasing spatial-power measurements and CPU-stat label strings, destroying the initialized PRS and DL HARQ mutexes, and making `term_nr_ue_transport()` available to simulator callers.
- Give the three full simulators an ordered exit path: stop their worker pools first, terminate each UE's transport, statistics, and signal state, then release their remaining buffers, channels, configuration objects, and gNB state.
- Close the same ownership gaps in the direct paths by stopping `nr_ulschsim`'s UE LDPC worker before UE teardown, and releasing `nr_srssim`'s dynamically populated gNB configuration and gNB parent.
- Keep `nr_ulsim`'s CPU-stat labels and PTRS port storage for the lifetime of the simulation, so each iteration resets or reuses them instead of losing a fresh allocation.
- Record the TDL amplitude array and all `nb_tx * nb_rx` correlation rows as descriptor-owned, so the channel destructor can release them without touching borrowed delay data.
- Release the existing Mapping Type A or Type B DMRS configuration subtree before `nr_dlsim` installs its replacement.