### PR TITLE
fix(mac, nr_ue): print RI value to reflect real rank

### DIFF
--- a/openair2/NR_UE_PHY_INTERFACE/NR_IF_Module.c
+++ b/openair2/NR_UE_PHY_INTERFACE/NR_IF_Module.c
@@ -59,7 +59,7 @@ void print_ue_mac_stats(const module_id_t mod, const int frame_rx, const int slo
                   mac->mib_ssb,
                   ssb->ssb_sinr_dB,
                   ssb->ssb_rsrp_dBm,
-                  csi->ri);
+                  csi->ri + 1);
   if (csi->rsrp_dBm != 0)
     cur += snprintf(cur, end - cur, "CQI %d CSI-RS RSRP %d dBm\n", csi->cqi, csi->rsrp_dBm);
   else


### PR DESCRIPTION
The `rank_indicator` field stores the RI index, not the actual rank value. The actual rank is `rank_indicator + 1`, representing the number of layers. Updated the MAC status line print to display the correct rank value to match PHY debug log in `csi_rx.c`:
```
    case 26 :
      LOG_D(NR_PHY, "RI = %i i1 = %i.%i.%i, i2 = %i, SINR = %i dB, CQI = %i\n",
            rank_indicator + 1, i1[0], i1[1], i1[2], i2[0], precoded_sinr_dB, cqi);
      break;
    case 27 :
      LOG_D(NR_PHY, "RSRP = %i dBm, RI = %i i1 = %i.%i.%i, i2 = %i, SINR = %i dB, CQI = %i\n",
            rsrp_dBm, rank_indicator + 1, i1[0], i1[1], i1[2], i2[0], precoded_sinr_dB, cqi);
      break;
```
