### PR TITLE
Add scheduler policy registry + HARQ observers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1209,6 +1209,7 @@ set (MAC_NR_SRC
   ${NR_GNB_MAC_DIR}/gNB_scheduler_dlsch_default_policies.c
   ${NR_GNB_MAC_DIR}/gNB_scheduler_ulsch.c
   ${NR_GNB_MAC_DIR}/gNB_scheduler_ulsch_default_policies.c
+  ${NR_GNB_MAC_DIR}/nr_sched_registries.c
   ${NR_GNB_MAC_DIR}/gNB_scheduler_primitives.c
   ${NR_GNB_MAC_DIR}/gNB_scheduler_phytest.c
   ${NR_GNB_MAC_DIR}/gNB_scheduler_uci.c

--- a/ci-scripts/conf_files/gnb-vnf.sa.band78.273prb.aerial.conf
+++ b/ci-scripts/conf_files/gnb-vnf.sa.band78.273prb.aerial.conf
@@ -192,6 +192,19 @@ MACRLCs = (
   pucch_TargetSNRx10 = 200;
   dl_max_mcs         = 28;
   ul_max_mcs         = 28;
+  dl_preprocessor_policy   = "default";
+  dl_ri_pmi_select_policy  = "default";
+  dl_tda_select_policy     = "default";
+  dl_beam_select_policy    = "default";
+  dl_mcs_select_policy     = "default";
+  dl_rb_alloc_policy       = "default";
+  dl_lcid_alloc_policy     = "default";
+  ul_preprocessor_policy   = "default";
+  ul_ri_tpmi_select_policy = "default";
+  ul_tda_select_policy     = "default";
+  ul_beam_select_policy    = "default";
+  ul_mcs_select_policy     = "default";
+  ul_rb_alloc_policy       = "default";
 }
 );
 

--- a/ci-scripts/conf_files/gnb-vnf.sa.band78.273prb.aerial.conf
+++ b/ci-scripts/conf_files/gnb-vnf.sa.band78.273prb.aerial.conf
@@ -205,6 +205,8 @@ MACRLCs = (
   ul_beam_select_policy    = "default";
   ul_mcs_select_policy     = "default";
   ul_rb_alloc_policy       = "default";
+  dl_harq_result_observers = ();
+  ul_harq_result_observers = ();
 }
 );
 

--- a/ci-scripts/conf_files/gnb.sa.band78.106prb.rfsim.conf
+++ b/ci-scripts/conf_files/gnb.sa.band78.106prb.rfsim.conf
@@ -180,6 +180,19 @@ MACRLCs = (
     tr_n_preference  = "local_RRC";
     pusch_TargetSNRx10 = 200;
     pucch_TargetSNRx10 = 200;
+    dl_preprocessor_policy   = "default";
+    dl_ri_pmi_select_policy  = "default";
+    dl_tda_select_policy     = "default";
+    dl_beam_select_policy    = "default";
+    dl_mcs_select_policy     = "default";
+    dl_rb_alloc_policy       = "default";
+    dl_lcid_alloc_policy     = "default";
+    ul_preprocessor_policy   = "default";
+    ul_ri_tpmi_select_policy = "default";
+    ul_tda_select_policy     = "default";
+    ul_beam_select_policy    = "default";
+    ul_mcs_select_policy     = "default";
+    ul_rb_alloc_policy       = "default";
   }
 );
 

--- a/ci-scripts/conf_files/gnb.sa.band78.106prb.rfsim.conf
+++ b/ci-scripts/conf_files/gnb.sa.band78.106prb.rfsim.conf
@@ -193,6 +193,8 @@ MACRLCs = (
     ul_beam_select_policy    = "default";
     ul_mcs_select_policy     = "default";
     ul_rb_alloc_policy       = "default";
+    dl_harq_result_observers = ();
+    ul_harq_result_observers = ();
   }
 );
 

--- a/common/utils/sched_registry.h
+++ b/common/utils/sched_registry.h
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ *
+ * Small typed registry used by scheduler policies and observers.  Entries are
+ * registered at load time, which lets policy objects remain independent from
+ * the scheduler core.
+ */
+
+#ifndef SCHED_REGISTRY_H
+#define SCHED_REGISTRY_H
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define SCHED_REGISTRY_DECLARE(registry, fn_type)         \
+  void registry##_register(const char *name, fn_type fn); \
+  fn_type registry##_lookup(const char *name);            \
+  const char *registry##_names(void)
+
+#define SCHED_REGISTRY_DEFINE(registry, fn_type)                                               \
+  typedef struct registry##_entry_s {                                                          \
+    const char *name;                                                                          \
+    fn_type fn;                                                                                \
+    struct registry##_entry_s *next;                                                           \
+  } registry##_entry_t;                                                                        \
+  static registry##_entry_t *registry##_entries;                                               \
+  void registry##_register(const char *name, fn_type fn)                                       \
+  {                                                                                            \
+    registry##_entry_t *entry = calloc(1, sizeof(*entry));                                     \
+    if (entry == NULL)                                                                         \
+      abort();                                                                                 \
+    entry->name = name;                                                                        \
+    entry->fn = fn;                                                                            \
+    entry->next = registry##_entries;                                                          \
+    registry##_entries = entry;                                                                \
+  }                                                                                            \
+  fn_type registry##_lookup(const char *name)                                                  \
+  {                                                                                            \
+    for (registry##_entry_t *entry = registry##_entries; entry != NULL; entry = entry->next)   \
+      if (strcmp(entry->name, name) == 0)                                                      \
+        return entry->fn;                                                                      \
+    return NULL;                                                                               \
+  }                                                                                            \
+  const char *registry##_names(void)                                                           \
+  {                                                                                            \
+    static char names[512];                                                                    \
+    names[0] = '\0';                                                                           \
+    for (registry##_entry_t *entry = registry##_entries; entry != NULL; entry = entry->next) { \
+      if (names[0] != '\0')                                                                    \
+        strncat(names, ", ", sizeof(names) - strlen(names) - 1);                               \
+      strncat(names, entry->name, sizeof(names) - strlen(names) - 1);                          \
+    }                                                                                          \
+    return names;                                                                              \
+  }
+
+#define SCHED_REGISTRY_ADD(registry, entry_name, fn)                         \
+  static void __attribute__((constructor)) registry##_add_##entry_name(void) \
+  {                                                                          \
+    registry##_register(#entry_name, fn);                                    \
+  }
+
+#endif /* SCHED_REGISTRY_H */

--- a/doc/MAC/scheduler-architecture.md
+++ b/doc/MAC/scheduler-architecture.md
@@ -29,7 +29,7 @@ Default policy implementations are in
 [`gNB_scheduler_dlsch_default_policies.c`](../../openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch_default_policies.c)
 and
 [`gNB_scheduler_ulsch_default_policies.c`](../../openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch_default_policies.c).
-Named policy registries are declared in
+Named policy and observer registries are declared in
 [`nr_sched_registries.h`](../../openair2/LAYER2/NR_MAC_gNB/nr_sched_registries.h).
 
 ## Selecting scheduler policies
@@ -55,9 +55,18 @@ MACRLCs = (
     ul_beam_select_policy = "default";
     ul_mcs_select_policy = "default";
     ul_rb_alloc_policy = "default";
+
+    dl_harq_result_observers = ();
+    ul_harq_result_observers = ();
   }
 );
 ```
+
+DL and UL HARQ result observers are separate lists, execute in configuration
+order, and receive ACK, NACK, DTX, and scheduler-missing results for their
+direction. Each callback also receives `mac->sched_stateful_data`, the persistent
+context shared with the configured scheduler policies. Observer callbacks run
+synchronously under the MAC scheduler lock and therefore must not block.
 
 Built-in implementations register themselves with `SCHED_REGISTRY_ADD`. The
 `--phy-test` mode continues to override both configured preprocessors with the

--- a/doc/MAC/scheduler-architecture.md
+++ b/doc/MAC/scheduler-architecture.md
@@ -29,8 +29,39 @@ Default policy implementations are in
 [`gNB_scheduler_dlsch_default_policies.c`](../../openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch_default_policies.c)
 and
 [`gNB_scheduler_ulsch_default_policies.c`](../../openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch_default_policies.c).
-Function pointers are assigned at startup in
-[`main.c`](../../openair2/LAYER2/NR_MAC_gNB/main.c).
+Named policy registries are declared in
+[`nr_sched_registries.h`](../../openair2/LAYER2/NR_MAC_gNB/nr_sched_registries.h).
+
+## Selecting scheduler policies
+
+Every existing scheduler function pointer can be selected by name in the
+`MACRLCs` section. All selectors default to `"default"`, so configurations that
+omit them retain the current scheduler behavior:
+
+```ini
+MACRLCs = (
+  {
+    dl_preprocessor_policy = "default";
+    dl_ri_pmi_select_policy = "default";
+    dl_tda_select_policy = "default";
+    dl_beam_select_policy = "default";
+    dl_mcs_select_policy = "default";
+    dl_rb_alloc_policy = "default";
+    dl_lcid_alloc_policy = "default";
+
+    ul_preprocessor_policy = "default";
+    ul_ri_tpmi_select_policy = "default";
+    ul_tda_select_policy = "default";
+    ul_beam_select_policy = "default";
+    ul_mcs_select_policy = "default";
+    ul_rb_alloc_policy = "default";
+  }
+);
+```
+
+Built-in implementations register themselves with `SCHED_REGISTRY_ADD`. The
+`--phy-test` mode continues to override both configured preprocessors with the
+registered `phytest` implementations.
 
 ## Scheduler Pipeline
 

--- a/openair2/GNB_APP/MACRLC_nr_paramdef.h
+++ b/openair2/GNB_APP/MACRLC_nr_paramdef.h
@@ -54,6 +54,19 @@
 #define MACRLC_PUSCH_RSSI_THRESHOLD          "pusch_RSSI_Threshold"
 #define MACRLC_PUCCH_RSSI_THRESHOLD          "pucch_RSSI_Threshold"
 #define MACRLC_STATS_MAX_UE                  "stats_max_ue"
+#define MACRLC_DL_PREPROCESSOR_POLICY        "dl_preprocessor_policy"
+#define MACRLC_DL_RI_PMI_SELECT_POLICY       "dl_ri_pmi_select_policy"
+#define MACRLC_DL_TDA_SELECT_POLICY          "dl_tda_select_policy"
+#define MACRLC_DL_BEAM_SELECT_POLICY         "dl_beam_select_policy"
+#define MACRLC_DL_MCS_SELECT_POLICY          "dl_mcs_select_policy"
+#define MACRLC_DL_RB_ALLOC_POLICY            "dl_rb_alloc_policy"
+#define MACRLC_DL_LCID_ALLOC_POLICY          "dl_lcid_alloc_policy"
+#define MACRLC_UL_PREPROCESSOR_POLICY        "ul_preprocessor_policy"
+#define MACRLC_UL_RI_TPMI_SELECT_POLICY      "ul_ri_tpmi_select_policy"
+#define MACRLC_UL_TDA_SELECT_POLICY          "ul_tda_select_policy"
+#define MACRLC_UL_BEAM_SELECT_POLICY         "ul_beam_select_policy"
+#define MACRLC_UL_MCS_SELECT_POLICY          "ul_mcs_select_policy"
+#define MACRLC_UL_RB_ALLOC_POLICY            "ul_rb_alloc_policy"
 #define MACRLC_SPATIAL_STREAM_IDX            "spatial_stream_index"
 
 #define HLP_MACRLC_UL_PRBBLACK "SNR threshold to decide whether a PRB will be blacklisted or not"
@@ -76,6 +89,7 @@
 #define HLP_MACRLC_PUSCH_RSSI_THRESHOLD "Limits PUSCH TPC commands based on RSSI to prevent ADC railing. Value range [-1280, 0], unit 0.1 dBm/dBFS"
 #define HLP_MACRLC_PUCCH_RSSI_THRESHOLD "Limits PUCCH TPC commands based on RSSI to prevent ADC railing. Value range [-1280, 0], unit 0.1 dBm/dBFS"
 #define HLP_MACRLC_STATS_MAX_UE "Maximum number of UEs before disabling periodical output (0 to disable)"
+#define HLP_SCHED_POLICY "Name of the registered scheduler policy"
 #define HLP_MACRLC_SPATIAL_STREAM_INDEX "Array of RU antenna ports / eAxCIDs to be used by L1. This may only be applicable for MU-MIMO. Value range [0, 15]"
 
 /*-------------------------------------------------------------------------------------------------------------------------------------------------------*/
@@ -125,6 +139,19 @@
   {MACRLC_PUCCH_RSSI_THRESHOLD,        HLP_MACRLC_PUCCH_RSSI_THRESHOLD, \
                                                                                0, .iptr=NULL,   .defintval=0,               TYPE_INT,     0}, \
   {MACRLC_STATS_MAX_UE,                HLP_MACRLC_STATS_MAX_UE,  0, .iptr=NULL,   .defintval=8,               TYPE_INT,     0}, \
+  {MACRLC_DL_PREPROCESSOR_POLICY,      HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_DL_RI_PMI_SELECT_POLICY,     HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_DL_TDA_SELECT_POLICY,        HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_DL_BEAM_SELECT_POLICY,       HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_DL_MCS_SELECT_POLICY,        HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_DL_RB_ALLOC_POLICY,          HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_DL_LCID_ALLOC_POLICY,        HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_UL_PREPROCESSOR_POLICY,      HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_UL_RI_TPMI_SELECT_POLICY,    HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_UL_TDA_SELECT_POLICY,        HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_UL_BEAM_SELECT_POLICY,       HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_UL_MCS_SELECT_POLICY,        HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_UL_RB_ALLOC_POLICY,          HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
   {MACRLC_SPATIAL_STREAM_IDX,          HLP_MACRLC_SPATIAL_STREAM_INDEX, \
                                                                                0, .uptr=NULL,   .defintarrayval=0,          TYPE_INTARRAY,0}, \
 }
@@ -173,6 +200,19 @@
   { .s2 =  { config_check_intrange, {-1280, 0}} }, /* PUSCH RSSI threshold range */ \
   { .s2 =  { config_check_intrange, {-1280, 0}} }, /* PUCCH RSSI threshold range */ \
   { .s5 = { NULL } }, \
+  { .s5 = { NULL } }, /* DL preprocessor policy */ \
+  { .s5 = { NULL } }, /* DL RI/PMI policy */ \
+  { .s5 = { NULL } }, /* DL TDA policy */ \
+  { .s5 = { NULL } }, /* DL beam policy */ \
+  { .s5 = { NULL } }, /* DL MCS policy */ \
+  { .s5 = { NULL } }, /* DL RB-allocation policy */ \
+  { .s5 = { NULL } }, /* DL LCID-allocation policy */ \
+  { .s5 = { NULL } }, /* UL preprocessor policy */ \
+  { .s5 = { NULL } }, /* UL RI/TPMI policy */ \
+  { .s5 = { NULL } }, /* UL TDA policy */ \
+  { .s5 = { NULL } }, /* UL beam policy */ \
+  { .s5 = { NULL } }, /* UL MCS policy */ \
+  { .s5 = { NULL } }, /* UL RB-allocation policy */ \
   { .s2 = { NULL } }, /* Spatial stream index */ \
 }
 

--- a/openair2/GNB_APP/MACRLC_nr_paramdef.h
+++ b/openair2/GNB_APP/MACRLC_nr_paramdef.h
@@ -67,6 +67,8 @@
 #define MACRLC_UL_BEAM_SELECT_POLICY         "ul_beam_select_policy"
 #define MACRLC_UL_MCS_SELECT_POLICY          "ul_mcs_select_policy"
 #define MACRLC_UL_RB_ALLOC_POLICY            "ul_rb_alloc_policy"
+#define MACRLC_DL_HARQ_RESULT_OBSERVERS      "dl_harq_result_observers"
+#define MACRLC_UL_HARQ_RESULT_OBSERVERS      "ul_harq_result_observers"
 #define MACRLC_SPATIAL_STREAM_IDX            "spatial_stream_index"
 
 #define HLP_MACRLC_UL_PRBBLACK "SNR threshold to decide whether a PRB will be blacklisted or not"
@@ -90,6 +92,7 @@
 #define HLP_MACRLC_PUCCH_RSSI_THRESHOLD "Limits PUCCH TPC commands based on RSSI to prevent ADC railing. Value range [-1280, 0], unit 0.1 dBm/dBFS"
 #define HLP_MACRLC_STATS_MAX_UE "Maximum number of UEs before disabling periodical output (0 to disable)"
 #define HLP_SCHED_POLICY "Name of the registered scheduler policy"
+#define HLP_SCHED_OBSERVERS "Ordered list of registered scheduler observers"
 #define HLP_MACRLC_SPATIAL_STREAM_INDEX "Array of RU antenna ports / eAxCIDs to be used by L1. This may only be applicable for MU-MIMO. Value range [0, 15]"
 
 /*-------------------------------------------------------------------------------------------------------------------------------------------------------*/
@@ -152,6 +155,8 @@
   {MACRLC_UL_BEAM_SELECT_POLICY,       HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
   {MACRLC_UL_MCS_SELECT_POLICY,        HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
   {MACRLC_UL_RB_ALLOC_POLICY,          HLP_SCHED_POLICY,         0, .strptr=NULL,  .defstrval="default",       TYPE_STRING,  0}, \
+  {MACRLC_DL_HARQ_RESULT_OBSERVERS,    HLP_SCHED_OBSERVERS,      0, .strlistptr=NULL, .defstrlistval=NULL,    TYPE_STRINGLIST, 0}, \
+  {MACRLC_UL_HARQ_RESULT_OBSERVERS,    HLP_SCHED_OBSERVERS,      0, .strlistptr=NULL, .defstrlistval=NULL,    TYPE_STRINGLIST, 0}, \
   {MACRLC_SPATIAL_STREAM_IDX,          HLP_MACRLC_SPATIAL_STREAM_INDEX, \
                                                                                0, .uptr=NULL,   .defintarrayval=0,          TYPE_INTARRAY,0}, \
 }
@@ -213,6 +218,8 @@
   { .s5 = { NULL } }, /* UL beam policy */ \
   { .s5 = { NULL } }, /* UL MCS policy */ \
   { .s5 = { NULL } }, /* UL RB-allocation policy */ \
+  { .s5 = { NULL } }, /* DL HARQ observers */ \
+  { .s5 = { NULL } }, /* UL HARQ observers */ \
   { .s2 = { NULL } }, /* Spatial stream index */ \
 }
 

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -25,6 +25,7 @@
 #include "asn_internal.h"
 #include "NR_MAC_gNB/nr_mac_gNB.h"
 #include "NR_MAC_gNB/mac_proto.h"
+#include "NR_MAC_gNB/nr_sched_registries.h"
 #include "common/5g_platform_types.h"
 #include "common/config/config_paramdesc.h"
 #include "common/config/config_userapi.h"
@@ -1730,6 +1731,44 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg)
         ul_bler_options->harq_round_max = 1;
       else
         ul_bler_options->harq_round_max = *gpd(params, np, MACRLC_UL_HARQ_ROUND_MAX)->u8ptr;
+
+#define LOAD_SCHED_POLICY(config_key, registry, field, fn_type)              \
+  do {                                                                       \
+    const char *policy_name = *gpd(params, np, config_key)->strptr;          \
+    fn_type policy = registry##_lookup(policy_name);                         \
+    AssertFatal(policy != NULL,                                              \
+                "Unknown scheduler policy '%s' for '%s' (registered: %s)\n", \
+                policy_name,                                                 \
+                config_key,                                                  \
+                registry##_names());                                         \
+    RC.nrmac[j]->field = policy;                                             \
+  } while (0)
+
+      LOAD_SCHED_POLICY(MACRLC_DL_PREPROCESSOR_POLICY, dl_preprocessor_policy, pre_processor_dl, nr_pp_impl_dl);
+      LOAD_SCHED_POLICY(MACRLC_DL_RI_PMI_SELECT_POLICY, dl_ri_pmi_select_policy, dl_ri_pmi_select, nr_dl_ri_pmi_select_fn);
+      LOAD_SCHED_POLICY(MACRLC_DL_TDA_SELECT_POLICY, dl_tda_select_policy, dl_tda_select, nr_dl_tda_select_fn);
+      LOAD_SCHED_POLICY(MACRLC_DL_BEAM_SELECT_POLICY, dl_beam_select_policy, dl_beam_select, nr_dl_beam_select_fn);
+      LOAD_SCHED_POLICY(MACRLC_DL_MCS_SELECT_POLICY, dl_mcs_select_policy, dl_mcs_select, nr_dl_mcs_select_fn);
+      LOAD_SCHED_POLICY(MACRLC_DL_RB_ALLOC_POLICY, dl_rb_alloc_policy, dl_rb_alloc, nr_dl_rb_alloc_fn);
+      LOAD_SCHED_POLICY(MACRLC_DL_LCID_ALLOC_POLICY, dl_lcid_alloc_policy, dl_lcid_alloc, nr_dl_lcid_alloc_fn);
+      LOAD_SCHED_POLICY(MACRLC_UL_PREPROCESSOR_POLICY, ul_preprocessor_policy, pre_processor_ul, nr_pp_impl_ul);
+      LOAD_SCHED_POLICY(MACRLC_UL_RI_TPMI_SELECT_POLICY, ul_ri_tpmi_select_policy, ul_ri_tpmi_select, nr_ul_ri_tpmi_select_fn);
+      LOAD_SCHED_POLICY(MACRLC_UL_TDA_SELECT_POLICY, ul_tda_select_policy, ul_tda_select, nr_ul_tda_select_fn);
+      LOAD_SCHED_POLICY(MACRLC_UL_BEAM_SELECT_POLICY, ul_beam_select_policy, ul_beam_select, nr_ul_beam_select_fn);
+      LOAD_SCHED_POLICY(MACRLC_UL_MCS_SELECT_POLICY, ul_mcs_select_policy, ul_mcs_select, nr_ul_mcs_select_fn);
+      LOAD_SCHED_POLICY(MACRLC_UL_RB_ALLOC_POLICY, ul_rb_alloc_policy, ul_rb_alloc, nr_ul_rb_alloc_fn);
+
+#undef LOAD_SCHED_POLICY
+
+      /* phy-test has always owned the two preprocessors regardless of the
+       * normal scheduler configuration. Preserve that command-line override. */
+      if (get_softmodem_params()->phy_test) {
+        RC.nrmac[j]->pre_processor_dl = dl_preprocessor_policy_lookup("phytest");
+        RC.nrmac[j]->pre_processor_ul = ul_preprocessor_policy_lookup("phytest");
+        AssertFatal(RC.nrmac[j]->pre_processor_dl != NULL && RC.nrmac[j]->pre_processor_ul != NULL,
+                    "phytest scheduler preprocessors are not registered\n");
+      }
+
       RC.nrmac[j]->min_grant_prb = *gpd(params, np, MACRLC_MIN_GRANT_PRB)->u16ptr;
       long sc_fdma = NR_PUSCH_Config__transformPrecoder_enabled;
       NR_BWP_UplinkCommon_t *bwp = RC.nrmac[j]->common_channels[0].ServingCellConfigCommon->uplinkConfigCommon->initialUplinkBWP;

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -1769,6 +1769,39 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg)
                     "phytest scheduler preprocessors are not registered\n");
       }
 
+#define LOAD_HARQ_RESULT_OBSERVERS(config_key, registry, fn_type, field, count_field)   \
+  do {                                                                                  \
+    const paramdef_t *observer_param = gpd(params, np, config_key);                     \
+    AssertFatal(observer_param->numelt <= NR_SCHED_MAX_HARQ_RESULT_OBSERVERS,           \
+                "At most %d observers are supported for '%s' (configured %d)\n",        \
+                NR_SCHED_MAX_HARQ_RESULT_OBSERVERS,                                     \
+                config_key,                                                             \
+                observer_param->numelt);                                                \
+    RC.nrmac[j]->count_field = 0;                                                       \
+    for (int observer_idx = 0; observer_idx < observer_param->numelt; ++observer_idx) { \
+      const char *observer_name = observer_param->strlistptr[observer_idx];             \
+      fn_type observer = registry##_lookup(observer_name);                              \
+      AssertFatal(observer != NULL,                                                     \
+                  "Unknown observer '%s' for '%s' (registered: %s)\n",                  \
+                  observer_name,                                                        \
+                  config_key,                                                           \
+                  registry##_names());                                                  \
+      RC.nrmac[j]->field[RC.nrmac[j]->count_field++] = observer;                        \
+    }                                                                                   \
+  } while (0)
+
+      LOAD_HARQ_RESULT_OBSERVERS(MACRLC_DL_HARQ_RESULT_OBSERVERS,
+                                 dl_harq_result_observer,
+                                 nr_dl_harq_result_observer_fn,
+                                 dl_harq_result_observers,
+                                 num_dl_harq_result_observers);
+      LOAD_HARQ_RESULT_OBSERVERS(MACRLC_UL_HARQ_RESULT_OBSERVERS,
+                                 ul_harq_result_observer,
+                                 nr_ul_harq_result_observer_fn,
+                                 ul_harq_result_observers,
+                                 num_ul_harq_result_observers);
+
+#undef LOAD_HARQ_RESULT_OBSERVERS
       RC.nrmac[j]->min_grant_prb = *gpd(params, np, MACRLC_MIN_GRANT_PRB)->u16ptr;
       long sc_fdma = NR_PUSCH_Config__transformPrecoder_enabled;
       NR_BWP_UplinkCommon_t *bwp = RC.nrmac[j]->common_channels[0].ServingCellConfigCommon->uplinkConfigCommon->initialUplinkBWP;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch.c
@@ -11,6 +11,7 @@
 #include "NR_MAC_COMMON/nr_mac.h"
 #include "NR_MAC_gNB/nr_mac_gNB.h"
 #include "LAYER2/NR_MAC_gNB/mac_proto.h"
+#include "LAYER2/NR_MAC_gNB/nr_sched_registries.h"
 #include "openair2/LAYER2/nr_rlc/nr_rlc_oai_api.h"
 
 /*TAG*/
@@ -1418,3 +1419,5 @@ void nr_schedule_ue_spec(module_id_t module_id,
   /* PREPROCESSOR */
   gNB_mac->pre_processor_dl(gNB_mac, &pdsch);
 }
+
+SCHED_REGISTRY_ADD(dl_preprocessor_policy, default, nr_dlsch_preprocessor);

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch_default_policies.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch_default_policies.c
@@ -14,6 +14,7 @@
 
 #include "common/utils/nr/nr_common.h"
 #include "gNB_scheduler_dlsch_default_policies.h"
+#include "nr_sched_registries.h"
 /*MAC*/
 #include "NR_MAC_COMMON/nr_mac.h"
 #include "NR_MAC_gNB/nr_mac_gNB.h"
@@ -170,6 +171,13 @@ void nr_dl_mcs_select_default(const gNB_MAC_INST *mac, nr_dl_candidate_t *candid
       cand->UE->UE_sched_ctrl.dl_bler_stats.mcs = mcs;
   }
 }
+
+SCHED_REGISTRY_ADD(dl_ri_pmi_select_policy, default, nr_dl_ri_pmi_select_default);
+SCHED_REGISTRY_ADD(dl_tda_select_policy, default, nr_dl_tda_select_default);
+SCHED_REGISTRY_ADD(dl_beam_select_policy, default, nr_dl_beam_select_default);
+SCHED_REGISTRY_ADD(dl_mcs_select_policy, default, nr_dl_mcs_select_default);
+SCHED_REGISTRY_ADD(dl_rb_alloc_policy, default, nr_dl_proportional_fair);
+SCHED_REGISTRY_ADD(dl_lcid_alloc_policy, default, nr_dl_lcid_alloc_default);
 
 static int compare_dl_pf_rb_ptrs(const void *a, const void *b)
 {

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_phytest.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_phytest.c
@@ -8,6 +8,7 @@
 
 #include "nr_mac_gNB.h"
 #include "NR_MAC_gNB/mac_proto.h"
+#include "NR_MAC_gNB/nr_sched_registries.h"
 #include "LAYER2/NR_MAC_COMMON/nr_mac_common.h"
 #include "executables/nr-softmodem.h"
 #include "LAYER2/NR_MAC_COMMON/nr_mac.h"
@@ -358,3 +359,6 @@ void nr_ul_preprocessor_phytest(gNB_MAC_INST *nr_mac, post_process_pusch_t *pp_p
   for (int rb = rbStart; rb < rbStart + rbSize; rb++)
     vrb_map_UL[rb+BWPStart] |= SL_to_bitmap(tda_info.startSymbolIndex, tda_info.nrOfSymbols);
 }
+
+SCHED_REGISTRY_ADD(dl_preprocessor_policy, phytest, nr_preprocessor_phytest);
+SCHED_REGISTRY_ADD(ul_preprocessor_policy, phytest, nr_ul_preprocessor_phytest);

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_uci.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_uci.c
@@ -12,6 +12,7 @@
 #include <softmodem-common.h>
 #include "NR_MAC_gNB/nr_mac_gNB.h"
 #include "NR_MAC_gNB/mac_proto.h"
+#include "NR_MAC_gNB/nr_sched_registries.h"
 #include "common/ran_context.h"
 #include "common/utils/T/T.h"
 #include "common/utils/nr/nr_common.h"
@@ -365,12 +366,29 @@ int get_pucch_resourceid(NR_PUCCH_Config_t *pucch_Config, int O_uci, int pucch_r
   return *resource_id;
 }
 
-static void handle_dl_harq(gNB_MAC_INST *mac, NR_UE_info_t * UE, int8_t harq_pid, bool success, int harq_round_max)
+static void notify_dl_harq_result(gNB_MAC_INST *mac,
+                                  const NR_UE_info_t *UE,
+                                  int8_t harq_pid,
+                                  uint8_t round,
+                                  nr_harq_result_status_t status)
+{
+  const nr_harq_result_t result = {
+      .rnti = UE->rnti,
+      .harq_pid = harq_pid,
+      .round = round,
+      .status = status,
+  };
+  nr_notify_dl_harq_result(mac, &result);
+}
+
+static void handle_dl_harq(gNB_MAC_INST *mac, NR_UE_info_t *UE, int8_t harq_pid, nr_harq_result_status_t status, int harq_round_max)
 {
   NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
   NR_UE_harq_t *harq = &sched_ctrl->harq_processes[harq_pid];
+  notify_dl_harq_result(mac, UE, harq_pid, harq->round, status);
   harq->feedback_slot = -1;
   harq->is_waiting = false;
+  const bool success = status == NR_HARQ_RESULT_ACK;
   if (success) {
     if (harq->sched_pdsch.action)
       harq->sched_pdsch.action(mac, UE);
@@ -858,7 +876,7 @@ static void extract_pucch_csi_report(NR_CSI_MeasConfig_t *csi_MeasConfig,
     beam_switching_procedure(nrmac, UE, new_bf_index);
 }
 
-static NR_UE_harq_t *find_harq(frame_t frame, slot_t slot, NR_UE_info_t * UE, int harq_round_max)
+static NR_UE_harq_t *find_harq(gNB_MAC_INST *nrmac, frame_t frame, slot_t slot, NR_UE_info_t *UE)
 {
   /* In case of realtime problems: we can only identify a HARQ process by
    * timing. If the HARQ process's feedback_frame/feedback_slot is not the one we
@@ -883,7 +901,7 @@ static NR_UE_harq_t *find_harq(frame_t frame, slot_t slot, NR_UE_info_t * UE, in
           frame,
           slot);
     remove_front_nr_list(&sched_ctrl->feedback_dl_harq);
-    handle_dl_harq(NULL, UE, pid, false, harq_round_max);
+    handle_dl_harq(nrmac, UE, pid, NR_HARQ_RESULT_MISSING, nrmac->dl_bler.harq_round_max);
     pid = sched_ctrl->feedback_dl_harq.head;
     if (pid < 0)
       return NULL;
@@ -928,7 +946,7 @@ void handle_nr_uci_pucch_0_1(module_id_t mod_id, frame_t frame, slot_t slot, con
     for (int harq_bit = 0; harq_bit < uci_01->harq.num_harq; harq_bit++) {
       const uint8_t harq_value = uci_01->harq.harq_list[harq_bit].harq_value;
       const uint8_t harq_confidence = uci_01->harq.harq_confidence_level;
-      NR_UE_harq_t *harq = find_harq(frame, slot, UE, nrmac->dl_bler.harq_round_max);
+      NR_UE_harq_t *harq = find_harq(nrmac, frame, slot, UE);
       if (!harq) {
         LOG_E(NR_MAC, "UE %04x: Could not find a HARQ process at %4d.%2d!\n", UE->rnti, frame, slot);
         break;
@@ -938,7 +956,10 @@ void handle_nr_uci_pucch_0_1(module_id_t mod_id, frame_t frame, slot_t slot, con
       remove_front_nr_list(&sched_ctrl->feedback_dl_harq);
       LOG_D(NR_MAC,"%4d.%2d bit %d pid %d ack/nack %d\n",frame, slot, harq_bit,pid,harq_value);
       nr_mac_update_pdcch_closed_loop_adjust(sched_ctrl, harq_confidence != 0);
-      bool success = harq_value == 0 && harq_confidence == 0;
+      nr_harq_result_status_t status = harq_confidence != 0 ? NR_HARQ_RESULT_DTX
+                                       : harq_value == 0    ? NR_HARQ_RESULT_ACK
+                                                            : NR_HARQ_RESULT_NACK;
+      bool success = status == NR_HARQ_RESULT_ACK;
       // TCI state switch occurs at the first slot that is after slot n_+ T_HARQ + 3N_sf_slot (8.10.3 of 38.133)
       if (success && harq->start_tci_timer) {
         int slots = 3 * nrmac->frame_structure.numb_slots_frame / 10;
@@ -946,7 +967,7 @@ void handle_nr_uci_pucch_0_1(module_id_t mod_id, frame_t frame, slot_t slot, con
         nr_timer_start(&sched_ctrl->tci_beam_switch);
         harq->start_tci_timer = false;
       }
-      handle_dl_harq(nrmac, UE, pid, success, nrmac->dl_bler.harq_round_max);
+      handle_dl_harq(nrmac, UE, pid, status, nrmac->dl_bler.harq_round_max);
       if (is_ra) {
         bool ue_rejected = nr_check_Msg4_MsgB_Ack(mod_id, frame, slot, UE, success);
         if (ue_rejected) {
@@ -1029,7 +1050,7 @@ void handle_nr_uci_pucch_2_3_4(module_id_t mod_id, frame_t frame, slot_t slot, c
     // iterate over received harq bits
     for (int harq_bit = 0; harq_bit < uci_234->harq.harq_bit_len; harq_bit++) {
       const int acknack = ((uci_234->harq.harq_payload[harq_bit >> 3]) >> harq_bit) & 0x01;
-      NR_UE_harq_t *harq = find_harq(frame, slot, UE, RC.nrmac[mod_id]->dl_bler.harq_round_max);
+      NR_UE_harq_t *harq = find_harq(nrmac, frame, slot, UE);
       if (!harq) {
         LOG_E(NR_MAC, "UE %04x: Could not find a HARQ process at %4d.%2d!\n", UE->rnti, frame, slot);
         break;
@@ -1039,14 +1060,17 @@ void handle_nr_uci_pucch_2_3_4(module_id_t mod_id, frame_t frame, slot_t slot, c
       remove_front_nr_list(&sched_ctrl->feedback_dl_harq);
       LOG_D(NR_MAC,"%4d.%2d bit %d pid %d ack/nack %d\n",frame, slot, harq_bit, pid, acknack);
       // TCI state switch occurs at the first slot that is after slot n_+ T_HARQ + 3N_sf_slot (8.10.3 of 38.133)
-      bool success = uci_234->harq.harq_crc != 1 && acknack;
+      nr_harq_result_status_t status = uci_234->harq.harq_crc == 1 ? NR_HARQ_RESULT_DTX
+                                       : acknack                   ? NR_HARQ_RESULT_ACK
+                                                                   : NR_HARQ_RESULT_NACK;
+      bool success = status == NR_HARQ_RESULT_ACK;
       if (success && harq->start_tci_timer) {
         int slots = 3 * nrmac->frame_structure.numb_slots_frame / 10;
         nr_timer_setup(&sched_ctrl->tci_beam_switch, slots, 1);
         nr_timer_start(&sched_ctrl->tci_beam_switch);
         harq->start_tci_timer = false;
       }
-      handle_dl_harq(nrmac, UE, pid, success, nrmac->dl_bler.harq_round_max);
+      handle_dl_harq(nrmac, UE, pid, status, nrmac->dl_bler.harq_round_max);
     }
     free(uci_234->harq.harq_payload);
   }

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -674,10 +674,26 @@ static void abort_nr_ul_harq(NR_UE_info_t *UE, int8_t harq_pid)
     sched_ctrl->sched_ul_bytes = 0;
 }
 
-static void handle_nr_ul_harq(gNB_MAC_INST *nrmac, NR_UE_info_t *UE, rnti_t rnti, int crc_harq_id, bool crc_status)
+static void notify_ul_harq_result(gNB_MAC_INST *mac,
+                                  const NR_UE_info_t *UE,
+                                  int8_t harq_pid,
+                                  uint8_t round,
+                                  nr_harq_result_status_t status)
+{
+  const nr_harq_result_t result = {
+      .rnti = UE->rnti,
+      .harq_pid = harq_pid,
+      .round = round,
+      .status = status,
+  };
+  nr_notify_ul_harq_result(mac, &result);
+}
+
+static void handle_nr_ul_harq(gNB_MAC_INST *nrmac, NR_UE_info_t *UE, rnti_t rnti, int crc_harq_id, nr_harq_result_status_t status)
 {
   if (nrmac->radio_config.disable_harq) {
     LOG_D(NR_MAC, "skipping UL feedback handling as HARQ is disabled\n");
+    notify_ul_harq_result(nrmac, UE, crc_harq_id, 0, status);
     return;
   }
 
@@ -690,12 +706,14 @@ static void handle_nr_ul_harq(gNB_MAC_INST *nrmac, NR_UE_info_t *UE, rnti_t rnti
       return;
 
     remove_front_nr_list(&sched_ctrl->feedback_ul_harq);
-    sched_ctrl->ul_harq_processes[harq_pid].is_waiting = false;
+    NR_UE_ul_harq_t *missed_harq = &sched_ctrl->ul_harq_processes[harq_pid];
+    missed_harq->is_waiting = false;
+    notify_ul_harq_result(nrmac, UE, harq_pid, missed_harq->round, NR_HARQ_RESULT_MISSING);
 
-    if(sched_ctrl->ul_harq_processes[harq_pid].round >= nrmac->ul_bler.harq_round_max - 1) {
+    if (missed_harq->round >= nrmac->ul_bler.harq_round_max - 1) {
       abort_nr_ul_harq(UE, harq_pid);
     } else {
-      sched_ctrl->ul_harq_processes[harq_pid].round++;
+      missed_harq->round++;
       add_tail_nr_list(&sched_ctrl->retrans_ul_harq, harq_pid);
     }
     harq_pid = sched_ctrl->feedback_ul_harq.head;
@@ -705,13 +723,14 @@ static void handle_nr_ul_harq(gNB_MAC_INST *nrmac, NR_UE_info_t *UE, rnti_t rnti
   DevAssert(harq->is_waiting);
   harq->feedback_slot = -1;
   harq->is_waiting = false;
-  if (!crc_status) {
+  notify_ul_harq_result(nrmac, UE, harq_pid, harq->round, status);
+  if (status == NR_HARQ_RESULT_ACK) {
     finish_nr_ul_harq(sched_ctrl, harq_pid);
     LOG_D(NR_MAC,
           "Ulharq id %d crc passed for RNTI %04x\n",
           harq_pid,
           rnti);
-  } else if (harq->round >= nrmac->ul_bler.harq_round_max  - 1) {
+  } else if (harq->round >= nrmac->ul_bler.harq_round_max - 1) {
     abort_nr_ul_harq(UE, harq_pid);
     LOG_D(NR_MAC,
           "RNTI %04x: Ulharq id %d crc failed in all rounds\n",
@@ -1024,7 +1043,10 @@ static void _nr_rx_sdu(const module_id_t gnb_mod_idP,
         nr_mac_trigger_ul_failure(&UE->UE_sched_ctrl, UE->current_UL_BWP.scs);
       }
     }
-    handle_nr_ul_harq(gNB_mac, UE, current_rnti, harq_pid, sduP == NULL);
+    nr_harq_result_status_t status = sduP != NULL                      ? NR_HARQ_RESULT_ACK
+                                     : ul_cqi == 0xff || ul_cqi <= 128 ? NR_HARQ_RESULT_DTX
+                                                                       : NR_HARQ_RESULT_NACK;
+    handle_nr_ul_harq(gNB_mac, UE, current_rnti, harq_pid, status);
   } else {
     nr_rx_ra_sdu(gnb_mod_idP, CC_idP, frameP, slotP, current_rnti, sduP, sdu_lenP, harq_pid, timing_advance, ul_cqi, rssi);
   }

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -8,6 +8,7 @@
 
 
 #include "LAYER2/NR_MAC_gNB/mac_proto.h"
+#include "LAYER2/NR_MAC_gNB/nr_sched_registries.h"
 #include "executables/softmodem-common.h"
 #include "common/utils/nr/nr_common.h"
 #include "utils.h"
@@ -2993,3 +2994,5 @@ bool commit_ul_alloc(const nr_ul_sched_params_t *params, nr_ul_candidate_t *cand
     vrb_map[cand->sched_pusch.rbStart + cand->bwp_start + rb] |= cand->alloc_slbitmap;
   return true;
 }
+
+SCHED_REGISTRY_ADD(ul_preprocessor_policy, default, nr_ulsch_preprocessor);

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch_default_policies.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch_default_policies.c
@@ -11,6 +11,7 @@
  */
 
 #include "gNB_scheduler_ulsch_default_policies.h"
+#include "nr_sched_registries.h"
 #include "LAYER2/NR_MAC_gNB/mac_proto.h"
 #include "executables/softmodem-common.h"
 #include "common/utils/nr/nr_common.h"
@@ -214,6 +215,12 @@ void nr_ul_mcs_select_default(const gNB_MAC_INST *mac, nr_ul_candidate_t *candid
       cand->UE->UE_sched_ctrl.ul_bler_stats.mcs = mcs;
   }
 }
+
+SCHED_REGISTRY_ADD(ul_ri_tpmi_select_policy, default, nr_ul_ri_tpmi_select_default);
+SCHED_REGISTRY_ADD(ul_tda_select_policy, default, nr_ul_tda_select_default);
+SCHED_REGISTRY_ADD(ul_beam_select_policy, default, nr_ul_beam_select_default);
+SCHED_REGISTRY_ADD(ul_mcs_select_policy, default, nr_ul_mcs_select_default);
+SCHED_REGISTRY_ADD(ul_rb_alloc_policy, default, nr_ul_proportional_fair);
 
 static int compare_ul_pf_rb_ptrs(const void *a, const void *b)
 {

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -976,6 +976,34 @@ typedef struct gNB_MAC_INST_s gNB_MAC_INST;
 typedef void (*nr_pp_impl_dl)(gNB_MAC_INST *nr_mac, post_process_pdsch_t *pp_pdsch);
 typedef void (*nr_pp_impl_ul)(gNB_MAC_INST *nr_mac, post_process_pusch_t *pp_pusch);
 
+/// Result of one HARQ transmission attempt as observed by MAC.
+typedef enum {
+  NR_HARQ_RESULT_ACK,
+  NR_HARQ_RESULT_NACK,
+  NR_HARQ_RESULT_DTX,
+  NR_HARQ_RESULT_MISSING,
+} nr_harq_result_status_t;
+
+/// HARQ result emitted before the corresponding HARQ process is advanced or released.
+typedef struct {
+  rnti_t rnti;
+  int8_t harq_pid;
+  uint8_t round;
+  nr_harq_result_status_t status;
+} nr_harq_result_t;
+
+/// Observer invoked synchronously under the MAC scheduler lock. Implementations
+/// must not block or retain the result pointer. sched_stateful_data is the same
+/// persistent context shared by the configured scheduler policies.
+typedef void (*nr_dl_harq_result_observer_fn)(gNB_MAC_INST *mac,
+                                              const nr_harq_result_t *result,
+                                              void *sched_stateful_data);
+typedef void (*nr_ul_harq_result_observer_fn)(gNB_MAC_INST *mac,
+                                              const nr_harq_result_t *result,
+                                              void *sched_stateful_data);
+
+#define NR_SCHED_MAX_HARQ_RESULT_OBSERVERS 8
+
 /// RI/PMI selection: sets nrOfLayers and pm_index per candidate from CSI feedback.
 /// For retransmissions, nrOfLayers must match the original transmission.
 /// Custom implementations may use SRS reciprocity to override the UE's reported RI/PMI.
@@ -1279,7 +1307,13 @@ typedef struct gNB_MAC_INST_s {
   nr_ul_mcs_select_fn ul_mcs_select;
   nr_ul_rb_alloc_fn ul_rb_alloc;
 
-  /// Optional state persistence for scheduling policies.
+  /// Direction-specific HARQ-result fan-out. Observers run in configuration order.
+  nr_dl_harq_result_observer_fn dl_harq_result_observers[NR_SCHED_MAX_HARQ_RESULT_OBSERVERS];
+  int num_dl_harq_result_observers;
+  nr_ul_harq_result_observer_fn ul_harq_result_observers[NR_SCHED_MAX_HARQ_RESULT_OBSERVERS];
+  int num_ul_harq_result_observers;
+
+  /// Optional persistent context shared by scheduling policies and observers.
   void *sched_stateful_data;
 
   nr_mac_config_t radio_config;

--- a/openair2/LAYER2/NR_MAC_gNB/nr_sched_registries.c
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_sched_registries.c
@@ -5,3 +5,18 @@
 #define DEFINE_NR_SCHED_POLICY_REGISTRY(registry, fn_type) SCHED_REGISTRY_DEFINE(registry, fn_type);
 NR_SCHED_POLICY_REGISTRIES(DEFINE_NR_SCHED_POLICY_REGISTRY)
 #undef DEFINE_NR_SCHED_POLICY_REGISTRY
+
+SCHED_REGISTRY_DEFINE(dl_harq_result_observer, nr_dl_harq_result_observer_fn);
+SCHED_REGISTRY_DEFINE(ul_harq_result_observer, nr_ul_harq_result_observer_fn);
+
+void nr_notify_dl_harq_result(gNB_MAC_INST *mac, const nr_harq_result_t *result)
+{
+  for (int i = 0; i < mac->num_dl_harq_result_observers; ++i)
+    mac->dl_harq_result_observers[i](mac, result, mac->sched_stateful_data);
+}
+
+void nr_notify_ul_harq_result(gNB_MAC_INST *mac, const nr_harq_result_t *result)
+{
+  for (int i = 0; i < mac->num_ul_harq_result_observers; ++i)
+    mac->ul_harq_result_observers[i](mac, result, mac->sched_stateful_data);
+}

--- a/openair2/LAYER2/NR_MAC_gNB/nr_sched_registries.c
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_sched_registries.c
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: LicenseRef-CSSL-1.0 */
+
+#include "nr_sched_registries.h"
+
+#define DEFINE_NR_SCHED_POLICY_REGISTRY(registry, fn_type) SCHED_REGISTRY_DEFINE(registry, fn_type);
+NR_SCHED_POLICY_REGISTRIES(DEFINE_NR_SCHED_POLICY_REGISTRY)
+#undef DEFINE_NR_SCHED_POLICY_REGISTRY

--- a/openair2/LAYER2/NR_MAC_gNB/nr_sched_registries.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_sched_registries.h
@@ -25,4 +25,10 @@
 NR_SCHED_POLICY_REGISTRIES(DECLARE_NR_SCHED_POLICY_REGISTRY)
 #undef DECLARE_NR_SCHED_POLICY_REGISTRY
 
+SCHED_REGISTRY_DECLARE(dl_harq_result_observer, nr_dl_harq_result_observer_fn);
+SCHED_REGISTRY_DECLARE(ul_harq_result_observer, nr_ul_harq_result_observer_fn);
+
+void nr_notify_dl_harq_result(gNB_MAC_INST *mac, const nr_harq_result_t *result);
+void nr_notify_ul_harq_result(gNB_MAC_INST *mac, const nr_harq_result_t *result);
+
 #endif /* NR_SCHED_REGISTRIES_H */

--- a/openair2/LAYER2/NR_MAC_gNB/nr_sched_registries.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_sched_registries.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: LicenseRef-CSSL-1.0 */
+
+#ifndef NR_SCHED_REGISTRIES_H
+#define NR_SCHED_REGISTRIES_H
+
+#include "common/utils/sched_registry.h"
+#include "nr_mac_gNB.h"
+
+#define NR_SCHED_POLICY_REGISTRIES(M)                  \
+  M(dl_preprocessor_policy, nr_pp_impl_dl)             \
+  M(dl_ri_pmi_select_policy, nr_dl_ri_pmi_select_fn)   \
+  M(dl_tda_select_policy, nr_dl_tda_select_fn)         \
+  M(dl_beam_select_policy, nr_dl_beam_select_fn)       \
+  M(dl_mcs_select_policy, nr_dl_mcs_select_fn)         \
+  M(dl_rb_alloc_policy, nr_dl_rb_alloc_fn)             \
+  M(dl_lcid_alloc_policy, nr_dl_lcid_alloc_fn)         \
+  M(ul_preprocessor_policy, nr_pp_impl_ul)             \
+  M(ul_ri_tpmi_select_policy, nr_ul_ri_tpmi_select_fn) \
+  M(ul_tda_select_policy, nr_ul_tda_select_fn)         \
+  M(ul_beam_select_policy, nr_ul_beam_select_fn)       \
+  M(ul_mcs_select_policy, nr_ul_mcs_select_fn)         \
+  M(ul_rb_alloc_policy, nr_ul_rb_alloc_fn)
+
+#define DECLARE_NR_SCHED_POLICY_REGISTRY(registry, fn_type) SCHED_REGISTRY_DECLARE(registry, fn_type);
+NR_SCHED_POLICY_REGISTRIES(DECLARE_NR_SCHED_POLICY_REGISTRY)
+#undef DECLARE_NR_SCHED_POLICY_REGISTRY
+
+#endif /* NR_SCHED_REGISTRIES_H */

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-vnf.sa.band78.273prb.aerial.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-vnf.sa.band78.273prb.aerial.conf
@@ -187,6 +187,19 @@ MACRLCs = (
   pucch_TargetSNRx10 = 100; #200;
   dl_max_mcs         = 25;
   ul_max_mcs         = 25;
+  dl_preprocessor_policy   = "default";
+  dl_ri_pmi_select_policy  = "default";
+  dl_tda_select_policy     = "default";
+  dl_beam_select_policy    = "default";
+  dl_mcs_select_policy     = "default";
+  dl_rb_alloc_policy       = "default";
+  dl_lcid_alloc_policy     = "default";
+  ul_preprocessor_policy   = "default";
+  ul_ri_tpmi_select_policy = "default";
+  ul_tda_select_policy     = "default";
+  ul_beam_select_policy    = "default";
+  ul_mcs_select_policy     = "default";
+  ul_rb_alloc_policy       = "default";
 }
 );
 

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-vnf.sa.band78.273prb.aerial.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb-vnf.sa.band78.273prb.aerial.conf
@@ -200,6 +200,8 @@ MACRLCs = (
   ul_beam_select_policy    = "default";
   ul_mcs_select_policy     = "default";
   ul_rb_alloc_policy       = "default";
+  dl_harq_result_observers = ();
+  ul_harq_result_observers = ();
 }
 );
 


### PR DESCRIPTION
This PR adds a policy registry to make it easy to swap between MAC policies from the config file. It also adds the HARQ observers necessary for the OLLA rebuild