### PR TITLE
Fix PRACH regression with Microamp FR2 + Add Microamp FR2 to CI

### DIFF
--- a/ci-scripts/Jenkinsfile-GitHub-Container
+++ b/ci-scripts/Jenkinsfile-GitHub-Container
@@ -804,6 +804,29 @@ pipeline {
             }
           }
         }
+        stage ("SA-FHI72-FR2-CN5G") {
+          when { expression {do5Gtest} }
+          steps {
+            script {
+              triggerDownstreamJob ('RAN-SA-FHI72-FR2-CN5G')
+            }
+          }
+          post {
+            always {
+              script {
+                // Using a unique variable name for each test stage to avoid overwriting on a global variable
+                // due to parallel-time concurrency
+                saFHI72FR2Status = finalizeDownstreamJob('RAN-SA-FHI72-FR2-CN5G')
+              }
+            }
+            failure {
+              script {
+                currentBuild.result = 'FAILURE'
+                failingStages += saFHI72FR2Status
+              }
+            }
+          }
+        }
         stage ("SA-ORU-CN5G") {
           when { expression {do5Gtest} }
           steps {

--- a/ci-scripts/ci_infra.yaml
+++ b/ci-scripts/ci_infra.yaml
@@ -141,6 +141,14 @@ oc-cn5g-20897-stonechat:
   Undeploy: "! scripts/oc-cn5g-undeploy.sh /opt/oai-cn5g-fed-develop-2025-jan oaicicd-core-for-fhi72"
   LogCollect: "! scripts/oc-cn5g-logcollect.sh /opt/oai-cn5g-fed-develop-2025-jan oaicicd-core-for-fhi72  %%log_dir%%"
 
+oc-cn5g-20899-stonechat:
+  Host: stonechat
+  NetworkScript: echo "inet 172.21.6.121"
+  RunIperf3Server: False
+  Deploy: "! scripts/oc-cn5g-deploy.sh /opt/oai-cn5g-fed-develop-20899 oaicicd-core-for-fhi72-fr2"
+  Undeploy: "! scripts/oc-cn5g-undeploy.sh /opt/oai-cn5g-fed-develop-20899 oaicicd-core-for-fhi72-fr2"
+  LogCollect: "! scripts/oc-cn5g-logcollect.sh /opt/oai-cn5g-fed-develop-20899 oaicicd-core-for-fhi72-fr2  %%log_dir%%"
+
 oc-cn5g-20899-always-on:
   Host: stonechat
   NetworkScript: echo "inet 172.21.6.12"

--- a/ci-scripts/ci_infra.yaml
+++ b/ci-scripts/ci_infra.yaml
@@ -52,6 +52,14 @@ up3:
   IF: wwan0
   MTU: 1500
 
+up4:
+  Host: up4
+  AttachScript: sudo /opt/mbim-fhi72/start_quectel_mbim.sh
+  DetachScript: sudo /opt/mbim-fhi72/stop_quectel_mbim.sh
+  NetworkScript: ip a show dev wwan0
+  IF: wwan0
+  MTU: 1500
+
 adb_ue_1:
   Host: nano
   InitScript: /home/oaicicd/ci_ctl_adb.sh initialize R3CM40LZPHT

--- a/ci-scripts/conf_files/gnb.sa.band257.66prb.fhi72.2x2-microamp.conf
+++ b/ci-scripts/conf_files/gnb.sa.band257.66prb.fhi72.2x2-microamp.conf
@@ -164,7 +164,7 @@ gNBs =
     };
 
     ////////// AMF parameters:
-    amf_ip_address = ({ ipv4 = "172.21.6.5"; });
+    amf_ip_address = ({ ipv4 = "172.21.6.119"; });
 
     NETWORK_INTERFACES :
     {

--- a/ci-scripts/conf_files/gnb.sa.band257.66prb.fhi72.2x2-microamp.conf
+++ b/ci-scripts/conf_files/gnb.sa.band257.66prb.fhi72.2x2-microamp.conf
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+Active_gNBs = ( "eurecom-gnb");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    =  0xe99;
+    cell_type =  "CELL_MACRO_GNB";
+
+    gNB_name  =  "eurecom-gnb";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  1;
+    plmn_list = ({ mcc = 208; mnc = 99; mnc_length = 2; snssaiList = ( { sst = 1; }); });
+    nr_cellid = 1;
+
+    ////////// Physical parameters:
+    pdsch_AntennaPorts_XP = 2; 
+    pusch_AntennaPorts    = 2;
+    maxMIMO_layers        = 2;
+    do_CSIRS              = 1;
+    min_rxtxtime          = 3;
+
+    servingCellConfigCommon = (
+    {
+ #spCellConfigCommon
+
+      physCellId                                                    = 0;
+
+#  downlinkConfigCommon
+    #frequencyInfoDL
+      absoluteFrequencySSB                                           = 2080027; 
+      dl_frequencyBand                                                 = 257;  
+      dl_absoluteFrequencyPointA                                       = 2079195;
+
+      #scs-SpecificCarrierList
+        dl_offstToCarrier                                              = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+        dl_subcarrierSpacing                                           = 3;
+        dl_carrierBandwidth                                            = 66; #32;
+     #initialDownlinkBWP
+      #genericParameters
+        # this is RBstart=0,L=32 (275*(L-1))+RBstart
+        initialDLBWPlocationAndBandwidth                                        = 17875; 
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+        initialDLBWPsubcarrierSpacing                                           = 3;
+      #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero                                      = 2;
+        initialDLBWPsearchSpaceZero                                             = 0;
+
+  #uplinkConfigCommon 
+     #frequencyInfoUL
+      ul_frequencyBand                                                 = 257;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                              = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+      ul_subcarrierSpacing                                           = 3;
+      ul_carrierBandwidth                                            = 66;
+      pMax                                                          = 20;
+     #initialUplinkBWP
+      #genericParameters
+        initialULBWPlocationAndBandwidth                                        = 17875;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+        initialULBWPsubcarrierSpacing                                           = 3;
+      #rach-ConfigCommon
+        #rach-ConfigGeneric
+          prach_ConfigurationIndex                                  = 135;
+#prach_msg1_FDM
+#0 = one, 1=two, 2=four, 3=eight
+          prach_msg1_FDM                                            = 0;
+          prach_msg1_FrequencyStart                                 = 0;
+          zeroCorrelationZoneConfig                                 = 15;
+          preambleReceivedTargetPower                               = -100;
+#preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+          preambleTransMax                                          = 8;
+#powerRampingStep
+# 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep                                            = 2; 
+#ra_ReponseWindow
+#1,2,4,8,10,20,40,80
+        ra_ResponseWindow                                           = 7;
+
+#ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+#1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+#oneHalf (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 15;
+#ra_ContentionResolutionTimer
+#(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer                                = 7;
+        rsrp_ThresholdSSB                                           = 19;
+#prach-RootSequenceIndex_PR
+#1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR                                  = 2;
+        prach_RootSequenceIndex                                     = 1;
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        #  
+        msg1_SubcarrierSpacing                                      = 3,
+
+# restrictedSetConfig
+# 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig                                         = 0,
+
+        msg3_DeltaPreamble                                          = 0;
+        p0_NominalWithGrant                                         = -96;
+
+# pucch-ConfigCommon setup :
+# pucchGroupHopping
+# 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping                                           = 0;
+        hoppingId                                                   = 0;
+        p0_nominal                                                  = -96;
+
+      ssb_PositionsInBurst_Bitmap                                   = 0x1;
+
+# ssb_periodicityServingCell
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1 
+      ssb_periodicityServingCell                                    = 4;
+
+# dmrs_TypeA_position
+# 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+      subcarrierSpacing                                             = 3;
+
+
+  #tdd-UL-DL-ConfigurationCommon
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+      referenceSubcarrierSpacing                                    = 3;
+      # pattern1 
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 1; 
+      nrofDownlinkSlots                                             = 3; 
+      nrofDownlinkSymbols                                           = 10;
+      nrofUplinkSlots                                               = 1;
+      nrofUplinkSymbols                                             = 2;
+
+
+  ssPBCH_BlockPower                                             = 5;
+  }
+
+  );
+
+
+
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+    ////////// AMF parameters:
+    amf_ip_address = ({ ipv4 = "172.21.6.5"; });
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "172.21.10.20";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "172.21.10.20";
+        GNB_PORT_FOR_NGU                         = 2152; # Spec 2152
+    };
+  }
+);
+
+MACRLCs = (
+	{
+	    tr_s_preference     = "local_L1";
+	    tr_n_preference     = "local_RRC";
+	    pusch_TargetSNRx10  = 150;
+      pucch_TargetSNRx10  = 250;
+      pusch_FailureThres = 100;
+      set_analog_beamforming      = "lophy";
+      beam_duration               = 1;
+      beams_per_period            = 1;
+      beam_weights = [68];
+
+    }
+);
+
+L1s = (
+{
+  tr_n_preference = "local_mac";
+  prach_dtx_threshold = 120;
+  pucch0_dtx_threshold = 50;
+  pusch_dtx_threshold = -200;
+  max_ldpc_iterations = 15;
+  tx_amp_backoff_dB = 6;
+  L1_rx_thread_core = 37;
+  L1_tx_thread_core = 36;
+  phase_compensation = 0;
+
+}
+);
+
+RUs = (
+    {		  
+  local_rf       = "no";
+  nb_tx          = 2;
+  nb_rx          = 2;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [257];
+  max_pdschReferenceSignalPower = -40;
+  max_rxgain                    = 60;
+  eNB_instances  = [0];
+  ru_thread_core = 35;
+  sl_ahead       = 10;
+  tr_preference  = "raw_if4p5";
+  do_precoding = 0;
+    }
+);  
+
+security = {
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms = ( "nea0" );
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms = ( "nia2", "nia0" );
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};
+
+fhi_72 = {
+  dpdk_devices = ("0000:41:11.0");
+  dpdk_iova_mode = "VA";
+  system_core = 32;
+  io_core = 33;
+  worker_cores = (34);
+  ru_addr = ("10:70:FD:B8:86:02"); # one VF is used for both C- and U-planes
+  mtu = 9216; 
+  fh_config = ({
+    T1a_cp_dl = (100, 124); # (min, max)
+    T1a_cp_ul = (60, 104); # (min, max)
+    T1a_up = (35, 70); # (min, max)
+    Ta4 = (0, 65); # 0 45 (min, max)
+    ru_config = {
+      iq_width = 9;
+      iq_width_prach = 16;
+    };
+    prach_config = {
+      eAxC_offset = 0;
+      kbar = 4;
+    };
+  });
+};

--- a/ci-scripts/scripts/microamp-check-ru.sh
+++ b/ci-scripts/scripts/microamp-check-ru.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+#
+# Wait until the Microamp FR2 RU is reachable and PTP-synchronized, and print
+# its configuration.
+#
+# usage: microamp-check-ru.sh [bandwidth-in-MHz] [RU-management-IP]
+#
+# Note: the CI framework aborts custom scripts after 90s, so the overall
+# waiting time is kept well below that.
+
+set -e
+
+BANDWIDTH=${1:-100}
+RU_IP=${2:-10.10.0.117}
+RU_USER=remctl
+RU_PASS=microampcfg
+# maximum PTP offset (rms, in ns) we consider synchronized
+PTP_RMS_THRESHOLD=100
+REACHABLE_RETRIES=25
+PTP_RETRIES=10
+
+ssh_ru() {
+  sshpass -p "$RU_PASS" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    -o ConnectTimeout=10 "$RU_USER@$RU_IP" "$@" < /dev/null
+}
+
+echo "→ Waiting for Microamp RU at $RU_IP to be reachable..."
+i=0
+while [ $i -lt $REACHABLE_RETRIES ]; do
+  if CFG=$(ssh_ru get-cfg 2>/dev/null); then
+    echo "✓ RU is reachable"
+    break
+  fi
+  i=$((i+1))
+  sleep 2
+done
+if [ $i -eq $REACHABLE_RETRIES ]; then
+  echo "✗ RU not reachable after $((REACHABLE_RETRIES*2))s"
+  exit 1
+fi
+
+echo "$CFG"
+if ! echo "$CFG" | grep -qiE "^[[:space:]]*Bandwidth:[[:space:]]*${BANDWIDTH}M"; then
+  echo "✗ RU is not configured for ${BANDWIDTH} MHz"
+  exit 1
+fi
+echo "✓ RU configured for ${BANDWIDTH} MHz"
+
+echo "→ Checking that the RU is PTP-synchronized..."
+i=0
+while [ $i -lt $PTP_RETRIES ]; do
+  # keep the last reported rms value of ptp4l, "none" if ptp4l reported nothing
+  RMS=$(ssh_ru logs-ptp 2>/dev/null | awk '/rms/ { rms=$8; found=1 } END { print found ? rms+0 : "none" }')
+  if [ "$RMS" != "none" ] && [ "$RMS" -le $PTP_RMS_THRESHOLD ]; then
+    echo "✓ RU is PTP-synchronized (ptp4l rms ${RMS}ns)"
+    exit 0
+  fi
+  echo "  ptp4l rms = ${RMS}ns, waiting..."
+  i=$((i+1))
+  sleep 3
+done
+
+echo "✗ RU not PTP-synchronized (last ptp4l rms ${RMS}ns > ${PTP_RMS_THRESHOLD}ns)"
+exit 1

--- a/ci-scripts/xml_files/container_sa_fhi72_microamp_2x2_100MHz_up4.xml
+++ b/ci-scripts/xml_files/container_sa_fhi72_microamp_2x2_100MHz_up4.xml
@@ -1,0 +1,151 @@
+<!-- SPDX-License-Identifier: LicenseRef-CSSL-1.0 -->
+
+<testCaseList>
+  <htmlTabRef>test-5g-fhi72-microamp-2x2-100MHz</htmlTabRef>
+  <htmlTabName>100 MHz 2x2 TDD SA FR2 Microamp</htmlTabName>
+  <htmlTabIcon>tasks</htmlTabIcon>
+
+  <!-- the 5G Core (PLMN 208/99) is always on, so it is neither deployed nor
+       undeployed here -->
+
+  <testCase>
+    <class>Custom_Script</class>
+    <desc>Check Microamp FR2 RU configuration and PTP synchronization</desc>
+    <node>stonechat</node>
+    <script>scripts/microamp-check-ru.sh</script>
+    <args>100</args>
+  </testCase>
+
+  <testCase>
+    <class>Pull_Local_Registry</class>
+    <desc>Pull Images from Local Registry</desc>
+    <node>stonechat</node>
+    <images>oai-gnb-fhi72</images>
+  </testCase>
+
+  <testCase>
+    <class>Create_Workspace</class>
+    <desc>Create new Workspace</desc>
+    <node>stonechat</node>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy gNB (TDD/Band257/100MHz/Microamp) in a container</desc>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_microamp_2x2_100MHz_gnb</yaml_path>
+    <node>stonechat</node>
+    <num_attempts>2</num_attempts>
+  </testCase>
+
+  <testCase>
+    <class>Attach_UE</class>
+    <desc>Attach UE</desc>
+    <id>up4</id>
+  </testCase>
+
+  <testCase>
+    <class>Ping</class>
+    <desc>Ping: 100 pings in 10 sec</desc>
+    <id>up4</id>
+    <svr_id>oc-cn5g-20899-always-on</svr_id>
+    <ping_args>-c 100 -i 0.1</ping_args>
+    <ping_packetloss_threshold>1</ping_packetloss_threshold>
+    <ping_rttavg_threshold>15</ping_rttavg_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>iperf (DL/200Mbps/UDP)(60 sec)</desc>
+    <iperf_args>-u -b 200M -t 60 -R -l 1428</iperf_args>
+    <id>up4</id>
+    <iperf_packetloss_threshold>20</iperf_packetloss_threshold>
+    <iperf_bitrate_threshold>80</iperf_bitrate_threshold>
+    <iperf_profile>balanced</iperf_profile>
+    <svr_id>oc-cn5g-20899-always-on</svr_id>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>iperf (DL/400Mbps/UDP)(60 sec)</desc>
+    <iperf_args>-u -b 400M -t 60 -R -l 1428</iperf_args>
+    <id>up4</id>
+    <iperf_packetloss_threshold>20</iperf_packetloss_threshold>
+    <iperf_bitrate_threshold>80</iperf_bitrate_threshold>
+    <iperf_profile>balanced</iperf_profile>
+    <svr_id>oc-cn5g-20899-always-on</svr_id>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>Optional iperf (DL/550Mbps/UDP)(60 sec)</desc>
+    <iperf_args>-u -b 550M -t 60 -R -l 1428</iperf_args>
+    <may_fail>true</may_fail>
+    <id>up4</id>
+    <iperf_packetloss_threshold>20</iperf_packetloss_threshold>
+    <iperf_bitrate_threshold>80</iperf_bitrate_threshold>
+    <iperf_profile>balanced</iperf_profile>
+    <svr_id>oc-cn5g-20899-always-on</svr_id>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>iperf (UL/45Mbps/UDP)(30 sec)</desc>
+    <iperf_args>-u -b 45M -t 30</iperf_args>
+    <id>up4</id>
+    <iperf_packetloss_threshold>20</iperf_packetloss_threshold>
+    <iperf_bitrate_threshold>80</iperf_bitrate_threshold>
+    <iperf_profile>balanced</iperf_profile>
+    <svr_id>oc-cn5g-20899-always-on</svr_id>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>iperf (DL/TCP)(30 sec)</desc>
+    <iperf_args>-t 30 -R</iperf_args>
+    <id>up4</id>
+    <iperf_tcp_rate_target>200</iperf_tcp_rate_target>
+    <svr_id>oc-cn5g-20899-always-on</svr_id>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>iperf (UL/TCP)(30 sec)</desc>
+    <iperf_args>-t 30</iperf_args>
+    <id>up4</id>
+    <iperf_tcp_rate_target>30</iperf_tcp_rate_target>
+    <svr_id>oc-cn5g-20899-always-on</svr_id>
+  </testCase>
+
+  <testCase>
+    <class>Detach_UE</class>
+    <always_exec>true</always_exec>
+    <desc>Detach UE</desc>
+    <id>up4</id>
+  </testCase>
+
+  <testCase>
+    <class>IdleSleep</class>
+    <desc>Sleep</desc>
+    <idle_sleep_time_in_sec>5</idle_sleep_time_in_sec>
+  </testCase>
+
+  <testCase>
+    <class>Undeploy_Object</class>
+    <always_exec>true</always_exec>
+    <desc>Undeploy gNB</desc>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_microamp_2x2_100MHz_gnb</yaml_path>
+    <node>stonechat</node>
+    <analysis>
+      <services>oai-gnb=EndsWithBye</services>
+    </analysis>
+  </testCase>
+
+  <testCase>
+    <class>Clean_Test_Server_Images</class>
+    <always_exec>true</always_exec>
+    <desc>Clean Test Images on Test Server</desc>
+    <node>stonechat</node>
+    <images>oai-gnb-fhi72</images>
+  </testCase>
+
+</testCaseList>

--- a/ci-scripts/xml_files/container_sa_fhi72_microamp_2x2_100MHz_up4.xml
+++ b/ci-scripts/xml_files/container_sa_fhi72_microamp_2x2_100MHz_up4.xml
@@ -5,8 +5,11 @@
   <htmlTabName>100 MHz 2x2 TDD SA FR2 Microamp</htmlTabName>
   <htmlTabIcon>tasks</htmlTabIcon>
 
-  <!-- the 5G Core (PLMN 208/99) is always on, so it is neither deployed nor
-       undeployed here -->
+  <testCase>
+    <class>DeployCoreNetwork</class>
+    <desc>Initialize 5G Core</desc>
+    <cn_id>oc-cn5g-20899-stonechat</cn_id>
+  </testCase>
 
   <testCase>
     <class>Custom_Script</class>
@@ -47,7 +50,7 @@
     <class>Ping</class>
     <desc>Ping: 100 pings in 10 sec</desc>
     <id>up4</id>
-    <svr_id>oc-cn5g-20899-always-on</svr_id>
+    <svr_id>oc-cn5g-20899-stonechat</svr_id>
     <ping_args>-c 100 -i 0.1</ping_args>
     <ping_packetloss_threshold>1</ping_packetloss_threshold>
     <ping_rttavg_threshold>15</ping_rttavg_threshold>
@@ -55,36 +58,25 @@
 
   <testCase>
     <class>Iperf</class>
-    <desc>iperf (DL/200Mbps/UDP)(60 sec)</desc>
-    <iperf_args>-u -b 200M -t 60 -R -l 1428</iperf_args>
+    <desc>iperf (DL/400Mbps/UDP)(30 sec)</desc>
+    <iperf_args>-u -b 400M -t 30 -R -l 1428</iperf_args>
     <id>up4</id>
     <iperf_packetloss_threshold>20</iperf_packetloss_threshold>
     <iperf_bitrate_threshold>80</iperf_bitrate_threshold>
     <iperf_profile>balanced</iperf_profile>
-    <svr_id>oc-cn5g-20899-always-on</svr_id>
+    <svr_id>oc-cn5g-20899-stonechat</svr_id>
   </testCase>
 
   <testCase>
     <class>Iperf</class>
-    <desc>iperf (DL/400Mbps/UDP)(60 sec)</desc>
-    <iperf_args>-u -b 400M -t 60 -R -l 1428</iperf_args>
-    <id>up4</id>
-    <iperf_packetloss_threshold>20</iperf_packetloss_threshold>
-    <iperf_bitrate_threshold>80</iperf_bitrate_threshold>
-    <iperf_profile>balanced</iperf_profile>
-    <svr_id>oc-cn5g-20899-always-on</svr_id>
-  </testCase>
-
-  <testCase>
-    <class>Iperf</class>
-    <desc>Optional iperf (DL/550Mbps/UDP)(60 sec)</desc>
-    <iperf_args>-u -b 550M -t 60 -R -l 1428</iperf_args>
+    <desc>Optional iperf (DL/550Mbps/UDP)(30 sec)</desc>
+    <iperf_args>-u -b 550M -t 30 -R -l 1428</iperf_args>
     <may_fail>true</may_fail>
     <id>up4</id>
     <iperf_packetloss_threshold>20</iperf_packetloss_threshold>
     <iperf_bitrate_threshold>80</iperf_bitrate_threshold>
     <iperf_profile>balanced</iperf_profile>
-    <svr_id>oc-cn5g-20899-always-on</svr_id>
+    <svr_id>oc-cn5g-20899-stonechat</svr_id>
   </testCase>
 
   <testCase>
@@ -95,7 +87,7 @@
     <iperf_packetloss_threshold>20</iperf_packetloss_threshold>
     <iperf_bitrate_threshold>80</iperf_bitrate_threshold>
     <iperf_profile>balanced</iperf_profile>
-    <svr_id>oc-cn5g-20899-always-on</svr_id>
+    <svr_id>oc-cn5g-20899-stonechat</svr_id>
   </testCase>
 
   <testCase>
@@ -104,7 +96,7 @@
     <iperf_args>-t 30 -R</iperf_args>
     <id>up4</id>
     <iperf_tcp_rate_target>200</iperf_tcp_rate_target>
-    <svr_id>oc-cn5g-20899-always-on</svr_id>
+    <svr_id>oc-cn5g-20899-stonechat</svr_id>
   </testCase>
 
   <testCase>
@@ -113,7 +105,7 @@
     <iperf_args>-t 30</iperf_args>
     <id>up4</id>
     <iperf_tcp_rate_target>30</iperf_tcp_rate_target>
-    <svr_id>oc-cn5g-20899-always-on</svr_id>
+    <svr_id>oc-cn5g-20899-stonechat</svr_id>
   </testCase>
 
   <testCase>
@@ -146,6 +138,13 @@
     <desc>Clean Test Images on Test Server</desc>
     <node>stonechat</node>
     <images>oai-gnb-fhi72</images>
+  </testCase>
+
+  <testCase>
+    <class>UndeployCoreNetwork</class>
+    <always_exec>true</always_exec>
+    <desc>Terminate 5G Core</desc>
+    <cn_id>oc-cn5g-20899-stonechat</cn_id>
   </testCase>
 
 </testCaseList>

--- a/ci-scripts/yaml_files/sa_fhi_7.2_microamp_2x2_100MHz_gnb/docker-compose.yml
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_microamp_2x2_100MHz_gnb/docker-compose.yml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+
+services:
+    dpdk-init:
+        image: docker.io/library/oai-dpdk-init:latest
+        network_mode: host
+        container_name: dpdk-init
+        entrypoint: "/tmp/setup_sriov.sh"
+        privileged: true
+        devices:
+            - /dev/vfio:/dev/vfio/
+        volumes:
+            - ./setup_sriov_microamp.sh:/tmp/setup_sriov.sh
+            - /lib/modules:/lib/modules
+            - /usr/lib/modules:/usr/lib/modules
+    oai-gnb:
+        image: ${REGISTRY-oaisoftwarealliance/}oai-gnb-fhi72:${TAG:-develop}
+        cap_add:
+            - IPC_LOCK
+            - SYS_NICE
+        cap_drop:
+            - ALL
+        container_name: oai-gnb
+        environment:
+            TZ: Europe/Paris
+            USE_ADDITIONAL_OPTIONS: --thread-pool 38,39,40,41,42,43,44,45 --log_config.global_log_options level,nocolor,utc_time
+        devices:
+            - /dev/vfio:/dev/vfio/
+        volumes:
+            - ../../../ci-scripts/conf_files/gnb.sa.band257.66prb.fhi72.2x2-microamp.conf:/opt/oai-gnb/etc/gnb.conf
+            - /dev/hugepages:/dev/hugepages
+        # Please change these values based on your system
+        cpuset: "32,33,34,35,36,37,38,39,40,41,42,43,44,45"
+        networks:
+            oai-net:
+                ipv4_address: 172.21.10.20
+        depends_on:
+           dpdk-init:
+             condition: service_completed_successfully
+        healthcheck:
+           test: /bin/bash -c "/opt/oai-gnb/bin/check-prach-io.sh"
+           start_period: 15s
+           start_interval: 500ms
+           interval: 5s
+           timeout: 5s
+           retries: 10
+
+networks:
+    oai-net:
+        driver: macvlan
+        name: oai-net
+        ipam:
+            config:
+                - subnet: "172.21.8.0/22"
+                  ip_range: "172.21.10.20/32"
+                  gateway: "172.21.11.254"
+        driver_opts:
+            com.docker.network.bridge.name: "oai-net"
+            parent: bond0

--- a/ci-scripts/yaml_files/sa_fhi_7.2_microamp_2x2_100MHz_gnb/setup_sriov_microamp.sh
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_microamp_2x2_100MHz_gnb/setup_sriov_microamp.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+IF_NAME=ens2f1
+# O-DU C/U-plane MAC address and VLAN, has to match the "du-mac" and
+# "ecpri-vlan-tag" settings of the Microamp RU
+C_U_PLANE_MAC_ADDR=50:7C:6F:31:00:61
+C_U_PLANE_VLAN=600
+# MTU has to match "mtu" in the fhi_72 section of the gNB configuration file
+MTU=9216
+NUM_VFs=1
+# has to match "dpdk_devices" in the fhi_72 section of the gNB configuration file
+C_U_PLANE_PCI=41:11.0
+DPDK_DEVBIND_PREFIX=/usr/local/bin
+
+ethtool -G $IF_NAME rx 8160
+ethtool -G $IF_NAME tx 8160
+sh -c "echo 0 > /sys/class/net/$IF_NAME/device/sriov_numvfs"
+sh -c "echo $NUM_VFs > /sys/class/net/$IF_NAME/device/sriov_numvfs"
+modprobe -r iavf
+modprobe iavf
+# one VF is used for both C- and U-planes
+ip link set $IF_NAME vf 0 mac $C_U_PLANE_MAC_ADDR vlan $C_U_PLANE_VLAN spoofchk off mtu $MTU
+sleep 1
+${DPDK_DEVBIND_PREFIX}/dpdk-devbind.py --unbind $C_U_PLANE_PCI
+modprobe vfio-pci
+${DPDK_DEVBIND_PREFIX}/dpdk-devbind.py --bind vfio-pci $C_U_PLANE_PCI
+echo "Successfully configured C-PLANE and U-PLANE:
+  - C/U-PLANE MAC: $C_U_PLANE_MAC_ADDR, VLAN: $C_U_PLANE_VLAN, PCI: $C_U_PLANE_PCI"
+exit 0

--- a/doc/ORAN_FHI7.2_Tutorial.md
+++ b/doc/ORAN_FHI7.2_Tutorial.md
@@ -648,6 +648,14 @@ eAXC_id 0 1 # set PRACH eAxC IDs
 
 #### Microamp FR2
 
+Two OAI configuration files are provided for this RU, both with TDD pattern
+`DDDSU` (0.625ms) and 2x2 on band n257:
+- 200MHz: [`gnb.sa.band257.132prb.fhi72.2x2-microamp.conf`](../targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf)
+- 100MHz: [`gnb.sa.band257.66prb.fhi72.2x2-microamp.conf`](../ci-scripts/conf_files/gnb.sa.band257.66prb.fhi72.2x2-microamp.conf)
+
+Both use the same carrier frequency (28.04928GHz), so switching between them
+only requires to change the bandwidth of the RU (see below).
+
 #### Firmware starting from 0.1.174
 
 Requirements:
@@ -699,12 +707,9 @@ You can use the following command to display the current RU configuration:
 sshpass -p microampcfg ssh remctl@<RU_IP_ADDR> get-cfg
 ```
 
-<details>
-  <summary>
-  The OAI configuration file [`gnb.sa.band257.132prb.fhi72.2x2-microamp.conf`](../targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf) corresponds to the following RU configuration:
-  </summary>
+The OAI configuration file [`gnb.sa.band257.132prb.fhi72.2x2-microamp.conf`](../targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf) corresponds to the following RU configuration:
 
-  ```
+```
   PRACH0 CC ID: 0
   PRACH0 RU port ID: 0
   PRACH1 CC ID: 1
@@ -724,9 +729,8 @@ sshpass -p microampcfg ssh remctl@<RU_IP_ADDR> get-cfg
     RU MAC: 10-70-FD-B8-86-02
     DU MAC: 50-7C-6F-31-00-61
   RF Power level: -5 dB - relative to maximum
-  ```
+```
 
-</details>
 
 Execute the following command to check how to configure the RU:
 
@@ -929,12 +933,10 @@ To check PTP status, you can use `rucfg ptp`.
 
 You can use `rucfg show` command to display the current RU configuration. 
 
-<details>
-  <summary>
-  The OAI configuration file [`gnb.sa.band257.132prb.fhi72.2x2-microamp.conf`](../targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf) corresponds to the following RU configuration:
-  </summary>
 
-  ```
+The OAI configuration file [`gnb.sa.band257.132prb.fhi72.2x2-microamp.conf`](../targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf) corresponds to the following RU configuration:
+
+```
   [INFO] Check if RU is available
   [INFO] RU available
   [INFO] Check SSH to RU available
@@ -960,10 +962,7 @@ You can use `rucfg show` command to display the current RU configuration.
     VLAN MGMT: False
     Beamforming: dynamic-mirrored-beam
   }
-  ```
-
-</details>
-
+```
 
 Execute `rucfg config -h` to check how to configure the RU.
 

--- a/radio/fhi_72/oaioran.c
+++ b/radio/fhi_72/oaioran.c
@@ -238,7 +238,6 @@ void oai_xran_fh_rx_prach_callback(void *pCallbackTag, xran_status_t status, uin
             struct xran_prb_map *pRbMap = (struct xran_prb_map *)bufs->prachdstdecomp[ant_id][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
             AssertFatal(pRbMap != NULL, "(%d:%d:%d)pRbMapPrach == NULL. Aborting.\n", cc_id, tti % XRAN_N_FE_BUF_LEN, ant_id);
             for (uint32_t sym_id = 0; sym_id < XRAN_NUM_OF_SYMBOL_PER_SLOT; sym_id++) {
-              AssertFatal(pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt <= 1, "PRACH segmentation is not supported\n");
               info->nRxPkt[cc_id][ant_id + ru_idx * fh_config->neAxc][sym_id] = pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt;
               pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt = 0;
             }
@@ -364,11 +363,8 @@ int xran_fh_rx_prach_read_slot(PHY_VARS_gNB *gNB, ru_info_t *ru, int *frame, int
           LOG_D(HW, "read_prach %d.%d.%d saa = %d: nRxPkt = 0!\n", *frame, *slot, sym_idx, aa);
           memset(&dst[sym_idx], 0, N_ZC * 2 * sizeof(*dst));
           continue;
-        } else if (nRxPkt > 1) { // protection
-          LOG_E(HW, "read_prach %d.%d.%d saa = %d: nRxPkt = %d!\n", *frame, *slot, sym_idx, aa, nRxPkt);
-          memset(&dst[sym_idx], 0, N_ZC * 2 * sizeof(*dst));
-          continue;
-        } else {
+        }
+        else {
           src = (int16_t *)p_rx_packet_ctl->pData[0];
           if (src == NULL) { // protection
             LOG_E(HW, "read_prach %d.%d.%d saa = %d:  src = NULL!!\n", *frame, *slot, sym_idx, aa);

--- a/radio/fhi_72/oaioran.c
+++ b/radio/fhi_72/oaioran.c
@@ -238,6 +238,7 @@ void oai_xran_fh_rx_prach_callback(void *pCallbackTag, xran_status_t status, uin
             struct xran_prb_map *pRbMap = (struct xran_prb_map *)bufs->prachdstdecomp[ant_id][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
             AssertFatal(pRbMap != NULL, "(%d:%d:%d)pRbMapPrach == NULL. Aborting.\n", cc_id, tti % XRAN_N_FE_BUF_LEN, ant_id);
             for (uint32_t sym_id = 0; sym_id < XRAN_NUM_OF_SYMBOL_PER_SLOT; sym_id++) {
+              AssertFatal(pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt <= 1, "PRACH segmentation is not supported\n");
               info->nRxPkt[cc_id][ant_id + ru_idx * fh_config->neAxc][sym_id] = pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt;
               pRbMap->sFrontHaulRxPacketCtrl[sym_id].nRxPkt = 0;
             }
@@ -359,18 +360,22 @@ int xran_fh_rx_prach_read_slot(PHY_VARS_gNB *gNB, ru_info_t *ru, int *frame, int
         struct xran_prb_map * pPrbMap = (struct xran_prb_map *)bufs->prachdstdecomp[aa % nb_rx_per_ru][tti % XRAN_N_FE_BUF_LEN].pBuffers->pData;
         struct xran_rx_packet_ctl *p_rx_packet_ctl = &pPrbMap->sFrontHaulRxPacketCtrl[sym_idx];
         int32_t nRxPkt = info->nRxPkt[cc_id][aa][sym_idx];
-        /* known issue: for aa = 2, the packet (one per symbol) is not received/stored on time */
-        if (nRxPkt != 1) {
-          LOG_D(HW, "[%d.%d] tti %d aa %d sym_idx %d nRxPkt %d (expected 1 packet)\n", *frame, *slot, tti, aa, sym_idx, nRxPkt);
+        if (nRxPkt == 0) {
+          LOG_D(HW, "read_prach %d.%d.%d saa = %d: nRxPkt = 0!\n", *frame, *slot, sym_idx, aa);
+          memset(&dst[sym_idx], 0, N_ZC * 2 * sizeof(*dst));
           continue;
-        }
-
-        src = (int16_t *)p_rx_packet_ctl->pData[0];
-        if (src == NULL) { // protection
-          LOG_E(HW, "[%d.%d] tti %d aa %d sym_idx %d src = NULL\n", *frame, *slot, tti, aa, sym_idx);
+        } else if (nRxPkt > 1) { // protection
+          LOG_E(HW, "read_prach %d.%d.%d saa = %d: nRxPkt = %d!\n", *frame, *slot, sym_idx, aa, nRxPkt);
+          memset(&dst[sym_idx], 0, N_ZC * 2 * sizeof(*dst));
           continue;
+        } else {
+          src = (int16_t *)p_rx_packet_ctl->pData[0];
+          if (src == NULL) { // protection
+            LOG_E(HW, "read_prach %d.%d.%d saa = %d:  src = NULL!!\n", *frame, *slot, sym_idx, aa);
+            memset(&dst[sym_idx], 0, N_ZC * 2 * sizeof(*dst));
+            continue;
+          }
         }
-
         num_prbu = p_rx_packet_ctl->nRBSize[0];
         /* convert Network order to host order */
         if (ru_conf->compMeth_PRACH == XRAN_COMPMETHOD_NONE) {

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf
@@ -165,8 +165,8 @@ gNBs =
 
     NETWORK_INTERFACES :
     {
-        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "172.21.18.51";
-        GNB_IPV4_ADDRESS_FOR_NGU                 = "172.21.18.51";
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "172.21.8.200";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "172.21.8.200";
         GNB_PORT_FOR_S1U                         = 2152; # Spec 2152
     };
   }
@@ -186,7 +186,7 @@ MACRLCs = (
   set_analog_beamforming      = "lophy";
   beam_duration               = 1;
   beams_per_period            = 1;
-  beam_weights = [0];
+  beam_weights = [68];
 }
 );
 
@@ -256,17 +256,17 @@ log_config :
 };
 
 fhi_72 = {
-  dpdk_devices = ("01:01.0","01:01.1"); # one VF can be used as well
+  dpdk_devices = ("0000:41:11.0"); # one VF can be used as well
   system_core = 32;
   io_core = 33;
   worker_cores = (34);
-  ru_addr = ("10:70:FD:B8:86:02", "10:70:FD:B8:86:02");
+  ru_addr = ("10:70:FD:B8:86:02");
   mtu = 9216;
   fh_config = ({
     T1a_cp_dl = (100, 124);
-    T1a_cp_ul = (60, 70);
-    T1a_up = (35, 108); 
-    Ta4 = (0, 45)
+    T1a_cp_ul = (60, 104);
+    T1a_up = (35, 70);
+    Ta4 = (0, 65)
     ru_config = {
       iq_width = 9;
       iq_width_prach = 16;


### PR DESCRIPTION
This PR fixes a regression with Microamp FR2 and add CI tests for this RU. 
Symptoms: PRACH_I0 = 0
Analysis: xran doesn't extract PRACH IQ from PRACH packets. 

It also adds a new FR2 SA OTA pipeline: https://jenkins-oai.eurecom.fr/job/RAN-SA-FHI72-FR2-CN5G/