### PR TITLE
docs: update Ubuntu 24.04 ISO links to 24.04.4

### DIFF
--- a/doc/NR_SA_Tutorial_COTS_UE.md
+++ b/doc/NR_SA_Tutorial_COTS_UE.md
@@ -13,7 +13,7 @@ Minimum hardware requirements:
 
 - Laptop/Desktop/Server for OAI CN5G and OAI gNB
 
-    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.2-desktop-amd64.iso)
+    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
     - CPU: 8 cores x86_64 @ 3.5 GHz
     - RAM: 32 GB
 

--- a/doc/NR_SA_Tutorial_COTS_UE.md
+++ b/doc/NR_SA_Tutorial_COTS_UE.md
@@ -13,7 +13,7 @@ Minimum hardware requirements:
 
 - Laptop/Desktop/Server for OAI CN5G and OAI gNB
 
-    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
+    - Operating System: [Ubuntu Desktop 24.04.4 LTS, Intel or AMD 64-bit architecture](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
     - CPU: 8 cores x86_64 @ 3.5 GHz
     - RAM: 32 GB
 

--- a/doc/NR_SA_Tutorial_OAI_CN5G.md
+++ b/doc/NR_SA_Tutorial_OAI_CN5G.md
@@ -13,7 +13,7 @@ Minimum hardware requirements:
 
 - Laptop/Desktop/Server for OAI CN5G and OAI gNB
 
-    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.2-desktop-amd64.iso)
+    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
     - CPU: 8 cores x86_64 @ 3.5 GHz
     - RAM: 32 GB
 

--- a/doc/NR_SA_Tutorial_OAI_CN5G.md
+++ b/doc/NR_SA_Tutorial_OAI_CN5G.md
@@ -13,7 +13,7 @@ Minimum hardware requirements:
 
 - Laptop/Desktop/Server for OAI CN5G and OAI gNB
 
-    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
+    - Operating System: [Ubuntu Desktop 24.04.4 LTS, Intel or AMD 64-bit architecture](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
     - CPU: 8 cores x86_64 @ 3.5 GHz
     - RAM: 32 GB
 

--- a/doc/NR_SA_Tutorial_OAI_nrUE.md
+++ b/doc/NR_SA_Tutorial_OAI_nrUE.md
@@ -13,13 +13,13 @@ Minimum hardware requirements:
 
 - Laptop/Desktop/Server for OAI CN5G and OAI gNB
 
-    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.2-desktop-amd64.iso)
+    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
     - CPU: 8 cores x86_64 @ 3.5 GHz
     - RAM: 32 GB
 
 - Laptop for UE
 
-    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.2-desktop-amd64.iso)
+    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
     - CPU: 8 cores x86_64 @ 3.5 GHz
     - RAM: 8 GB
 

--- a/doc/NR_SA_Tutorial_OAI_nrUE.md
+++ b/doc/NR_SA_Tutorial_OAI_nrUE.md
@@ -13,13 +13,13 @@ Minimum hardware requirements:
 
 - Laptop/Desktop/Server for OAI CN5G and OAI gNB
 
-    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
+    - Operating System: [Ubuntu Desktop 24.04.4 LTS, Intel or AMD 64-bit architecture](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
     - CPU: 8 cores x86_64 @ 3.5 GHz
     - RAM: 32 GB
 
 - Laptop for UE
 
-    - Operating System: [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
+    - Operating System: [Ubuntu Desktop 24.04.4 LTS, Intel or AMD 64-bit architecture](https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso)
     - CPU: 8 cores x86_64 @ 3.5 GHz
     - RAM: 8 GB
 


### PR DESCRIPTION
Closes: #288

The Ubuntu 24.04 desktop ISO links in the NR_SA tutorials point to `ubuntu-24.04.2-desktop-amd64.iso`, which is no longer served by releases.ubuntu.com (404). Updated all four occurrences (CN5G, COTS_UE, and two in nrUE) to `ubuntu-24.04.4-desktop-amd64.iso`.

Verified with HEAD requests: 24.04.4 returns 200, 24.04.2 returns 404.

Note: the UHD version references mentioned in #288 are left untouched, per the earlier maintainer confirmation that the pinned UHD version is intentional (CI uses it).