### PR TITLE
libxran: fix beam-id in PUSCH CP

### DIFF
--- a/radio/fhi_72/oaioran.c
+++ b/radio/fhi_72/oaioran.c
@@ -684,7 +684,7 @@ int xran_fh_tx_send_slot(ru_info_t *ru, int frame, int slot, uint64_t timestamp)
           p_sec_desc = &pRbElm->sec_desc[sym_idx];
           LOG_D(HW, "pPrbMap[%d] : PRBstart %d nPRBs %d\n", idxElm, startRB, numRB);
           // For Liteon FR2 with RunSlotPrbMapBySymbolEnable xran_prb_map will have xran_prb_elm prbMap[14], each idxElm matches to sym_idx.
-          if (fh_cfg->RunSlotPrbMapBySymbolEnable && (sym_idx < pRbElm->nStartSymb || sym_idx >= pRbElm->nStartSymb + pRbElm->numSymb) && !p_sec_desc->pCtrl)
+          if (fh_cfg->RunSlotPrbMapBySymbolEnable && (sym_idx < pRbElm->nStartSymb || sym_idx >= pRbElm->nStartSymb + pRbElm->numSymb))
             continue;
 
           pRbElm->nBeamIndex = ru->beam_id[slot * XRAN_NUM_OF_SYMBOL_PER_SLOT + sym_idx][ant_id];


### PR DESCRIPTION
This PR fixes a beamforming anomaly happening with liteon FR2 in PUSCH CP packets sent in same slots as PRACH CP packets