### PR TITLE
docs: update OAI CN5G reference to OpenAirInterface GitHub repository

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -8,7 +8,7 @@ This page describes how to build OAI.
 
 ## Overview
 
-The [OAI EPC](https://github.com/OPENAIRINTERFACE/openair-epc-fed/blob/master/docs/DEPLOY_HOME_MAGMA_MME.md) and [OAI 5GC](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-fed/-/blob/master/docs/DEPLOY_HOME.md) are developed in distinct projects with their own documentation and are not further described here.
+The [OAI EPC](https://github.com/OPENAIRINTERFACE/openair-epc-fed/blob/master/docs/DEPLOY_HOME_MAGMA_MME.md) and [OAI 5GC](https://github.com/openairinterface/oai-cn5g-fed/blob/develop/docs/DEPLOY_HOME.md) are developed in distinct projects with their own documentation and are not further described here.
 
 OAI softmodem sources, which aim to implement 3GPP compliant UEs, eNodeB and gNodeB can be downloaded from the Eurecom [gitlab repository](./GET_SOURCES.md).
 

--- a/doc/E1AP/E1-design.md
+++ b/doc/E1AP/E1-design.md
@@ -134,7 +134,7 @@ Alternatively, you can use the config files `ci-scripts/conf_files/gnb-cucp.sa.f
 
 ### 2.2 Steps to Run the Split in rfsimulator with OAI UE
 
-Note: A 5G core must be running at this point. Steps to start the OAI 5G core can be found [in the oai-cn5g-fed repository](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-fed/-/blob/master/docs/DEPLOY_HOME.md) or [here](../NR_SA_Tutorial_OAI_CN5G.md).
+Note: A 5G core must be running at this point. Steps to start the OAI 5G core can be found [in the oai-cn5g-fed repository](https://github.com/openairinterface/oai-cn5g-fed/blob/develop/docs/DEPLOY_HOME.md) or [here](../NR_SA_Tutorial_OAI_CN5G.md).
 
 0. Open wireshark to capture the E1AP messages. You might set the capture filter
    to `sctp` to limit the number of captured packages.


### PR DESCRIPTION
The OAI CN5G repositories have been migrated from GitLab to GitHub.

This PR updates the affected documentation references to replace the old GitLab URLs with the corresponding OpenAirInterface GitHub repository links.

For more details, see the [Announcement](https://github.com/orgs/openairinterface/discussions/3)

All OAI Core Network repositories can be accessed through the [OpenAirInterface CN5G GitHub topic](https://github.com/topics/openairinterface-cn5g)