### PR TITLE
NR MAC: remove the redundant post-publication UE state reset

### DIFF
--- a/openair2/LAYER2/NR_MAC_gNB/main.c
+++ b/openair2/LAYER2/NR_MAC_gNB/main.c
@@ -332,11 +332,9 @@ void mac_top_init_gNB(ngran_node_t node_type,
     RC.nrmac = NULL;
   }
 
-  // Initialize Linked-List for Active UEs
   for (module_id_t i = 0; i < RC.nb_nr_macrlc_inst; i++) {
     gNB_MAC_INST *nrmac = RC.nrmac[i];
     nrmac->if_inst = NR_IF_Module_init(i);
-    memset(&nrmac->UE_info, 0, sizeof(nrmac->UE_info));
   }
 
   du_init_f1_ue_data();


### PR DESCRIPTION
The gNB MAC instance is zero-initialized and its UE UID allocator is explicitly initialized before `MAC_STATS` starts, but `mac_top_init_gNB()` later clears the complete `UE_info` object again without holding `sched_lock`. On uncorrected `fb944fbad6`, `physim.5g.nr_dlsim.basic.test7` reported a TSan race between `dump_mac_stats()` reading the connected-UE list and this late main-thread reset.

This change removes only the redundant post-publication reset and its stale comment. It preserves the established empty UE state before reader publication. The existing thread-creation point and scheduler-lock usage remain unchanged, and the patch modifies no scheduler, statistics-output, public-API, or ABI code.

The corrected invocation of the same named `nr_dlsim` CTest, using the same command, completed without a TSan diagnostic. One selected case from each of `nr_dlsim`, `nr_ulsim`, and `nr_ulsim_mu_mimo` passed both under TSan and in the normal build, and the normal `nr-softmodem` target built and linked successfully.