### PR TITLE
Fix nrUE fails to get IPv6 address from Open5GS core

### DIFF
--- a/common/utils/tuntap_if.c
+++ b/common/utils/tuntap_if.c
@@ -232,6 +232,9 @@ bool tun_config(const char* ifname, const char *ipv4, const char *ipv6)
     success = flags >= 0 && set_if_flags(sock_fd, ifname, (flags | IFF_NOARP | IFF_POINTOPOINT) & ~IFF_MULTICAST);
   }
 
+  // Note: only the link-local IPv6 address is available at this point.
+  // The global IPv6 address is assigned after receiving a Router Advertisement, which triggers SLAAC
+  // (3GPP TS 23.501, Section 5.8.2.2.3; IETF RFC 4862).
   if (success)
     LOG_A(OIP, "TUN Interface %s successfully configured, IPv4 %s, IPv6 %s\n", ifname, ipv4, ipv6);
   else

--- a/openair2/SDAP/nr_sdap/nr_sdap_entity.c
+++ b/openair2/SDAP/nr_sdap/nr_sdap_entity.c
@@ -408,8 +408,9 @@ static void nr_sdap_qfi2drb_map_del(nr_sdap_entity_t *entity, const uint8_t qfi)
 static const qfi2drb_t *nr_sdap_qfi2drb(const nr_sdap_entity_t *entity, uint8_t qfi)
 {
   /* Fetch DRB ID mapped to QFI */
-  const qfi2drb_t *row = &entity->qfi2drb_table[qfi];
-  if (row->drb_id) {
+  // Handle the out-of-bound case when a DL PDU arrives with no QFI marking (QFI = -1 (255 in uint8_t)).
+  const qfi2drb_t *row = qfi < SDAP_MAX_QFI ? &entity->qfi2drb_table[qfi] : NULL;
+  if (row && row->drb_id) {
     /* QoS flow to DRB mapping rule exists, return corresponding DRB ID */
     LOG_D(SDAP, "Existing QoS flow to DRB mapping rule: QFI %u to DRB %d\n", qfi, row->drb_id);
     return row;

--- a/openair2/SDAP/nr_sdap/nr_sdap_entity.c
+++ b/openair2/SDAP/nr_sdap/nr_sdap_entity.c
@@ -151,6 +151,21 @@ static bool nr_sdap_tx_entity(nr_sdap_entity_t *entity,
     return 0;
   }
 
+  // Reuse a QFI that the UE has already mapped to the default DRB to avoid
+  // encoding an invalid QFI in the SDAP header. This follows TS 37.324 5.2.1,
+  // which maps SDAP SDUs from unmapped QoS flows (e.g., a UFP-generated Router Advertisement) to the default DRB.
+  uint8_t hdr_qfi = qfi;
+  if (qfi >= SDAP_MAX_QFI) { // qfi = -1 (uint_8 255)
+    for (int i = 0; i < SDAP_MAX_QFI; i++) {
+      if (entity->qfi2drb_table[i].drb_id == drb_id) {
+        hdr_qfi = i;
+        break;
+      }
+    }
+    DevAssert (hdr_qfi < SDAP_MAX_QFI);
+    LOG_W(SDAP, "TX SDAP SDU with no QFI marking: reusing QFI %u already mapped to DRB %d\n", hdr_qfi, drb_id);
+  }
+
   if (sdap_dl_tx) { // create DL Data PDU with SDAP header
     offset = SDAP_HDR_LENGTH;
     /*
@@ -160,7 +175,7 @@ static bool nr_sdap_tx_entity(nr_sdap_entity_t *entity,
      * Construct the DL SDAP data PDU.
      */
     nr_sdap_dl_hdr_t sdap_hdr;
-    sdap_hdr.QFI = qfi;
+    sdap_hdr.QFI = hdr_qfi;
     sdap_hdr.RQI = rqi;
     sdap_hdr.RDI = 0; // SDAP Hardcoded Value
     /* Add the SDAP DL Header to the buffer */
@@ -179,7 +194,7 @@ static bool nr_sdap_tx_entity(nr_sdap_entity_t *entity,
      * construct the UL SDAP data PDU as specified in the subclause 6.2.2.3.
      */
     nr_sdap_ul_hdr_t sdap_hdr;
-    sdap_hdr.QFI = qfi;
+    sdap_hdr.QFI = hdr_qfi;
     sdap_hdr.R = 0;
     sdap_hdr.DC = rqi;
     /* Add the SDAP UL Header to the buffer */

--- a/openair3/NAS/NR_UE/5GS/5GSM/MSG/PduSessionEstablishmentAccept.c
+++ b/openair3/NAS/NR_UE/5GS/5GSM/MSG/PduSessionEstablishmentAccept.c
@@ -126,8 +126,8 @@ int decode_pdu_session_establishment_accept_msg(pdu_session_establishment_accept
           for (int i = 0; i < IPv4_ADDRESS_LENGTH + IPv6_INTERFACE_ID_LENGTH; ++i)
             addr[i] = *curPtr++;
           LOG_I(NAS, "Received PDU Session Establishment Accept, UE IPv4v6: %u.%u.%u.%u/%u.%u.%u.%u.%u.%u.%u.%u\n",
-                addr[0], addr[1], addr[2], addr[3],
-                addr[4], addr[5], addr[6], addr[7], addr[8], addr[9], addr[10], addr[11]);
+                addr[8], addr[9], addr[10], addr[11],
+                addr[0], addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7]);
         } else {
           LOG_E(NAS, "unknown/unhandled PDU session establishment accept PDU type %d\n", psea_msg->pdu_addr_ie.pdu_type);
           curPtr += psea_msg->pdu_addr_ie.pdu_length;

--- a/openair3/ocp-gtpu/gtp_itf.cpp
+++ b/openair3/ocp-gtpu/gtp_itf.cpp
@@ -1241,7 +1241,11 @@ static int Gtpv1uHandleGpdu(int h, uint8_t *msgBuf, uint32_t msgBufLen, const st
   const uint32_t destinationL2Id = 0;
 
   if (sdu_buffer_size > 0) {
-    if (qfi != NO_QFI && uedata.callBackSDAP) {
+    // TS 29.281 5.2.2.7 / TS 38.415 require a QFI (PDU Session Container) on every N3 G-PDU,
+    // so a DL PDU with no QFI (e.g. a UPF-generated Router Advertisement) is out-of-spec.
+    // We still forward it through SDAP, by following the TS 37.324 5.2.1, where defined that
+    // an unmapped QoS flow shall map the SDAP SDU to the default DRB.
+    if (uedata.callBackSDAP) {
       if (!uedata.callBackSDAP(&ctxt,
                                        uedata.ue_id,
                                        srb_flag,


### PR DESCRIPTION
### Observation:
The nrUE cannot get an IPv6 address in the tun interface while testing with Open5GS core (v2.7.5)
nrUE log:
```
[NAS]    Received PDU Session Establishment Accept, UE IPv4v6: 12.5.1.25/0.0.0.0.0.0.0.18
[NR_RRC]  Logical Channel UL-DCCH (SRB1), Generating RRCReconfigurationComplete (bytes 2)
[NR_RRC] MeasurementReport Encoded 53 bits (7 bytes)
[SDAP]   UE 0 PDU session 1: cached QFI 1
[SDAP]   UE 0 PDU session 1: bringing TUN oaitun_ue1 up
[UTIL]   threadCreate() for ue_tun_read_0_p1: creating thread with affinity ffffffff, priority 1
[OIP]    TUN Interface oaitun_ue1 successfully configured, IPv4 12.5.1.25, IPv6 fe80::0000:0000:0000:0012
[SDAP]   UE - TODD 5.4
[SDAP]   [UE 0] PDU session 1 DL delivery: drb_id=1 drb_role=0x9 sdap_header_rx=1 size=96 offset=1 ip_version_nibble@0=6 ip_version_nibble@offset=0 raw_bytes(from buf[0])=[60 00 00 01 00 38 3a ff fe 80 00 00 00 00 00 00 00 00 00 00 ]
[SDAP]   write failed to fd 83! errno = Invalid argument
```
```
258: oaitun_ue1: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 500
    link/none
    inet 12.5.1.25/24 scope global oaitun_ue1
       valid_lft forever preferred_lft forever
    inet6 fe80::12/64 scope link
       valid_lft forever preferred_lft forever
```
nrUE configuration:
```
uicc0 :
{
    imsi = "001010000000001";
    key = "fec86ba6eb707ed08905757b1bb44b8f";
    opc = "C42449363BBAD02B66D16BC975D77CC1";
    pdu_sessions = (
      { dnn = "internet"; type = "IPv4v6"; nssai_sst = 1; }
    );
}
```

### Troubleshooting:
- Confirmed Open5GS assigned both IPv4 and IPv6 to the UE
```
[smf] INFO: UE SUPI[imsi-001010000000001] DNN[internet] IPv4[12.5.1.25] IPv6[2001:db8:cafe:11::12] (../src/src/smf/npcf-handler.c:580)
[upf] INFO: [Added] Number of UPF-Sessions is now 1 (../src/src/upf/context.c:209)
[upf] INFO: UE F-SEID[UP:0xcf0 CP:0xe9e] APN[internet] PDN-Type[3] IPv4[12.5.1.25] IPv6[2001:db8:cafe:11::12] (../src/src/upf/context.c:495)
```
- Found that the received GTP-U message at the gNB side has `qfi=-1 `, which is the Router Advertisement sent from the UPF
```
[GTPU]   [80] N3 DL PDU: teid=0x902e6616 ue=1 pdusession_id=1 ext_hdr_present=0 qfi=-1 rqi=0 has_sdap_callback=1 sdu_buffer_size=96 ip_version_nibble=6 raw_bytes(from sdu_buffer[0])=[60 00 00 01 00 38 3a ff fe 80 00 00 00 00 00 00 00 00 00 00 ]
```
Router Advertisement message sent from the UPF (`172.21.13.64`) to gNB (`172.21.13.40`)
<img width="756" height="173" alt="image" src="https://github.com/user-attachments/assets/c6a79622-611d-48ea-adc0-f7b260552be9" />
- Found that the UE strips a byte assuming an SDAP header is present  (sdap_header_rx=1, offset=1), but `ip_version_nibble@offset=0` shows the resulting payload no longer starts with a valid IP version nibble, which means the SDAP header was stripped from a packet that never had one.
```
[SDAP]   [UE 0] PDU session 1 DL delivery: drb_id=1 drb_role=0x9 sdap_header_rx=1 size=96 offset=1 ip_version_nibble@0=6 ip_version_nibble@offset=0 raw_bytes(from buf[0])=[60 00 00 01 00 38 3a ff fe 80 00 00 00 00 00 00 00 00 00 00 ]
```


### Root cause:
- In `openair3/ocp-gtpu/gtp_itf.cpp:Gtpv1uHandleGpdu() `, the DL PDU skips the SDAP layer whenever `qfi == NO_QFI`, therefore, the packet went straight to PDCP with no SDAP header added.
```
if (qfi != NO_QFI && uedata.callBackSDAP) {                                    
    // ... route to sdap_data_req()                                                         
  } else {                                                                       
    // ... route to nr_pdcp_data_req_drb()                       
  }  
```
- However, the UE's SDAP RX entity still expects an SDAP header on that DRB `if (sdap_header_rx) ` in `nr_sdap_rx_entity()`:
```
else { //nrUE
    /*
     * TS 37.324 5.2 Data transfer
     * 5.2.2 Downlink
     * if the DRB from which this SDAP data PDU is received is configured by RRC with the presence of SDAP header.
     */
    int offset = 0;
    if (sdap_header_rx) { // DL Data/Control PDU with SDAP header
```
it strips a byte that was never added, corrupting the packet, and the `write()` at `nr_sdap_rx_entity()` to the TUN device fails:
```
int len = write(entity->pdusession_sock, &buf[offset], size - offset);
```

### After fix, the results of UE ip:
```
260: oaitun_ue1: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 500
    link/none
    inet 12.5.1.27/24 scope global oaitun_ue1
       valid_lft forever preferred_lft forever
    inet6 2001:db8:cafe:13::14/64 scope global dynamic mngtmpaddr
       valid_lft forever preferred_lft forever
    inet6 fe80::14/64 scope link
       valid_lft forever preferred_lft forever
```