### PR TITLE
Mac races MIB

### DIFF
--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
@@ -3756,6 +3756,10 @@ void get_type0_PDCCH_CSS_config_parameters(NR_Type0_PDCCH_CSS_config_t *type0_PD
                                            uint32_t ssb_period,
                                            uint32_t ssb_offset_point_a)
 {
+  if (!mib) {
+    LOG_E(MAC, "get_type0_PDCCH_CSS_config_parameters() called while mib is not available, mac layer incoherency\n");
+    return;
+  }
   // according to Table 5.3.5-1 in 38.104
   // band 79 is the only one which minimum is 40
   // for all the other channels it is either 10 or 5

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_dci_configuration.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_dci_configuration.c
@@ -84,6 +84,10 @@ static void config_dci_pdu(NR_UE_MAC_INST_t *mac,
                            const int slot,
                            const NR_SearchSpace_t *ss)
 {
+  if (!mac->mib) {
+    LOG_E(MAC, "Incoherent call to dci configuration while mib decode not yet available\n");
+    return;
+  }
   const NR_UE_DL_BWP_t *current_DL_BWP = mac->current_DL_BWP;
   const NR_UE_UL_BWP_t *current_UL_BWP = mac->current_UL_BWP;
   NR_BWP_Id_t dl_bwp_id = current_DL_BWP ? current_DL_BWP->bwp_id : 0;
@@ -504,19 +508,23 @@ void update_pdcch_config(NR_UE_MAC_INST_t *mac)
     ssb_sc_offset_norm = mac->ssb_subcarrier_offset;
   uint16_t ssb_offset_point_a = (mac->ssb_start_subcarrier - ssb_sc_offset_norm) / 12;
   int ssb_start_symbol = get_ssb_start_symbol(mac->nr_band, scs, mac->mib_ssb);
-  get_type0_PDCCH_CSS_config_parameters(&mac->type0_PDCCH_CSS_config,
-                                        mac->mib_frame,
-                                        mac->mib,
-                                        slots_per_frame,
-                                        ssb_sc_offset_norm,
-                                        ssb_start_symbol,
-                                        scs,
-                                        mac->frequency_range,
-                                        mac->nr_band,
-                                        273,  // at this point UE in principle doesn't know the grid size (we assume the largest)
-                                        mac->mib_ssb,
-                                        1, // If the UE is not configured with a periodicity, the UE assumes a periodicity of a half frame
-                                        ssb_offset_point_a);
+  if (mac->mib)
+    get_type0_PDCCH_CSS_config_parameters(
+        &mac->type0_PDCCH_CSS_config,
+        mac->mib_frame,
+        mac->mib,
+        slots_per_frame,
+        ssb_sc_offset_norm,
+        ssb_start_symbol,
+        scs,
+        mac->frequency_range,
+        mac->nr_band,
+        273, // at this point UE in principle doesn't know the grid size (we assume the largest)
+        mac->mib_ssb,
+        1, // If the UE is not configured with a periodicity, the UE assumes a periodicity of a half frame
+        ssb_offset_point_a);
+  else
+    LOG_E(MAC, "Call update_pdcch_config( but no mib\n");
   if (mac->search_space_zero == NULL)
     mac->search_space_zero = calloc(1, sizeof(*mac->search_space_zero));
   if (mac->coreset0 == NULL)
@@ -532,6 +540,8 @@ void ue_dci_configuration(NR_UE_MAC_INST_t *mac, fapi_nr_dl_config_request_t *dl
   NR_BWP_PDCCH_t *pdcch_config = &mac->config_BWP_PDCCH[dl_bwp_id];
   int scs = current_DL_BWP ? current_DL_BWP->scs : mac->numerology;
   const int slots_per_frame = get_slots_per_frame_from_scs(scs);
+  if (!mac->mib)
+    return;
   if (mac->get_sib1 || mac->update_pdcch_config) {
     update_pdcch_config(mac);
     mac->update_pdcch_config = false;

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
@@ -2403,14 +2403,14 @@ static bool fill_mac_sdu(NR_UE_MAC_INST_t *mac,
  * @ulsch_buffer  Pointer to ULSCH PDU
  * @buflen        TBS
  */
-static uint8_t nr_ue_get_sdu(NR_UE_MAC_INST_t *mac,
-                             frame_t frame,
-                             slot_t slot,
-                             uint8_t *ulsch_buffer,
-                             const uint32_t buflen,
-                             int tx_power,
-                             int P_CMAX,
-                             bool *BSRsent)
+static bool nr_ue_get_sdu(NR_UE_MAC_INST_t *mac,
+                          frame_t frame,
+                          slot_t slot,
+                          uint8_t *ulsch_buffer,
+                          const uint32_t buflen,
+                          int tx_power,
+                          int P_CMAX,
+                          bool *BSRsent)
 {
   NR_UE_MAC_CE_INFO mac_ce_info;
 
@@ -2437,7 +2437,7 @@ static uint8_t nr_ue_get_sdu(NR_UE_MAC_INST_t *mac,
   // variable used to build the lcids with positive Bj
   if (!mac->lc_ordered_list.count) {
     LOG_E(NR_MAC, "Failed to init lcids_bj_pos: mac->lc_ordered_list.count = 0\n");
-    return 0;
+    return false;
   }
   nr_lcordered_info_t *lcids_bj_pos[mac->lc_ordered_list.count];
   int avail_lcids_count = select_logical_channels(mac, lcids_bj_pos);
@@ -2542,7 +2542,7 @@ static uint8_t nr_ue_get_sdu(NR_UE_MAC_INST_t *mac,
   log_dump(NR_MAC, ulsch_buffer, buflen, LOG_DUMP_CHAR, "\n");
 #endif
 
-  return mac_ce_info.num_sdus > 0; // success if we got at least one sdu
+  return true; // success if we got at least one sdu
 }
 
 void nr_ue_ul_scheduler(NR_UE_MAC_INST_t *mac, nr_uplink_indication_t *ul_info)
@@ -2622,13 +2622,18 @@ void nr_ue_ul_scheduler(NR_UE_MAC_INST_t *mac, nr_uplink_indication_t *ul_info)
                                     tp_enabled,
                                     pdu->rb_size,
                                     pdu->rb_start);
-
-          nr_ue_get_sdu(mac, frame_tx, slot_tx, ulsch_input_buffer, TBS_bytes, tx_power, P_CMAX, &BSRsent);
-          pdu->tx_request_body.fapiTxPdu = ulsch_input_buffer;
-          pdu->tx_request_body.pdu_length = TBS_bytes;
-          number_of_pdus++;
-          T(T_NRUE_MAC_UL_PDU_WITH_DATA, T_INT(mac->crnti), T_INT(frame_tx), T_INT(slot_tx),
-            T_INT(ulcfg_pdu->pusch_config_pdu.pusch_data.harq_process_id), T_BUFFER(ulsch_input_buffer, TBS_bytes));
+          if (nr_ue_get_sdu(mac, frame_tx, slot_tx, ulsch_input_buffer, TBS_bytes, tx_power, P_CMAX, &BSRsent)) {
+            pdu->tx_request_body.fapiTxPdu = ulsch_input_buffer;
+            pdu->tx_request_body.pdu_length = TBS_bytes;
+            number_of_pdus++;
+            T(T_NRUE_MAC_UL_PDU_WITH_DATA,
+              T_INT(mac->crnti),
+              T_INT(frame_tx),
+              T_INT(slot_tx),
+              T_INT(ulcfg_pdu->pusch_config_pdu.pusch_data.harq_process_id),
+              T_BUFFER(ulsch_input_buffer, TBS_bytes));
+          } else
+            LOG_E(MAC, "nr_ue_get_sdu() failed\n");
           // start or restart dataInactivityTimer  if any MAC entity transmits a MAC SDU for DTCH logical channel,
           // or DCCH logical channel
           if (mac->data_inactivity_timer)


### PR DESCRIPTION
First commit: identifies and protect cases where we use the mib pointer, while it is not yet available in regular ue attach processing
I think, we have the same issue during HO: it won't segv (as it does in attch processing), but will use the wrong mib