### PR TITLE
fix (rrc): do not reject N2 Handover Request for N2 source UE

### DIFF
--- a/openair2/RRC/NR/rrc_gNB_NGAP.c
+++ b/openair2/RRC/NR/rrc_gNB_NGAP.c
@@ -1440,17 +1440,29 @@ void rrc_gNB_send_NGAP_HANDOVER_FAILURE(gNB_RRC_INST *rrc, ngap_handover_failure
 /** @brief Process NG Handover Request message (8.4.2.2 3GPP TS 38.413) */
 int rrc_gNB_process_Handover_Request(gNB_RRC_INST *rrc, ngap_handover_request_t *msg)
 {
-  // Check if UE context already exists for this AMF UE NGAP ID
   rrc_gNB_ue_context_t *existing_ue_context = rrc_gNB_get_ue_context_by_amf_ue_ngap_id(rrc, msg->amf_ue_ngap_id);
   if (existing_ue_context != NULL) {
-    LOG_E(RRC, "UE context already exists for AMF UE NGAP ID %ld, cannot process handover request\n", msg->amf_ue_ngap_id);
-    ngap_handover_failure_t fail = {
-        .amf_ue_ngap_id = msg->amf_ue_ngap_id,
-        .cause.type = NGAP_CAUSE_RADIO_NETWORK,
-        .cause.value = NGAP_CAUSE_RADIO_NETWORK_HO_FAILURE_IN_TARGET_5GC_NGRAN_NODE_OR_TARGET_SYSTEM,
-    };
-    rrc_gNB_send_NGAP_HANDOVER_FAILURE(rrc, &fail);
-    return -1;
+    gNB_RRC_UE_t *ue = &existing_ue_context->ue_context;
+    /* A UE with this AMF-UE-NGAP-ID is already present on this node as an N2
+     * source. This can happen when source and target NG-RAN node are the same or
+     * when the UE is already in a N2 HO procedure. Allow the request only while that
+     * UE is still in N2 source preparation (target not yet allocated), otherwise reject
+     * to prevent duplicate target contexts. */
+    const bool n2_source_only = ue->ho_context && ue->ho_context->source && !ue->ho_context->target;
+    if (!n2_source_only) {
+      LOG_E(NR_RRC,
+            "Reject Handover Request: ongoing procedure for UE %u (AMF UE NGAP ID %ld)\n",
+            ue->rrc_ue_id,
+            msg->amf_ue_ngap_id);
+      ngap_handover_failure_t fail = {
+          .amf_ue_ngap_id = msg->amf_ue_ngap_id,
+          .cause.type = NGAP_CAUSE_RADIO_NETWORK,
+          .cause.value = NGAP_CAUSE_RADIO_NETWORK_INTERACTION_WITH_OTHER_PROCEDURE,
+      };
+      rrc_gNB_send_NGAP_HANDOVER_FAILURE(rrc, &fail);
+      return -1;
+    }
+    LOG_I(NR_RRC, "N2 HO to self (AMF UE NGAP ID %ld): creating target context for UE %u\n", msg->amf_ue_ngap_id, ue->rrc_ue_id);
   }
 
   // Get cell by cell_id


### PR DESCRIPTION
Handover Request may carry the same AMF-UE-NGAP-ID as the source UE (OAI AMF reuses the same ID, Open5gs generates a new one). 38.401 6.2.1 uniqueness is in the AMF, not per gNB. 38.413 8.4.2.4 does not require Failure for that.

However, when source and target NG-RAN node are the same, the old check always matched the source UE and sent Handover Failure. This was done in 59803e221f to stop a second Handover Request from creating another target UE after Handover Preparation phase was passed. We keep that reject when the match is not N2 source-only, as we consider it incompatible with the state of the UE's HO context.

When the node refuses the Request, Handover Failure is the unsuccessful outcome of Handover Resource Allocation (38.413 8.4.2.3): if the target cannot admit the UE, it sends Handover Failure with a Cause. §10.4 then says: for a Class 1 initiating message that is not compatible with receiver state, send that procedure’s unsuccessful-outcome message

This is relevant in Telnet, for testing purposes, when self N2 HO can proceed past Handover Request.

Changes:
- rrc_gNB_process_Handover_Request(): if the matching UE is N2 source-only (source HO context, no target yet), create a new target context, otherwise reject
- Handover Failure cause for that reject is "interaction with other procedure"

Closes: #119 