### PR TITLE
Rfsim beam management

### DIFF
--- a/ci-scripts/conf_files/gnb.sa.band257.u3.66prb.rfsim.4beams.conf
+++ b/ci-scripts/conf_files/gnb.sa.band257.u3.66prb.rfsim.4beams.conf
@@ -39,7 +39,7 @@ gNBs =
       #scs-SpecificCarrierList
         dl_offstToCarrier                                              = 0;
 # subcarrierSpacing
-# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
         dl_subcarrierSpacing                                           = 3;
         dl_carrierBandwidth                                            = 66;
      #initialDownlinkBWP
@@ -47,19 +47,19 @@ gNBs =
         # this is RBstart=0,L=32 (275*(L-1))+RBstart
         initialDLBWPlocationAndBandwidth                                        = 17875;
 # subcarrierSpacing
-# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
         initialDLBWPsubcarrierSpacing                                           = 3;
       #pdcch-ConfigCommon
         initialDLBWPcontrolResourceSetZero                                      = 4;
         initialDLBWPsearchSpaceZero                                             = 0;
 
-  #uplinkConfigCommon 
+  #uplinkConfigCommon
      #frequencyInfoUL
       ul_frequencyBand                                                 = 257;
       #scs-SpecificCarrierList
       ul_offstToCarrier                                              = 0;
 # subcarrierSpacing
-# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       ul_subcarrierSpacing                                           = 3;
       ul_carrierBandwidth                                            = 66;
       pMax                                                          = 20;
@@ -67,11 +67,12 @@ gNBs =
       #genericParameters
         initialULBWPlocationAndBandwidth                                        = 17875;
 # subcarrierSpacing
-# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
         initialULBWPsubcarrierSpacing                                           = 3;
       #rach-ConfigCommon
         #rach-ConfigGeneric
-          prach_ConfigurationIndex                                  = 53;
+          # 4 active SSBs need more RACH occasions than the single-SSB config: use index 70 (as opposed to 53)
+          prach_ConfigurationIndex                                  = 70;
 #prach_msg1_FDM
 #0 = one, 1=two, 2=four, 3=eight
           prach_msg1_FDM                                            = 0;
@@ -97,7 +98,7 @@ gNBs =
         prach_RootSequenceIndex_PR                                  = 2;
         prach_RootSequenceIndex                                     = 1;
         # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
-        #  
+        #
         msg1_SubcarrierSpacing                                      = 3;
 # restrictedSetConfig
 # 0=unrestricted, 1=restricted type A, 2=restricted type B
@@ -113,10 +114,11 @@ gNBs =
         hoppingId                                                   = 40;
         p0_nominal                                                  = -90;
 
-      ssb_PositionsInBurst_Bitmap                                   = 1;
+      # 4 active SSBs: 0b01010101 = SSB indices 0, 2, 4, 6 (as opposed to 1 = SSB 0 only)
+      ssb_PositionsInBurst_Bitmap                                   = 85;
 
 # ssb_periodicityServingCell
-# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1 
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
       ssb_periodicityServingCell                                    = 2;
 
 # dmrs_TypeA_position
@@ -124,15 +126,15 @@ gNBs =
       dmrs_TypeA_Position                                           = 0;
 
 # subcarrierSpacing
-# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       subcarrierSpacing                                             = 3;
 
 
   #tdd-UL-DL-ConfigurationCommon
 # subcarrierSpacing
-# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120  
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       referenceSubcarrierSpacing                                    = 3;
-      # pattern1 
+      # pattern1
       # dl_UL_TransmissionPeriodicity
       # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
       dl_UL_TransmissionPeriodicity                                 = 3;
@@ -175,7 +177,7 @@ MACRLCs = ({
   set_analog_beamforming      = "lophy";
   beam_duration               = 1;
   beams_per_period            = 1;
-  beam_weights = [0]; // single SSB -> one analog beam
+  beam_weights = [0, 1, 2, 3]; // 4 SSBs -> 4 analog beams, swept one at a time
 });
 
 L1s = (

--- a/ci-scripts/run_locally.sh
+++ b/ci-scripts/run_locally.sh
@@ -9,7 +9,7 @@ TESTCASE=$1
 
 if [ $# -eq 0 ]
   then
-    echo "Provide a testcase as an argument"
+    echo "Provide the path to a testcase XML (relative to ci-scripts/, e.g. xml_files/container_5g_rfsim.xml) as an argument"
     exit 1
 fi
 
@@ -26,12 +26,12 @@ set -x
 # docker build . -f docker/Dockerfile.build.ubuntu -t ran-build
 # docker build . -f docker/Dockerfile.base.ubuntu -t ran-base
 
-docker tag oai-nr-ue oai-ci/oai-nr-ue:develop-${SHORT_COMMIT_SHA}
-docker tag oai-gnb oai-ci/oai-gnb:develop-${SHORT_COMMIT_SHA}
-docker tag oai-nr-cuup oai-ci/oai-nr-cuup:develop-${SHORT_COMMIT_SHA}
+docker tag oai-nr-ue oai-ci/oai-nr-ue:${CURRENT_BRANCH}
+docker tag oai-gnb oai-ci/oai-gnb:${CURRENT_BRANCH}
+docker tag oai-nr-cuup oai-ci/oai-nr-cuup:${CURRENT_BRANCH}
 
 python3 main.py --mode=InitiateHtml --repository=NONE --branch=${CURRENT_BRANCH} \
-    --XMLTestFile=xml_files/${TESTCASE} --local --datefmt="%H:%M:%S"
+    --XMLTestFile=${TESTCASE} --local --datefmt="%H:%M:%S"
 
 python3 main.py --mode=TesteNB --repository=NONE --branch=${CURRENT_BRANCH} \
     --ranAllowMerge=false \

--- a/ci-scripts/xml_files/container_5g_rfsim_fr2_66prb.xml
+++ b/ci-scripts/xml_files/container_5g_rfsim_fr2_66prb.xml
@@ -42,8 +42,15 @@
   </testCase>
 
   <testCase>
+    <class>Custom_Command</class>
+    <desc>Delay 1 second due to stabilize connection</desc>
+    <node>localhost</node>
+    <command>sleep 1</command>
+  </testCase>
+
+  <testCase>
     <class>Ping</class>
-    <desc>Ping ext-dn from NR-UE</desc>
+    <desc>Ping ext-dn from NR-UE on the initial beam (0)</desc>
     <id>rfsim5g_ue</id>
     <node>localhost</node>
     <svr_id>rfsim5g_ext_dn</svr_id>
@@ -53,8 +60,22 @@
   </testCase>
 
   <testCase>
+    <class>Custom_Command</class>
+    <desc>Move UE to beam 2 via the rfsimulator's telnet interface and verify the switch was acknowledged</desc>
+    <node>localhost</node>
+    <command>echo rfsimulator setbeamids 2 | ncat 192.168.71.150 8091 | grep -q "Beam ids set"</command>
+  </testCase>
+
+  <testCase>
+    <class>Custom_Command</class>
+    <desc>Verify from the gNB MAC log that the scheduler actually switched the UE's serving beam to 2</desc>
+    <node>localhost</node>
+    <command><![CDATA[for i in $(seq 1 20); do docker logs rfsim5g-oai-gnb 2>&1 | grep -q "Switching to beam with ID 2" && exit 0; sleep 1; done; exit 1]]></command>
+  </testCase>
+
+  <testCase>
     <class>Ping</class>
-    <desc>Ping NR-UE from ext-dn</desc>
+    <desc>Ping NR-UE from ext-dn after the beam switch</desc>
     <id>rfsim5g_ext_dn</id>
     <node>localhost</node>
     <svr_id>rfsim5g_ue</svr_id>
@@ -70,7 +91,7 @@
     <node>localhost</node>
     <yaml_path>ci-scripts/yaml_files/5g_rfsimulator_fr2_66prb</yaml_path>
     <analysis>
-      <services>oai-gnb=RetxCheck=10,0,0,0 oai-gnb=EndsWithBye oai-nr-ue</services>
+      <services>oai-gnb=RetxCheck=10,100,100,100 oai-gnb=EndsWithBye oai-nr-ue</services>
     </analysis>
   </testCase>
 

--- a/ci-scripts/xml_files/container_5g_rfsim_fr2_66prb.xml
+++ b/ci-scripts/xml_files/container_5g_rfsim_fr2_66prb.xml
@@ -63,7 +63,7 @@
     <class>Custom_Command</class>
     <desc>Move UE to beam 2 via the rfsimulator's telnet interface and verify the switch was acknowledged</desc>
     <node>localhost</node>
-    <command>echo rfsimulator setbeamids 2 | ncat 192.168.71.150 8091 | grep -q "Beam ids set"</command>
+    <command>echo rfsimulator setbeamids 2 | ncat 192.168.71.150 8091</command>
   </testCase>
 
   <testCase>

--- a/ci-scripts/yaml_files/5g_rfsimulator_fr2_66prb/docker-compose.yaml
+++ b/ci-scripts/yaml_files/5g_rfsimulator_fr2_66prb/docker-compose.yaml
@@ -99,12 +99,13 @@ services:
             - ALL
         environment:
             USE_ADDITIONAL_OPTIONS: --rfsim --log_config.global_log_options level,nocolor,time
+                                    --rfsimulator.[0].enable_beams --rfsimulator.[0].beam_gains 0,-5,-10,-15
             ASAN_OPTIONS: detect_leaks=0
         networks:
             public_net:
                 ipv4_address: 192.168.71.140
         volumes:
-            - ../../conf_files/gnb.sa.band257.u3.66prb.rfsim.conf:/opt/oai-gnb/etc/gnb.conf
+            - ../../conf_files/gnb.sa.band257.u3.66prb.rfsim.4beams.conf:/opt/oai-gnb/etc/gnb.conf
         healthcheck:
             test: /bin/bash -c "pgrep nr-softmodem"
             start_period: 10s
@@ -125,7 +126,9 @@ services:
             USE_ADDITIONAL_OPTIONS: --rfsim
                                     --rfsimulator.[0].serveraddr 192.168.71.140 --log_config.global_log_options level,nocolor,time
                                     -C 27975360000 -r 66 --numerology 3 --ssb 48 --band 257
-            ASAN_OPTIONS: detect_leaks=0
+                                    --rfsimulator.[0].enable_beams --rfsimulator.[0].beam_gains 0,-5,-10,-15 --rfsimulator.[0].beam_ids 0
+                                    --telnetsrv --telnetsrv.shrmod ciUE --telnetsrv.listenaddr 192.168.71.150 --telnetsrv.listenport 8091
+            ASAN_OPTIONS: detect_leaks=0:detect_odr_violation=0
         devices:
              - /dev/net/tun:/dev/net/tun
         volumes:

--- a/executables/nr-ru.c
+++ b/executables/nr-ru.c
@@ -395,8 +395,47 @@ int tx_rf_symbols(RU_t *ru, int frame, int slot, uint64_t timestamp, int start_s
   return transmitted_symbols;
 }
 
+// Pushes the per-antenna analog beam IDs assigned to this slot's symbols (ru->common.beam_id,
+// filled in from the gNB's precoding step) down to the RF device, one trx_set_beams() call per
+// symbol at which the beam vector changes. Only relevant for devices that need to be told about
+// beams explicitly (e.g. rfsimulator); USRP GPIO-controlled beam switching is handled separately
+// via get_gpio_flags(), embedded directly in the TX burst flags.
+//
+// Must run after nr_feptx_tp()/nr_feptx_prec() have copied this slot's beam_id from the gNB's
+// common_vars (done from ru_tx_func(), called below in tx_rf()) -- calling this any earlier reads
+// last frame's leftover beam_id instead of the one the MAC scheduler just picked for this slot.
+//
+// Only calls trx_set_beams() when the beam vector actually changes between symbols, to avoid
+// issuing redundant beam-switch commands to real hardware.
+static void ctrl_rf(RU_t *ru, int frame, int slot, uint64_t timestamp)
+{
+  if (!ru->rfdevice.trx_set_beams || !ru->gNB_list[0]->common_vars.analog_bf)
+    return;
+
+  NR_DL_FRAME_PARMS *fp = ru->nr_frame_parms;
+  int nb_tx = ru->nb_tx;
+  uint16_t **beam_id = ru->common.beam_id;
+
+  uint16_t last_beams[nb_tx];
+  memcpy(last_beams, beam_id[slot * fp->symbols_per_slot], nb_tx * sizeof(uint16_t));
+  uint64_t event_ts = timestamp + ru->ts_offset;
+  LOG_D(NR_PHY, "RU Control [%d.%d]: set beams at symbol 0, ts %lu\n", frame, slot, event_ts);
+  ru->rfdevice.trx_set_beams(&ru->rfdevice, last_beams, nb_tx, event_ts);
+
+  for (int j = 1; j < fp->symbols_per_slot; j++) {
+    uint16_t *cur_beams = beam_id[slot * fp->symbols_per_slot + j];
+    if (memcmp(cur_beams, last_beams, nb_tx * sizeof(uint16_t)) == 0)
+      continue;
+    memcpy(last_beams, cur_beams, nb_tx * sizeof(uint16_t));
+    event_ts = timestamp + ru->ts_offset + get_samples_symbol_duration(fp, slot, 0, j);
+    LOG_D(NR_PHY, "RU Control [%d.%d]: beam switch at symbol %d, ts %lu\n", frame, slot, j, event_ts);
+    ru->rfdevice.trx_set_beams(&ru->rfdevice, last_beams, nb_tx, event_ts);
+  }
+}
+
 void tx_rf(RU_t *ru, int frame, int slot, uint64_t timestamp)
 {
+  ctrl_rf(ru, frame, slot, timestamp);
   tx_rf_symbols(ru, frame, slot, timestamp, 0, 14);
 }
 

--- a/openair1/SCHED_NR/nr_ru_procedures.c
+++ b/openair1/SCHED_NR/nr_ru_procedures.c
@@ -217,24 +217,25 @@ void nr_feptx(void *arg)
 void nr_feptx_tp(RU_t *ru, int frame_tx, int slot)
 {
   nfapi_nr_config_request_scf_t *cfg = &ru->gNB_list[0]->gNB_config;
-  if (nr_slot_select(cfg, frame_tx, slot) == NR_UPLINK_SLOT)
-    return;
-  start_meas(&ru->ofdm_total_stats);
-
   const NR_DL_FRAME_PARMS *fp = ru->nr_frame_parms;
-  int nt = fp->nb_antennas_tx;
-  size_t const sz = nt + (ru->half_slot_parallelization > 0) * nt;
-  feptx_cmd_t arr[sz];
-  task_ans_t ans;
-  init_task_ans(&ans, sz);
 
-  // Copy beam IDs
+  // Copy beam IDs for both TX and RX; ctrl_rf() is called for all types of slots when analog_bf is set.
   if (ru->gNB_list[0]->common_vars.analog_bf) {
     for (uint_fast16_t i = 0; i < fp->symbols_per_slot; i++)
       memcpy(ru->common.beam_id[slot * fp->symbols_per_slot + i],
              ru->gNB_list[0]->common_vars.beam_id[slot * fp->symbols_per_slot + i],
              (ru->nb_tx) * sizeof(**ru->common.beam_id));
   }
+
+  if (nr_slot_select(cfg, frame_tx, slot) == NR_UPLINK_SLOT)
+    return;
+  start_meas(&ru->ofdm_total_stats);
+
+  int nt = fp->nb_antennas_tx;
+  size_t const sz = nt + (ru->half_slot_parallelization > 0) * nt;
+  feptx_cmd_t arr[sz];
+  task_ans_t ans;
+  init_task_ans(&ans, sz);
 
   int nbfeptx = 0;
   for (int aid = 0; aid < nt; aid++) {

--- a/radio/COMMON/common_lib.h
+++ b/radio/COMMON/common_lib.h
@@ -395,23 +395,6 @@ struct openair0_device {
   /*! \brief Called to send samples to the RF target
       @param device pointer to the device structure specific to the RF hardware target
       @param timestamp The timestamp at whicch the first sample MUST be sent
-      @param buff Buffer which holds the samples (3 dimensional)
-      @param nsamps number of samples to be sent
-      @param nb_antennas_tx number of antennas
-      @param num_beams number of beams
-      @param flags flags must be set to true if timestamp parameter needs to be applied
-  */
-  int (*trx_write_beams_func)(openair0_device_t *device,
-                              openair0_timestamp_t timestamp,
-                              void ***buff,
-                              int nsamps,
-                              int nb_antennas_tx,
-                              int num_beams,
-                              int flags);
-
-  /*! \brief Called to send samples to the RF target
-      @param device pointer to the device structure specific to the RF hardware target
-      @param timestamp The timestamp at whicch the first sample MUST be sent
       @param buff Buffer which holds the samples (2 dimensional)
       @param nsamps number of samples to be sent
       @param nb_antennas_tx number of antennas
@@ -451,26 +434,6 @@ struct openair0_device {
    */
 
   int (*trx_read_func)(openair0_device_t *device, openair0_timestamp_t *ptimestamp, void **buff, int nsamps, int num_antennas);
-
-  /*! \brief Receive samples from hardware.
-   * Read nsamps samples from each channel to buffers. buff[0] is the array for
-   * the first channel. *ptimestamp is the time at which the first sample
-   * was received.
-   * \param device the hardware to use
-   * \param[out] ptimestamp the time at which the first sample was received.
-   * \param[out] buff An array of pointers to buffers for received samples. The buffers must be large enough to hold the number of
-   * samples nsamps.
-   * \param nsamps Number of samples. One sample is 2 byte I + 2 byte Q => 4 byte.
-   * \param num_antennas number of antennas from which to receive samples
-   * \param num_beams number of beams from which to receive samples
-   * \returns the number of sample read
-   */
-  int (*trx_read_beams_func)(openair0_device_t *device,
-                             openair0_timestamp_t *ptimestamp,
-                             void ***buff,
-                             int nsamps,
-                             int num_antennas,
-                             int num_beams);
 
   /*! \brief Receive samples from hardware, this version provides a single antenna at a time and returns.
    * Read nsamps samples from each channel to buffers. buff[0] is the array for
@@ -537,26 +500,11 @@ struct openair0_device {
    * to the application to determine the beam of the received samples.
    *
    * \param device the hardware to use
-   * \param beam_map the beams to receive
-   * \return 0 on success
-   */
-  int (*trx_set_beams)(openair0_device_t *device, uint64_t beam_map, openair0_timestamp_t timestamp);
-
-  /*! \brief Set tx/rx beams
-   *
-   * Set the tx/rx beams. This has to be done in advance of the reception in order to
-   * allow the underlying device to change receiver configuration. The exact time depends
-   * on the device.
-   *
-   * NOTICE: the samples returned from trx_read_func may belong to more than one beam. It is up
-   * to the application to determine the beam of the received samples.
-   *
-   * \param device the hardware to use
    * \param beams pointer to array of beam ids
-   * \param num_beams number of beams
+   * \param num_beams number of beams. Expected to be equal to number of antennas
    * \return 0 on success
    */
-  int (*trx_set_beams2)(openair0_device_t *device, int *beams, int num_beams, openair0_timestamp_t timestamp);
+  int (*trx_set_beams)(openair0_device_t *device, uint16_t *beams, int num_beams, openair0_timestamp_t timestamp);
 
   /*! \brief RRU Configuration callback
    * \param idx RU index
@@ -607,7 +555,6 @@ typedef struct {
   uint64_t timestamp;      // Timestamp value of first sample
   uint32_t option_value;   // Option value
   uint32_t option_flag;    // Option flag
-  uint64_t beam_map;
 } samplesBlockHeader_t;
 
 #ifdef __cplusplus

--- a/radio/rfsimulator/README.md
+++ b/radio/rfsimulator/README.md
@@ -216,7 +216,11 @@ You can further [tune your machine](../../doc/tuning_and_security.md)
 
 # Beam simulation
 
-RFsimulator supports beam domain simulation.
+RFsimulator supports beam domain simulation. Each antenna element (`nb_tx`/`nb_rx`) carries exactly one
+beam ID at a time — not a set of concurrent beams. Different antennas may be assigned the same beam ID
+(e.g. to form a wider physical beam out of several antennas), but a single antenna cannot carry more than
+one beam ID simultaneously. The beam vector sent alongside the samples therefore always has one entry per
+antenna, and there is no separate "concurrent beam count" to configure.
 
 ## Configuration
 
@@ -240,17 +244,17 @@ these values onto the diagonals, making it symmetric.
  Using the example above, if gNB is receiving in beam 1 and the UE is transmitting in beam 1, an additional
  2 dB pathloss will be applied on top of the pathloss from the channel model (if present).
 
-* `--rfsimulator.[0].beam_map <beam_map>` : where `<beam_map>` is a `uint64_t` value where each bit is an enabled TX/RX beam.
-   For gNB: Initial beam_map, i.e. which beams gNB transmits/receives before calling beam APIs.
-   For UE: Beam position in beam space in the simulation. The UE is not expected to use the beam APIs for now.
-* `--rfsimulator.[0].beam_ids <beam_ids>` : where `<beam_ids>` is a comma separated list. Same as above but added for convenience.
+* `--rfsimulator.[0].beam_ids <beam_ids>` : where `<beam_ids>` is a comma-separated list of initial beam IDs,
+   one per antenna/IQ stream (`nb_tx`/`nb_rx`).
+   For gNB: initial beam ID per antenna, i.e. which beam the gNB transmits/receives on before calling the beam API.
+   For UE: beam position in beam space in the simulation. The UE is not expected to use the beam API for now.
 
 ## Runtime commands
 
 ### Moving the UE in beam space
 
-Use telnet command `rfsimu setbeams <beam_map>` or `rfsimu setbeamids <beam_ids>`. They correspond to the CLI parameters described
-above and work the same way.
+Use telnet command `rfsimulator setbeamids <beam_id1,beam_id2,...>` (one beam ID per antenna). It corresponds to
+the `beam_ids` CLI parameter described above and works the same way, replacing the beam ID(s) currently in effect.
 
 ### Modifying the gNB beam
 
@@ -260,8 +264,10 @@ to modify the tx/rx beam of the gNB. The gNB does not need to be beam-aware and 
 ## Programming guide
 
 RFsimulator is attempting to simulate hardware device operation, but there are differences. Like with real hardware,
-it is expected that you provide the configured beams in `set_beams` function ahead of sample reception. This is due
-to the fact that a hardware device will buffer received samples before the driver requests them.
+it is expected that you provide the configured beams in the `trx_set_beams` function ahead of sample reception. This
+is due to the fact that a hardware device will buffer received samples before the driver requests them.
 
-For rfsimulator, as long as the call to `set_beams` with timestamp `n` is done before `trx_read` which is expected
-to return sample `n` the beam switch command will apply to the received samples.
+`trx_set_beams(device, uint16_t *beams, int num_beams, timestamp)` takes a beam ID array whose length (`num_beams`)
+must equal the number of antennas (`nb_tx` for TX, `nb_rx` for RX): `beams[a]` is the beam ID to apply on antenna `a`
+starting at `timestamp`. As long as the call to `trx_set_beams` with timestamp `n` is done before `trx_read` which is
+expected to return sample `n`, the beam switch command will apply to the received samples.

--- a/radio/rfsimulator/simulator.cpp
+++ b/radio/rfsimulator/simulator.cpp
@@ -73,8 +73,6 @@ typedef enum { SIMU_ROLE_SERVER = 1, SIMU_ROLE_CLIENT } simuRole;
 #define RFSIMU_PROP_DELAY "prop_delay"
 #define RFSIMU_WAIT_TIMEOUT "wait_timeout"
 #define RFSIMU_ENABLE_BEAMS "enable_beams"
-#define RFSIMU_NUM_CONCURRENT_BEAMS "num_concurrent_beams"
-#define RFSIMU_BEAM_MAP "beam_map"
 #define RFSIMU_BEAM_GAINS "beam_gains"
 #define RFSIMU_BEAM_IDS "beam_ids"
 
@@ -102,8 +100,6 @@ typedef enum { SIMU_ROLE_SERVER = 1, SIMU_ROLE_CLIENT } simuRole;
   DOUBLEPARAM(RFSIMU_PROP_DELAY,        "<propagation delay in ms>\n",              simOpt, NULL,                             0.0),                   \
   INTPARAM(RFSIMU_WAIT_TIMEOUT,         "<wait timeout if no UE connected>\n",      simOpt, NULL,                             1),                     \
   BOOLPARAM(RFSIMU_ENABLE_BEAMS,        "<enable simplified beam simulation>\n",    simBool,NULL,                             0),                     \
-  INTPARAM(RFSIMU_NUM_CONCURRENT_BEAMS, "<number of concurrent beams supported>\n", simOpt, NULL,                             1),                     \
-  UINT64PARAM(RFSIMU_BEAM_MAP,          "<initial beam map>\n",                     simOpt, NULL,                             1),                     \
   STRINGPARAM(RFSIMU_BEAM_IDS,          "<initial beam ids>\n",                     simOpt, NULL,                             NULL),                  \
   STRINGPARAM(RFSIMU_BEAM_GAINS,        "<beam gain matrix in toeplitz form>\n",    simOpt, NULL,                             NULL),                  \
 };
@@ -113,7 +109,6 @@ static int rfsimu_setchanmod_cmd(char *buff, int debug, telnet_printfunc_t prnt,
 static int rfsimu_setdistance_cmd(char *buff, int debug, telnet_printfunc_t prnt, void *arg);
 static int rfsimu_getdistance_cmd(char *buff, int debug, telnet_printfunc_t prnt, void *arg);
 static int rfsimu_vtime_cmd(char *buff, int debug, telnet_printfunc_t prnt, void *arg);
-static int rfsimu_set_beam(char *buff, int debug, telnet_printfunc_t prnt, void *arg);
 static int rfsimu_set_beamids(char *buff, int debug, telnet_printfunc_t prnt, void *arg);
 // clang-format off
 static telnetshell_cmddef_t rfsimu_cmdarray[] = {
@@ -122,7 +117,6 @@ static telnetshell_cmddef_t rfsimu_cmdarray[] = {
     {"setdistance", "<model name> <distance>", (cmdfunc_t)rfsimu_setdistance_cmd, {NULL}, TELNETSRV_CMDFLAG_PUSHINTPOOLQ | TELNETSRV_CMDFLAG_NEEDPARAM },
     {"getdistance", "<model name>", (cmdfunc_t)rfsimu_getdistance_cmd, {NULL}, TELNETSRV_CMDFLAG_PUSHINTPOOLQ},
     {"vtime", "", (cmdfunc_t)rfsimu_vtime_cmd, {NULL}, TELNETSRV_CMDFLAG_PUSHINTPOOLQ | TELNETSRV_CMDFLAG_AUTOUPDATE},
-    {"setbeam", "beam_map", (cmdfunc_t)rfsimu_set_beam, {NULL}, TELNETSRV_CMDFLAG_PUSHINTPOOLQ},
     {"setbeamids", "beam_id1,beam_id2,...", (cmdfunc_t)rfsimu_set_beamids, {NULL}, TELNETSRV_CMDFLAG_PUSHINTPOOLQ},
     {"", "", NULL},
 };
@@ -133,12 +127,12 @@ static telnetshell_vardef_t rfsimu_vardef[] = {{"", 0, 0, NULL}};
 typedef c16_t sample_t; // 2*16 bits complex number
 
 typedef struct beam_switch_command_t {
-  std::vector<int> beams;
+  std::vector<uint16_t> beams;
   openair0_timestamp_t timestamp;
 } beam_switch_command_t;
 
 typedef struct {
-  std::vector<int> beams;
+  std::vector<uint16_t> beams;
   std::queue<beam_switch_command_t> cmd_queue;
   std::mutex mutex;
 } beam_state_t;
@@ -166,7 +160,6 @@ typedef struct buffer_s {
 
 typedef struct {
   int enable_beams;
-  int num_concurrent_beams;
   std::vector<std::vector<float>> beam_gains;
   beam_state_t tx;
   beam_state_t rx;
@@ -212,10 +205,10 @@ typedef struct {
  * @param nsamps_out output pointer to receive the number of samples until the next beam switch.
  * @return The beam map (uint64_t) valid for the given timestamp.
  */
-static std::vector<int> get_beams(beam_state_t *beam_state, openair0_timestamp_t timestamp, uint32_t nsamps, uint32_t *nsamps_out)
+static std::vector<uint16_t> get_beams(beam_state_t *beam_state, openair0_timestamp_t timestamp, uint32_t nsamps, uint32_t *nsamps_out)
 {
   std::lock_guard<std::mutex> lock(beam_state->mutex);
-  std::vector<int> current_beams = beam_state->beams;
+  std::vector<uint16_t> current_beams = beam_state->beams;
   uint32_t samples_to_next_switch = nsamps;
 
   // Find the latest beam_switch_command_t with timestamp <= requested timestamp
@@ -242,30 +235,6 @@ static std::vector<int> get_beams(beam_state_t *beam_state, openair0_timestamp_t
 
   return current_beams;
 }
-
-
-static std::vector<int> beam_map_to_beams(uint64_t beam_map)
-{
-  int num_beams = __builtin_popcountll(beam_map);
-  AssertFatal(num_beams > 0, "Needs at least one beam\n");
-  std::vector<int> beam_ids;
-  for (int i = 0; i < MAX_BEAMS; i++) {
-    if (beam_map & (1ULL << i)) {
-      beam_ids.push_back(i);
-    }
-  }
-  return beam_ids;
-}
-
-static uint64_t beams_to_beam_map(const std::vector<int> &beam_ids)
-{
-  uint64_t beam_map = 0;
-  for (size_t i = 0; i < beam_ids.size(); i++) {
-    beam_map |= (1ULL << beam_ids[i]);
-  }
-  return beam_map;
-}
-
 
 /**
  * @brief Clears outdated beam switch commands from the queue and updates the current beam map.
@@ -466,25 +435,13 @@ static float get_rx_gain_db(rfsimulator_state_t *rfsimulator, uint rx_beam, uint
   return rfsimulator->beam_ctrl->beam_gains[rx_beam][tx_beam];
 }
 
-static int rfsimulator_set_beams(openair0_device_t *device, uint64_t beam_map, openair0_timestamp_t timestamp)
+static int rfsimulator_set_beams_vector(openair0_device_t *device, uint16_t *beams, int num_beams, openair0_timestamp_t timestamp)
 {
   rfsimulator_state_t *s = static_cast<rfsimulator_state_t *>(device->priv);
   rfsim_beam_ctrl_t *beam_ctrl = s->beam_ctrl;
   std::lock_guard<std::mutex> lock_tx(beam_ctrl->tx.mutex);
   std::lock_guard<std::mutex> lock_rx(beam_ctrl->rx.mutex);
-  beam_switch_command_t command = {.beams = beam_map_to_beams(beam_map), .timestamp = timestamp};
-  beam_ctrl->rx.cmd_queue.emplace(command);
-  beam_ctrl->tx.cmd_queue.emplace(command);
-  return 0;
-}
-
-static int rfsimulator_set_beams_vector(openair0_device_t *device, int *beams, int num_beams, openair0_timestamp_t timestamp)
-{
-  rfsimulator_state_t *s = static_cast<rfsimulator_state_t *>(device->priv);
-  rfsim_beam_ctrl_t *beam_ctrl = s->beam_ctrl;
-  std::lock_guard<std::mutex> lock_tx(beam_ctrl->tx.mutex);
-  std::lock_guard<std::mutex> lock_rx(beam_ctrl->rx.mutex);
-  beam_switch_command_t command = {.beams = std::vector<int>(beams, beams + num_beams), .timestamp = timestamp};
+  beam_switch_command_t command = {.beams = std::vector<uint16_t>(beams, beams + num_beams), .timestamp = timestamp};
   beam_ctrl->rx.cmd_queue.emplace(command);
   beam_ctrl->tx.cmd_queue.emplace(command);
   return 0;
@@ -545,8 +502,6 @@ static void rfsimulator_readconfig(rfsimulator_state_t *rfsimulator)
 
   rfsim_beam_ctrl_t *beam_ctrl = rfsimulator->beam_ctrl;
   beam_ctrl->enable_beams = *(gpd(rfsimuParam, sizeofArray(rfsimuParams), RFSIMU_ENABLE_BEAMS)->iptr);
-  beam_ctrl->num_concurrent_beams = *(gpd(rfsimuParam, sizeofArray(rfsimuParams), RFSIMU_NUM_CONCURRENT_BEAMS)->iptr);
-  uint64_t beam_map = *(gpd(rfsimuParam, sizeofArray(rfsimuParams), RFSIMU_BEAM_MAP)->u64ptr);
 
   rfsimulator->saveIQfile = -1;
 
@@ -582,13 +537,9 @@ static void rfsimulator_readconfig(rfsimulator_state_t *rfsimulator)
     process_gains(*rfsimuParam[beam_gains_param_index].strptr, beam_ctrl);
   }
 
-  std::vector<int> initial_beams = beam_map_to_beams(beam_map);
-  beam_ctrl->rx.beams = initial_beams;
-  beam_ctrl->tx.beams = initial_beams;
-
   int beam_ids_param_index = config_paramidx_fromname(rfsimuParams, sizeofArray(rfsimuParams), RFSIMU_BEAM_IDS);
   if (rfsimuParam[beam_ids_param_index].strptr) {
-    std::vector<int> beam_ids;
+    std::vector<uint16_t> beam_ids;
     std::stringstream ss(*rfsimuParam[beam_ids_param_index].strptr);
     std::string token;
     while (std::getline(ss, token, ',')) {
@@ -604,28 +555,13 @@ static void rfsimulator_readconfig(rfsimulator_state_t *rfsimulator)
     rfsimulator->role = SIMU_ROLE_CLIENT;
 }
 
-static int rfsimu_set_beam(char *buff, int debug, telnet_printfunc_t prnt, void *arg)
-{
-  UNUSED(debug);
-  rfsimulator_state_t *t = (rfsimulator_state_t *)arg;
-  rfsim_beam_ctrl_t *beam_ctrl = t->beam_ctrl;
-  AssertFatal(beam_ctrl->enable_beams, "Beam simualtion is disabled, cannot set beams\n");
-  uint64_t beam_map = strtoull(buff, NULL, 0);
-  std::lock_guard<std::mutex> lock_tx(beam_ctrl->tx.mutex);
-  std::lock_guard<std::mutex> lock_rx(beam_ctrl->rx.mutex);
-  beam_ctrl->rx.beams = beam_map_to_beams(beam_map);
-  beam_ctrl->tx.beams = beam_map_to_beams(beam_map);
-  prnt("Beam map set to 0x%lx\n", beam_map);
-  return CMDSTATUS_FOUND;
-}
-
 static int rfsimu_set_beamids(char *buff, int debug, telnet_printfunc_t prnt, void *arg)
 {
   UNUSED(debug);
   rfsimulator_state_t *t = (rfsimulator_state_t *)arg;
   rfsim_beam_ctrl_t *beam_ctrl = t->beam_ctrl;
   AssertFatal(beam_ctrl->enable_beams, "Beam simualtion is disabled, cannot set beams\n");
-  std::vector<int> beam_ids;
+  std::vector<uint16_t> beam_ids;
   std::stringstream ss(buff);
   std::string token;
   while (std::getline(ss, token, ',')) {
@@ -735,7 +671,7 @@ static int rfsimu_setdistance_cmd(char *buff, int debug, telnet_printfunc_t prnt
 
   rfsimulator_state_t *t = (rfsimulator_state_t *)arg;
   const double sample_rate = t->sample_rate;
-  const double c = (double) SPEED_OF_LIGHT;
+  const double c = (double)SPEED_OF_LIGHT;
 
   const uint64_t new_offset = (double)distance * sample_rate / c;
   const double new_distance = (double)new_offset * c / sample_rate;
@@ -771,7 +707,7 @@ static int rfsimu_getdistance_cmd(char *buff, int debug, telnet_printfunc_t prnt
 
   rfsimulator_state_t *t = (rfsimulator_state_t *)arg;
   const double sample_rate = t->sample_rate;
-  const double c = (double) SPEED_OF_LIGHT;
+  const double c = (double)SPEED_OF_LIGHT;
 
   for (int i = 0; i < MAX_FD_RFSIMU; i++) {
     buffer_t *b = &t->buf[i];
@@ -953,10 +889,10 @@ static int startClient(openair0_device_t *device)
 
 static int rfsimulator_write_internal(rfsimulator_state_t *t,
                                       openair0_timestamp_t timestamp,
-                                      void ***samplesVoid,
+                                      sample_t **samples,
                                       int nsamps,
                                       int nbAnt,
-                                      std::vector<int> tx_beams,
+                                      std::vector<uint16_t> tx_beams,
                                       int flags)
 {
   mutexlock(t->Sockmutex);
@@ -966,20 +902,12 @@ static int rfsimulator_write_internal(rfsimulator_state_t *t,
     buffer_t *b = &t->buf[i];
 
     if (b->conn_sock >= 0) {
-      samplesBlockHeader_t header = {(uint32_t)nsamps, (uint32_t)nbAnt, (uint64_t)timestamp, 0, 0, beams_to_beam_map(tx_beams)};
+      samplesBlockHeader_t header = {(uint32_t)nsamps, (uint32_t)nbAnt, (uint64_t)timestamp, 0, 0};
       fullwrite(b->conn_sock, &header, sizeof(header), t);
-      int num_beams = tx_beams.size();
-      // Send beams in order of beam index. This is required for beam_map to work correctly on the receiver side.
-      std::vector<size_t> indices(tx_beams.size());
-      std::iota(indices.begin(), indices.end(), 0);
-      std::sort(indices.begin(), indices.end(), [&](size_t i, size_t j) { return tx_beams[i] < tx_beams[j]; });
-
-      AssertFatal(num_beams > 0, "Must set at least one bit in beam_map\n");
-      for (int beam = 0; beam < num_beams; beam++) {
-        for (int a = 0; a < nbAnt; a++) {
-          sample_t *in = (sample_t *)samplesVoid[indices[beam]][a];
-          fullwrite(b->conn_sock, (void *)in, sampleToByte(nsamps, 1), t);
-        }
+      AssertFatal((uint)nbAnt == tx_beams.size(), "rfsim requires one beam per IQ stream\n");
+      fullwrite(b->conn_sock, tx_beams.data(), sizeof(uint16_t) * nbAnt, t);
+      for (int a = 0; a < nbAnt; a++) {
+        fullwrite(b->conn_sock, (void *)samples[a], sampleToByte(nsamps, 1), t);
       }
     }
   }
@@ -1002,54 +930,46 @@ static int rfsimulator_write_internal(rfsimulator_state_t *t,
         nsamps,
         timestamp,
         timestamp + nsamps,
-        signal_energy(static_cast<int32_t *>(samplesVoid[0][0]), nsamps));
+        signal_energy_nodc(samples[0], nsamps));
 
   /* trace only first antenna */
-  T(T_USRP_TX_ANT0, T_INT(timestamp), T_BUFFER(samplesVoid[0][0], (int)sampleToByte(nsamps, 1)));
+  T(T_USRP_TX_ANT0, T_INT(timestamp), T_BUFFER(samples[0], (int)sampleToByte(nsamps, 1)));
 
   return nsamps;
 }
 
-static int rfsimulator_write_beams(openair0_device_t *device,
-                                   openair0_timestamp_t timestamp,
-                                   void ***samplesVoid,
-                                   int nsamps,
-                                   int nbAnt,
-                                   int num_beams,
-                                   int flags)
+static int rfsimulator_write(openair0_device_t *device,
+                             openair0_timestamp_t timestamp,
+                             void **samplesVoid,
+                             int nsamps,
+                             int nbAnt,
+                             int flags)
 {
   timestamp -= device->openair0_cfg->command_line_sample_advance;
   int nsamps_initial = nsamps;
   rfsimulator_state_t *t = static_cast<rfsimulator_state_t *>(device->priv);
-  void *samples[num_beams][nbAnt];
-  void **samples_ptr[num_beams];
-  for (int beam = 0; beam < num_beams; beam++) {
-    samples_ptr[beam] = samples[beam];
-    for (int aatx = 0; aatx < nbAnt; aatx++) {
-      samples[beam][aatx] = samplesVoid[beam][aatx];
-    }
+  sample_t *samples[nbAnt];
+  for (int aatx = 0; aatx < nbAnt; aatx++) {
+    samples[aatx] = (sample_t *)samplesVoid[aatx];
   }
   while (nsamps > 0) {
     uint32_t nsamps_beam_map;
-    std::vector<int> beams = get_beams(&t->beam_ctrl->tx, timestamp, nsamps, &nsamps_beam_map);
-    rfsimulator_write_internal(t, timestamp, samples_ptr, nsamps_beam_map, nbAnt, beams, flags);
-    for (int beam = 0; beam < num_beams; beam++) {
-      for (int aatx = 0; aatx < nbAnt; aatx++) {
-        char *ptr = (char *)samples_ptr[beam][aatx];
-        samples_ptr[beam][aatx] = (void *)(ptr + nsamps_beam_map * sizeof(sample_t));
-      }
+    std::vector<uint16_t> tx_beams = get_beams(&t->beam_ctrl->tx, timestamp, nsamps, &nsamps_beam_map);
+    if (t->beam_ctrl->enable_beams && (int)tx_beams.size() != nbAnt) {
+      LOG_W(HW, "Number of beams does not match application request nbAnt %d, beams %lu\n", nbAnt, tx_beams.size());
+    }
+    while ((int)tx_beams.size() < nbAnt)
+      tx_beams.push_back(0);
+
+    rfsimulator_write_internal(t, timestamp, samples, nsamps_beam_map, nbAnt, tx_beams, flags);
+    for (int aatx = 0; aatx < nbAnt; aatx++) {
+      samples[aatx] += nsamps_beam_map;
     }
     timestamp += nsamps_beam_map;
     nsamps -= nsamps_beam_map;
   }
   clear_beam_queue(&t->beam_ctrl->tx, timestamp + nsamps);
   return nsamps_initial;
-}
-
-static int rfsimulator_write(openair0_device_t *device, openair0_timestamp_t timestamp, void **buff, int nsamps, int cc, int flags)
-{
-  void **tmp = buff;
-  return rfsimulator_write_beams(device, timestamp, &tmp, nsamps, cc, 1, flags);
 }
 
 static bool add_client(rfsimulator_state_t *t)
@@ -1075,13 +995,17 @@ static bool add_client(rfsimulator_state_t *t)
   getnameinfo((struct sockaddr *)&sa, socklen, ip, sizeof(ip), NULL, 0, NI_NUMERICHOST);
   uint16_t port = ((struct sockaddr_in *)&sa)->sin_port;
   LOG_I(HW, "Client connects from %s:%d\n", ip, port);
-  c16_t v = {0};
-  void *samplesVoid[t->tx_num_channels];
-  for (int i = 0; i < t->tx_num_channels; i++)
-    samplesVoid[i] = (void *)&v;
-  samplesBlockHeader_t header = {1, (uint32_t)t->tx_num_channels, (uint64_t)t->lastWroteTS, 0, 0, 1};
+  samplesBlockHeader_t header = {1, (uint32_t)t->tx_num_channels, (uint64_t)t->lastWroteTS, 0, 0};
+
   fullwrite(conn_sock, &header, sizeof(header), t);
-  fullwrite(conn_sock, samplesVoid, sampleToByte(1, t->tx_num_channels), t);
+  uint16_t beam_ids[t->tx_num_channels];
+  for (int i = 0; i < t->tx_num_channels; i++)
+    beam_ids[i] = 0;
+  fullwrite(conn_sock, beam_ids, sizeof(beam_ids), t);
+
+  c16_t v[t->rx_num_channels];
+  memset(v, 0, sizeof(v));
+  fullwrite(conn_sock, v, sizeof(v), t);
 
   if (new_buf->channel_model)
     new_buf->channel_model->start_TS = t->lastWroteTS;
@@ -1089,7 +1013,7 @@ static bool add_client(rfsimulator_state_t *t)
   return true;
 }
 
-static void process_recv_header(rfsimulator_state_t *t, buffer_t *b, bool first_time)
+static void process_recv_header(buffer_t *b, bool first_time)
 {
   b->headerMode = false; // We got the header
   AssertFatal(b->th.nbAnt != 0, "Number of antennas not set\n");
@@ -1112,14 +1036,12 @@ static void process_recv_header(rfsimulator_state_t *t, buffer_t *b, bool first_
     }
   }
 
-  int num_beams = __builtin_popcountll(b->th.beam_map);
-  AssertFatal(b->th.beam_map == 1ULL || t->beam_ctrl->enable_beams == 1,
-              "The transmitter has enabled beam simulation while this receiver has not\n");
-  size_t payload_sz = sampleToByte(b->th.size, b->th.nbAnt) * num_beams;
-  b->packet_ptr = static_cast<rfsim_packet_t *>(malloc_or_fail(payload_sz + sizeof(samplesBlockHeader_t)));
+  size_t beam_payload_size = b->th.nbAnt * sizeof(uint16_t);
+  size_t payload_sz = sampleToByte(b->th.size, b->th.nbAnt);
+  b->packet_ptr = static_cast<rfsim_packet_t *>(malloc_or_fail(beam_payload_size + payload_sz + sizeof(samplesBlockHeader_t)));
   b->packet_ptr->header = b->th;
   b->transferPtr = b->packet_ptr->payload;
-  b->remainToTransfer = payload_sz;
+  b->remainToTransfer = payload_sz + beam_payload_size;
   return;
 }
 
@@ -1143,7 +1065,6 @@ static void process_recv_header(rfsimulator_state_t *t, buffer_t *b, bool first_
 static void combine_received_beams(rfsimulator_state_t *t,
                                    std::queue<rfsim_packet_t *> &received_packets,
                                    uint64_t start_timestamp,
-                                   int num_aatx,
                                    size_t num_samples,
                                    int rx_beam_id,
                                    c16_t **samples)
@@ -1162,47 +1083,24 @@ static void combine_received_beams(rfsimulator_state_t *t,
       break;
     }
 
-    // The beams transmitted in are ordered by beam index
-    std::vector<int> tx_beams = beam_map_to_beams(pkt->header.beam_map);
-    for (uint beam = 0; beam < tx_beams.size(); beam++) {
-      float gain_dB = get_rx_gain_db(t, rx_beam_id, tx_beams[beam]);
+    // Each TX antenna carries exactly one beam; accumulate every TX antenna's stream, gain-adjusted
+    // for the RX beam, directly into the same-indexed RX antenna buffer.
+    uint16_t *beams = (uint16_t *)pkt->payload;
+    c16_t *buffer = (c16_t *)&pkt->payload[sizeof(uint16_t) * pkt->header.nbAnt];
+    uint64_t overlap_start = std::max(start_timestamp, pkt->header.timestamp);
+    uint64_t overlap_end = std::min(start_timestamp + num_samples, pkt->header.timestamp + pkt->header.size);
+    int write_start_idx = overlap_start - start_timestamp;
+    int write_end_idx = overlap_end - start_timestamp;
+    int read_start_idx = overlap_start - pkt->header.timestamp;
+    for (uint aatx = 0; aatx < pkt->header.nbAnt; aatx++) {
+      int beam = beams[aatx];
+      float gain_dB = get_rx_gain_db(t, rx_beam_id, beam);
       float gain_linear = powf(10, gain_dB / 20.0);
-      uint64_t overlap_start = std::max(start_timestamp, pkt->header.timestamp);
-      uint64_t overlap_end = std::min(start_timestamp + num_samples, pkt->header.timestamp + pkt->header.size);
-      int write_start_idx = overlap_start - start_timestamp;
-      int write_end_idx = overlap_end - start_timestamp;
-      int read_start_idx = overlap_start - pkt->header.timestamp;
-      for (int aatx = 0; aatx < num_aatx; aatx++) {
-        c16_t *buffer = (c16_t *)pkt->payload;
-        c16_t *tx_ant_buffer_in = &buffer[(num_aatx * beam + aatx) * pkt->header.size + read_start_idx];
-        if (beam == 0) {
-          // For the first beam, we can directly copy the samples
-          if (gain_dB == 0.0f) {
-            // If gain is 0 dB, we can use memcpy for efficiency
-            memcpy(&samples[aatx][write_start_idx], tx_ant_buffer_in, (write_end_idx - write_start_idx) * sizeof(c16_t));
-          } else {
-            for (int s = write_start_idx; s < write_end_idx; s++) {
-              samples[aatx][s].r = tx_ant_buffer_in->r * gain_linear;
-              samples[aatx][s].i = tx_ant_buffer_in->i * gain_linear;
-              tx_ant_buffer_in++;
-            }
-          }
-        } else {
-          // For subsequent beams, we need to ensure we accumulate the samples
-          if (gain_dB == 0.0f) {
-            for (int s = write_start_idx; s < write_end_idx; s++) {
-              samples[aatx][s].r += tx_ant_buffer_in->r;
-              samples[aatx][s].i += tx_ant_buffer_in->i;
-              tx_ant_buffer_in++;
-            }
-          } else {
-            for (int s = write_start_idx; s < write_end_idx; s++) {
-              samples[aatx][s].r += tx_ant_buffer_in->r * gain_linear;
-              samples[aatx][s].i += tx_ant_buffer_in->i * gain_linear;
-              tx_ant_buffer_in++;
-            }
-          }
-        }
+      c16_t *tx_ant_buffer_in = &buffer[aatx * pkt->header.size + read_start_idx];
+      for (int s = write_start_idx; s < write_end_idx; s++) {
+        samples[aatx][s].r += tx_ant_buffer_in->r * gain_linear;
+        samples[aatx][s].i += tx_ant_buffer_in->i * gain_linear;
+        tx_ant_buffer_in++;
       }
     }
     packets_copy.pop();
@@ -1253,7 +1151,7 @@ static bool flushInput(rfsimulator_state_t *t, int timeout, bool first_time)
     b->transferPtr += sz;
     if (b->remainToTransfer == 0) {
       if (b->headerMode)
-        process_recv_header(t, b, first_time);
+        process_recv_header(b, first_time);
       else {
         LOG_D(HW, "UEsock: %d Completed block reception: %ld\n", b->conn_sock, b->lastReceivedTS);
         b->headerMode = true;
@@ -1276,17 +1174,15 @@ static bool flushInput(rfsimulator_state_t *t, int timeout, bool first_time)
 }
 
 static void rfsimulator_read_internal(rfsimulator_state_t *t,
-                                      c16_t **samples,
+                                      sample_t **samples,
                                       openair0_timestamp_t timestamp,
                                       int nsamps,
                                       int nbAnt,
-                                      int rx_beam_id,
-                                      bool is_first_beam)
+                                      std::vector<uint16_t> rx_beams)
 {
   cf_t temp_array[nbAnt][nsamps];
   bool channel_modelling = false;
   // Add all input nodes signal in the output buffer
-  bool is_first_peer = true;
   for (int sock = 0; sock < MAX_FD_RFSIMU; sock++) {
     buffer_t *ptr = &t->buf[sock];
 
@@ -1312,46 +1208,63 @@ static void rfsimulator_read_internal(rfsimulator_state_t *t,
           input[aatx] = ant_buffers[aatx].data();
         }
 
-        combine_received_beams(t,
-                               ptr->received_packets,
-                               timestamp - channel_offset - (channel_length - 1),
-                               ptr->nbAnt,
-                               nsamps + channel_length - 1,
-                               rx_beam_id,
-                               input);
-
         for (int aarx = 0; aarx < nbAnt; aarx++) {
+          combine_received_beams(t,
+                                 ptr->received_packets,
+                                 timestamp - channel_offset - (channel_length - 1),
+                                 nsamps + channel_length - 1,
+                                 rx_beams[aarx],
+                                 input);
+
           rxAddInput(input, temp_array[aarx], aarx, ptr->channel_model, nsamps);
         }
       } else {
-        if (is_first_beam && is_first_peer && (ptr->nbAnt == 1 && nbAnt == 1)) {
-          // optimization: The buffer is uninitialized so samples can be written directly in the buffer
-          combine_received_beams(t, ptr->received_packets, timestamp - t->chan_offset, 1, nsamps, rx_beam_id, samples);
-        } else {
-          std::vector<std::vector<c16_t>> ant_buffers(ptr->nbAnt, std::vector<c16_t>(nsamps, {0, 0}));
-          c16_t *input[ant_buffers.size()];
-          for (uint aatx = 0; aatx < ant_buffers.size(); aatx++) {
-            input[aatx] = ant_buffers[aatx].data();
+        // Assume received_packets is ordered by timestamp
+        std::queue<rfsim_packet_t *> packets_copy = ptr->received_packets;
+        while (!packets_copy.empty()) {
+          rfsim_packet_t *pkt = packets_copy.front();
+          if (static_cast<int64_t>(pkt->header.timestamp + pkt->header.size) <= timestamp) {
+            // This packet is before the start timestamp, discard it
+            packets_copy.pop();
+            continue;
           }
-          combine_received_beams(t, ptr->received_packets, timestamp - t->chan_offset, ptr->nbAnt, nsamps, rx_beam_id, input);
+          if (static_cast<int64_t>(pkt->header.timestamp) > timestamp + nsamps) {
+            // This packet is after the end of the buffer, stop processing
+            break;
+          }
+
+          // The beams transmitted in are ordered by beam index
+          uint16_t *tx_beams = (uint16_t *)pkt->payload;
+          uint64_t overlap_start = std::max(timestamp, static_cast<int64_t>(pkt->header.timestamp));
+          uint64_t overlap_end = std::min(timestamp + nsamps, static_cast<int64_t>(pkt->header.timestamp + pkt->header.size));
+          int write_start_idx = overlap_start - timestamp;
+          int write_end_idx = overlap_end - timestamp;
+          int read_start_idx = overlap_start - pkt->header.timestamp;
+          c16_t *buffer = (c16_t *)&pkt->payload[sizeof(uint16_t) * pkt->header.nbAnt];
+
           for (int aarx = 0; aarx < nbAnt; aarx++) {
-            double H_awgn_mimo_coeff[ant_buffers.size()];
-            for (int aatx = 0; aatx < (int)ant_buffers.size(); aatx++) {
+            double H_awgn_mimo_coeff[pkt->header.nbAnt];
+            for (int aatx = 0; aatx < (int)pkt->header.nbAnt; aatx++) {
               uint32_t ant_diff = std::abs(aatx - aarx);
               H_awgn_mimo_coeff[aatx] = ant_diff ? (0.2 / ant_diff) : 1.0;
+              float gain_dB = get_rx_gain_db(t, rx_beams[aarx], tx_beams[aatx]);
+              float gain_linear = powf(10, gain_dB / 20.0);
+              H_awgn_mimo_coeff[aatx] *= gain_linear;
             }
 
-            for (uint aatx = 0; aatx < ant_buffers.size(); aatx++) {
-              for (int i = 0; i < nsamps; i++) {
-                samples[aarx][i].r += ant_buffers[aatx][i].r * H_awgn_mimo_coeff[aatx];
-                samples[aarx][i].i += ant_buffers[aatx][i].i * H_awgn_mimo_coeff[aatx];
+            for (uint aatx = 0; aatx < pkt->header.nbAnt; aatx++) {
+              c16_t *tx_ant_buffer_in = &buffer[aatx * pkt->header.size + read_start_idx];
+              for (int i = write_start_idx; i < write_end_idx; i++) {
+                samples[aarx][i].r += tx_ant_buffer_in->r * H_awgn_mimo_coeff[aatx];
+                samples[aarx][i].i += tx_ant_buffer_in->i * H_awgn_mimo_coeff[aatx];
+                tx_ant_buffer_in++;
               }
             }
           }
+          packets_copy.pop();
         }
       }
     }
-    is_first_peer = false;
   }
 
   bool apply_global_noise = get_noise_power_dBFS() != INVALID_DBFS_VALUE;
@@ -1379,12 +1292,7 @@ static void rfsimulator_read_internal(rfsimulator_state_t *t,
   }
 }
 
-static int rfsimulator_read_beams(openair0_device_t *device,
-                                  openair0_timestamp_t *ptimestamp,
-                                  void ***samplesVoid,
-                                  int nsamps,
-                                  int nbAnt,
-                                  int num_beams)
+static int rfsimulator_read(openair0_device_t *device, openair0_timestamp_t *ptimestamp, void **samplesVoid, int nsamps, int nbAnt)
 {
   rfsimulator_state_t *t = static_cast<rfsimulator_state_t *>(device->priv);
   LOG_D(HW,
@@ -1407,9 +1315,8 @@ static int rfsimulator_read_beams(openair0_device_t *device,
       LOG_I(HW, "No connected device, generating void samples...\n");
 
     if (!flushInput(t, t->wait_timeout, false)) {
-      for (int beam = 0; beam < num_beams; beam++)
-        for (int x = 0; x < nbAnt; x++)
-          memset(samplesVoid[beam][x], 0, sampleToByte(nsamps, 1));
+      for (int x = 0; x < nbAnt; x++)
+        memset(samplesVoid[x], 0, sampleToByte(nsamps, 1));
 
       t->nextRxTstamp += nsamps;
 
@@ -1458,41 +1365,29 @@ static int rfsimulator_read_beams(openair0_device_t *device,
     t->poll_telnetcmdq(t->telnetcmd_qid, t);
 
   // Clear the output buffer
-  for (int beam = 0; beam < num_beams; beam++)
-    for (int a = 0; a < nbAnt; a++)
-      memset(samplesVoid[beam][a], 0, sampleToByte(nsamps, 1));
+  for (int a = 0; a < nbAnt; a++)
+    memset(samplesVoid[a], 0, sampleToByte(nsamps, 1));
 
   openair0_timestamp_t timestamp = t->nextRxTstamp;
+  sample_t *samples[nbAnt];
+  for (int a = 0; a < nbAnt; a++)
+    samples[a] = (sample_t *)samplesVoid[a];
   int nsamps_to_process = nsamps;
   while (nsamps_to_process > 0) {
     uint32_t nsamps_beam_map;
-    std::vector<int> rx_beams = get_beams(&t->beam_ctrl->tx, timestamp, nsamps_to_process, &nsamps_beam_map);
-    if ((int)rx_beams.size() != num_beams) {
-      LOG_D(HW,
-            "Number of beams does not match application request num_beams %d, beam_map beams %lu\n",
-            num_beams,
-            rx_beams.size());
+    std::vector<uint16_t> rx_beams = get_beams(&t->beam_ctrl->tx, timestamp, nsamps_to_process, &nsamps_beam_map);
+    if (t->beam_ctrl->enable_beams && (int)rx_beams.size() != nbAnt) {
+      LOG_D(HW, "Number of beams does not match application request nbAnt %d, beams %lu\n", nbAnt, rx_beams.size());
     }
-    for (int beam = 0; beam < num_beams && beam < (int)rx_beams.size(); beam++) {
-      c16_t *samples_beam[nbAnt];
-      for (int i = 0; i < nbAnt; i++) {
-        samples_beam[i] = (c16_t *)samplesVoid[beam][i] + timestamp - t->nextRxTstamp;
-      }
-      rfsimulator_read_internal(t, samples_beam, timestamp, nsamps_beam_map, nbAnt, rx_beams[beam], beam == 0);
+    while ((int)rx_beams.size() < nbAnt)
+      rx_beams.push_back(0);
+
+    rfsimulator_read_internal(t, samples, timestamp, nsamps_beam_map, nbAnt, rx_beams);
+    for (int a = 0; a < nbAnt; a++) {
+      samples[a] += nsamps_beam_map;
     }
     timestamp += nsamps_beam_map;
     nsamps_to_process -= nsamps_beam_map;
-  }
-
-  struct timespec end_time;
-  ret = clock_gettime(CLOCK_REALTIME, &end_time);
-  AssertFatal(ret == 0, "clock_gettime() failed: errno %d, %s\n", errno, strerror(errno));
-  double diff_ns = (end_time.tv_sec - start_time.tv_sec) * 1000000000 + (end_time.tv_nsec - start_time.tv_nsec);
-  static double average = 0.0;
-  average = (average * 0.98) + (nsamps / (diff_ns / 1e9) * 0.02);
-  static int calls = 0;
-  if (calls++ % 10000 == 0) {
-    LOG_D(HW, "Rfsimulator: velocity %.2f Msps, realtime requirements %.2f Msps\n", average / 1e6, t->sample_rate / 1e6);
   }
 
   *ptimestamp = t->nextRxTstamp; // return the time of the first sample
@@ -1503,7 +1398,7 @@ static int rfsimulator_read_beams(openair0_device_t *device,
         nsamps,
         *ptimestamp,
         t->nextRxTstamp,
-        signal_energy(static_cast<int32_t *>(samplesVoid[0][0]), nsamps));
+        signal_energy_nodc(samples[0], nsamps));
 
   /* trace only first antenna */
   T(T_USRP_RX_ANT0, T_INT(t->nextRxTstamp), T_BUFFER(samplesVoid[0], (int)sampleToByte(nsamps, 1)));
@@ -1526,21 +1421,18 @@ static int rfsimulator_read_beams(openair0_device_t *device,
   return nsamps;
 }
 
-static int rfsimulator_read(openair0_device_t *device, openair0_timestamp_t *ptimestamp, void **samplesVoid, int nsamps, int nbAnt)
-{
-  return rfsimulator_read_beams(device, ptimestamp, &samplesVoid, nsamps, nbAnt, 1);
-}
-
 static int rfsimulator_get_stats(openair0_device_t *device)
 {
   UNUSED(device);
   return 0;
 }
+
 static int rfsimulator_reset_stats(openair0_device_t *device)
 {
   UNUSED(device);
   return 0;
 }
+
 static void rfsimulator_end(openair0_device_t *device)
 {
   rfsimulator_state_t *s = static_cast<rfsimulator_state_t *>(device->priv);
@@ -1621,10 +1513,7 @@ extern "C" __attribute__((__visibility__("default"))) int device_init(openair0_d
   device->trx_set_gains_func = rfsimulator_set_gains;
   device->trx_write_func = rfsimulator_write;
   device->trx_read_func = rfsimulator_read;
-  if (rfsimulator->beam_ctrl->enable_beams) {
-    device->trx_write_beams_func = rfsimulator_write_beams;
-    device->trx_read_beams_func = rfsimulator_read_beams;
-  }
+
   /* let's pretend to be a b2x0 */
   device->type = RFSIMULATOR;
   device->host_type = RAU_HOST;
@@ -1632,8 +1521,7 @@ extern "C" __attribute__((__visibility__("default"))) int device_init(openair0_d
   device->openair0_cfg = openair0_cfg;
   device->priv = rfsimulator;
   device->trx_write_init = rfsimulator_write_init;
-  device->trx_set_beams = rfsimulator_set_beams;
-  device->trx_set_beams2 = rfsimulator_set_beams_vector;
+  device->trx_set_beams = rfsimulator_set_beams_vector;
 
   for (int i = 0; i < MAX_FD_RFSIMU; i++)
     rfsimulator->buf[i].conn_sock = -1;

--- a/radio/rfsimulator/stored_node.c
+++ b/radio/rfsimulator/stored_node.c
@@ -163,7 +163,6 @@ int main(int argc, char *argv[]) {
       timestamp+=blockSize;
       header.option_value=0;
       header.option_flag=0;
-      header.beam_map = 1;
     } else {
       int ret = read(fd, &header, sizeof(header));
       AssertFatal(ret == sizeof(header), "%s", strerror(errno));

--- a/radio/vrtsim/vrtsim.c
+++ b/radio/vrtsim/vrtsim.c
@@ -912,18 +912,6 @@ static int vrtsim_write(openair0_device_t *device,
   }
 }
 
-static int vrtsim_write_beams(openair0_device_t *device,
-                              openair0_timestamp_t timestamp,
-                              void ***buff,
-                              int nsamps,
-                              int nb_antennas_tx,
-                              int num_beams,
-                              int flags)
-{
-  vrtsim_write(device, timestamp, (void **)buff[0], nsamps, nb_antennas_tx, flags);
-  return nsamps;
-}
-
 static int vrtsim_read(openair0_device_t *device, openair0_timestamp_t *ptimestamp, void **samplesVoid, int nsamps, int nbAnt)
 {
   vrtsim_state_t *vrtsim_state = (vrtsim_state_t *)device->priv;
@@ -1084,12 +1072,7 @@ static int vrtsim_set_freq(openair0_device_t *device, openair0_config_t *openair
   return 0;
 }
 
-static int vrtsim_set_beams(openair0_device_t *device, uint64_t beam_map, openair0_timestamp_t timestamp)
-{
-  return 0;
-}
-
-static int vrtsim_set_beams2(openair0_device_t *device, int *beam_ids, int num_beams, openair0_timestamp_t timestamp)
+static int vrtsim_set_beams(openair0_device_t *device, uint16_t *beam_ids, int num_beams, openair0_timestamp_t timestamp)
 {
   return 0;
 }
@@ -1124,12 +1107,7 @@ __attribute__((__visibility__("default"))) int device_init(openair0_device_t *de
   device->trx_set_gains_func = vrtsim_stub2;
   device->trx_write_func = vrtsim_write;
   device->trx_read_func = vrtsim_read;
-  device->trx_write_beams_func = vrtsim_write_beams;
   device->trx_set_beams = vrtsim_set_beams;
-  device->trx_set_beams2 = vrtsim_set_beams2;
-  if (vrtsim_state->role == ROLE_SERVER) {
-    device->get_timestamp = vrtsim_get_timestamp;
-  }
 
   device->type = RFSIMULATOR;
   device->openair0_cfg = &openair0_cfg[0];


### PR DESCRIPTION
This is the conclusion of last weeks conversation.

I have omitted changing the execution condition (`cfg->analog_beamforming_ve.analog_bf_vendor_ext.value`) due to issues with other parts of the code.

# Description

Brings in the rfsimulator beamforming rewrite (one beam ID per antenna element instead of a concurrent-beam bitmap)

Adds `ctrl_rf()` to push the MAC-scheduler-picked per-antenna beam down to the RF device every slot, and fixes `nr_feptx_tp()` copying `beam_id` from the gNB *after* already returning early for uplink slots, which left `ctrl_rf` pushing a stale beam during RX.

Adds a new CI scenario exercising this end-to-end: a gNB with 4 analog beams, a UE moved from beam 0 to beam 2 mid-test via the rfsimulator's telnet interface, verified against the gNB's own MAC scheduler log plus pings before/after to confirm connectivity survives the switch.

Also fixes two independent bugs in `run_locally.sh` that broke running any local CI test with it (inconsistent `xml_files/` prefixing between its two `main.py` calls, and image tags that never matched what the framework resolves from the branch name).