### PR TITLE
[FHI72] New split 7.2 API

### DIFF
--- a/ci-scripts/conf_files/gnb-du.sa.band77.273prb.fhi72.4x4-4L-benetel550.conf
+++ b/ci-scripts/conf_files/gnb-du.sa.band77.273prb.fhi72.4x4-4L-benetel550.conf
@@ -202,8 +202,6 @@ RUs = (
   ru_thread_core = 12;
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding = 0; # needs to match O-RU configuration
-  
 }
 );
 

--- a/ci-scripts/conf_files/gnb-du.sa.band77.273prb.fhi72.4x4-4L-vvdn.conf
+++ b/ci-scripts/conf_files/gnb-du.sa.band77.273prb.fhi72.4x4-4L-vvdn.conf
@@ -204,7 +204,6 @@ RUs = (
   ru_thread_core = 10;
   sl_ahead       = 8;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/ci-scripts/conf_files/gnb-du.sa.band77.273prb.fhi72.8x8-benetel650_650.conf
+++ b/ci-scripts/conf_files/gnb-du.sa.band77.273prb.fhi72.8x8-benetel650_650.conf
@@ -210,7 +210,6 @@ RUs = (
   ru_thread_core = 10;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/ci-scripts/conf_files/gnb-du.sa.band78.273prb.fhi72.4x4-4L-liteon.conf
+++ b/ci-scripts/conf_files/gnb-du.sa.band78.273prb.fhi72.4x4-4L-liteon.conf
@@ -189,7 +189,6 @@ RUs = (
   ru_thread_core = 10;
   sl_ahead       = 8;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/ci-scripts/conf_files/gnb-du.sa.band78.273prb.fhi72.4x4-4L-metanoia.conf
+++ b/ci-scripts/conf_files/gnb-du.sa.band78.273prb.fhi72.4x4-4L-metanoia.conf
@@ -195,7 +195,6 @@ RUs = (
   ru_thread_core = 10;
   sl_ahead       = 8;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding = 0; # needs to match O-RU configuration
 }
 );
 

--- a/ci-scripts/conf_files/gnb-pnf.sa.band77.273prb.fhi72.4x4-4L-vvdn.conf
+++ b/ci-scripts/conf_files/gnb-pnf.sa.band77.273prb.fhi72.4x4-4L-vvdn.conf
@@ -34,7 +34,6 @@ RUs = (
   ru_thread_core = 10;
   sl_ahead       = 6;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/ci-scripts/conf_files/gnb.band77.273prb.fhi72.4x4-vvdn-phytest.conf
+++ b/ci-scripts/conf_files/gnb.band77.273prb.fhi72.4x4-vvdn-phytest.conf
@@ -208,7 +208,6 @@ RUs = (
   ru_thread_core = 10;
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru.conf
+++ b/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru.conf
@@ -209,7 +209,6 @@ RUs = (
   ru_thread_core = 12;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/ci-scripts/conf_files/gnb.sa.band77.273prb.fhi72.4x4-4layers-vvdn.conf
+++ b/ci-scripts/conf_files/gnb.sa.band77.273prb.fhi72.4x4-4layers-vvdn.conf
@@ -207,7 +207,6 @@ RUs = (
   ru_thread_core = 10;
   sl_ahead       = 8;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/ci-scripts/conf_files/gnb.sa.band77.273prb.fhi72.4x4-vvdn.conf
+++ b/ci-scripts/conf_files/gnb.sa.band77.273prb.fhi72.4x4-vvdn.conf
@@ -209,7 +209,6 @@ RUs = (
   ru_thread_core = 5;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/ci-scripts/conf_files/gnb.sa.band78.106prb.fhi72.4x4-benetel550-9b-mplane.conf
+++ b/ci-scripts/conf_files/gnb.sa.band78.106prb.fhi72.4x4-benetel550-9b-mplane.conf
@@ -209,7 +209,6 @@ RUs = (
   ru_thread_core = 5;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/ci-scripts/conf_files/gnb.sa.band78.273prb.fhi72.2x2-benetel550-9b-mplane.conf
+++ b/ci-scripts/conf_files/gnb.sa.band78.273prb.fhi72.2x2-benetel550-9b-mplane.conf
@@ -207,7 +207,6 @@ RUs = (
   ru_thread_core = 5;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/ci-scripts/conf_files/ru.band77.mu1.106prb.1x1.conf
+++ b/ci-scripts/conf_files/ru.band77.mu1.106prb.1x1.conf
@@ -40,7 +40,6 @@ RUs = (
   eNB_instances  = [0];
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
   # PRACH configuration
   num_tp_cores = 4;
   tp_cores = [-1,-1,-1,-1];

--- a/executables/nr-gnb.c
+++ b/executables/nr-gnb.c
@@ -28,6 +28,7 @@
 #include "PHY/TOOLS/tools_defs.h"
 #include "PHY/defs_RU.h"
 #include "PHY/defs_gNB.h"
+#include "executables/nr-softmodem.h" // declares ru_tx_func(), implemented in nr-ru.c
 #include "PHY/defs_nr_common.h"
 #include "PHY/impl_defs_nr.h"
 #include "SCHED_NR/phy_frame_config_nr.h"
@@ -46,6 +47,8 @@
 #define TICK_TO_US(ts) (ts.trials==0?0:ts.diff/ts.trials)
 #define L1STATSSTRLEN 16384
 static void rx_func(processingData_L1_t *param);
+
+// ru_tx_func is implemented in nr-ru.c: stays generic (ru->fh_south_out only) regardless of split
 
 static void tx_func(processingData_L1tx_t *info)
 {

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -623,7 +623,6 @@ void *ru_thread(void *param)
   int                slot     = fp->slots_per_frame-1;
   int                frame    = 1023;
   char               threadname[40];
-  int initial_wait = 0;
 
   bool rx_tti_busy[RU_RX_SLOT_DEPTH] = {false};
   // set default return value
@@ -732,18 +731,7 @@ void *ru_thread(void *param)
     AssertFatal(ru->fh_south_in, "No fronthaul interface at south port");
     ru->fh_south_in(ru, &frame, &slot);
 
-    if (initial_wait == 1 && proc->frame_rx < 300) {
-      if (proc->frame_rx > 0 && ((proc->frame_rx % 100) == 0) && proc->tti_rx == 0) {
-        LOG_D(PHY, "delay processing to let RX stream settle, frame %d (trials %d)\n", proc->frame_rx, ru->rx_fhaul.trials);
-        print_meas(&ru->rx_fhaul, "rx_fhaul", NULL, NULL);
-        reset_meas(&ru->rx_fhaul);
-      }
-      continue;
-    }
-    if (proc->frame_rx>=300)  {
-      initial_wait = 0;
-    }
-    if (initial_wait == 0 && ru->rx_fhaul.trials > 1000) {
+    if (ru->rx_fhaul.trials > 1000) {
         reset_meas(&ru->rx_fhaul);
         reset_meas(&ru->tx_fhaul);
     }

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -612,17 +612,18 @@ static bool wait_free_rx_tti(notifiedFIFO_t *L1_rx_out, bool rx_tti_busy[RU_RX_S
   return true;
 }
 
-/* @brief RX-side per-slot handling: front-end processing, scope-copy, PRACH extraction. Factored
- * out of ru_thread() so it can be reused as-is by an upcoming second RU southbound interface that
- * needs the same handling but not the surrounding IQ sample-clock bookkeeping.
+/* @brief RX-side per-slot handling for split 8 (ru_thread()) only - split 7.2's split7_thread()
+ * (radio/fhi_72/oran_isolate.c) never calls this, it has no time-domain front-end step and relies
+ * on the O-RU/xran side instead.
  *
- * ru->feprx is called unconditionally now: previously, scope-copy and PRACH extraction lived
- * inside the "if (ru->feprx)" branch, which meant a southbound interface without a front-end DFT
- * step (none exists yet, but one is coming) would accidentally skip both, even though rxdataF is
- * valid either way. The ru->common.rxdata guard below is the one genuinely split-specific check
- * that remains: not every interface will have full-rate time-domain IQ to extract PRACH from.
+ * ru->feprx is called unconditionally: previously, scope-copy and PRACH extraction lived inside
+ * an "if (ru->feprx)" branch, which only happened to work because every caller of this code set
+ * it; now that it's a standalone function, that's made explicit instead of implicit.
+ *
+ * PRACH extraction is time-domain-only (rx_nr_prach_ru() needs raw ru->common.rxdata, which only
+ * split 8 has - see nr_phy_init_RU()), hence the ru->common.rxdata guard below.
  */
-static void ru_rx_slot(RU_t *ru, PHY_VARS_gNB *gNB, int frame_rx, int slot_rx)
+void ru_rx_slot(RU_t *ru, PHY_VARS_gNB *gNB, int frame_rx, int slot_rx)
 {
   ru->feprx(ru, slot_rx);
 
@@ -651,10 +652,10 @@ static void ru_rx_slot(RU_t *ru, PHY_VARS_gNB *gNB, int frame_rx, int slot_rx)
   }
 }
 
-/* @brief hand the just-processed slot off to the gNB TX pipeline (tx_func() in nr-gnb.c). Factored
- * out of ru_thread() alongside ru_rx_slot() for the same reason - reusable as-is by an upcoming
- * second RU southbound interface. */
-static void ru_push_tx_job(PHY_VARS_gNB *gNB, int frame_tx, int slot_tx, int frame_rx, int slot_rx, uint64_t timestamp_tx)
+/* @brief hand the just-processed slot off to the gNB TX pipeline (tx_func() in nr-gnb.c), shared
+ * by every RU southbound interface - both ru_thread() and split7_thread() (radio/fhi_72/
+ * oran_isolate.c) call it. */
+void ru_push_tx_job(PHY_VARS_gNB *gNB, int frame_tx, int slot_tx, int frame_rx, int slot_rx, uint64_t timestamp_tx)
 {
   notifiedFIFO_elt_t *resTx = newNotifiedFIFO_elt(sizeof(processingData_L1tx_t), 0, &gNB->L1_tx_out, NULL);
   resTx->key = slot_tx;

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -16,12 +16,14 @@
 #include "common/utils/assertions.h"
 #include "common/utils/system.h"
 #include "common/utils/fsn.h"
+#include "common/utils/load_module_shlib.h"
 #include "common/ran_context.h"
 
 #include "radio/ETHERNET/ethernet_lib.h"
 
 #include "PHY/defs_nr_common.h"
-#include "PHY/phy_extern.h"
+#include "PHY/phy_extern.h" // defines RU_t, must come before oran.h
+#include "radio/fhi_72/oran.h"
 #include "PHY/NR_TRANSPORT/nr_transport_proto.h"
 #include "PHY/INIT/nr_phy_init.h"
 #include "SCHED_NR/sched_nr.h"
@@ -48,6 +50,11 @@ static int DEFRUTPCORES[] = {-1,-1,-1,-1};
 #include "executables/nr-softmodem-common.h"
 
 static void NRRCconfig_RU(configmodule_interface_t *cfg);
+
+/* O-RAN 7.2 fronthaul instance for this process. Only one RU is supported today (RC.ru[0]
+ * throughout this file), so a single static instance mirrors that rather than threading a handle
+ * through call sites that don't otherwise need one. */
+static fhi72_transport_t fhi72_transport;
 
 /*************************************************************/
 /* Southbound Fronthaul functions, RCC/RAU                   */
@@ -558,16 +565,17 @@ void ru_tx_func(void *param)
   int frame_tx = info->frame_tx;
   int slot_tx = info->slot_tx;
 
-  // do TX front-end processing if needed (precoding and/or IDFTs)
-  if (ru->feptx_prec)
-    ru->feptx_prec(ru,frame_tx,slot_tx);
-
-  // do OFDM with/without TX front-end processing  if needed
-  if (ru->feptx_ofdm)
+  // split 7.2 has its own, leaner FH callback (no RU_t, no IQ-sample timestamp) - see
+  // radio/fhi_72/oran.h. Every other split still goes through the generic ru->fh_south_out.
+  if (ru->if_south == REMOTE_IF4p5) {
+    start_meas(&ru->tx_fhaul);
+    nr_feptx_prec(ru,frame_tx,slot_tx);
+    fhi72_transport.fh_south_out(ru->common.txdataF_BF, ru->common.beam_id, frame_tx, slot_tx);
+    stop_meas(&ru->tx_fhaul);
+  } else {
     ru->feptx_ofdm(ru, frame_tx, slot_tx);
-
-  if (ru->fh_south_out)
     ru->fh_south_out(ru, frame_tx, slot_tx, info->timestamp_tx);
+  }
 }
 
 /* @brief wait for the next RX TTI to be free
@@ -616,9 +624,8 @@ static bool wait_free_rx_tti(notifiedFIFO_t *L1_rx_out, bool rx_tti_busy[RU_RX_S
  * (radio/fhi_72/oran_isolate.c) never calls this, it has no time-domain front-end step and relies
  * on the O-RU/xran side instead.
  *
- * ru->feprx is called unconditionally: previously, scope-copy and PRACH extraction lived inside
- * an "if (ru->feprx)" branch, which only happened to work because every caller of this code set
- * it; now that it's a standalone function, that's made explicit instead of implicit.
+ * ru->feprx (nr_fep_tp) turns raw IQ into frequency-domain rxdataF; both LOCAL_RF and REMOTE_IF5
+ * always set it, so it's called unconditionally here.
  *
  * PRACH extraction is time-domain-only (rx_nr_prach_ru() needs raw ru->common.rxdata, which only
  * split 8 has - see nr_phy_init_RU()), hence the ru->common.rxdata guard below.
@@ -637,7 +644,7 @@ void ru_rx_slot(RU_t *ru, PHY_VARS_gNB *gNB, int frame_rx, int slot_rx)
                gNB->frame_parms.samples_per_slot_wCP,
                slot_rx * gNB->frame_parms.samples_per_slot_wCP);
 
-  if (ru->common.rxdata) {
+  if (ru->common.rxdata) { // time-domain IQ available: split 8 only, see comment above
     fsn_t now = {.f = frame_rx, .s = slot_rx, .mu = ru->nr_frame_parms->numerology_index};
     prach_item_t p;
     while (get_next_nr_prach(&gNB->prach_ru_queue, &now, &p)) {
@@ -653,8 +660,7 @@ void ru_rx_slot(RU_t *ru, PHY_VARS_gNB *gNB, int frame_rx, int slot_rx)
 }
 
 /* @brief hand the just-processed slot off to the gNB TX pipeline (tx_func() in nr-gnb.c), shared
- * by every RU southbound interface - both ru_thread() and split7_thread() (radio/fhi_72/
- * oran_isolate.c) call it. */
+ * by every RU southbound interface. */
 void ru_push_tx_job(PHY_VARS_gNB *gNB, int frame_tx, int slot_tx, int frame_rx, int slot_rx, uint64_t timestamp_tx)
 {
   notifiedFIFO_elt_t *resTx = newNotifiedFIFO_elt(sizeof(processingData_L1tx_t), 0, &gNB->L1_tx_out, NULL);
@@ -681,24 +687,13 @@ void *ru_thread(void *param)
   char               threadname[40];
 
   bool rx_tti_busy[RU_RX_SLOT_DEPTH] = {false};
-  int cpu = sched_getcpu();
-  if (ru->ru_thread_core > -1 && cpu != ru->ru_thread_core) {
-    /* we start the ru_thread using threadCreate(), which already sets CPU
-     * affinity; let's force it here again as per feature request #732 */
-    cpu_set_t cpuset;
-    CPU_ZERO(&cpuset);
-    CPU_SET(ru->ru_thread_core, &cpuset);
-    int ret = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
-    AssertFatal(ret == 0, "Error in pthread_getaffinity_np(): ret: %d, errno: %d", ret, errno);
-    LOG_I(PHY, "RU %d: manually set CPU affinity to CPU %d\n", ru->idx, ru->ru_thread_core);
-  }
 
   // set default return value
   ru_thread_status = 0;
   // set default return value
   sprintf(threadname,"ru_thread %u",ru->idx);
 
-  LOG_I(PHY,"Starting RU %d (%s,%s) on cpu %d\n",ru->idx,NB_functions[ru->function],NB_timing[ru->if_timing],cpu);
+  LOG_I(PHY,"Starting RU %d (%s,%s) on cpu %d\n",ru->idx,NB_functions[ru->function],NB_timing[ru->if_timing],sched_getcpu());
 
   LOG_I(PHY, "Signaling main thread that RU %d is ready, sl_ahead %d\n",ru->idx,ru->sl_ahead);
   pthread_mutex_lock(&RC.ru_mutex);
@@ -734,6 +729,9 @@ void *ru_thread(void *param)
         reset_meas(&ru->rx_fhaul);
         reset_meas(&ru->tx_fhaul);
     }
+    // IQ sample-clock bookkeeping: only meaningful when a real sample stream is being scheduled
+    // (LOCAL_RF/REMOTE_IF5). split 7.2 doesn't need this - see split7_thread() in
+    // radio/fhi_72/oran_isolate.c.
     proc->timestamp_tx = proc->timestamp_rx;
     for (int i = proc->tti_rx; i < proc->tti_rx + ru->sl_ahead; i++)
       proc->timestamp_tx += get_samples_per_slot(i % fp->slots_per_frame, fp);
@@ -769,12 +767,10 @@ void *ru_thread(void *param)
   return &ru_thread_status;
 }
 
-void configure_NR_RU(void)
+static void configure_NR_RU(RU_t *ru)
 {
-  RU_t *ru = RC.ru[0];
   NR_DL_FRAME_PARMS  *fp = ru->nr_frame_parms;
   PHY_VARS_gNB *gNB = RC.gNB[0];
-  int ret;
 
   ru->config = gNB->gNB_config;
   nr_init_frame_parms(&ru->config, fp);
@@ -782,23 +778,17 @@ void configure_NR_RU(void)
   nr_phy_init_RU(ru);
   fill_rf_config(ru, ru->rf_config_file);
   fill_split7_2_config(&ru->openair0_cfg.split7, &ru->config, fp);
+}
 
-  // Start IF device if any
-  if (ru->nr_start_if) {
+/* split 8 (LOCAL_RF / REMOTE_IF5): real IQ samples, either over a local RF device or an IF5
+ * transport, both openair0_device_t-shaped. Only called from start_NR_RU() below. */
+static void start_split8(RU_t *ru)
+{
+  int ret;
+  if (ru->if_south == REMOTE_IF5) {
     LOG_I(PHY, "starting transport\n");
     ret = openair0_transport_load(&ru->ifdevice, &ru->openair0_cfg);
     AssertFatal(ret == 0, "RU %u: openair0_transport_init() ret %d: cannot initialize transport protocol\n", ru->idx, ret);
-
-    if (ru->ifdevice.get_internal_parameter) {
-      /* it seems the device can "overwrite" (request?) to set the callbacks
-       * for fh_south_in()/fh_south_out() differently */
-      void *t = ru->ifdevice.get_internal_parameter("fh_if4p5_south_in");
-      if (t != NULL)
-        ru->fh_south_in = t;
-      t = ru->ifdevice.get_internal_parameter("fh_if4p5_south_out");
-      if (t != NULL)
-        ru->fh_south_out = t;
-    }
 
     LOG_I(PHY, "Starting IF interface for RU %d, nb_rx %d\n", ru->idx, ru->nb_rx);
     AssertFatal(ru->nr_start_if(ru) == 0, "Could not start the IF device\n");
@@ -806,6 +796,22 @@ void configure_NR_RU(void)
   } else if (ru->if_south == LOCAL_RF) { // configure RF parameters only
     ret = openair0_device_load(&ru->rfdevice,&ru->openair0_cfg);
     AssertFatal(ret==0,"Cannot connect to local radio\n");
+
+    if (ru->start_rf(ru) != 0)
+      LOG_E(HW, "Could not start the RF device\n");
+    else
+      LOG_I(PHY, "RU %d rf device ready\n", ru->idx);
+
+    // start trx write thread
+    if (usrp_tx_thread == 1) {
+      if (ru->start_write_thread) {
+        if (ru->start_write_thread(ru) != 0) {
+          LOG_E(HW, "Could not start tx write thread\n");
+        } else {
+          LOG_I(PHY, "tx write thread ready\n");
+        }
+      }
+    }
   }
 
   if (setup_RU_buffers(ru)!=0) {
@@ -813,26 +819,35 @@ void configure_NR_RU(void)
     exit(-1);
   }
 
-  // Start RF device if any
-  if (ru->start_rf) {
-    if (ru->start_rf(ru) != 0)
-      LOG_E(HW, "Could not start the RF device\n");
-    else
-      LOG_I(PHY, "RU %d rf device ready\n", ru->idx);
-  } else
-    LOG_I(PHY, "RU %d no rf device\n", ru->idx);
+  threadCreate(&ru->proc.pthread_FH, ru_thread, ru, "ru_thread", ru->ru_thread_core, OAI_PRIORITY_RT_MAX);
+}
 
-  LOG_I(PHY, "RU %d RF started cpu_meas_enabled %d\n", ru->idx, cpu_meas_enabled);
-  // start trx write thread
-  if (usrp_tx_thread == 1) {
-    if (ru->start_write_thread) {
-      if (ru->start_write_thread(ru) != 0) {
-        LOG_E(HW, "Could not start tx write thread\n");
-      } else {
-        LOG_I(PHY, "tx write thread ready\n");
-      }
-    }
-  }
+/* split 7.2 (REMOTE_IF4p5): O-RAN fronthaul over xran, deliberately NOT openair0_device_t-shaped -
+ * see fhi72_transport_t in radio/fhi_72/oran.h. Only called from start_NR_RU() below.
+ *
+ * oran_fhi72_init() spawns and owns the FH thread itself (split7_thread(), in
+ * radio/fhi_72/oran_isolate.c) - it has to: xran/DPDK set up per-lcore state tied to the calling
+ * thread, so oai_oran_initialize()/xran startup must run from that thread once it's pinned to its
+ * final core, and a dlopen()'d module can't hand a function pointer back across the boundary for
+ * us to threadCreate() here instead. That's also why RU buffers must be ready *before* this call:
+ * the thread starts reading/writing ru->common.* as soon as it's spawned. */
+static void start_split72(RU_t *ru)
+{
+  fhi72_init_t init = (fhi72_init_t)load_transport_shlib("oran_fhi72_init");
+  int ret = init(&ru->openair0_cfg, ru, &fhi72_transport);
+  AssertFatal(ret == 0, "RU %u: cannot initialize O-RAN 7.2 fronthaul\n", ru->idx);
+}
+
+/* @brief start the RU: dispatches on ru->if_south to the split-specific startup, so callers
+ * (nr-softmodem.c) don't need to know split 7.2 exists. */
+void start_NR_RU(void)
+{
+  RU_t *ru = RC.ru[0];
+  configure_NR_RU(ru);
+  if (ru->if_south == REMOTE_IF4p5)
+    start_split72(ru);
+  else
+    start_split8(ru);
 }
 
 int start_streaming(RU_t *ru) {
@@ -842,9 +857,8 @@ int start_streaming(RU_t *ru) {
 
 int nr_start_if(struct RU_t_s *ru)
 {
-  if (ru->if_south <= REMOTE_IF5)
-    for (int i = 0; i < ru->nb_rx; i++)
-      ru->openair0_cfg.rxbase[i] = ru->common.rxdata[i];
+  for (int i = 0; i < ru->nb_rx; i++)
+    ru->openair0_cfg.rxbase[i] = ru->common.rxdata[i];
   ru->openair0_cfg.rxsize = ru->nr_frame_parms->samples_per_subframe*10;
   return ru->ifdevice.trx_start_func(&ru->ifdevice);
 }
@@ -887,7 +901,18 @@ void kill_NR_RU_proc(int inst) {
   pthread_mutex_unlock(proc->mutex_fep);
   pthread_join(proc->pthread_FH, NULL);
 
-  // everything should be stopped now, we can safely stop the RF device
+  // everything should be stopped now, we can safely stop the RF/transport device
+  if (ru->if_south == REMOTE_IF4p5) {
+    if (fhi72_transport.get_stats)
+      fhi72_transport.get_stats(&fhi72_transport);
+    if (fhi72_transport.stop)
+      fhi72_transport.stop(&fhi72_transport);
+    if (fhi72_transport.end)
+      fhi72_transport.end(&fhi72_transport);
+    LOG_I(PHY, "RU %d O-RAN 7.2 fronthaul stopped\n", ru->idx);
+    return;
+  }
+
   if (ru->stop_rf == NULL) {
     LOG_W(PHY, "No stop_rf() for RU %d defined, cannot stop RF!\n", ru->idx);
     return;
@@ -930,15 +955,8 @@ void set_function_spec_param(RU_t *ru)
       break;
 
     case REMOTE_IF4p5:
-      ru->feprx = NULL; // DFTs
-      ru->feptx_prec = nr_feptx_prec; // Precoding operation
-      ru->feptx_ofdm = NULL; // no OFDM mod
-      ru->fh_south_in = NULL;
-      ru->fh_south_out = NULL;
-      ru->start_rf = NULL; // no local RF
-      ru->stop_rf = NULL;
-      ru->start_write_thread = NULL;
-      ru->nr_start_if = nr_start_if; // need to start if interface for IF4p5
+      // Nothing to set here: split 7.2 doesn't use any of the ru-> function-pointer fields above
+      // (start_split72()/oran_fhi72_init() wire up its own path instead, see start_NR_RU() below).
       break;
 
     default:
@@ -1027,12 +1045,6 @@ void init_NR_RU(configmodule_interface_t *cfg, char *rf_config_file)
   } // for ru_id
 
   LOG_D(HW,"[nr-softmodem.c] RU threads created\n");
-}
-
-void start_NR_RU()
-{
-  RU_t *ru = RC.ru[0];
-  threadCreate(&ru->proc.pthread_FH, ru_thread, ru, "ru_thread", ru->ru_thread_core, OAI_PRIORITY_RT_MAX);
 }
 
 void stop_RU(int nb_ru) {

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -619,66 +619,29 @@ void *ru_thread(void *param)
   RU_proc_t          *proc    = &ru->proc;
   NR_DL_FRAME_PARMS  *fp      = ru->nr_frame_parms;
   PHY_VARS_gNB *gNB = RC.gNB[0]; // this RU main loop handes only one RU
-  int                ret;
   int                slot     = fp->slots_per_frame-1;
   int                frame    = 1023;
   char               threadname[40];
 
   bool rx_tti_busy[RU_RX_SLOT_DEPTH] = {false};
+  int cpu = sched_getcpu();
+  if (ru->ru_thread_core > -1 && cpu != ru->ru_thread_core) {
+    /* we start the ru_thread using threadCreate(), which already sets CPU
+     * affinity; let's force it here again as per feature request #732 */
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(ru->ru_thread_core, &cpuset);
+    int ret = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+    AssertFatal(ret == 0, "Error in pthread_getaffinity_np(): ret: %d, errno: %d", ret, errno);
+    LOG_I(PHY, "RU %d: manually set CPU affinity to CPU %d\n", ru->idx, ru->ru_thread_core);
+  }
+
   // set default return value
   ru_thread_status = 0;
   // set default return value
   sprintf(threadname,"ru_thread %u",ru->idx);
-  LOG_I(PHY,"Starting RU %d (%s,%s) on cpu %d\n",ru->idx,NB_functions[ru->function],NB_timing[ru->if_timing],sched_getcpu());
-  ru->config = gNB->gNB_config;
 
-  nr_init_frame_parms(&ru->config, fp);
-  nr_dump_frame_parms(fp);
-  nr_phy_init_RU(ru);
-  fill_rf_config(ru, ru->rf_config_file);
-  fill_split7_2_config(&ru->openair0_cfg.split7, &ru->config, fp);
-
-  // Start IF device if any
-  if (ru->nr_start_if) {
-    LOG_I(PHY, "starting transport\n");
-    ret = openair0_transport_load(&ru->ifdevice, &ru->openair0_cfg);
-    AssertFatal(ret == 0, "RU %u: openair0_transport_init() ret %d: cannot initialize transport protocol\n", ru->idx, ret);
-
-    if (ru->ifdevice.get_internal_parameter) {
-      /* it seems the device can "overwrite" (request?) to set the callbacks
-       * for fh_south_in()/fh_south_out() differently */
-      void *t = ru->ifdevice.get_internal_parameter("fh_if4p5_south_in");
-      if (t != NULL)
-        ru->fh_south_in = t;
-      t = ru->ifdevice.get_internal_parameter("fh_if4p5_south_out");
-      if (t != NULL)
-        ru->fh_south_out = t;
-    }
-
-    int cpu = sched_getcpu();
-    if (ru->ru_thread_core > -1 && cpu != ru->ru_thread_core) {
-      /* we start the ru_thread using threadCreate(), which already sets CPU
-       * affinity; let's force it here again as per feature request #732 */
-      cpu_set_t cpuset;
-      CPU_ZERO(&cpuset);
-      CPU_SET(ru->ru_thread_core, &cpuset);
-      int ret = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
-      AssertFatal(ret == 0, "Error in pthread_getaffinity_np(): ret: %d, errno: %d", ret, errno);
-      LOG_I(PHY, "RU %d: manually set CPU affinity to CPU %d\n", ru->idx, ru->ru_thread_core);
-    }
-
-    LOG_I(PHY, "Starting IF interface for RU %d, nb_rx %d\n", ru->idx, ru->nb_rx);
-    AssertFatal(ru->nr_start_if(ru) == 0, "Could not start the IF device\n");
-
-  } else if (ru->if_south == LOCAL_RF) { // configure RF parameters only
-    ret = openair0_device_load(&ru->rfdevice,&ru->openair0_cfg);
-    AssertFatal(ret==0,"Cannot connect to local radio\n");
-  }
-
-  if (setup_RU_buffers(ru)!=0) {
-    LOG_E(PHY, "Exiting, cannot initialize RU Buffers\n");
-    exit(-1);
-  }
+  LOG_I(PHY,"Starting RU %d (%s,%s) on cpu %d\n",ru->idx,NB_functions[ru->function],NB_timing[ru->if_timing],cpu);
 
   LOG_I(PHY, "Signaling main thread that RU %d is ready, sl_ahead %d\n",ru->idx,ru->sl_ahead);
   pthread_mutex_lock(&RC.ru_mutex);
@@ -686,27 +649,6 @@ void *ru_thread(void *param)
   pthread_cond_signal(&RC.ru_cond);
   pthread_mutex_unlock(&RC.ru_mutex);
   wait_sync("ru_thread");
-
-  // Start RF device if any
-  if (ru->start_rf) {
-    if (ru->start_rf(ru) != 0)
-      LOG_E(HW, "Could not start the RF device\n");
-    else
-      LOG_I(PHY, "RU %d rf device ready\n", ru->idx);
-  } else
-    LOG_I(PHY, "RU %d no rf device\n", ru->idx);
-
-  LOG_I(PHY, "RU %d RF started cpu_meas_enabled %d\n", ru->idx, cpu_meas_enabled);
-  // start trx write thread
-  if (usrp_tx_thread == 1) {
-    if (ru->start_write_thread) {
-      if (ru->start_write_thread(ru) != 0) {
-        LOG_E(HW, "Could not start tx write thread\n");
-      } else {
-        LOG_I(PHY, "tx write thread ready\n");
-      }
-    }
-  }
 
   // This is a forever while loop, it loops over subframes which are scheduled by incoming samples from HW devices
   struct timespec slot_start;
@@ -802,6 +744,72 @@ void *ru_thread(void *param)
 
   ru_thread_status = 0;
   return &ru_thread_status;
+}
+
+void configure_NR_RU(void)
+{
+  RU_t *ru = RC.ru[0];
+  NR_DL_FRAME_PARMS  *fp = ru->nr_frame_parms;
+  PHY_VARS_gNB *gNB = RC.gNB[0];
+  int ret;
+
+  ru->config = gNB->gNB_config;
+  nr_init_frame_parms(&ru->config, fp);
+  nr_dump_frame_parms(fp);
+  nr_phy_init_RU(ru);
+  fill_rf_config(ru, ru->rf_config_file);
+  fill_split7_2_config(&ru->openair0_cfg.split7, &ru->config, fp);
+
+  // Start IF device if any
+  if (ru->nr_start_if) {
+    LOG_I(PHY, "starting transport\n");
+    ret = openair0_transport_load(&ru->ifdevice, &ru->openair0_cfg);
+    AssertFatal(ret == 0, "RU %u: openair0_transport_init() ret %d: cannot initialize transport protocol\n", ru->idx, ret);
+
+    if (ru->ifdevice.get_internal_parameter) {
+      /* it seems the device can "overwrite" (request?) to set the callbacks
+       * for fh_south_in()/fh_south_out() differently */
+      void *t = ru->ifdevice.get_internal_parameter("fh_if4p5_south_in");
+      if (t != NULL)
+        ru->fh_south_in = t;
+      t = ru->ifdevice.get_internal_parameter("fh_if4p5_south_out");
+      if (t != NULL)
+        ru->fh_south_out = t;
+    }
+
+    LOG_I(PHY, "Starting IF interface for RU %d, nb_rx %d\n", ru->idx, ru->nb_rx);
+    AssertFatal(ru->nr_start_if(ru) == 0, "Could not start the IF device\n");
+
+  } else if (ru->if_south == LOCAL_RF) { // configure RF parameters only
+    ret = openair0_device_load(&ru->rfdevice,&ru->openair0_cfg);
+    AssertFatal(ret==0,"Cannot connect to local radio\n");
+  }
+
+  if (setup_RU_buffers(ru)!=0) {
+    LOG_E(PHY, "Exiting, cannot initialize RU Buffers\n");
+    exit(-1);
+  }
+
+  // Start RF device if any
+  if (ru->start_rf) {
+    if (ru->start_rf(ru) != 0)
+      LOG_E(HW, "Could not start the RF device\n");
+    else
+      LOG_I(PHY, "RU %d rf device ready\n", ru->idx);
+  } else
+    LOG_I(PHY, "RU %d no rf device\n", ru->idx);
+
+  LOG_I(PHY, "RU %d RF started cpu_meas_enabled %d\n", ru->idx, cpu_meas_enabled);
+  // start trx write thread
+  if (usrp_tx_thread == 1) {
+    if (ru->start_write_thread) {
+      if (ru->start_write_thread(ru) != 0) {
+        LOG_E(HW, "Could not start tx write thread\n");
+      } else {
+        LOG_I(PHY, "tx write thread ready\n");
+      }
+    }
+  }
 }
 
 int start_streaming(RU_t *ru) {

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -612,6 +612,62 @@ static bool wait_free_rx_tti(notifiedFIFO_t *L1_rx_out, bool rx_tti_busy[RU_RX_S
   return true;
 }
 
+/* @brief RX-side per-slot handling: front-end processing, scope-copy, PRACH extraction. Factored
+ * out of ru_thread() so it can be reused as-is by an upcoming second RU southbound interface that
+ * needs the same handling but not the surrounding IQ sample-clock bookkeeping.
+ *
+ * ru->feprx is called unconditionally now: previously, scope-copy and PRACH extraction lived
+ * inside the "if (ru->feprx)" branch, which meant a southbound interface without a front-end DFT
+ * step (none exists yet, but one is coming) would accidentally skip both, even though rxdataF is
+ * valid either way. The ru->common.rxdata guard below is the one genuinely split-specific check
+ * that remains: not every interface will have full-rate time-domain IQ to extract PRACH from.
+ */
+static void ru_rx_slot(RU_t *ru, PHY_VARS_gNB *gNB, int frame_rx, int slot_rx)
+{
+  ru->feprx(ru, slot_rx);
+
+  LOG_D(NR_PHY, "Setting %d.%d (%d) to busy\n", frame_rx, slot_rx, slot_rx % RU_RX_SLOT_DEPTH);
+  LOG_D(PHY, "RU proc: frame_rx = %d, tti_rx = %d\n", frame_rx, slot_rx);
+  gNBscopeCopy(gNB,
+               gNBRxdataF,
+               ru->common.rxdataF[0],
+               sizeof(c16_t),
+               1,
+               gNB->frame_parms.samples_per_slot_wCP,
+               slot_rx * gNB->frame_parms.samples_per_slot_wCP);
+
+  if (ru->common.rxdata) {
+    fsn_t now = {.f = frame_rx, .s = slot_rx, .mu = ru->nr_frame_parms->numerology_index};
+    prach_item_t p;
+    while (get_next_nr_prach(&gNB->prach_ru_queue, &now, &p)) {
+      // need to extract RACH data for later processing by rx_nr_prach()
+      rx_nr_prach_ru(&p, ru->common.rxdata, ru->nr_frame_parms, ru->N_TA_offset, gNB->enable_analog_das);
+      bool success = spsc_q_put(&gNB->prach_l1rx_queue, &p, sizeof(p));
+      // assume prach_l1rx_queue never full: prach_ru_queue filled at
+      // constant pace, but prach_l1rx_queue emptied as fast as possible,
+      // see rx_func()
+      DevAssert(success);
+    }
+  }
+}
+
+/* @brief hand the just-processed slot off to the gNB TX pipeline (tx_func() in nr-gnb.c). Factored
+ * out of ru_thread() alongside ru_rx_slot() for the same reason - reusable as-is by an upcoming
+ * second RU southbound interface. */
+static void ru_push_tx_job(PHY_VARS_gNB *gNB, int frame_tx, int slot_tx, int frame_rx, int slot_rx, uint64_t timestamp_tx)
+{
+  notifiedFIFO_elt_t *resTx = newNotifiedFIFO_elt(sizeof(processingData_L1tx_t), 0, &gNB->L1_tx_out, NULL);
+  resTx->key = slot_tx;
+  processingData_L1tx_t *syncMsgTx = NotifiedFifoData(resTx);
+  *syncMsgTx = (processingData_L1tx_t){.gNB = gNB,
+                                       .frame = frame_tx,
+                                       .slot = slot_tx,
+                                       .frame_rx = frame_rx,
+                                       .slot_rx = slot_rx,
+                                       .timestamp_tx = timestamp_tx};
+  pushNotifiedFIFO(&gNB->L1_tx_out, resTx);
+}
+
 void *ru_thread(void *param)
 {
   static int ru_thread_status;
@@ -702,44 +758,10 @@ void *ru_thread(void *param)
     if (slot_type == NR_UPLINK_SLOT || slot_type == NR_MIXED_SLOT) {
       if (!wait_free_rx_tti(&gNB->L1_rx_out, rx_tti_busy, proc->frame_rx, proc->tti_rx))
         break; // nothing to wait for: we have to stop
-      if (ru->feprx) {
-        ru->feprx(ru,proc->tti_rx);
-        LOG_D(NR_PHY, "Setting %d.%d (%d) to busy\n", proc->frame_rx, proc->tti_rx, proc->tti_rx % RU_RX_SLOT_DEPTH);
-        //LOG_M("rxdata.m","rxs",ru->common.rxdata[0],1228800,1,1);
-        LOG_D(PHY,"RU proc: frame_rx = %d, tti_rx = %d\n", proc->frame_rx, proc->tti_rx);
-        gNBscopeCopy(gNB,
-                     gNBRxdataF,
-                     ru->common.rxdataF[0],
-                     sizeof(c16_t),
-                     1,
-                     gNB->frame_parms.samples_per_slot_wCP,
-                     proc->tti_rx * gNB->frame_parms.samples_per_slot_wCP);
+      ru_rx_slot(ru, gNB, proc->frame_rx, proc->tti_rx);
+    }
 
-        // Do PRACH RU processing
-        fsn_t now = {.f = proc->frame_rx, .s = proc->tti_rx, .mu = fp->numerology_index};
-        prach_item_t p;
-        while (get_next_nr_prach(&gNB->prach_ru_queue, &now, &p)) {
-          // need to extract RACH data for later processing by rx_nr_prach()
-          rx_nr_prach_ru(&p, ru->common.rxdata, ru->nr_frame_parms, ru->N_TA_offset, gNB->enable_analog_das);
-          bool success = spsc_q_put(&gNB->prach_l1rx_queue, &p, sizeof(p));
-          // assume prach_l1rx_queue never full: prach_ru_queue filled at
-          // constant pace, but prach_l1rx_queue emptied as fast as possible,
-          // see rx_func()
-          DevAssert(success);
-        } // end if (prach_id >= 0)
-      } // end if (ru->feprx)
-    } // end if (slot_type == NR_UPLINK_SLOT || slot_type == NR_MIXED_SLOT) {
-
-    notifiedFIFO_elt_t *resTx = newNotifiedFIFO_elt(sizeof(processingData_L1tx_t), 0, &gNB->L1_tx_out, NULL);
-    resTx->key = proc->tti_tx;
-    processingData_L1tx_t *syncMsgTx = NotifiedFifoData(resTx);
-    *syncMsgTx = (processingData_L1tx_t){.gNB = gNB,
-                                         .frame = proc->frame_tx,
-                                         .slot = proc->tti_tx,
-                                         .frame_rx = proc->frame_rx,
-                                         .slot_rx = proc->tti_rx,
-                                         .timestamp_tx = proc->timestamp_tx};
-    pushNotifiedFIFO(&gNB->L1_tx_out, resTx);
+    ru_push_tx_job(gNB, proc->frame_tx, proc->tti_tx, proc->frame_rx, proc->tti_rx, proc->timestamp_tx);
   }
 
   ru_thread_status = 0;

--- a/executables/nr-softmodem.c
+++ b/executables/nr-softmodem.c
@@ -425,6 +425,7 @@ int start_L1L2(module_id_t gnb_id)
 
   init_NR_RU(config_get_if(), NULL);
 
+  configure_NR_RU();
   start_NR_RU();
   wait_RUs();
   init_eNB_afterRU();
@@ -641,8 +642,10 @@ int main( int argc, char **argv ) {
   if (NFAPI_MODE != NFAPI_MODE_PNF && (NODE_IS_DU(node_type) || NODE_IS_MONOLITHIC(node_type)))
     wait_f1_setup_response();
 
-  if (RC.nb_RU > 0)
+  if (RC.nb_RU > 0) {
+    configure_NR_RU();
     start_NR_RU();
+  }
 
   if (NFAPI_MODE == NFAPI_MODE_PNF) {
     wait_RUs();

--- a/executables/nr-softmodem.c
+++ b/executables/nr-softmodem.c
@@ -425,7 +425,6 @@ int start_L1L2(module_id_t gnb_id)
 
   init_NR_RU(config_get_if(), NULL);
 
-  configure_NR_RU();
   start_NR_RU();
   wait_RUs();
   init_eNB_afterRU();
@@ -642,10 +641,8 @@ int main( int argc, char **argv ) {
   if (NFAPI_MODE != NFAPI_MODE_PNF && (NODE_IS_DU(node_type) || NODE_IS_MONOLITHIC(node_type)))
     wait_f1_setup_response();
 
-  if (RC.nb_RU > 0) {
-    configure_NR_RU();
+  if (RC.nb_RU > 0)
     start_NR_RU();
-  }
 
   if (NFAPI_MODE == NFAPI_MODE_PNF) {
     wait_RUs();

--- a/executables/nr-softmodem.h
+++ b/executables/nr-softmodem.h
@@ -60,11 +60,11 @@ extern void stop_gNB(int);
 
 // In nr-ru.c
 extern void init_NR_RU(configmodule_interface_t *cfg, char *);
-extern void configure_NR_RU(void);
 extern void start_NR_RU(void);
 extern void stop_RU(int nb_ru);
 extern void kill_NR_RU_proc(int inst);
 extern void set_function_spec_param(RU_t *ru);
+extern void ru_tx_func(void *param);
 
 void init_eNB_afterRU(void);
 

--- a/executables/nr-softmodem.h
+++ b/executables/nr-softmodem.h
@@ -60,6 +60,7 @@ extern void stop_gNB(int);
 
 // In nr-ru.c
 extern void init_NR_RU(configmodule_interface_t *cfg, char *);
+extern void configure_NR_RU(void);
 extern void start_NR_RU(void);
 extern void stop_RU(int nb_ru);
 extern void kill_NR_RU_proc(int inst);

--- a/openair1/PHY/defs_RU.h
+++ b/openair1/PHY/defs_RU.h
@@ -601,11 +601,11 @@ typedef struct RU_t_s {
 } RU_t;
 
 /* ru_rx_slot(): RX-side per-slot handling (front-end processing, scope-copy, PRACH extraction)
- * for split 8's ru_thread() only - split 7.2's split7_thread() (radio/fhi_72/oran_isolate.c) has
- * no time-domain front-end step and doesn't call it.
+ * for split 8's ru_thread() only - split 7.2 has no time-domain front-end step and doesn't call
+ * it (see split7_thread() in radio/fhi_72/oran_isolate.c).
  *
- * ru_push_tx_job(): hands the just-processed slot to the gNB TX pipeline, shared by every RU
- * southbound interface - both ru_thread() and split7_thread() call it.
+ * ru_push_tx_job(): hands the just-processed slot to the gNB TX pipeline, genuinely shared by
+ * every RU southbound interface - both ru_thread() and split7_thread() call it.
  *
  * Both defined in executables/nr-ru.c. */
 void ru_rx_slot(RU_t *ru, struct PHY_VARS_gNB_s *gNB, int frame_rx, int slot_rx);

--- a/openair1/PHY/defs_RU.h
+++ b/openair1/PHY/defs_RU.h
@@ -600,6 +600,17 @@ typedef struct RU_t_s {
   void* scopeData;
 } RU_t;
 
+/* ru_rx_slot(): RX-side per-slot handling (front-end processing, scope-copy, PRACH extraction)
+ * for split 8's ru_thread() only - split 7.2's split7_thread() (radio/fhi_72/oran_isolate.c) has
+ * no time-domain front-end step and doesn't call it.
+ *
+ * ru_push_tx_job(): hands the just-processed slot to the gNB TX pipeline, shared by every RU
+ * southbound interface - both ru_thread() and split7_thread() call it.
+ *
+ * Both defined in executables/nr-ru.c. */
+void ru_rx_slot(RU_t *ru, struct PHY_VARS_gNB_s *gNB, int frame_rx, int slot_rx);
+void ru_push_tx_job(struct PHY_VARS_gNB_s *gNB, int frame_tx, int slot_tx, int frame_rx, int slot_rx, uint64_t timestamp_tx);
+
 
 typedef enum {
   RAU_tick=0,

--- a/radio/COMMON/common_lib.c
+++ b/radio/COMMON/common_lib.c
@@ -143,6 +143,18 @@ int openair0_transport_load(openair0_device_t *device, openair0_config_t *openai
   return rc;
 }
 
+void *load_transport_shlib(char *fname)
+{
+  char *devname = NULL;
+  paramdef_t device_params = {"name", CONFIG_HLP_DEVICE, 0, .strptr = &devname, .defstrval = OAI_TP_LIBNAME, TYPE_STRING, 0};
+  config_get(config_get_if(), &device_params, 1, DEVICE_SECTION);
+
+  loader_shlibfunc_t shlib_fdesc = {.fname = fname};
+  int ret = load_module_shlib(devname, &shlib_fdesc, 1, NULL);
+  AssertFatal(ret >= 0, "Library %s couldn't be loaded\n", devname);
+  return shlib_fdesc.fptr;
+}
+
 static void writerEnqueue(re_order_t *ctx, openair0_timestamp_t timestamp, void **txp, int nsamps, int nbAnt, int flags)
 {
   pthread_mutex_lock(&ctx->mutex_store);

--- a/radio/COMMON/common_lib.h
+++ b/radio/COMMON/common_lib.h
@@ -635,6 +635,14 @@ int openair0_device_load(openair0_device_t *device, openair0_config_t *openair0_
 /*! \brief Initialize transport protocol . It returns 0 if OK */
 int openair0_transport_load(openair0_device_t *device, openair0_config_t *openair0_cfg);
 
+/*! \brief Look up and dlopen the configured "device.name" shared lib (same shared-lib/config
+ *  convention as openair0_device_load()/openair0_transport_load()), and return the raw function
+ *  pointer for the requested exported symbol. Unlike the two functions above, this does not
+ *  assume an openair0_device_t-shaped init function - the caller casts the result to whatever
+ *  signature that symbol actually has. Used by transports that aren't RF/IQ devices, e.g. the
+ *  O-RAN 7.2 fronthaul in radio/fhi_72 (see fhi72_init_t in radio/fhi_72/oran.h). */
+void *load_transport_shlib(char *fname);
+
 /*! \brief Set RX frequencies
  * \param device the hardware to use
  * \param openair0_cfg RF frontend parameters set by application

--- a/radio/fhi_72/README.md
+++ b/radio/fhi_72/README.md
@@ -13,7 +13,7 @@ The main source files and their purpose are as follows:
 - `oran_isolate.c`: main entry point and definition of function pointers for OAI
   callbacks.
 
-The entry point for the driver library is `transport_init()` in `oran_isolate.c`.
+The entry point for the driver library is `oran_fhi72_init()` in `oran_isolate.c`.
 This function is concerned with setting necessary function pointers for OAI
 integration, and prepares xran configuration through `get_xran_config()`. This
 function reads 7.2 specific configuration and deduces some of the parameters

--- a/radio/fhi_72/oaioran.c
+++ b/radio/fhi_72/oaioran.c
@@ -445,35 +445,16 @@ static bool is_tdd_ul_symbol(const struct xran_frame_config *frame_conf, int slo
   return frame_conf->sSlotConfig[slot_in_period].nSymbolType[sym_idx] == 1 /* UL */;
 }
 
-/** @brief Check if symbol in slot is DL.
- *
- * @param frame_conf xran frame configuration
- * @param slot the current (absolute) slot (number)
- * @param sym_idx the current symbol index */
-static bool is_tdd_dl_symbol(const struct xran_frame_config *frame_conf, int slot, int sym_idx)
-{
-  int tdd_period = frame_conf->nTddPeriod;
-  int slot_in_period = slot % tdd_period;
-  /* check if symbol is UL */
-  return frame_conf->sSlotConfig[slot_in_period].nSymbolType[sym_idx] == 0 /* DL */;
-}
-
-/** @brief Check if current slot is guard/mixed */
-static bool is_tdd_guard_slot(const struct xran_frame_config *frame_conf, int slot)
-{
-  return (is_tdd_dl_symbol(frame_conf, slot, 0) && is_tdd_ul_symbol(frame_conf, slot,  XRAN_NUM_OF_SYMBOL_PER_SLOT - 1));
-}
-
 /** @brief Check if current slot is DL or guard/mixed without UL (i.e., current
  * slot is not UL). */
-static bool is_tdd_dl_guard_slot(const struct xran_frame_config *frame_conf, int slot)
+bool is_tdd_dl_guard_slot(const struct xran_frame_config *frame_conf, int slot)
 {
   return !is_tdd_ul_symbol(frame_conf, slot, 0);
 }
 
-/** @brief Check if current slot is UL or guard/mixed without UL (i.e., current
+/** @brief Check if current slot is UL or guard/mixed without DL (i.e., current
  * slot is not UL). */
-static bool is_tdd_ul_guard_slot(const struct xran_frame_config *frame_conf, int slot)
+bool is_tdd_ul_guard_slot(const struct xran_frame_config *frame_conf, int slot)
 {
   return is_tdd_ul_symbol(frame_conf, slot, XRAN_NUM_OF_SYMBOL_PER_SLOT - 1);
 }
@@ -641,211 +622,123 @@ int xran_fh_rx_read_slot(ru_info_t *ru, int *frame, int *slot)
   return (0);
 }
 
+// Send CP DL/UL packets
+int xran_send_cp_slot(const uint8_t nb_ant, uint16_t **beams, const int tti, const int slot, struct xran_buffer_list buf[XRAN_MAX_ANTENNA_NR][XRAN_N_FE_BUF_LEN])
+{
+  for (uint8_t ant_id = 0; ant_id < nb_ant; ant_id++) {
+    struct xran_prb_map *pPrbMap = (struct xran_prb_map *)buf[ant_id][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
+    // (1) nPrbElm is the number of fragments; (2) For Liteon FR2 with RunSlotPrbMapBySymbolEnable each idxElm matches to one symbol
+    LOG_D(HW, "pPrbMap->nPrbElm %d\n", pPrbMap->nPrbElm);
+    for (uint32_t idxElm = 0; idxElm < pPrbMap->nPrbElm; idxElm++) {
+      struct xran_prb_elm *pRbElm = &pPrbMap->prbMap[idxElm];
+      int numRB = pRbElm->UP_nRBSize;
+      int startRB = pRbElm->UP_nRBStart;
+      LOG_D(HW, "pPrbMap[%d] : PRBstart %d nPRBs %d\n", idxElm, startRB, numRB);
+
+      for (int32_t sym_idx = pRbElm->nStartSymb; sym_idx < pRbElm->nStartSymb + pRbElm->numSymb; sym_idx++) {
+        LOG_D(HW, "ant_id %d sym_idx %d pPrbMap[%d] (startRB %d numRB %d)\n", ant_id, sym_idx, idxElm, startRB, numRB);
+	pRbElm->nBeamIndex = beams[slot * XRAN_NUM_OF_SYMBOL_PER_SLOT + sym_idx][ant_id];
+      }
+    }
+  }
+  return (0);
+}
+
 /** @details Write PDSCH IQ-data from OAI txdataF_BF buffer to xran buffers. If
  * I/Q compression (bitwidth < 16 bits) is configured, compresses the data
  * before writing. */
-int xran_fh_tx_send_slot(ru_info_t *ru, int frame, int slot, uint64_t timestamp)
+int xran_fh_tx_send_slot(int32_t **txdataF_BF, const int fft_size, const uint8_t nb_ant, const int tti, oran_buf_list_t *bufs)
 {
-  void *ptr = NULL;
   int32_t *pos = NULL;
   int idx = 0;
 
-  const struct xran_fh_init *fh_init = get_xran_fh_init();
-  const struct xran_fh_config *fh_cfg = get_xran_fh_config(0);
-  uint8_t mu_number = fh_cfg->mu_number[0];
-  int fftsize = 1 << fh_cfg->perMu[mu_number].nDLFftSize;
-  int slots_per_frame = 10 << mu_number;
-  int tti = slots_per_frame * frame + slot;
-  int nb_tx_per_ru = ru->nb_tx / fh_init->xran_ports;
-  int nb_rx_per_ru = ru->nb_rx / fh_init->xran_ports;
+  for (uint8_t ant_id = 0; ant_id < nb_ant; ant_id++) {
+    struct xran_prb_map *pPrbMap = (struct xran_prb_map *)bufs->srccp[ant_id][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
+    // even when the fragmentation occurs, nRBSize & nRBStart carry the same values in each prbMap
+    // therefore, I took the liberty to just extract these values from the first prbMap
+    int num_totalRB = pPrbMap->prbMap[0].nRBSize;
+    int start_totalRB = pPrbMap->prbMap[0].nRBStart;
 
-  // Handle CP UL packet here instead of at xran_fh_rx_read_slot() as oran_fh_if4p5_south_in() lags behind
-  // oran_fh_if4p5_south_out() (which is invoked at the right time slot) by 4 slots.
-  // Need to use --continuous-tx so that this routine will be triggered in RX slot.
-  for (uint16_t cc_id = 0; cc_id < 1 /*nSectorNum*/; cc_id++) { // OAI does not support multiple CC yet.
-    for (uint8_t ant_id = 0; ant_id < ru->nb_rx; ant_id++) {
-      const struct xran_frame_config *frame_conf = &get_xran_fh_config(ant_id / nb_rx_per_ru)->frame_conf;
-      // skip processing this slot is TX (no RX in this slot)
-      if (frame_conf->nFrameDuplexType != XRAN_FDD && !is_tdd_ul_guard_slot(frame_conf, slot)) {
-        continue;
-      }
-      // This loop would better be more inner to avoid confusion and maybe also errors.
-      for (int32_t sym_idx = 0; sym_idx < XRAN_NUM_OF_SYMBOL_PER_SLOT; sym_idx++) {
-        /* skip DL and guard symbols. */
-        if (frame_conf->nFrameDuplexType != XRAN_FDD && !is_tdd_ul_symbol(frame_conf, slot, sym_idx)) {
-          continue;
+    for (uint32_t idxElm = 0; idxElm < pPrbMap->nPrbElm; idxElm++) {
+      struct xran_prb_elm *p_prbMapElm = &pPrbMap->prbMap[idxElm];
+      int16_t startRB = p_prbMapElm->UP_nRBStart;
+      int16_t numRB = p_prbMapElm->UP_nRBSize;
+
+      for (int32_t sym_idx = p_prbMapElm->nStartSymb; sym_idx < p_prbMapElm->nStartSymb + p_prbMapElm->numSymb; sym_idx++) {
+        uint8_t *dst = bufs->src[ant_id][tti % XRAN_N_FE_BUF_LEN].pBuffers[sym_idx % XRAN_NUM_OF_SYMBOL_PER_SLOT].pData;
+        pos = &txdataF_BF[ant_id][sym_idx * fft_size];
+
+        uint8_t *u8dptr = dst;
+        int16_t payload_len = 0;
+
+        // application layer fragmentation supported
+        struct xran_section_desc *p_sec_desc = &p_prbMapElm->sec_desc[sym_idx];
+        if (p_sec_desc == NULL) {
+          printf("p_sec_desc == NULL\n");
+          exit(-1);
         }
-        oran_buf_list_t *bufs = get_xran_buffers(ant_id / nb_rx_per_ru);
-        uint8_t *pPrbMapData = bufs->dstcp[ant_id % nb_rx_per_ru][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
-        struct xran_prb_map *pPrbMap = (struct xran_prb_map *)pPrbMapData;
 
-        LOG_D(HW, "pPrbMap->nPrbElm %d\n", pPrbMap->nPrbElm);
-        for (uint32_t idxElm = 0; idxElm < pPrbMap->nPrbElm; idxElm++) {
-          struct xran_section_desc *p_sec_desc = NULL;
-          struct xran_prb_elm *pRbElm = &pPrbMap->prbMap[idxElm];
-          int numRB, startRB;
-          numRB = pRbElm->UP_nRBSize;
-          startRB = pRbElm->UP_nRBStart;
-          p_sec_desc = &pRbElm->sec_desc[sym_idx];
-          LOG_D(HW, "pPrbMap[%d] : PRBstart %d nPRBs %d\n", idxElm, startRB, numRB);
-          // For Liteon FR2 with RunSlotPrbMapBySymbolEnable xran_prb_map will have xran_prb_elm prbMap[14], each idxElm matches to sym_idx.
-          if (fh_cfg->RunSlotPrbMapBySymbolEnable && (sym_idx < pRbElm->nStartSymb || sym_idx >= pRbElm->nStartSymb + pRbElm->numSymb) && !p_sec_desc->pCtrl)
-            continue;
+        dst = xran_add_hdr_offset(dst, p_prbMapElm->compMethod);
 
-          pRbElm->nBeamIndex = ru->beam_id[slot * XRAN_NUM_OF_SYMBOL_PER_SLOT + sym_idx][ant_id];
-        }
-      }
-    }
-  }
+        uint16_t *dst16 = (uint16_t *)dst;
 
-  for (uint16_t cc_id = 0; cc_id < 1 /*nSectorNum*/; cc_id++) { // OAI does not support multiple CC yet.
-    for (uint8_t ant_id = 0; ant_id < ru->nb_tx; ant_id++) {
-      oran_buf_list_t *bufs = get_xran_buffers(ant_id / nb_tx_per_ru);
-      const struct xran_frame_config *frame_conf = &get_xran_fh_config(ant_id / nb_tx_per_ru)->frame_conf;
-      // skip processing this slot is TX (no TX in this slot)
-      if (frame_conf->nFrameDuplexType != XRAN_FDD && !is_tdd_dl_guard_slot(frame_conf, slot)) {
-        continue;
-      }
+        // Start of this section
+        int32_t *pos_start = pos + (start_totalRB + startRB) * N_SC_PER_PRB;
 
-      /* TODO: Remove this hack to set nPrbElm for mixed slot. This can be set statically during init based on TDD pattern. */
-      if (fh_cfg->RunSlotPrbMapBySymbolEnable) {
-        uint8_t *pPrbMapData = bufs->srccp[ant_id % nb_tx_per_ru][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
-        struct xran_prb_map *pPrbMap = (struct xran_prb_map *)pPrbMapData;
-        struct xran_prb_map *pRbMap = pPrbMap;
-        int32_t dl_sym_end = 0;
-        for (int32_t sym_idx = 0; sym_idx < XRAN_NUM_OF_SYMBOL_PER_SLOT; sym_idx++) {
-          if (!is_tdd_dl_symbol(frame_conf, slot, sym_idx)) {
-            dl_sym_end = sym_idx;
-            break;
-          }
-        }
-        if (frame_conf->nFrameDuplexType != XRAN_FDD && is_tdd_guard_slot(frame_conf, slot))
-          pRbMap->nPrbElm = dl_sym_end;
-        else
-          pRbMap->nPrbElm = XRAN_NUM_OF_SYMBOL_PER_SLOT;
-      }
+        if (p_prbMapElm->compMethod == XRAN_COMPMETHOD_NONE) {
+          payload_len = numRB * N_SC_PER_PRB * 4L;
+          /* convert to Network order */
+          // NOTE: ggc 11 knows how to generate AVX2 for this!
+          for (idx = 0; idx < (numRB * N_SC_PER_PRB) * 2; idx++)
+            ((uint16_t *)dst16)[idx] = htons(((uint16_t *)pos_start)[idx]);
+        } else if (p_prbMapElm->compMethod == XRAN_COMPMETHOD_BLKFLOAT) {
+          payload_len = (3 * p_prbMapElm->iqWidth + 1) * numRB;
 
-      // This loop would better be more inner to avoid confusion and maybe also errors.
-      for (int32_t sym_idx = 0; sym_idx < XRAN_NUM_OF_SYMBOL_PER_SLOT; sym_idx++) {
-        /* skip UL and guard symbols. */
-        if (frame_conf->nFrameDuplexType != XRAN_FDD && !is_tdd_dl_symbol(frame_conf, slot, sym_idx)) {
-          continue;
-        }
-        uint8_t *pData =
-            bufs->src[ant_id % nb_tx_per_ru][tti % XRAN_N_FE_BUF_LEN].pBuffers[sym_idx % XRAN_NUM_OF_SYMBOL_PER_SLOT].pData;
-        uint8_t *pPrbMapData = bufs->srccp[ant_id % nb_tx_per_ru][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
-        struct xran_prb_map *pPrbMap = (struct xran_prb_map *)pPrbMapData;
-        ptr = pData;
-        pos = &ru->txdataF_BF[ant_id][sym_idx * fftsize];
+          /* Although arm intrinsics natively handle unaligned memory
+          access, we use a 64 byte aligned input here for maximum
+          performance. So the src_compr buffer is used for both x86 and arm.
+          */
+          uint32_t src_compr[num_totalRB * N_SC_PER_PRB] __attribute__((aligned(64)));
 
-        uint8_t *u8dptr;
-        // even when the fragmentation occurs, nRBSize & nRBStart carry the same values in each prbMap
-        // therefore, I took the liberty to just extract these values from the first prbMap
-        struct xran_prb_elm *p_prbMapElm = &pPrbMap->prbMap[0];
-        int num_totalRB = p_prbMapElm->nRBSize;
-        int start_totalRB = p_prbMapElm->nRBStart;
-
-        if (ptr && pos) {
-          u8dptr = (uint8_t *)ptr;
-          int16_t payload_len = 0;
-
-          uint8_t *dst = (uint8_t *)u8dptr;
-
-          for (uint32_t idxElm = 0; idxElm < pPrbMap->nPrbElm; idxElm++) {
-            struct xran_section_desc *p_sec_desc = NULL;
-            struct xran_prb_elm *p_prbMapElm = &pPrbMap->prbMap[idxElm];
-
-            // radio-transport fragmentation is not supported in xran F release;
-            // E-bit = 1 => each ethernet frame is considered as the last fragment;
-            // a group of PRBs per each symbol is encapsulated in one ethernet frame.
-            // => seems that the RUs don't check for E-bit
-            p_sec_desc = &p_prbMapElm->sec_desc[sym_idx];
-            int16_t startRB = p_prbMapElm->UP_nRBStart;
-            int16_t numRB = p_prbMapElm->UP_nRBSize;
-
-            if (p_sec_desc == NULL) {
-              printf("p_sec_desc == NULL\n");
-              exit(-1);
-            }
-
-            // For Liteon FR2 with RunSlotPrbMapBySymbolEnable xran_prb_map will have xran_prb_elm prbMap[14], each idxElm matches to sym_idx.
-            if (fh_cfg->RunSlotPrbMapBySymbolEnable) {
-              /* skip, if not scheduled */
-              if(sym_idx < p_prbMapElm->nStartSymb || sym_idx >= p_prbMapElm->nStartSymb + p_prbMapElm->numSymb){
-                  p_sec_desc->iq_buffer_offset = 0;
-                  p_sec_desc->iq_buffer_len    = 0;
-                  continue;
-              }
-            }
-            p_prbMapElm->nBeamIndex = ru->beam_id[slot * XRAN_NUM_OF_SYMBOL_PER_SLOT + sym_idx][ant_id];
-
-            dst = xran_add_hdr_offset(dst, p_prbMapElm->compMethod);
-
-            uint16_t *dst16 = (uint16_t *)dst;
-
-            // Start of this section
-            int32_t *pos_start = pos + (start_totalRB + startRB) * N_SC_PER_PRB;
-
-            if (p_prbMapElm->compMethod == XRAN_COMPMETHOD_NONE) {
-              payload_len = numRB * N_SC_PER_PRB * 4L;
-              /* convert to Network order */
-              // NOTE: ggc 11 knows how to generate AVX2 for this!
-              for (idx = 0; idx < (numRB * N_SC_PER_PRB) * 2; idx++)
-                ((uint16_t *)dst16)[idx] = htons(((uint16_t *)pos_start)[idx]);
-            } else if (p_prbMapElm->compMethod == XRAN_COMPMETHOD_BLKFLOAT) {
-              payload_len = (3 * p_prbMapElm->iqWidth + 1) * numRB;
-
-              /* Although arm intrinsics natively handle unaligned memory
-              access, we use a 64 byte aligned input here for maximum
-              performance. So the src_compr buffer is used for both x86 and arm.
-              */
-              uint32_t src_compr[num_totalRB * N_SC_PER_PRB] __attribute__((aligned(64)));
-
-              /* Copy from txdataF with current symbol's PRB start (nRBStart) +
-              current section's PRB start (UP_nPRBStart) */
-              memcpy(src_compr, pos_start, (numRB * N_SC_PER_PRB) * sizeof(*pos_start));
+          /* Copy from txdataF with current symbol's PRB start (nRBStart) +
+          current section's PRB start (UP_nPRBStart) */
+          memcpy(src_compr, pos_start, (numRB * N_SC_PER_PRB) * sizeof(*pos_start));
 
 #if defined(__i386__) || defined(__x86_64__)
-              struct xranlib_compress_request bfp_com_req = {};
-              struct xranlib_compress_response bfp_com_rsp = {};
+          struct xranlib_compress_request bfp_com_req = {};
+          struct xranlib_compress_response bfp_com_rsp = {};
 
-              bfp_com_req.data_in = (int16_t *)src_compr;
+          bfp_com_req.data_in = (int16_t *)src_compr;
 
-              bfp_com_req.numRBs = numRB;
-              bfp_com_req.len = payload_len;
-              bfp_com_req.compMethod = p_prbMapElm->compMethod;
-              bfp_com_req.iqWidth = p_prbMapElm->iqWidth;
+          bfp_com_req.numRBs = numRB;
+          bfp_com_req.len = payload_len;
+          bfp_com_req.compMethod = p_prbMapElm->compMethod;
+          bfp_com_req.iqWidth = p_prbMapElm->iqWidth;
 
-              bfp_com_rsp.data_out = (int8_t *)dst;
-              bfp_com_rsp.len = 0;
+          bfp_com_rsp.data_out = (int8_t *)dst;
+          bfp_com_rsp.len = 0;
 
-              xranlib_compress_avx512(&bfp_com_req, &bfp_com_rsp);
+          xranlib_compress_avx512(&bfp_com_req, &bfp_com_rsp);
 #elif defined(__arm__) || defined(__aarch64__)
-              armral_bfp_compression(p_prbMapElm->iqWidth, numRB, (int16_t *)src_compr, (int8_t *)dst);
+          armral_bfp_compression(p_prbMapElm->iqWidth, numRB, (int16_t *)src_compr, (int8_t *)dst);
 #else
-              AssertFatal(1 == 0, "BFP compression not supported on this architecture");
+          AssertFatal(1 == 0, "BFP compression not supported on this architecture");
 #endif
-            } else {
-              printf("p_prbMapElm->compMethod == %d is not supported\n", p_prbMapElm->compMethod);
-              exit(-1);
-            }
-
-            p_sec_desc->iq_buffer_offset = RTE_PTR_DIFF(dst, u8dptr);
-            p_sec_desc->iq_buffer_len = payload_len;
-
-            dst += payload_len;
-            dst = xran_add_hdr_offset(dst, p_prbMapElm->compMethod);
-          }
-
-          // The tti should be updated as it increased.
-          pPrbMap->tti_id = tti;
-
         } else {
-          printf("ptr ==NULL\n");
-          exit(-1); // fails here??
+          printf("p_prbMapElm->compMethod == %d is not supported\n", p_prbMapElm->compMethod);
+          exit(-1);
         }
-      }
-    }
-  }
+
+        p_sec_desc->iq_buffer_offset = RTE_PTR_DIFF(dst, u8dptr);
+        p_sec_desc->iq_buffer_len = payload_len;
+
+        dst += payload_len;
+        dst = xran_add_hdr_offset(dst, p_prbMapElm->compMethod);
+      } // pPrbMap->nPrbElm
+
+      // The tti should be updated as it increased.
+      pPrbMap->tti_id = tti;
+    } // XRAN_NUM_OF_SYMBOL_PER_SLOT
+  } // nb_ant
   return (0);
 }

--- a/radio/fhi_72/oran.h
+++ b/radio/fhi_72/oran.h
@@ -11,14 +11,16 @@
  * split 7.2 never does IQ-sample read/write, beamforming, or third-party RRU control, so none of
  * openair0_device_t's fields apply. This is the whole surface nr-ru.c needs.
  *
- * The FH thread itself (split7_thread(), in oran_isolate.c) lives inside the shared lib and owns
- * xran startup there directly, so that doesn't need a slot here either. */
+ * The FH thread itself (split7_thread(), in oran_isolate.c) lives inside the shared lib - it owns
+ * xran startup and fh_south_in there directly, so neither needs a slot here. Only fh_south_out
+ * still crosses into nr-ru.c's ru_tx_func(), which stays shared across every southbound split. */
 typedef struct fhi72_transport_s {
   void *priv; // opaque per-instance state, owned by the fhi_72 shared lib
   int (*stop)(struct fhi72_transport_s *t);
   void (*end)(struct fhi72_transport_s *t);
   int (*get_stats)(struct fhi72_transport_s *t);
-  void (*fh_south_out)(RU_t *ru, int frame, int slot, uint64_t timestamp);
+  // No RU antenna counts either: oran_fh_if4p5_south_out() derives them per xran port itself.
+  void (*fh_south_out)(int32_t **txdataF_BF, uint16_t **beam_id, int frame, int slot);
 } fhi72_transport_t;
 
 /* Symbol exported (visibility default) by the O-RAN 7.2 FH shared library (radio/fhi_72), looked

--- a/radio/fhi_72/oran.h
+++ b/radio/fhi_72/oran.h
@@ -5,12 +5,27 @@
 #ifndef _ORAN_H_
 #define _ORAN_H_
 
-#include "shared_buffers.h"
 #include "common_lib.h"
-void oran_fh_if4p5_south_out(RU_t *ru, int frame, int slot, uint64_t timestamp);
 
-void oran_fh_if4p5_south_in(RU_t *ru, int *frame, int *slot);
+/* Purpose-built contract for the O-RAN 7.2 fronthaul, deliberately NOT openair0_device_t:
+ * split 7.2 never does IQ-sample read/write, beamforming, or third-party RRU control, so none of
+ * openair0_device_t's fields apply. This is the whole surface nr-ru.c needs.
+ *
+ * The FH thread itself (split7_thread(), in oran_isolate.c) lives inside the shared lib and owns
+ * xran startup there directly, so that doesn't need a slot here either. */
+typedef struct fhi72_transport_s {
+  void *priv; // opaque per-instance state, owned by the fhi_72 shared lib
+  int (*stop)(struct fhi72_transport_s *t);
+  void (*end)(struct fhi72_transport_s *t);
+  int (*get_stats)(struct fhi72_transport_s *t);
+  void (*fh_south_out)(RU_t *ru, int frame, int slot, uint64_t timestamp);
+} fhi72_transport_t;
 
-int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg);
+/* Symbol exported (visibility default) by the O-RAN 7.2 FH shared library (radio/fhi_72), looked
+ * up dynamically via load_transport_shlib() from executables/nr-ru.c and never called directly -
+ * so linking nr-softmodem does NOT require xran/DPDK unless split 7.2 is actually configured.
+ * Takes RU_t directly (rather than handing back a start function) because it spawns and owns the
+ * FH thread itself - see split7_thread() in oran_isolate.c. */
+typedef int (*fhi72_init_t)(openair0_config_t *cfg, RU_t *ru, fhi72_transport_t *transport);
 
 #endif /* _ORAN_H_ */

--- a/radio/fhi_72/oran_isolate.c
+++ b/radio/fhi_72/oran_isolate.c
@@ -200,19 +200,44 @@ void oran_fh_if4p5_south_in(RU_t *ru, int *frame, int *slot)
 void oran_fh_if4p5_south_out(RU_t *ru, int frame, int slot, uint64_t timestamp)
 {
   start_meas(&ru->tx_fhaul);
-  ru_info_t ru_info = {
-      .nb_rx = ru->nb_rx,
-      .nb_tx = ru->nb_tx,
-      .txdataF_BF = ru->common.txdataF_BF,
-      .beam_id = ru->common.beam_id,
-  };
 
-  // printf("south_out:\tframe=%d\tslot=%d\ttimestamp=%ld\n",frame,slot,timestamp);
+  int ret;
+  const struct xran_fh_init *fh_init = get_xran_fh_init();
 
-  int ret = xran_fh_tx_send_slot(&ru_info, frame, slot, timestamp);
-  if (ret != 0) {
-    printf("ORAN: ORAN_fh_if4p5_south_out ERROR in TX function \n");
+  for (uint16_t cc_id = 0; cc_id < 1 /*nSectorNum*/; cc_id++) { // OAI does not support multiple CC yet.
+    for (int xran_port = 0; xran_port < fh_init->xran_ports; xran_port++) {
+      oran_buf_list_t *bufs = get_xran_buffers(xran_port);
+      const struct xran_fh_config *fh_cfg = get_xran_fh_config(xran_port);
+      const uint8_t mu_number = fh_cfg->mu_number[0];
+      const int slots_per_frame = 10 << mu_number;
+      const int tti = slots_per_frame * frame + slot;
+      const struct xran_frame_config *frame_conf = &fh_cfg->frame_conf;
+
+      // UL slot
+      if (frame_conf->nFrameDuplexType == XRAN_FDD || is_tdd_ul_guard_slot(frame_conf, slot)) {
+        // Send CP UL
+        ret = xran_send_cp_slot(fh_cfg->neAxcUl, ru->common.beam_id, tti, slot, bufs->dstcp);
+        if (ret != 0) {
+          LOG_W(HW, "[%d.%d] xran_send_cp_slot UL error for xran_port %d\n", frame, slot, xran_port);
+        }
+      }
+
+      // DL slot
+      if (frame_conf->nFrameDuplexType == XRAN_FDD || is_tdd_dl_guard_slot(frame_conf, slot)) {
+        // Send CP DL
+        ret = xran_send_cp_slot(fh_cfg->neAxc, ru->common.beam_id, tti, slot, bufs->srccp);
+        if (ret != 0) {
+          LOG_W(HW, "[%d.%d] xran_send_cp_slot DL error for xran_port %d\n", frame, slot, xran_port);
+        }
+        const int fft_size = 1 << fh_cfg->perMu[mu_number].nDLFftSize;
+        ret = xran_fh_tx_send_slot(ru->common.txdataF_BF, fft_size, fh_cfg->neAxc, tti, bufs);
+        if (ret != 0) {
+          LOG_W(HW, "[%d.%d] xran_fh_tx_send_slot error for xran_port %d\n", frame, slot, xran_port);
+        }
+      }
+    }
   }
+
   stop_meas(&ru->tx_fhaul);
 }
 

--- a/radio/fhi_72/oran_isolate.c
+++ b/radio/fhi_72/oran_isolate.c
@@ -3,9 +3,7 @@
  */
 
 #include <stdio.h>
-#include <string.h>
 #include "common_lib.h"
-#include "radio/ETHERNET/ethernet_lib.h"
 #include "oran_isolate.h"
 #include "oran-init.h"
 #include "xran_fh_o_du.h"
@@ -31,6 +29,16 @@
 #include "mplane/connect-mplane.h"
 #endif
 
+/* One instance per O-RAN 7.2 RU - xran itself only supports a single instance today, but this
+ * keeps state ownership consistent with every other transport in this codebase instead of relying
+ * on file-scope globals. Owned via fhi72_transport_t::priv for the NR-facing oran_fhi72_init()
+ * contract below.
+ *
+ * fh_init/fh_config are gathered by oran_fhi72_configure() (runs on whichever thread loads the
+ * transport), but oai_oran_initialize() itself must run from the FH thread once it's pinned to
+ * its final core (see trx_oran_start() below) - xran/DPDK set up per-lcore state tied to the
+ * calling thread, so it can't be done ahead of time on a different thread. That's why fh_init/
+ * fh_config are carried here instead of being locals of the configure step. */
 typedef struct {
   void *oran_priv;
   void *mplane_priv;
@@ -45,9 +53,7 @@ notifiedFIFO_t oran_sync_fifo;
 notifiedFIFO_t oran_sync_fifo_prach;
 
 /* Must be called from the thread that will actually poll xran (the FH thread), after it is
- * already pinned to its final core - not from whichever thread loaded the transport. Moved here
- * (out of transport_init()'s body) so split7_thread() below can defer it the same way: xran/DPDK
- * set up per-lcore state tied to the calling thread. */
+ * already pinned to its final core - not from whichever thread loaded the transport. */
 static int trx_oran_start(oran_eth_state_t *s)
 {
   LOG_I(HW, "Initializing O-RAN 7.2 FH interface through xran library (compiled against headers of %s)\n", VERSIONX);
@@ -143,25 +149,6 @@ static int trx_oran_get_stats(oran_eth_state_t *s)
   return (0);
 }
 
-/* Adapters binding the shared trx_oran_* core above to the legacy openair0_device_t contract
- * (transport_init(), still used by executables/lte-ru.c). */
-static int trx_oran_start_dev(openair0_device_t *device)
-{
-  return trx_oran_start(device->priv);
-}
-static int trx_oran_stop_dev(openair0_device_t *device)
-{
-  return trx_oran_stop(device->priv);
-}
-static void trx_oran_end_dev(openair0_device_t *device)
-{
-  trx_oran_end(device->priv);
-}
-static int trx_oran_get_stats_dev(openair0_device_t *device)
-{
-  return trx_oran_get_stats(device->priv);
-}
-
 /* Adapters binding the shared trx_oran_* core above to the fhi72_transport_t contract
  * (oran_fhi72_init(), used by executables/nr-ru.c). trx_oran_start() itself has no _fhi adapter -
  * it's only ever called from split7_thread(), in this same file, below. */
@@ -245,11 +232,13 @@ static void oran_fh_if4p5_south_in(RU_t *ru, int *frame, int *slot)
   }
 }
 
-static void oran_fh_if4p5_south_out(RU_t *ru, int frame, int slot, uint64_t timestamp)
+/* timestamp isn't a parameter here: xran_fh_tx_send_slot() takes one, but never reads it (xran
+ * schedules TX by frame/slot, not by IQ sample clock) - see the fh_south_out comment in oran.h.
+ * ru->tx_fhaul timing now lives at the call site (ru_tx_func() in nr-ru.c), which still has RU_t. */
+static void oran_fh_if4p5_south_out(int32_t **txdataF_BF, uint16_t **beam_id, int frame, int slot)
 {
-  start_meas(&ru->tx_fhaul);
-
   int ret;
+
   const struct xran_fh_init *fh_init = get_xran_fh_init();
 
   for (uint16_t cc_id = 0; cc_id < 1 /*nSectorNum*/; cc_id++) { // OAI does not support multiple CC yet.
@@ -264,7 +253,7 @@ static void oran_fh_if4p5_south_out(RU_t *ru, int frame, int slot, uint64_t time
       // UL slot
       if (frame_conf->nFrameDuplexType == XRAN_FDD || is_tdd_ul_guard_slot(frame_conf, slot)) {
         // Send CP UL
-        ret = xran_send_cp_slot(fh_cfg->neAxcUl, ru->common.beam_id, tti, slot, bufs->dstcp);
+        ret = xran_send_cp_slot(fh_cfg->neAxcUl, beam_id, tti, slot, bufs->dstcp);
         if (ret != 0) {
           LOG_W(HW, "[%d.%d] xran_send_cp_slot UL error for xran_port %d\n", frame, slot, xran_port);
         }
@@ -273,12 +262,12 @@ static void oran_fh_if4p5_south_out(RU_t *ru, int frame, int slot, uint64_t time
       // DL slot
       if (frame_conf->nFrameDuplexType == XRAN_FDD || is_tdd_dl_guard_slot(frame_conf, slot)) {
         // Send CP DL
-        ret = xran_send_cp_slot(fh_cfg->neAxc, ru->common.beam_id, tti, slot, bufs->srccp);
-        if (ret != 0) {
+        ret = xran_send_cp_slot(fh_cfg->neAxc, beam_id, tti, slot, bufs->srccp);
+	if (ret != 0) {
           LOG_W(HW, "[%d.%d] xran_send_cp_slot DL error for xran_port %d\n", frame, slot, xran_port);
         }
         const int fft_size = 1 << fh_cfg->perMu[mu_number].nDLFftSize;
-        ret = xran_fh_tx_send_slot(ru->common.txdataF_BF, fft_size, fh_cfg->neAxc, tti, bufs);
+        ret = xran_fh_tx_send_slot(txdataF_BF, fft_size, fh_cfg->neAxc, tti, bufs);
         if (ret != 0) {
           LOG_W(HW, "[%d.%d] xran_fh_tx_send_slot error for xran_port %d\n", frame, slot, xran_port);
         }
@@ -286,22 +275,9 @@ static void oran_fh_if4p5_south_out(RU_t *ru, int frame, int slot, uint64_t time
     }
   }
 
-  stop_meas(&ru->tx_fhaul);
 }
 
-static void *get_internal_parameter(char *name)
-{
-  printf("ORAN: %s\n", __FUNCTION__);
-
-  if (!strcmp(name, "fh_if4p5_south_in"))
-    return (void *)oran_fh_if4p5_south_in;
-  if (!strcmp(name, "fh_if4p5_south_out"))
-    return (void *)oran_fh_if4p5_south_out;
-
-  return NULL;
-}
-
-/* Shared xran/M-plane configuration for both entry points below. Only gathers configuration -
+/* Shared xran/M-plane configuration for oran_fhi72_init() below. Only gathers configuration -
  * does NOT call oai_oran_initialize()/start xran itself, see trx_oran_start() above. */
 static oran_eth_state_t *oran_fhi72_configure(openair0_config_t *openair0_cfg)
 {
@@ -383,25 +359,6 @@ static oran_eth_state_t *oran_fhi72_configure(openair0_config_t *openair0_cfg)
   return eth;
 }
 
-/* Legacy entry point, dlsym'd by name ("transport_init") via openair0_transport_load() ->
- * load_lib() in radio/COMMON/common_lib.c. Still used by executables/lte-ru.c. */
-__attribute__((__visibility__("default"))) int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg)
-{
-  oran_eth_state_t *eth = oran_fhi72_configure(openair0_cfg);
-
-  device->host_type = RAU_HOST;
-  device->transp_type = ETHERNET_TP;
-  device->trx_start_func = trx_oran_start_dev;
-  device->trx_get_stats_func = trx_oran_get_stats_dev;
-  device->trx_end_func = trx_oran_end_dev;
-  device->trx_stop_func = trx_oran_stop_dev;
-  device->get_internal_parameter = get_internal_parameter;
-  device->priv = eth;
-  device->openair0_cfg = &openair0_cfg[0];
-
-  return 0;
-}
-
 typedef struct {
   RU_t *ru;
   oran_eth_state_t *eth;
@@ -409,7 +366,7 @@ typedef struct {
 
 /* @brief O-RAN 7.2 (REMOTE_IF4p5) FH thread. Lives here, not in executables/nr-ru.c, so it can
  * call oran_fh_if4p5_south_in()/trx_oran_start() directly - no function-pointer contract needed
- * for either, since caller and callee are in the same file.
+ * for either, since caller and callee are now in the same file.
  *
  * Deliberately a separate thread/function from ru_thread() (split 8, in nr-ru.c), not a reuse of
  * it: it is pinned to the CPU core xran itself wants (oran_eth_state_t::core, i.e. xran's
@@ -421,7 +378,7 @@ typedef struct {
  *
  * Unlike ru_thread(), this never calls ru_rx_slot(): split 7.2 has no time-domain front-end
  * processing, scope-copy, or (yet) PRACH extraction to do - the O-RU/xran side owns that. The only
- * part shared with ru_thread() is ru_push_tx_job() (in nr-ru.c, exposed via
+ * part still shared with ru_thread() is ru_push_tx_job() (in nr-ru.c, exposed via
  * openair1/PHY/defs_RU.h so this file can call it without duplicating that logic).
  *
  * trx_oran_start() (which runs oai_oran_initialize() and the xran/DPDK startup sequence) is
@@ -499,3 +456,4 @@ __attribute__((__visibility__("default"))) int oran_fhi72_init(openair0_config_t
 
   return 0;
 }
+

--- a/radio/fhi_72/oran_isolate.c
+++ b/radio/fhi_72/oran_isolate.c
@@ -15,6 +15,11 @@
 #include "openair1/PHY/defs_gNB.h"
 #include "oaioran.h"
 #include "oran-config.h"
+#include "oran.h"
+
+#include "common/ran_context.h" // RC, for split7_thread()
+#include "common/utils/system.h" // threadCreate()/OAI_PRIORITY_RT_MAX, for split7_thread()
+#include "executables/softmodem-common.h" // oai_exit, for split7_thread()
 
 // include the following file for VERSIONX, version of xran lib, to print it during
 // startup. Only relevant for printing, if it ever makes problem, remove this
@@ -31,16 +36,25 @@ typedef struct {
   void *mplane_priv;
   uint32_t nCC;
   uint32_t num_ports;
+  int core; // xran io_cfg.system_core - CPU core split7_thread() pins itself to
+  struct xran_fh_init fh_init;
+  struct xran_fh_config fh_config[XRAN_PORTS_NUM];
 } oran_eth_state_t;
 
 notifiedFIFO_t oran_sync_fifo;
 notifiedFIFO_t oran_sync_fifo_prach;
 
-int trx_oran_start(openair0_device_t *device)
+/* Must be called from the thread that will actually poll xran (the FH thread), after it is
+ * already pinned to its final core - not from whichever thread loaded the transport. Moved here
+ * (out of transport_init()'s body) so split7_thread() below can defer it the same way: xran/DPDK
+ * set up per-lcore state tied to the calling thread. */
+static int trx_oran_start(oran_eth_state_t *s)
 {
-  printf("ORAN: %s\n", __FUNCTION__);
+  LOG_I(HW, "Initializing O-RAN 7.2 FH interface through xran library (compiled against headers of %s)\n", VERSIONX);
+  s->oran_priv = oai_oran_initialize(&s->fh_init, s->fh_config);
+  AssertFatal(s->oran_priv != NULL, "can not initialize fronthaul");
 
-  oran_eth_state_t *s = device->priv;
+  printf("ORAN: %s\n", __FUNCTION__);
 
   // Start ORAN
   if (xran_timingsource_start() != 0) {
@@ -82,10 +96,9 @@ int trx_oran_start(openair0_device_t *device)
   return 0;
 }
 
-void trx_oran_end(openair0_device_t *device)
+static void trx_oran_end(oran_eth_state_t *s)
 {
   printf("ORAN: %s\n", __FUNCTION__);
-  oran_eth_state_t *s = device->priv;
   xran_shutdown(s->oran_priv);
   for (int32_t port_id = 0; port_id < s->num_ports; port_id++) {
     xran_close(((void **)s->oran_priv)[port_id]);
@@ -94,10 +107,9 @@ void trx_oran_end(openair0_device_t *device)
   xran_mem_mgr_leak_detector_destroy();
 }
 
-int trx_oran_stop(openair0_device_t *device)
+static int trx_oran_stop(oran_eth_state_t *s)
 {
   printf("ORAN: %s\n", __FUNCTION__);
-  oran_eth_state_t *s = device->priv;
 
   for (int32_t cc_id = 0; cc_id < s->nCC; cc_id++) {
     for (int32_t port_id = 0; port_id < s->num_ports; port_id++) {
@@ -119,8 +131,9 @@ int trx_oran_stop(openair0_device_t *device)
   return (0);
 }
 
-int trx_oran_get_stats(openair0_device_t *device)
+static int trx_oran_get_stats(oran_eth_state_t *s)
 {
+  (void)s;
   uint64_t total_time, used_time;
   uint32_t num_core_used, core_used[64];
   uint32_t ret = xran_get_time_stats(&total_time, &used_time, &num_core_used, &core_used[0], 0);
@@ -130,7 +143,42 @@ int trx_oran_get_stats(openair0_device_t *device)
   return (0);
 }
 
-void oran_fh_if4p5_south_in(RU_t *ru, int *frame, int *slot)
+/* Adapters binding the shared trx_oran_* core above to the legacy openair0_device_t contract
+ * (transport_init(), still used by executables/lte-ru.c). */
+static int trx_oran_start_dev(openair0_device_t *device)
+{
+  return trx_oran_start(device->priv);
+}
+static int trx_oran_stop_dev(openair0_device_t *device)
+{
+  return trx_oran_stop(device->priv);
+}
+static void trx_oran_end_dev(openair0_device_t *device)
+{
+  trx_oran_end(device->priv);
+}
+static int trx_oran_get_stats_dev(openair0_device_t *device)
+{
+  return trx_oran_get_stats(device->priv);
+}
+
+/* Adapters binding the shared trx_oran_* core above to the fhi72_transport_t contract
+ * (oran_fhi72_init(), used by executables/nr-ru.c). trx_oran_start() itself has no _fhi adapter -
+ * it's only ever called from split7_thread(), in this same file, below. */
+static int trx_oran_stop_fhi(fhi72_transport_t *t)
+{
+  return trx_oran_stop(t->priv);
+}
+static void trx_oran_end_fhi(fhi72_transport_t *t)
+{
+  trx_oran_end(t->priv);
+}
+static int trx_oran_get_stats_fhi(fhi72_transport_t *t)
+{
+  return trx_oran_get_stats(t->priv);
+}
+
+static void oran_fh_if4p5_south_in(RU_t *ru, int *frame, int *slot)
 {
   int ret = 0; // return code for PUSCH/PRACH processing
 
@@ -197,7 +245,7 @@ void oran_fh_if4p5_south_in(RU_t *ru, int *frame, int *slot)
   }
 }
 
-void oran_fh_if4p5_south_out(RU_t *ru, int frame, int slot, uint64_t timestamp)
+static void oran_fh_if4p5_south_out(RU_t *ru, int frame, int slot, uint64_t timestamp)
 {
   start_meas(&ru->tx_fhaul);
 
@@ -241,7 +289,7 @@ void oran_fh_if4p5_south_out(RU_t *ru, int frame, int slot, uint64_t timestamp)
   stop_meas(&ru->tx_fhaul);
 }
 
-void *get_internal_parameter(char *name)
+static void *get_internal_parameter(char *name)
 {
   printf("ORAN: %s\n", __FUNCTION__);
 
@@ -253,13 +301,13 @@ void *get_internal_parameter(char *name)
   return NULL;
 }
 
-__attribute__((__visibility__("default"))) int transport_init(openair0_device_t *device,
-                                                              openair0_config_t *openair0_cfg)
+/* Shared xran/M-plane configuration for both entry points below. Only gathers configuration -
+ * does NOT call oai_oran_initialize()/start xran itself, see trx_oran_start() above. */
+static oran_eth_state_t *oran_fhi72_configure(openair0_config_t *openair0_cfg)
 {
   oran_eth_state_t *eth = calloc_or_fail(1, sizeof(*eth));
-
-  struct xran_fh_init fh_init = {0};
-  struct xran_fh_config fh_config[XRAN_PORTS_NUM] = {0};
+  struct xran_fh_init *fh_init = &eth->fh_init;
+  struct xran_fh_config *fh_config = eth->fh_config;
 
   bool success = false;
 #ifdef OAI_MPLANE
@@ -318,33 +366,136 @@ __attribute__((__visibility__("default"))) int transport_init(openair0_device_t 
 
   eth->mplane_priv = ru_session_list;
 
-  success = get_xran_config(ru_session_list, openair0_cfg, &fh_init, fh_config);
+  success = get_xran_config(ru_session_list, openair0_cfg, fh_init, fh_config);
   AssertFatal(success, "[MPLANE] Cannot configure xran with M-plane info.\n");
 #else
-  success = get_xran_config(NULL, openair0_cfg, &fh_init, fh_config);
+  success = get_xran_config(NULL, openair0_cfg, fh_init, fh_config);
   AssertFatal(success, "cannot get configuration for xran\n");
 #endif
 
-  LOG_I(HW, "Initializing O-RAN 7.2 FH interface through xran library (compiled against headers of %s)\n", VERSIONX);
-  eth->oran_priv = oai_oran_initialize(&fh_init, fh_config);
-  AssertFatal(eth->oran_priv != NULL, "can not initialize fronthaul");
-  // create message queues for ORAN sync
+  eth->nCC = fh_config->nCC;
+  eth->num_ports = fh_init->xran_ports;
+  eth->core = fh_init->io_cfg.system_core;
 
   initNotifiedFIFO(&oran_sync_fifo);
   initNotifiedFIFO(&oran_sync_fifo_prach);
 
-  eth->nCC = fh_config->nCC;
-  eth->num_ports = fh_init.xran_ports;
+  return eth;
+}
+
+/* Legacy entry point, dlsym'd by name ("transport_init") via openair0_transport_load() ->
+ * load_lib() in radio/COMMON/common_lib.c. Still used by executables/lte-ru.c. */
+__attribute__((__visibility__("default"))) int transport_init(openair0_device_t *device, openair0_config_t *openair0_cfg)
+{
+  oran_eth_state_t *eth = oran_fhi72_configure(openair0_cfg);
 
   device->host_type = RAU_HOST;
   device->transp_type = ETHERNET_TP;
-  device->trx_start_func = trx_oran_start;
-  device->trx_get_stats_func = trx_oran_get_stats;
-  device->trx_end_func = trx_oran_end;
-  device->trx_stop_func = trx_oran_stop;
+  device->trx_start_func = trx_oran_start_dev;
+  device->trx_get_stats_func = trx_oran_get_stats_dev;
+  device->trx_end_func = trx_oran_end_dev;
+  device->trx_stop_func = trx_oran_stop_dev;
   device->get_internal_parameter = get_internal_parameter;
   device->priv = eth;
   device->openair0_cfg = &openair0_cfg[0];
+
+  return 0;
+}
+
+typedef struct {
+  RU_t *ru;
+  oran_eth_state_t *eth;
+} split7_thread_arg_t;
+
+/* @brief O-RAN 7.2 (REMOTE_IF4p5) FH thread. Lives here, not in executables/nr-ru.c, so it can
+ * call oran_fh_if4p5_south_in()/trx_oran_start() directly - no function-pointer contract needed
+ * for either, since caller and callee are in the same file.
+ *
+ * Deliberately a separate thread/function from ru_thread() (split 8, in nr-ru.c), not a reuse of
+ * it: it is pinned to the CPU core xran itself wants (oran_eth_state_t::core, i.e. xran's
+ * io_cfg.system_core), independent of the ru_thread_core config knob, and it has no IQ sample
+ * clock to maintain - the frame/slot wraparound below just keeps a running count the same way
+ * ru_thread() does, but there's no get_samples_per_slot()/timestamp accumulation on top of it,
+ * since xran schedules TX by frame/slot, not by sample clock (oran_fh_if4p5_south_in() still
+ * corrects frame/slot from xran's own timing, logging a mismatch if the two disagree).
+ *
+ * Unlike ru_thread(), this never calls ru_rx_slot(): split 7.2 has no time-domain front-end
+ * processing, scope-copy, or (yet) PRACH extraction to do - the O-RU/xran side owns that. The only
+ * part shared with ru_thread() is ru_push_tx_job() (in nr-ru.c, exposed via
+ * openair1/PHY/defs_RU.h so this file can call it without duplicating that logic).
+ *
+ * trx_oran_start() (which runs oai_oran_initialize() and the xran/DPDK startup sequence) is
+ * called here, first thing, rather than in oran_fhi72_init() before this thread is created:
+ * xran/DPDK set up per-lcore state tied to the calling thread, so it has to run from this thread
+ * once threadCreate() has already pinned it to its final core - not from whichever thread loaded
+ * the transport. */
+static void *split7_thread(void *param)
+{
+  split7_thread_arg_t *arg = param;
+  RU_t *ru = arg->ru;
+  oran_eth_state_t *eth = arg->eth;
+  free(arg);
+
+  RU_proc_t *proc = &ru->proc;
+  PHY_VARS_gNB *gNB = RC.gNB[0]; // this RU main loop handles only one RU
+  int frame = 1023;
+  int slot = ru->nr_frame_parms->slots_per_frame - 1;
+
+  if (trx_oran_start(eth) != 0)
+    LOG_E(HW, "Could not start the O-RAN 7.2 fronthaul\n");
+
+  LOG_I(PHY, "Signaling main thread that RU %d is ready, sl_ahead %d\n", ru->idx, ru->sl_ahead);
+  pthread_mutex_lock(&RC.ru_mutex);
+  RC.ru_mask &= ~(1 << ru->idx);
+  pthread_cond_signal(&RC.ru_cond);
+  pthread_mutex_unlock(&RC.ru_mutex);
+  wait_sync("split7_thread");
+
+  while (!oai_exit) {
+    if (slot==(ru->nr_frame_parms->slots_per_frame-1)) {
+      slot=0;
+      frame++;
+      frame&=1023;
+    } else {
+      slot++;
+    }
+
+    oran_fh_if4p5_south_in(ru, &frame, &slot); // also sets proc->{frame,tti}_{rx,tx} from xran's own timing
+
+    if (ru->rx_fhaul.trials > 1000) {
+      reset_meas(&ru->rx_fhaul);
+      reset_meas(&ru->tx_fhaul);
+    }
+
+    // no IQ sample clock for split 7.2: xran schedules TX by frame/slot, not by timestamp
+    ru_push_tx_job(gNB, proc->frame_tx, proc->tti_tx, proc->frame_rx, proc->tti_rx, 0);
+  }
+
+  return NULL;
+}
+
+/* NR entry point, dlsym'd by name ("oran_fhi72_init") via load_transport_shlib() in
+ * radio/COMMON/common_lib.c, called from executables/nr-ru.c. Deliberately not shaped like
+ * openair0_device_t - split 7.2 never does IQ-sample read/write, so that abstraction doesn't fit
+ * here; see fhi72_transport_t in oran.h.
+ *
+ * Spawns and owns the FH thread itself (split7_thread() above) instead of handing a start
+ * function back to nr-ru.c: a dlopen()'d module can't hand a function pointer back across the
+ * boundary for the caller to threadCreate() with, since nr-ru.c has no link-time symbol for it. */
+__attribute__((__visibility__("default"))) int oran_fhi72_init(openair0_config_t *openair0_cfg, RU_t *ru, fhi72_transport_t *transport)
+{
+  oran_eth_state_t *eth = oran_fhi72_configure(openair0_cfg);
+
+  transport->priv = eth;
+  transport->stop = trx_oran_stop_fhi;
+  transport->end = trx_oran_end_fhi;
+  transport->get_stats = trx_oran_get_stats_fhi;
+  transport->fh_south_out = oran_fh_if4p5_south_out;
+
+  split7_thread_arg_t *arg = calloc_or_fail(1, sizeof(*arg));
+  arg->ru = ru;
+  arg->eth = eth;
+  threadCreate(&ru->proc.pthread_FH, split7_thread, arg, "split7_thread", eth->core, OAI_PRIORITY_RT_MAX);
 
   return 0;
 }

--- a/radio/fhi_72/oran_isolate.h
+++ b/radio/fhi_72/oran_isolate.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include "xran_fh_o_du.h"
+#include "oran-init.h"
 #include "openair1/PHY/impl_defs_nr.h"
 #include "openair1/PHY/TOOLS/tools_defs.h"
 #include "openair1/PHY/defs_nr_common.h"
@@ -41,6 +42,9 @@ typedef struct ru_info_s {
 
 void print_fhi_counters(ru_info_t *ru, const int frame, const int slot);
 
+bool is_tdd_dl_guard_slot(const struct xran_frame_config *frame_conf, int slot);
+bool is_tdd_ul_guard_slot(const struct xran_frame_config *frame_conf, int slot);
+
 /** @brief Reads RX data PUSCH of next slot.
  *
  * @param ru pointer to structure keeping pointers to OAI data.
@@ -53,7 +57,9 @@ int xran_fh_rx_read_slot(ru_info_t *ru, int *frame, int *slot);
  * @param frame output of the frame which has been read.
  * @param slot output of the slot which has been read. */
 int xran_fh_rx_prach_read_slot(PHY_VARS_gNB *gNB, ru_info_t *ru, int *frame, int *slot);
+/** @brief Writes CP UL data for given slot. */
+int xran_send_cp_slot(const uint8_t nb_ant, uint16_t **beams, const int tti, const int slot, struct xran_buffer_list buf[XRAN_MAX_ANTENNA_NR][XRAN_N_FE_BUF_LEN]);
 /** @brief Writes TX data (PDSCH) of given slot. */
-int xran_fh_tx_send_slot(ru_info_t *ru, int frame, int slot, uint64_t timestamp);
+int xran_fh_tx_send_slot(int32_t **txdataF_BF, const int fft_size, const uint8_t nb_ant, const int tti, oran_buf_list_t *bufs);
 
 #endif /* _ORAN_ISOLATE_H_ */

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-du.sa.band77.273prb.fhi72.4x4-benetel650.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-du.sa.band77.273prb.fhi72.4x4-benetel650.conf
@@ -213,7 +213,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-du.sa.band77.273prb.fhi72.4x4-das-benetel650_650.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-du.sa.band77.273prb.fhi72.4x4-das-benetel650_650.conf
@@ -217,7 +217,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-du.sa.band77.273prb.fhi72.8x8-benetel650_650-mplane.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-du.sa.band77.273prb.fhi72.8x8-benetel650_650-mplane.conf
@@ -213,7 +213,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-du.sa.band77.273prb.fhi72.8x8-benetel650_650.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-du.sa.band77.273prb.fhi72.8x8-benetel650_650.conf
@@ -213,7 +213,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.band77.mu1.106rb.fhi.1x1.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.band77.mu1.106rb.fhi.1x1.conf
@@ -208,7 +208,6 @@ RUs = (
   eNB_instances  = [0];
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-liteon.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-liteon.conf
@@ -221,7 +221,6 @@ RUs = (
   ru_thread_core = 35;
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5";
-  do_precoding = 0;
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf
@@ -222,7 +222,6 @@ RUs = (
   ru_thread_core = 35;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5";
-  do_precoding = 0;
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.106prb.fhi72.1x1-oru.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.106prb.fhi72.1x1-oru.conf
@@ -208,7 +208,6 @@ RUs = (
   eNB_instances  = [0];
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.106prb.fhi72.4x4-vvdn.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.106prb.fhi72.4x4-vvdn.conf
@@ -215,7 +215,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.273prb.fhi72.2x2-benetel550-long-prach.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.273prb.fhi72.2x2-benetel550-long-prach.conf
@@ -215,7 +215,6 @@ RUs = (
   ru_thread_core = 8;
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.273prb.fhi72.2x2-vvdn-16b.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.273prb.fhi72.2x2-vvdn-16b.conf
@@ -212,7 +212,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.273prb.fhi72.4x4-vvdn.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.273prb.fhi72.4x4-vvdn.conf
@@ -214,7 +214,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.273prb.fhi72.4x4-wnc.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.273prb.fhi72.4x4-wnc.conf
@@ -211,7 +211,6 @@ RUs = (
   eNB_instances  = [0];
   ru_thread_core = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.106prb.fhi72.1x1-proto-ru.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.106prb.fhi72.1x1-proto-ru.conf
@@ -208,7 +208,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 11;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.2x2-benetel550-16b.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.2x2-benetel550-16b.conf
@@ -215,7 +215,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x2-benetel550.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x2-benetel550.conf
@@ -214,7 +214,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x4-benetel550-mplane.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x4-benetel550-mplane.conf
@@ -216,7 +216,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x4-benetel550.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x4-benetel550.conf
@@ -216,7 +216,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x4-foxconn.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x4-foxconn.conf
@@ -213,7 +213,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x4-liteon.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x4-liteon.conf
@@ -213,7 +213,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x4-metanoia.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band78.273prb.fhi72.4x4-metanoia.conf
@@ -196,7 +196,6 @@ RUs = (
   ru_thread_core = 9;
   sl_ahead       = 10;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.band77.mu1.106rb.1x1.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.band77.mu1.106rb.1x1.conf
@@ -40,7 +40,6 @@ RUs = (
   eNB_instances  = [0];
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
   # PRACH configuration
   num_tp_cores = 4;
   tp_cores = [-1,-1,-1,-1];

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.sa.band77.106prb.fhi72.1x1-oru.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.sa.band77.106prb.fhi72.1x1-oru.conf
@@ -42,7 +42,6 @@ RUs = (
   eNB_instances  = [0];
   sl_ahead       = 5;
   tr_preference  = "raw_if4p5"; # important: activate FHI7.2
-  do_precoding   = 0; # needs to match O-RU configuration
   # PRACH configuration
   num_tp_cores = 4;
   tp_cores = [-1,-1,-1,-1];


### PR DESCRIPTION
- Remove `do_precoding` parameter from fhi72 config files as not relevant for NR
- Remove unused `initial_wait` in `ru_thread()`
- Separate handling CP DL/UL -> can be dropped if #386 is merged beforehand
- Separate NR RU configuration into `configure_NR_RU()` from `ru_thread()` - relevant for all splits (called once before the thread starts)
- Further cleanup `ru_thread`
  a) `ru_rx_slot()` - extracts RX-side per-slot handling (front-end processing, scope-copy, PRACH extraction) for split 8
  b) `ru_push_tx_job()` - pushes the TX-job into a FIFO queue
- Introduces `fhi72_transport_t`/`oran_fhi72_init()` in `radio/fhi_72` and leave `openair0_device_t` for handling only split 8 (time-domain radios). `oran_fhi72_init()` triggers its own thread (`split7_thread()`)
- `start_NR_RU()` now dispatches to `start_split8()` (LOCAL_RF/REMOTE_IF5, unchanged behavior) or `start_split72()` (new, uses `load_transport_shlib()`/`oran_fhi72_init()`) based on `ru->if_south`
=> split 7.2 not dependent on `RU_t` function pointers and on `ru_thread()`

TODO:
- [ ] remove `ru_thread_core` from all fhi72 config files and `doc/ORAN_FHI7.2_Tutorial.md`; explain which functions are executed in `split7_thread` running on `system_core`
- [ ] remove `RU_t` arg for `split7_thread` and use `SLOTS_PER_SYSTEMFRAME` from xran -> try to limit `RU_t` usage for 7.2
- [ ] copy beam IDs properly for UL slots (currently copied only for DL and mixed slots)
- [ ] create function pointer in `fhi72_transport_t` for filling beam IDs in CP DL/UL messages -> remove `trx_set_fh_beams()` introduced in #386 
- [ ] maybe move `trx_oran_stop_fhi()`/`trx_oran_end_fhi()`/`trx_oran_get_stats_fhi()` at the exit of `while` loop in `split7_thread()`
- [ ] remove Rx and PRACH FIFO queues, and `ru_info_t` for split 7.2. But decompression shall remain in `split7_thread()`
- [ ] reset `nRxPkt` for previous TTI in Rx and PRACH callbacks -> these callbacks use `worker_cores` which is always at 100%
- [ ] remove DL TTI callback and call `xran_timingsource_get_slotidx()` in `split7_thread()` -> this callback uses `io_core` which is always at 100%