### PR TITLE
Remove RU options nr_scs_for_raster/nr_flag

### DIFF
--- a/ci-scripts/conf_files/gnb.sa.band78.51prb.aw2s.ddsuu.2x2.conf
+++ b/ci-scripts/conf_files/gnb.sa.band78.51prb.aw2s.ddsuu.2x2.conf
@@ -212,7 +212,6 @@ RUs = (
         rxfh_core_id   = 9;
         txfh_core_id   = 10;
         tp_cores       = [11,12,13,14];
-        nr_flag        = 1;
         eNB_instances  = [0];
         bands          = [78];
         sl_ahead       = 5;

--- a/ci-scripts/conf_files/gnb.sa.band78.51prb.aw2s.ddsuu.conf
+++ b/ci-scripts/conf_files/gnb.sa.band78.51prb.aw2s.ddsuu.conf
@@ -215,7 +215,6 @@ RUs = (
         rxfh_core_id   = 9;
         txfh_core_id   = 10;
         tp_cores       = [11,12,13,14];
-        nr_flag        = 1;
         eNB_instances  = [0];
         bands          = [78];
         sl_ahead       = 5;

--- a/doc/ORAN_FHI7.2_Tutorial.md
+++ b/doc/ORAN_FHI7.2_Tutorial.md
@@ -1544,10 +1544,7 @@ Edit the sample OAI gNB configuration file and check following parameters:
 
 * `RUs` section
   * Set an isolated core for RU thread `ru_thread_core`, in our environment we are using CPU 6
-  * If testing with a numerology different than 1 (e.g., FDD with numerology 0),
-    set `nr_scs_for_raster` to the used numerology, and adapt `sl_ahead`: it must be
-    strictly less than the number of slots in a frame (e.g., 5 for numerology 0).
-  
+
 * `fhi_72` (FrontHaul Interface) section: this config follows the structure
   that is employed by the xRAN library (`xran_fh_init` and `xran_fh_config`
   structs in the code):

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -431,6 +431,7 @@ void fill_rf_config(RU_t *ru, char *rf_config_file)
   cfg->num_distributed_ru = 1;
   LOG_I(PHY,"Setting RF config for N_RB %d, NB_RX %d, NB_TX %d\n",cfg->num_rb_dl,cfg->rx_num_channels,cfg->tx_num_channels);
   LOG_I(PHY,"tune_offset %.0f Hz, sample_rate %.0f Hz\n",cfg->tune_offset,cfg->sample_rate);
+  cfg->nr_flag = 1;
 
   for (int i = 0; i < ru->nb_tx; i++) {
     if (ru->if_frequency == 0) {
@@ -1166,12 +1167,7 @@ static void NRRCconfig_RU(configmodule_interface_t *cfg)
     ru->num_bands = param[RU_BAND_LIST_IDX].numelt;
     for (int i = 0; i < ru->num_bands; i++)
       ru->band[i] = param[RU_BAND_LIST_IDX].iptr[i];
-    ru->openair0_cfg.nr_flag = *param[RU_NR_FLAG].iptr;
     // TODO remove band from RU?
-    LOG_D(PHY,
-          "[RU %d] Setting nr_flag %d\n",
-          j,
-          ru->openair0_cfg.nr_flag);
     ru->openair0_cfg.rxfh_cores[0] = *param[RU_RXFH_CORE_ID].iptr;
     ru->openair0_cfg.txfh_cores[0] = *param[RU_TXFH_CORE_ID].iptr;
     ru->num_tpcores = *param[RU_NUM_TP_CORES].iptr;

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -470,6 +470,7 @@ void fill_split7_2_config(split7_config_t *split7, const nfapi_nr_config_request
   const nfapi_nr_cell_config_t *cell_config = &config->cell_config;
   const nfapi_nr_carrier_config_t *carrier_config = &config->carrier_config;
 
+  split7->mu = config->ssb_config.scs_common.value;
   DevAssert(prach_config->prach_ConfigurationIndex.tl.tag == NFAPI_NR_CONFIG_PRACH_CONFIG_INDEX_TAG);
   split7->prach_index = prach_config->prach_ConfigurationIndex.value;
   AssertFatal(prach_config->num_prach_fd_occasions.value >= 1, "must have at least one PRACH occasion\n");
@@ -1167,12 +1168,10 @@ static void NRRCconfig_RU(configmodule_interface_t *cfg)
       ru->band[i] = param[RU_BAND_LIST_IDX].iptr[i];
     ru->openair0_cfg.nr_flag = *param[RU_NR_FLAG].iptr;
     // TODO remove band from RU?
-    ru->openair0_cfg.nr_scs_for_raster = *param[RU_NR_SCS_FOR_RASTER].iptr;
     LOG_D(PHY,
-          "[RU %d] Setting nr_flag %d, nr_scs_for_raster %d\n",
+          "[RU %d] Setting nr_flag %d\n",
           j,
-          ru->openair0_cfg.nr_flag,
-          ru->openair0_cfg.nr_scs_for_raster);
+          ru->openair0_cfg.nr_flag);
     ru->openair0_cfg.rxfh_cores[0] = *param[RU_RXFH_CORE_ID].iptr;
     ru->openair0_cfg.txfh_cores[0] = *param[RU_TXFH_CORE_ID].iptr;
     ru->num_tpcores = *param[RU_NUM_TP_CORES].iptr;

--- a/openair2/ENB_APP/enb_paramdef.h
+++ b/openair2/ENB_APP/enb_paramdef.h
@@ -64,7 +64,6 @@ typedef enum {
 #define CONFIG_STRING_RU_DO_PRECODING             "do_precoding"
 #define CONFIG_STRING_RU_SF_AHEAD                 "sf_ahead"
 #define CONFIG_STRING_RU_SL_AHEAD                 "sl_ahead"
-#define CONFIG_STRING_RU_NR_FLAG                  "nr_flag"
 #define CONFIG_STRING_RU_TX_SUBDEV                "tx_subdev"
 #define CONFIG_STRING_RU_RX_SUBDEV                "rx_subdev"
 #define CONFIG_STRING_RU_RXFH_CORE_ID             "rxfh_core_id"
@@ -78,7 +77,6 @@ typedef enum {
 
 #define HLP_RU_SF_AHEAD "LTE TX processing advance"
 #define HLP_RU_SL_AHEAD "NR TX processing advance"
-#define HLP_RU_NR_FLAG "Use NR numerology (for AW2SORI)"
 #define HLP_RU_RXFH_CORE_ID "Core ID for RX Fronthaul thread (ECPRI IF5)"
 #define HLP_RU_TXFH_CORE_ID "Core ID for TX Fronthaul thread (ECPRI IF5)"
 #define HLP_RU_TP_CORES "List of cores for RU ThreadPool"
@@ -119,17 +117,16 @@ typedef enum {
 #define RU_DO_PRECODING               28
 #define RU_SF_AHEAD                   29
 #define RU_SL_AHEAD                   30 
-#define RU_NR_FLAG                    31 
-#define RU_TX_SUBDEV                  32
-#define RU_RX_SUBDEV                  33
-#define RU_RXFH_CORE_ID               34
-#define RU_TXFH_CORE_ID               35
-#define RU_TP_CORES                   36
-#define RU_NUM_TP_CORES               37
-#define RU_NUM_INTERFACES             38
-#define RU_HALF_SLOT_PARALLELIZATION  39
-#define RU_RU_THREAD_CORE             40
-#define RU_GPIO_CONTROL               41
+#define RU_TX_SUBDEV                  31
+#define RU_RX_SUBDEV                  32
+#define RU_RXFH_CORE_ID               33
+#define RU_TXFH_CORE_ID               34
+#define RU_TP_CORES                   35
+#define RU_NUM_TP_CORES               36
+#define RU_NUM_INTERFACES             37
+#define RU_HALF_SLOT_PARALLELIZATION  38
+#define RU_RU_THREAD_CORE             39
+#define RU_GPIO_CONTROL               40
 /*-----------------------------------------------------------------------------------------------------------------------------------------*/
 /*                                            RU configuration parameters                                                                  */
 /*   optname                                   helpstr   paramflags    XXXptr          defXXXval                   type      numelt        */
@@ -167,7 +164,6 @@ typedef enum {
   {CONFIG_STRING_RU_DO_PRECODING,              NULL,                              0,       .iptr=NULL,       .defintval=0,                 TYPE_INT,         0}, \
   {CONFIG_STRING_RU_SF_AHEAD,                  HLP_RU_SF_AHEAD,                   0,       .iptr=NULL,       .defintval=4,                 TYPE_INT,         0}, \
   {CONFIG_STRING_RU_SL_AHEAD,                  HLP_RU_SL_AHEAD,                   0,       .iptr=NULL,       .defintval=6,                 TYPE_INT,         0}, \
-  {CONFIG_STRING_RU_NR_FLAG,                   HLP_RU_NR_FLAG,                    0,       .iptr=NULL,       .defintval=0,                 TYPE_INT,         0}, \
   {CONFIG_STRING_RU_TX_SUBDEV,                 NULL,                              0,       .strptr=NULL,     .defstrval="",                TYPE_STRING,      0}, \
   {CONFIG_STRING_RU_RX_SUBDEV,                 NULL,                              0,       .strptr=NULL,     .defstrval="",                TYPE_STRING,      0}, \
   {CONFIG_STRING_RU_RXFH_CORE_ID,              HLP_RU_RXFH_CORE_ID,               0,       .uptr=NULL,       .defintval=0,                 TYPE_UINT,        0}, \

--- a/openair2/ENB_APP/enb_paramdef.h
+++ b/openair2/ENB_APP/enb_paramdef.h
@@ -65,7 +65,6 @@ typedef enum {
 #define CONFIG_STRING_RU_SF_AHEAD                 "sf_ahead"
 #define CONFIG_STRING_RU_SL_AHEAD                 "sl_ahead"
 #define CONFIG_STRING_RU_NR_FLAG                  "nr_flag"
-#define CONFIG_STRING_RU_NR_SCS_FOR_RASTER        "nr_scs_for_raster"
 #define CONFIG_STRING_RU_TX_SUBDEV                "tx_subdev"
 #define CONFIG_STRING_RU_RX_SUBDEV                "rx_subdev"
 #define CONFIG_STRING_RU_RXFH_CORE_ID             "rxfh_core_id"
@@ -80,7 +79,6 @@ typedef enum {
 #define HLP_RU_SF_AHEAD "LTE TX processing advance"
 #define HLP_RU_SL_AHEAD "NR TX processing advance"
 #define HLP_RU_NR_FLAG "Use NR numerology (for AW2SORI)"
-#define HLP_RU_NR_SCS_FOR_RASTER "NR SCS for raster (for AW2SORI)"
 #define HLP_RU_RXFH_CORE_ID "Core ID for RX Fronthaul thread (ECPRI IF5)"
 #define HLP_RU_TXFH_CORE_ID "Core ID for TX Fronthaul thread (ECPRI IF5)"
 #define HLP_RU_TP_CORES "List of cores for RU ThreadPool"
@@ -122,17 +120,16 @@ typedef enum {
 #define RU_SF_AHEAD                   29
 #define RU_SL_AHEAD                   30 
 #define RU_NR_FLAG                    31 
-#define RU_NR_SCS_FOR_RASTER          32
-#define RU_TX_SUBDEV                  33
-#define RU_RX_SUBDEV                  34
-#define RU_RXFH_CORE_ID               35
-#define RU_TXFH_CORE_ID               36
-#define RU_TP_CORES                   37
-#define RU_NUM_TP_CORES               38
-#define RU_NUM_INTERFACES             39
-#define RU_HALF_SLOT_PARALLELIZATION  40
-#define RU_RU_THREAD_CORE             41
-#define RU_GPIO_CONTROL               42
+#define RU_TX_SUBDEV                  32
+#define RU_RX_SUBDEV                  33
+#define RU_RXFH_CORE_ID               34
+#define RU_TXFH_CORE_ID               35
+#define RU_TP_CORES                   36
+#define RU_NUM_TP_CORES               37
+#define RU_NUM_INTERFACES             38
+#define RU_HALF_SLOT_PARALLELIZATION  39
+#define RU_RU_THREAD_CORE             40
+#define RU_GPIO_CONTROL               41
 /*-----------------------------------------------------------------------------------------------------------------------------------------*/
 /*                                            RU configuration parameters                                                                  */
 /*   optname                                   helpstr   paramflags    XXXptr          defXXXval                   type      numelt        */
@@ -171,7 +168,6 @@ typedef enum {
   {CONFIG_STRING_RU_SF_AHEAD,                  HLP_RU_SF_AHEAD,                   0,       .iptr=NULL,       .defintval=4,                 TYPE_INT,         0}, \
   {CONFIG_STRING_RU_SL_AHEAD,                  HLP_RU_SL_AHEAD,                   0,       .iptr=NULL,       .defintval=6,                 TYPE_INT,         0}, \
   {CONFIG_STRING_RU_NR_FLAG,                   HLP_RU_NR_FLAG,                    0,       .iptr=NULL,       .defintval=0,                 TYPE_INT,         0}, \
-  {CONFIG_STRING_RU_NR_SCS_FOR_RASTER,         HLP_RU_NR_SCS_FOR_RASTER,          0,       .iptr=NULL,       .defintval=1,                 TYPE_INT,         0}, \
   {CONFIG_STRING_RU_TX_SUBDEV,                 NULL,                              0,       .strptr=NULL,     .defstrval="",                TYPE_STRING,      0}, \
   {CONFIG_STRING_RU_RX_SUBDEV,                 NULL,                              0,       .strptr=NULL,     .defstrval="",                TYPE_STRING,      0}, \
   {CONFIG_STRING_RU_RXFH_CORE_ID,              HLP_RU_RXFH_CORE_ID,               0,       .uptr=NULL,       .defintval=0,                 TYPE_UINT,        0}, \

--- a/radio/COMMON/common_lib.h
+++ b/radio/COMMON/common_lib.h
@@ -150,6 +150,8 @@ typedef enum { SYMBOL_DIR_DL = 0, SYMBOL_DIR_UL = 1, SYMBOL_DIR_GU = 2 } symbol_
  * initialization of split 7 radios which reuses the interface of split 8.
  */
 typedef struct split7_config {
+  /*! Common numerology */
+  int mu;
   /*! PRACH index used for PRACH */
   int prach_index;
   /*! PRACH frequency start, from RRC's msg1-FrequencyStart */
@@ -241,8 +243,6 @@ typedef struct openair0_config {
   recplay_conf_t *recplay_conf;
   //! Flag to indicate this configuration is for NR
   int nr_flag;
-  //! NR scs for raster
-  int nr_scs_for_raster;
   //! Core IDs for RX FH
   int rxfh_cores[8];
   //! Core IDs for TX FH

--- a/radio/ETHERNET/eth_udp.c
+++ b/radio/ETHERNET/eth_udp.c
@@ -443,7 +443,7 @@ void *udp_read_thread(void *arg)
       if (oai_exit)
         break;
       aid = *(uint16_t*)(&buffer[ECPRICOMMON_BYTES]);
-      TS  = *(openair0_timestamp_t *)(&buffer[ECPRICOMMON_BYTES+ECPRIPCID_BYTES]);
+      memcpy(&TS, &buffer[ECPRICOMMON_BYTES+ECPRIPCID_BYTES], sizeof(TS));
       // convert TS to samples, /6 for AW2S @ 30.72 Ms/s, this is converted for other sample rates in OAI application
       TS = (eth->sampling_rate_ratio_n * TS) / (eth->sampling_rate_ratio_d * 6);
       AssertFatal(aid < 8,"Cannot handle more than 8 antennas, got aid %d\n",aid);

--- a/radio/fhi_72/mplane/yang/create-yang-config.c
+++ b/radio/fhi_72/mplane/yang/create-yang-config.c
@@ -95,7 +95,7 @@ static LY_ERR fill_uplane_ch_common_v2(const uplane_dir_t dir, const xran_mplane
   LY_ERR ret = LY_SUCCESS;
 
   char frame_str[8];
-  snprintf(frame_str, sizeof(frame_str), "%d", (oai->split7.fftSize << 4) + oai->nr_scs_for_raster); // 3GPP TS 38.211
+  snprintf(frame_str, sizeof(frame_str), "%d", (oai->split7.fftSize << 4) + oai->split7.mu); // 3GPP TS 38.211
   ret = lyd_new_term(*root, NULL, "frame-structure", frame_str, 0, NULL);
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"frame-structure\" node.\n");
 
@@ -117,9 +117,9 @@ static LY_ERR fill_uplane_ch_common_v2(const uplane_dir_t dir, const xran_mplane
 
   char freq_offset[8];
   if (dir == UP_CH_RX || dir == UP_CH_PRACH) {
-    snprintf(freq_offset, sizeof(freq_offset), "%d", oai->split7.ul_k0[oai->nr_scs_for_raster]);
+    snprintf(freq_offset, sizeof(freq_offset), "%d", oai->split7.ul_k0[oai->split7.mu]);
   } else {
-    snprintf(freq_offset, sizeof(freq_offset), "%d", oai->split7.dl_k0[oai->nr_scs_for_raster]);
+    snprintf(freq_offset, sizeof(freq_offset), "%d", oai->split7.dl_k0[oai->split7.mu]);
   }
   ret = lyd_new_term(*root, NULL, "offset-to-absolute-frequency-center", freq_offset, 0, NULL);
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"offset-to-absolute-frequency-center\" node.\n");
@@ -189,16 +189,16 @@ static bool fill_uplane_ch_rx_v2(const uplane_dir_t dir, const xran_mplane_t *xr
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"non-time-managed-delay-enabled\" node.\n");
 
   struct lyd_node *fft_offset = NULL;
-  ret = lyd_new_list(*root, NULL, "ul-fft-sampling-offsets", 0, &fft_offset, scs_name[oai->nr_scs_for_raster]);
+  ret = lyd_new_list(*root, NULL, "ul-fft-sampling-offsets", 0, &fft_offset, scs_name[oai->split7.mu]);
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"ul-fft-sampling-offsets\" node.\n");
 
   // Note: set of allowed values is restricted by SCS derived from values in supported-frame-structures.
   char ul_fft_offset[8];
   int frame = 0;
   if (dir == UP_CH_RX) {
-    frame = (oai->split7.fftSize << 4) + oai->nr_scs_for_raster;
+    frame = (oai->split7.fftSize << 4) + oai->split7.mu;
   } else if (dir == UP_CH_PRACH) {
-    frame = (oai->split7.prach_fftSize << 4) + oai->nr_scs_for_raster; // TODO: handle long PRACH
+    frame = (oai->split7.prach_fftSize << 4) + oai->split7.mu; // TODO: handle long PRACH
   }
   snprintf(ul_fft_offset, sizeof(ul_fft_offset), "%d", xran_mplane->frame_str - frame);
   ret = lyd_new_term(fft_offset, NULL, "ul-fft-sampling-offset", ul_fft_offset, 0, NULL);

--- a/radio/fhi_72/mplane/yang/create-yang-config.c
+++ b/radio/fhi_72/mplane/yang/create-yang-config.c
@@ -90,12 +90,12 @@ static bool create_proc_elem_v2(const ru_session_t *ru_session, const size_t idx
 
 typedef enum { UP_CH_RX, UP_CH_TX, UP_CH_PRACH } uplane_dir_t;
 
-static LY_ERR fill_uplane_ch_common_v2(const uplane_dir_t dir, const xran_mplane_t *xran_mplane, const openair0_config_t *oai, const size_t idx, struct lyd_node **root)
+static LY_ERR fill_uplane_ch_common_v2(const uplane_dir_t dir, const xran_mplane_t *xran_mplane, const split7_config_t *cfg, const size_t idx, struct lyd_node **root)
 {
   LY_ERR ret = LY_SUCCESS;
 
   char frame_str[8];
-  snprintf(frame_str, sizeof(frame_str), "%d", (oai->split7.fftSize << 4) + oai->split7.mu); // 3GPP TS 38.211
+  snprintf(frame_str, sizeof(frame_str), "%d", (cfg->fftSize << 4) + cfg->mu); // 3GPP TS 38.211
   ret = lyd_new_term(*root, NULL, "frame-structure", frame_str, 0, NULL);
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"frame-structure\" node.\n");
 
@@ -106,20 +106,20 @@ static LY_ERR fill_uplane_ch_common_v2(const uplane_dir_t dir, const xran_mplane
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"cp-type\" node.\n");
 
   char cp_len[8];
-  snprintf(cp_len, sizeof(cp_len), "%d", oai->split7.cp_prefix0);
+  snprintf(cp_len, sizeof(cp_len), "%d", cfg->cp_prefix0);
   ret = lyd_new_term(*root, NULL, "cp-length", cp_len, 0, NULL);
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"cp-length\" node.\n");
 
   char cp_len_other[8];
-  snprintf(cp_len_other, sizeof(cp_len_other), "%d", oai->split7.cp_prefix_other);
+  snprintf(cp_len_other, sizeof(cp_len_other), "%d", cfg->cp_prefix_other);
   ret = lyd_new_term(*root, NULL, "cp-length-other", cp_len_other, 0, NULL);
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"cp-length-other\" node.\n");
 
   char freq_offset[8];
   if (dir == UP_CH_RX || dir == UP_CH_PRACH) {
-    snprintf(freq_offset, sizeof(freq_offset), "%d", oai->split7.ul_k0[oai->split7.mu]);
+    snprintf(freq_offset, sizeof(freq_offset), "%d", cfg->ul_k0[cfg->mu]);
   } else {
-    snprintf(freq_offset, sizeof(freq_offset), "%d", oai->split7.dl_k0[oai->split7.mu]);
+    snprintf(freq_offset, sizeof(freq_offset), "%d", cfg->dl_k0[cfg->mu]);
   }
   ret = lyd_new_term(*root, NULL, "offset-to-absolute-frequency-center", freq_offset, 0, NULL);
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"offset-to-absolute-frequency-center\" node.\n");
@@ -177,11 +177,11 @@ static LY_ERR fill_uplane_ch_common_v2(const uplane_dir_t dir, const xran_mplane
   return LY_SUCCESS;
 }
 
-static bool fill_uplane_ch_rx_v2(const uplane_dir_t dir, const xran_mplane_t *xran_mplane, const openair0_config_t *oai, const size_t idx, struct lyd_node **root)
+static bool fill_uplane_ch_rx_v2(const uplane_dir_t dir, const xran_mplane_t *xran_mplane, const split7_config_t *cfg, const size_t idx, struct lyd_node **root)
 {
   LY_ERR ret = LY_SUCCESS;
 
-  ret = fill_uplane_ch_common_v2(dir, xran_mplane, oai, idx, root);
+  ret = fill_uplane_ch_common_v2(dir, xran_mplane, cfg, idx, root);
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create common nodes.\n");
 
   const char *managed_delay = xran_mplane->managed_delay ? "true" : "false";
@@ -189,16 +189,16 @@ static bool fill_uplane_ch_rx_v2(const uplane_dir_t dir, const xran_mplane_t *xr
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"non-time-managed-delay-enabled\" node.\n");
 
   struct lyd_node *fft_offset = NULL;
-  ret = lyd_new_list(*root, NULL, "ul-fft-sampling-offsets", 0, &fft_offset, scs_name[oai->split7.mu]);
+  ret = lyd_new_list(*root, NULL, "ul-fft-sampling-offsets", 0, &fft_offset, scs_name[cfg->mu]);
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"ul-fft-sampling-offsets\" node.\n");
 
   // Note: set of allowed values is restricted by SCS derived from values in supported-frame-structures.
   char ul_fft_offset[8];
   int frame = 0;
   if (dir == UP_CH_RX) {
-    frame = (oai->split7.fftSize << 4) + oai->split7.mu;
+    frame = (cfg->fftSize << 4) + cfg->mu;
   } else if (dir == UP_CH_PRACH) {
-    frame = (oai->split7.prach_fftSize << 4) + oai->split7.mu; // TODO: handle long PRACH
+    frame = (cfg->prach_fftSize << 4) + cfg->mu; // TODO: handle long PRACH
   }
   snprintf(ul_fft_offset, sizeof(ul_fft_offset), "%d", xran_mplane->frame_str - frame);
   ret = lyd_new_term(fft_offset, NULL, "ul-fft-sampling-offset", ul_fft_offset, 0, NULL);
@@ -207,11 +207,11 @@ static bool fill_uplane_ch_rx_v2(const uplane_dir_t dir, const xran_mplane_t *xr
   return true;
 }
 
-static bool fill_uplane_ch_tx_v2(const xran_mplane_t *xran_mplane, const openair0_config_t *oai, const size_t idx, struct lyd_node **root)
+static bool fill_uplane_ch_tx_v2(const xran_mplane_t *xran_mplane, const split7_config_t *cfg, const size_t idx, struct lyd_node **root)
 {
   LY_ERR ret = LY_SUCCESS;
 
-  ret = fill_uplane_ch_common_v2(UP_CH_TX, xran_mplane, oai, idx, root);
+  ret = fill_uplane_ch_common_v2(UP_CH_TX, xran_mplane, cfg, idx, root);
   VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create common nodes.\n");
 
   return true;
@@ -320,7 +320,7 @@ static bool create_uplane_conf_v2(const ru_session_t *ru_session, const openair0
     ret = lyd_new_list(*root, NULL, "low-level-rx-endpoints", 0, &pusch_node, ru_session->ru_mplane_config.rx_endpoints.name[i * i_rx]);
     VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"low-level-rx-endpoints\" node.\n");
     
-    success = fill_uplane_ch_rx_v2(UP_CH_RX, &ru_session->xran_mplane, oai, i, &pusch_node);
+    success = fill_uplane_ch_rx_v2(UP_CH_RX, &ru_session->xran_mplane, &oai->split7, i, &pusch_node);
     VERIFY_SUCCESS(success, "[MPLANE] Failed to fill \"low-level-rx-endpoints\" node for %s.\n", ru_session->ru_mplane_config.rx_endpoints.name[i * i_rx]);
 
     const size_t prach_endpoint_name_offset = i * i_rx + (ru_session->ru_mplane_config.rx_endpoints.num / 2);
@@ -328,7 +328,7 @@ static bool create_uplane_conf_v2(const ru_session_t *ru_session, const openair0
     ret = lyd_new_list(*root, NULL, "low-level-rx-endpoints", 0, &prach_node, ru_session->ru_mplane_config.rx_endpoints.name[prach_endpoint_name_offset]);
     VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"low-level-rx-endpoints\" node.\n");
 
-    success = fill_uplane_ch_rx_v2(UP_CH_PRACH, &ru_session->xran_mplane, oai, i + ru_session->xran_mplane.prach_offset, &prach_node);
+    success = fill_uplane_ch_rx_v2(UP_CH_PRACH, &ru_session->xran_mplane, &oai->split7, i + ru_session->xran_mplane.prach_offset, &prach_node);
     VERIFY_SUCCESS(success, "[MPLANE] Failed to fill \"low-level-rx-endpoints\" node for %s.\n", ru_session->ru_mplane_config.rx_endpoints.name[prach_endpoint_name_offset]);
   }
 
@@ -338,7 +338,7 @@ static bool create_uplane_conf_v2(const ru_session_t *ru_session, const openair0
     ret = lyd_new_list(*root, NULL, "low-level-tx-endpoints", 0, &pdsch_node, ru_session->ru_mplane_config.tx_endpoints.name[i * i_tx]);
     VERIFY_SUCCESS(ret == LY_SUCCESS, "[MPLANE] Failed to create \"low-level-tx-endpoints\" node.\n");
 
-    success = fill_uplane_ch_tx_v2(&ru_session->xran_mplane, oai, i, &pdsch_node);
+    success = fill_uplane_ch_tx_v2(&ru_session->xran_mplane, &oai->split7, i, &pdsch_node);
     VERIFY_SUCCESS(success, "[MPLANE] Failed to fill \"low-level-tx-endpoints\" node for %s.\n", ru_session->ru_mplane_config.tx_endpoints.name[i * i_tx]);
   }
 

--- a/radio/fhi_72/oran-config.c
+++ b/radio/fhi_72/oran-config.c
@@ -796,7 +796,7 @@ static bool set_fh_prach_config(void *mplane_api,
   const split7_config_t *s7cfg = &oai0->split7;
 
   prach_config->nPrachConfIdx = s7cfg->prach_index; // PRACH Configuration Index
-  prach_config->nPrachSubcSpacing = oai0->nr_scs_for_raster; // 0 -> 15kHz, 1 -> 30kHz, 2 -> 60kHz, 3 -> 120kHz
+  prach_config->nPrachSubcSpacing = s7cfg->mu; // 0 -> 15kHz, 1 -> 30kHz, 2 -> 60kHz, 3 -> 120kHz
   prach_config->nPrachZeroCorrConf = 0; // PRACH zeroCorrelationZoneConfig; should be saved from config file; not used in xran
   prach_config->nPrachRestrictSet = 0; /* PRACH restrictedSetConfig; should be saved from config file; 0 = unrestricted,
                                           1 = restricted type A, 2=restricted type B; not used in xran */
@@ -1029,7 +1029,7 @@ static bool set_fh_config(void *mplane_api, int ru_idx, int num_rus, enum xran_c
   fh_config->ttiCb = NULL; // check tti_to_phy_cb(), tx_cp_dl_cb() and tx_cp_ul_cb => first_call
   fh_config->ttiCbParam = NULL; // check tti_to_phy_cb(), tx_cp_dl_cb() and tx_cp_ul_cb => first_call
 
-  uint8_t mu_number = oai0->nr_scs_for_raster;
+  uint8_t mu_number = oai0->split7.mu;
   if(!set_fh_per_mu_cfg(mplane_api, ru_idx, num_rus, oai0, &fh_config->perMu[mu_number]))
     return false;
 
@@ -1081,7 +1081,7 @@ static bool set_fh_config(void *mplane_api, int ru_idx, int num_rus, enum xran_c
   fh_config->dssEnable = 0; // enable DSS (extension-9)
   fh_config->dssPeriod = 0; // DSS pattern period for LTE/NR
   // fh_config->technology[XRAN_MAX_DSS_PERIODICITY] // technology array represents slot is LTE(0)/NR(1); used only if DSS enabled
-  if (!set_activeMUs(&activeMUs, oai0->nr_scs_for_raster))
+  if (!set_activeMUs(&activeMUs, mu_number))
     return false;
   fh_config->activeMUs = &activeMUs;
 

--- a/radio/fhi_72/oran_isolate.c
+++ b/radio/fhi_72/oran_isolate.c
@@ -161,7 +161,7 @@ void oran_fh_if4p5_south_in(RU_t *ru, int *frame, int *slot)
     printf("ORAN: %d.%d ORAN_fh_if4p5_south_in ERROR in RX PRACH function \n", f_prach, sl_prach);
   }
 
-  int slots_per_frame = 10 << (ru->openair0_cfg.nr_scs_for_raster);
+  int slots_per_frame = 10 << (ru->openair0_cfg.split7.mu);
   proc->tti_rx = sl;
   proc->frame_rx = f;
   proc->tti_tx = (sl + ru->sl_ahead) % slots_per_frame;

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-liteon.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-liteon.conf
@@ -213,7 +213,6 @@ RUs = (
   att_tx         = 0
   att_rx         = 0;
   bands          = [257];
-  nr_scs_for_raster = 3;
   max_pdschReferenceSignalPower = -40;
   max_rxgain                    = 60;
   #sf_extension                  = 0;

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf
@@ -214,7 +214,6 @@ RUs = (
   att_tx         = 0
   att_rx         = 0;
   bands          = [257];
-  nr_scs_for_raster = 3;
   max_pdschReferenceSignalPower = -40;
   max_rxgain                    = 60;
   #sf_extension                  = 0;


### PR DESCRIPTION
Remove two confusing options that can be passed implicitly from the stack/higher layers instead of requiring to set it manually:

- nr_scs_for_raster: take it from FAPI information as in the rest
- nr_flag: implicitly clear depending on whether we run LTE/5G

Fix an additional unaligned access problem.