### PR TITLE
fix(nr-ue): use a monotonic TX deadline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1900,6 +1900,7 @@ add_executable(nr-uesoftmodem
   ${OPENAIR_DIR}/executables/nr-uesoftmodem.c
   ${OPENAIR_DIR}/executables/position_interface.c
   ${OPENAIR_DIR}/executables/nr-ue.c
+  ${OPENAIR_DIR}/executables/nr-ue-tx-deadline.c
   ${OPENAIR_DIR}/executables/nr-ue-ru.c
   ${OPENAIR1_DIR}/PHY/TOOLS/phy_scope_interface.c
   ${NFAPI_USER_DIR}/nfapi.c

--- a/executables/nr-ue-ru.c
+++ b/executables/nr-ue-ru.c
@@ -9,6 +9,8 @@
 #include "common/config/config_userapi.h"
 #include "openair1/PHY/phy_extern_nr_ue.h"
 
+#include <errno.h>
+
 /* NR UE RU configuration section name */
 #define CONFIG_STRING_NRUE_RU_LIST "RUs"
 
@@ -428,16 +430,26 @@ int nrue_ru_adjust_rx_gain(PHY_VARS_NR_UE *UE, int gain_change)
   return gain_change;
 }
 
-int nrue_ru_read(PHY_VARS_NR_UE *UE, openair0_timestamp_t *ptimestamp, void **buff, int nsamps, int num_antennas)
+int nrue_ru_read(PHY_VARS_NR_UE *UE,
+                 openair0_timestamp_t *ptimestamp,
+                 void **buff,
+                 int nsamps,
+                 int num_antennas,
+                 nr_ue_tx_deadline_anchor_t *deadline_anchor)
 {
   openair0_device_t *dev = &openair0_dev[UE->rf_map.card];
   openair0_timestamp_t tmp_timestamp;
   int ret = dev->trx_read_func(dev, &tmp_timestamp, buff, nsamps, num_antennas);
+  struct timespec monotonic_time = {0};
+  const int clock_status = deadline_anchor == NULL ? 0 : clock_gettime(CLOCK_MONOTONIC, &monotonic_time);
+  const int clock_error = clock_status == 0 ? 0 : errno;
   if (!dev->firstTS_initialized) {
     dev->firstTS = tmp_timestamp;
     dev->firstTS_initialized = true;
   }
   *ptimestamp = tmp_timestamp - dev->firstTS;
+  if (deadline_anchor != NULL)
+    *deadline_anchor = nr_ue_tx_deadline_make_anchor(*ptimestamp, ret, clock_status == 0 ? &monotonic_time : NULL, clock_error);
 
   if (UE->Mod_id != 0)
     return ret;

--- a/executables/nr-ue-ru.h
+++ b/executables/nr-ue-ru.h
@@ -5,6 +5,7 @@
 #ifndef NR_UE_RU_H
 #define NR_UE_RU_H
 
+#include "executables/nr-ue-tx-deadline.h"
 #include "PHY/defs_nr_UE.h"
 #include "radio/COMMON/common_lib.h"
 
@@ -26,7 +27,12 @@ void nrue_ru_stop(void);
 void nrue_ru_end(void);
 void nrue_ru_set_freq(PHY_VARS_NR_UE *UE, uint64_t ul_carrier, uint64_t dl_carrier, int freq_offset);
 int nrue_ru_adjust_rx_gain(PHY_VARS_NR_UE *UE, int gain_change);
-int nrue_ru_read(PHY_VARS_NR_UE *UE, openair0_timestamp_t *ptimestamp, void **buff, int nsamps, int num_antennas);
+int nrue_ru_read(PHY_VARS_NR_UE *UE,
+                 openair0_timestamp_t *ptimestamp,
+                 void **buff,
+                 int nsamps,
+                 int num_antennas,
+                 nr_ue_tx_deadline_anchor_t *deadline_anchor);
 int nrue_ru_write(PHY_VARS_NR_UE *UE, openair0_timestamp_t timestamp, void **buff, int nsamps, int num_antennas, int flags);
 int nrue_ru_write_reorder(PHY_VARS_NR_UE *UE, openair0_timestamp_t timestamp, void **txp, int nsamps, int nbAnt, int flags);
 void nrue_ru_write_reorder_clear_context(PHY_VARS_NR_UE *UE);

--- a/executables/nr-ue-tx-deadline.c
+++ b/executables/nr-ue-tx-deadline.c
@@ -1,0 +1,167 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include "nr-ue-tx-deadline.h"
+
+#include <errno.h>
+#include <limits.h>
+
+static int timespec_to_ns(const struct timespec *timestamp, uint64_t *nanoseconds)
+{
+  if (timestamp == NULL || timestamp->tv_sec < 0 || timestamp->tv_nsec < 0 || timestamp->tv_nsec >= 1000000000L)
+    return EINVAL;
+
+  const uint64_t seconds = timestamp->tv_sec;
+  const uint64_t fractional_ns = timestamp->tv_nsec;
+  if (seconds > (UINT64_MAX - fractional_ns) / UINT64_C(1000000000))
+    return EOVERFLOW;
+
+  *nanoseconds = seconds * UINT64_C(1000000000) + fractional_ns;
+  return 0;
+}
+
+static bool sample_offset_to_ns(int64_t sample_offset, int64_t samples_per_subframe, int64_t *nanoseconds)
+{
+  if (samples_per_subframe <= 0)
+    return false;
+
+  /* Round to nearest nanosecond, with exact ties away from zero. */
+  __int128 numerator = (__int128)sample_offset * INT64_C(1000000);
+  const __int128 rounding = samples_per_subframe / 2;
+  numerator += numerator >= 0 ? rounding : -rounding;
+  const __int128 result = numerator / samples_per_subframe;
+  if (result < INT64_MIN || result > INT64_MAX)
+    return false;
+
+  *nanoseconds = result;
+  return true;
+}
+
+static bool add_signed_ns(uint64_t anchor_ns, int64_t offset_ns, uint64_t *result_ns)
+{
+  if (offset_ns >= 0) {
+    const uint64_t offset = offset_ns;
+    if (__builtin_add_overflow(anchor_ns, offset, result_ns))
+      return false;
+    return true;
+  }
+
+  const uint64_t magnitude = (uint64_t)(-(offset_ns + 1)) + 1;
+  if (magnitude > anchor_ns)
+    return false;
+  *result_ns = anchor_ns - magnitude;
+  return true;
+}
+
+nr_ue_tx_deadline_anchor_t nr_ue_tx_deadline_make_anchor(int64_t first_sample_timestamp,
+                                                         int sample_count,
+                                                         const struct timespec *monotonic_time,
+                                                         int clock_error)
+{
+  nr_ue_tx_deadline_anchor_t anchor = {0};
+  bool radio_valid = false;
+  if (sample_count < 0) {
+    anchor.error_code = EINVAL;
+  } else if (__builtin_add_overflow(first_sample_timestamp, (int64_t)sample_count, &anchor.radio_timestamp)) {
+    anchor.error_code = EOVERFLOW;
+  } else {
+    radio_valid = true;
+  }
+
+  int time_error = 0;
+  if (monotonic_time == NULL)
+    time_error = clock_error != 0 ? clock_error : EIO;
+  else
+    time_error = timespec_to_ns(monotonic_time, &anchor.monotonic_ns);
+
+  if (anchor.error_code == 0)
+    anchor.error_code = time_error;
+  anchor.valid = radio_valid && time_error == 0;
+  return anchor;
+}
+
+nr_ue_tx_deadline_t nr_ue_tx_deadline_compute(const nr_ue_tx_deadline_anchor_t *anchor,
+                                              int64_t write_timestamp,
+                                              int64_t guard_samples,
+                                              int64_t samples_per_subframe)
+{
+  nr_ue_tx_deadline_t deadline = {0};
+  if (anchor == NULL) {
+    deadline.error_code = EINVAL;
+    return deadline;
+  }
+  if (!anchor->valid) {
+    deadline.error_code = anchor->error_code != 0 ? anchor->error_code : EINVAL;
+    return deadline;
+  }
+  if (guard_samples < 0 || samples_per_subframe <= 0) {
+    deadline.error_code = EINVAL;
+    return deadline;
+  }
+
+  int64_t radio_deadline = 0;
+  int64_t sample_offset = 0;
+  int64_t offset_ns = 0;
+  if (__builtin_sub_overflow(write_timestamp, guard_samples, &radio_deadline)
+      || __builtin_sub_overflow(radio_deadline, anchor->radio_timestamp, &sample_offset)
+      || !sample_offset_to_ns(sample_offset, samples_per_subframe, &offset_ns)
+      || !add_signed_ns(anchor->monotonic_ns, offset_ns, &deadline.monotonic_ns)) {
+    deadline.error_code = EOVERFLOW;
+    return deadline;
+  }
+
+  deadline.valid = true;
+  return deadline;
+}
+
+nr_ue_tx_deadline_check_t nr_ue_tx_deadline_check(const nr_ue_tx_deadline_t *deadline,
+                                                  const struct timespec *monotonic_time,
+                                                  int clock_error)
+{
+  nr_ue_tx_deadline_check_t check = {0};
+  if (deadline == NULL) {
+    check.error_code = EINVAL;
+    return check;
+  }
+  if (!deadline->valid) {
+    check.error_code = deadline->error_code != 0 ? deadline->error_code : EINVAL;
+    return check;
+  }
+  if (monotonic_time == NULL) {
+    check.error_code = clock_error != 0 ? clock_error : EIO;
+    return check;
+  }
+
+  check.error_code = timespec_to_ns(monotonic_time, &check.monotonic_now_ns);
+  if (check.error_code != 0)
+    return check;
+
+  if (check.monotonic_now_ns >= deadline->monotonic_ns) {
+    const uint64_t lateness = check.monotonic_now_ns - deadline->monotonic_ns;
+    if (lateness > INT64_MAX) {
+      check.error_code = EOVERFLOW;
+      return check;
+    }
+    check.lateness_ns = lateness;
+  } else {
+    const uint64_t headroom = deadline->monotonic_ns - check.monotonic_now_ns;
+    const uint64_t int64_min_magnitude = (uint64_t)INT64_MAX + UINT64_C(1);
+    if (headroom > int64_min_magnitude) {
+      check.error_code = EOVERFLOW;
+      return check;
+    }
+    check.lateness_ns = headroom == int64_min_magnitude ? INT64_MIN : -(int64_t)headroom;
+  }
+
+  check.valid = true;
+  check.missed = check.lateness_ns > 0;
+  return check;
+}
+
+bool nr_ue_tx_deadline_log_due(_Atomic(uint64_t) *counter)
+{
+  if (counter == NULL)
+    return false;
+  return atomic_fetch_add_explicit(counter, UINT64_C(1), memory_order_relaxed) % UINT64_C(1000) == 0;
+}

--- a/executables/nr-ue-tx-deadline.h
+++ b/executables/nr-ue-tx-deadline.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#ifndef NR_UE_TX_DEADLINE_H
+#define NR_UE_TX_DEADLINE_H
+
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <time.h>
+
+typedef struct {
+  int64_t radio_timestamp;
+  uint64_t monotonic_ns;
+  int error_code;
+  bool valid;
+} nr_ue_tx_deadline_anchor_t;
+
+typedef struct {
+  uint64_t monotonic_ns;
+  int error_code;
+  bool valid;
+} nr_ue_tx_deadline_t;
+
+typedef struct {
+  uint64_t monotonic_now_ns;
+  int64_t lateness_ns;
+  int error_code;
+  bool valid;
+  bool missed;
+} nr_ue_tx_deadline_check_t;
+
+nr_ue_tx_deadline_anchor_t nr_ue_tx_deadline_make_anchor(int64_t first_sample_timestamp,
+                                                         int sample_count,
+                                                         const struct timespec *monotonic_time,
+                                                         int clock_error);
+
+nr_ue_tx_deadline_t nr_ue_tx_deadline_compute(const nr_ue_tx_deadline_anchor_t *anchor,
+                                              int64_t write_timestamp,
+                                              int64_t guard_samples,
+                                              int64_t samples_per_subframe);
+
+nr_ue_tx_deadline_check_t nr_ue_tx_deadline_check(const nr_ue_tx_deadline_t *deadline,
+                                                  const struct timespec *monotonic_time,
+                                                  int clock_error);
+
+bool nr_ue_tx_deadline_log_due(_Atomic(uint64_t) *counter);
+
+#endif /* NR_UE_TX_DEADLINE_H */

--- a/executables/nr-ue.c
+++ b/executables/nr-ue.c
@@ -4,8 +4,12 @@
 
 #include "PHY/defs_nr_common.h"
 #define _GNU_SOURCE // For pthread_setname_np
+#include <errno.h>
+#include <inttypes.h>
 #include <pthread.h>
+#include <string.h>
 #include "executables/nr-ue-ru.h"
+#include "executables/nr-ue-tx-deadline.h"
 #include "executables/nr-uesoftmodem.h"
 #include "PHY/INIT/nr_phy_init.h"
 #include "NR_MAC_UE/mac_proto.h"
@@ -317,24 +321,35 @@ static void RU_write(nr_rxtx_thread_data_t *rxtxD, bool sl_tx_action, c16_t **tx
   }
 
   if (!IS_SOFTMODEM_RFSIM) {
-    uint64_t deadline_us = rxtxD->absolute_deadline_us;
-    struct timespec current_time;
-    if (clock_gettime(CLOCK_REALTIME, &current_time)) {
-      LOG_E(PHY, "clock_gettime failed\n");
-    }
-    uint64_t current_time_us = current_time.tv_sec * 1e6 + current_time.tv_nsec / 1e3;
-    if (current_time_us > deadline_us) {
-      static unsigned int deadline_warning_rate_limit = 0;
-      if (deadline_warning_rate_limit % 1000 == 0) {
-        LOG_W(PHY,
-              "Deadline missed for tx slot %d.%d (current time %lu us, deadline %lu us, missed by %lu)\n",
+    const nr_ue_tx_deadline_t deadline = {.monotonic_ns = rxtxD->tx_deadline_monotonic_ns,
+                                          .error_code = rxtxD->tx_deadline_error_code,
+                                          .valid = rxtxD->tx_deadline_valid};
+    struct timespec monotonic_time = {0};
+    const int clock_status = deadline.valid ? clock_gettime(CLOCK_MONOTONIC, &monotonic_time) : -1;
+    const int clock_error = deadline.valid && clock_status != 0 ? errno : deadline.error_code;
+    const nr_ue_tx_deadline_check_t check =
+        nr_ue_tx_deadline_check(&deadline, clock_status == 0 ? &monotonic_time : NULL, clock_error);
+    if (!check.valid) {
+      static _Atomic(uint64_t) deadline_error_rate_limit;
+      if (nr_ue_tx_deadline_log_due(&deadline_error_rate_limit))
+        LOG_E(PHY,
+              "Cannot %s deadline for tx slot %d.%d: error %d (%s)\n",
+              deadline.valid ? "check" : "construct",
               proc->frame_tx,
               proc->nr_slot_tx,
-              current_time_us,
-              deadline_us,
-              current_time_us - deadline_us);
-      }
-      deadline_warning_rate_limit++;
+              check.error_code,
+              strerror(check.error_code));
+    } else if (check.missed) {
+      static _Atomic(uint64_t) deadline_warning_rate_limit;
+      if (nr_ue_tx_deadline_log_due(&deadline_warning_rate_limit))
+        LOG_W(PHY,
+              "Deadline missed for tx slot %d.%d (monotonic time %" PRIu64 " ns, deadline %" PRIu64 " ns, missed by %" PRId64
+              " ns)\n",
+              proc->frame_tx,
+              proc->nr_slot_tx,
+              check.monotonic_now_ns,
+              deadline.monotonic_ns,
+              check.lateness_ns);
     }
   }
 
@@ -663,7 +678,7 @@ void readFrame(PHY_VARS_NR_UE *UE, openair0_timestamp_t *timestamp, int duration
           rxp[i] = &UE->common_vars.rxdata[i][x * fp->samples_per_subframe + get_samples_slot_timestamp(fp, slot_rx)];
 
       int readBlockSize = get_samples_per_slot(slot_rx, fp);
-      int tmp = nrue_ru_read(UE, timestamp, (void **)rxp, readBlockSize, fp->nb_antennas_rx);
+      int tmp = nrue_ru_read(UE, timestamp, (void **)rxp, readBlockSize, fp->nb_antennas_rx, NULL);
       UEscopeCopy(UE, ueTimeDomainSamplesBeforeSync, rxp[0], sizeof(c16_t), 1, readBlockSize, 0);
       AssertFatal(readBlockSize == tmp, "read rf board failed %d", tmp);
 
@@ -694,7 +709,7 @@ static void syncInFrame(PHY_VARS_NR_UE *UE, openair0_timestamp_t *timestamp, int
   while (size > 0) {
     // Set a maximum transfer size. As we usually read/write single slots, we use the size of slot 0 as maximum here.
     const int unitTransfer = min(get_samples_per_slot(0, fp), size);
-    const int res = nrue_ru_read(UE, timestamp, (void **)UE->common_vars.rxdata, unitTransfer, fp->nb_antennas_rx);
+    const int res = nrue_ru_read(UE, timestamp, (void **)UE->common_vars.rxdata, unitTransfer, fp->nb_antennas_rx, NULL);
     DevAssert(unitTransfer == res);
     if (IS_SOFTMODEM_RFSIM) {
       int ta = UE->timing_advance + UE->timing_advance_ntn;
@@ -876,7 +891,8 @@ void *UE_thread(void *arg)
                              &sync_timestamp,
                              (void **)UE->common_vars.rxdata,
                              fp->ofdm_symbol_size + fp->nb_prefix_samples0,
-                             fp->nb_antennas_rx);
+                             fp->nb_antennas_rx,
+                             NULL);
       AssertFatal(fp->ofdm_symbol_size + fp->nb_prefix_samples0 == ret, "read rf board failed %d", ret);
       // we have the decoded frame index in the return of the synch process
       // and we shifted above to the first slot of next frame
@@ -978,14 +994,16 @@ void *UE_thread(void *arg)
 
     const int readBlockSize = get_readBlockSize(slot_nr, fp) - iq_shift_to_apply;
     openair0_timestamp_t rx_timestamp;
-    int tmp = nrue_ru_read(UE, &rx_timestamp, (void **)rxp, readBlockSize, fp->nb_antennas_rx);
+    nr_ue_tx_deadline_anchor_t deadline_anchor = {.error_code = EINVAL};
+    int tmp = nrue_ru_read(UE,
+                           &rx_timestamp,
+                           (void **)rxp,
+                           readBlockSize,
+                           fp->nb_antennas_rx,
+                           slot_nr != nb_slot_frame - 1 ? &deadline_anchor : NULL);
     metadata meta = {.slot =  curMsg.proc.nr_slot_rx, .frame =  curMsg.proc.frame_rx};
     UEscopeCopyWithMetadata(UE, ueTimeDomainSamples, rxp[0] - firstSymSamp, sizeof(c16_t), 1, readBlockSize, 0, &meta);
     AssertFatal(readBlockSize == tmp, "read to rf board failed %d", tmp);
-    struct timespec current_time;
-    if (clock_gettime(CLOCK_REALTIME, &current_time)) {
-      LOG_E(PHY, "clock_gettime failed\n");
-    }
 
     if(slot_nr == (nb_slot_frame - 1)) {
       // read in first symbol of next frame and adjust for timing drift
@@ -993,11 +1011,17 @@ void *UE_thread(void *arg)
 
       if (first_symbols > 0) {
         openair0_timestamp_t ignore_timestamp;
-        int tmp = nrue_ru_read(UE, &ignore_timestamp, (void **)UE->common_vars.rxdata, first_symbols, fp->nb_antennas_rx);
+        int tmp = nrue_ru_read(UE,
+                               &ignore_timestamp,
+                               (void **)UE->common_vars.rxdata,
+                               first_symbols,
+                               fp->nb_antennas_rx,
+                               &deadline_anchor);
         AssertFatal(first_symbols == tmp, "read to rf board failed %d", tmp);
 
-      } else
+      } else {
         LOG_E(PHY,"can't compensate: diff =%d\n", first_symbols);
+      }
     }
 
     // use previous timing_advance value to compute writeTimestamp
@@ -1005,9 +1029,8 @@ void *UE_thread(void *arg)
         rx_timestamp + get_samples_slot_duration(fp, slot_nr, duration_rx_to_tx) - firstSymSamp - UE->N_TA_offset - timing_advance;
 
     // Calculate TX deadline, approximately 1 symbol before the first sample should be written
-    const uint64_t samples_diff = writeTimestamp - rx_timestamp - fp->ofdm_symbol_size;
-    const float deadline_us = samples_diff * 1e3 / fp->samples_per_subframe;
-    const uint64_t absolute_deadline_us = current_time.tv_sec * 1e6 + current_time.tv_nsec * 1e-3 + deadline_us;
+    const nr_ue_tx_deadline_t tx_deadline =
+        nr_ue_tx_deadline_compute(&deadline_anchor, writeTimestamp, fp->ofdm_symbol_size, fp->samples_per_subframe);
 
     // but use current UE->timing_advance value to compute writeBlockSize
     int writeBlockSize = get_samples_per_slot((slot_nr + duration_rx_to_tx) % nb_slot_frame, fp) - iq_shift_to_apply;
@@ -1064,7 +1087,9 @@ void *UE_thread(void *arg)
     curMsgTx->writeBlockSize = writeBlockSize;
     curMsgTx->proc.timestamp_tx = writeTimestamp;
     curMsgTx->UE = UE;
-    curMsgTx->absolute_deadline_us = absolute_deadline_us;
+    curMsgTx->tx_deadline_monotonic_ns = tx_deadline.monotonic_ns;
+    curMsgTx->tx_deadline_error_code = tx_deadline.error_code;
+    curMsgTx->tx_deadline_valid = tx_deadline.valid;
 
     int slot = curMsgTx->proc.nr_slot_tx;
     int slot_and_frame = slot + curMsgTx->proc.frame_tx * nb_slot_frame;

--- a/openair1/PHY/defs_nr_UE.h
+++ b/openair1/PHY/defs_nr_UE.h
@@ -597,7 +597,9 @@ typedef struct nr_rxtx_thread_data_s {
   int writeBlockSize;
   nr_phy_data_t phy_data;
   dynamic_barrier_t* next_barrier;
-  uint64_t absolute_deadline_us;
+  uint64_t tx_deadline_monotonic_ns;
+  int tx_deadline_error_code;
+  bool tx_deadline_valid;
 } nr_rxtx_thread_data_t;
 
 typedef struct LDPCDecode_ue_s {


### PR DESCRIPTION
While investigating nrUE transmit timing, we followed the existing `Deadline missed` warning back to a deadline derived from radio samples but mapped onto `CLOCK_REALTIME`. That made an elapsed-time diagnostic sensitive to wall-clock adjustments, and both clock-read failure paths could continue with an uninitialized timestamp. We also found that the host clock was sampled before the extra read at a frame boundary, so the deadline could pair the final radio timestamp with the wrong host instant.

Changes:

- Capture a `CLOCK_MONOTONIC` anchor immediately after the selected RU's device read, before UE 0 drains any unassigned RUs. When the frame-boundary extra read becomes the last relevant receive, it supplies a replacement radio/host anchor.
- Convert the signed radio-sample offset to nanoseconds with checked integer arithmetic and defined nearest-nanosecond rounding. Explicit validity and error fields carry any clock or overflow failure into the TX handoff.
- Check the deadline against the same monotonic clock immediately before TX classification. A clock or arithmetic error now reports the failed stage and skips the classification instead of using invalid data.
- Keep deadline construction, conversion, and classification in a private nrUE helper that is compiled only into `nr-uesoftmodem`.
- Rate-limit warning and error messages with relaxed atomic counters so concurrent TX actors cannot race on the shared diagnostic state.