### PR TITLE
NR RU: stop processing when the RF device fails to start

### DIFF
--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -690,10 +690,9 @@ void *ru_thread(void *param)
 
   // Start RF device if any
   if (ru->start_rf) {
-    if (ru->start_rf(ru) != 0)
-      LOG_E(HW, "Could not start the RF device\n");
-    else
-      LOG_I(PHY, "RU %d rf device ready\n", ru->idx);
+    ret = ru->start_rf(ru);
+    AssertFatal(ret == 0, "RU %u: start_rf() ret %d: cannot start RF device\n", ru->idx, ret);
+    LOG_I(PHY, "RU %d rf device ready\n", ru->idx);
   } else
     LOG_I(PHY, "RU %d no rf device\n", ru->idx);
 


### PR DESCRIPTION
The integrated NR RU treated a nonzero transceiver-start result as a log-only error. It then announced that RF had started and entered the RF loop, where receive or transmit callbacks could use a device that rejected startup.

Record the start result and apply the existing fatal startup policy before emitting success state, starting the TX writer, or invoking an RF callback. The diagnostic retains the RU index and backend return code. Successful starts and RUs without a local RF device keep their existing behavior.

A local RFsim oracle reproduced a poisoned read after return `-71`. After the fix, it observed no RF I/O and one completed cleanup callback. Normal and ASan/UBSan paired RFsim controls synchronized and exchanged samples.
