### PR TITLE
Fix RCconfig_nr_positioning() usage and improve error handling

### DIFF
--- a/openair2/COMMON/f1ap_messages_def.h
+++ b/openair2/COMMON/f1ap_messages_def.h
@@ -79,3 +79,7 @@ MESSAGE_DEF(F1AP_POSITIONING_MEASUREMENT_RESP,
             MESSAGE_PRIORITY_MED,
             f1ap_positioning_measurement_resp_t,
             f1ap_positioning_measurement_resp)
+MESSAGE_DEF(F1AP_POSITIONING_MEASUREMENT_FAILURE,
+            MESSAGE_PRIORITY_MED,
+            f1ap_positioning_measurement_failure_t,
+            f1ap_positioning_measurement_failure)

--- a/openair2/COMMON/f1ap_messages_def.h
+++ b/openair2/COMMON/f1ap_messages_def.h
@@ -66,6 +66,7 @@ MESSAGE_DEF(F1AP_POSITIONING_MEASUREMENT_REQ,
 
 /* DU -> CU*/
 MESSAGE_DEF(F1AP_TRP_INFORMATION_RESP, MESSAGE_PRIORITY_MED, f1ap_trp_information_resp_t, f1ap_trp_information_resp)
+MESSAGE_DEF(F1AP_TRP_INFORMATION_FAILURE, MESSAGE_PRIORITY_MED, f1ap_trp_information_failure_t, f1ap_trp_information_failure)
 MESSAGE_DEF(F1AP_POSITIONING_INFORMATION_RESP,
             MESSAGE_PRIORITY_MED,
             f1ap_positioning_information_resp_t,

--- a/openair2/COMMON/f1ap_messages_types.h
+++ b/openair2/COMMON/f1ap_messages_types.h
@@ -62,6 +62,7 @@
 #define F1AP_POSITIONING_ACTIVATION_RESP(mSGpTR) (mSGpTR)->ittiMsg.f1ap_positioning_activation_resp
 #define F1AP_POSITIONING_MEASUREMENT_REQ(mSGpTR) (mSGpTR)->ittiMsg.f1ap_positioning_measurement_req
 #define F1AP_POSITIONING_MEASUREMENT_RESP(mSGpTR) (mSGpTR)->ittiMsg.f1ap_positioning_measurement_resp
+#define F1AP_POSITIONING_MEASUREMENT_FAILURE(mSGpTR) (mSGpTR)->ittiMsg.f1ap_positioning_measurement_failure
 
 /* Length of the transport layer address string
  * 160 bits / 8 bits by char.

--- a/openair2/COMMON/f1ap_messages_types.h
+++ b/openair2/COMMON/f1ap_messages_types.h
@@ -55,6 +55,7 @@
 
 #define F1AP_TRP_INFORMATION_REQ(mSGpTR) (mSGpTR)->ittiMsg.f1ap_trp_information_req
 #define F1AP_TRP_INFORMATION_RESP(mSGpTR) (mSGpTR)->ittiMsg.f1ap_trp_information_resp
+#define F1AP_TRP_INFORMATION_FAILURE(mSGpTR) (mSGpTR)->ittiMsg.f1ap_trp_information_failure
 #define F1AP_POSITIONING_INFORMATION_REQ(mSGpTR) (mSGpTR)->ittiMsg.f1ap_positioning_information_req
 #define F1AP_POSITIONING_INFORMATION_RESP(mSGpTR) (mSGpTR)->ittiMsg.f1ap_positioning_information_resp
 #define F1AP_POSITIONING_ACTIVATION_REQ(mSGpTR) (mSGpTR)->ittiMsg.f1ap_positioning_activation_req

--- a/openair2/COMMON/nrppa_messages_def.h
+++ b/openair2/COMMON/nrppa_messages_def.h
@@ -26,3 +26,4 @@ MESSAGE_DEF(NRPPA_POSITIONING_ACTIVATION_RESP,
             nrppa_positioning_activation_resp)
 MESSAGE_DEF(NRPPA_MEASUREMENT_REQ, MESSAGE_PRIORITY_MED, nrppa_measurement_req_t, nrppa_measurement_req)
 MESSAGE_DEF(NRPPA_MEASUREMENT_RESP, MESSAGE_PRIORITY_MED, nrppa_measurement_resp_t, nrppa_measurement_resp)
+MESSAGE_DEF(NRPPA_MEASUREMENT_FAILURE, MESSAGE_PRIORITY_MED, nrppa_measurement_failure_t, nrppa_measurement_failure)

--- a/openair2/COMMON/nrppa_messages_def.h
+++ b/openair2/COMMON/nrppa_messages_def.h
@@ -7,6 +7,7 @@
 // LMF -> CU
 MESSAGE_DEF(NRPPA_TRP_INFORMATION_REQ, MESSAGE_PRIORITY_MED, nrppa_trp_information_req_t, nrppa_trp_information_req)
 MESSAGE_DEF(NRPPA_TRP_INFORMATION_RESP, MESSAGE_PRIORITY_MED, nrppa_trp_information_resp_t, nrppa_trp_information_resp)
+MESSAGE_DEF(NRPPA_TRP_INFORMATION_FAILURE, MESSAGE_PRIORITY_MED, nrppa_trp_information_failure_t, nrppa_trp_information_failure)
 MESSAGE_DEF(NRPPA_POSITIONING_INFORMATION_REQ,
             MESSAGE_PRIORITY_MED,
             nrppa_positioning_information_req_t,

--- a/openair2/COMMON/nrppa_messages_types.h
+++ b/openair2/COMMON/nrppa_messages_types.h
@@ -16,6 +16,7 @@
 #define NRPPA_POSITIONING_ACTIVATION_RESP(mSGpTR) (mSGpTR)->ittiMsg.nrppa_positioning_activation_resp
 #define NRPPA_MEASUREMENT_REQ(mSGpTR) (mSGpTR)->ittiMsg.nrppa_measurement_req
 #define NRPPA_MEASUREMENT_RESP(mSGpTR) (mSGpTR)->ittiMsg.nrppa_measurement_resp
+#define NRPPA_MEASUREMENT_FAILURE(mSGpTR) (mSGpTR)->ittiMsg.nrppa_measurement_failure
 
 /* Structure of Positioning related NRPPA messages */
 /* IE structures for Positioning related messages as per TS 38.455 V16.7.1*/
@@ -823,5 +824,14 @@ typedef struct nrppa_measurement_resp_s {
   // (optional)
   nrppa_measurement_response_list_t *measurement_response_list;
 } nrppa_measurement_resp_t;
+
+typedef struct nrppa_measurement_failure_s {
+  // IE 9.2.4 (mandatory)
+  uint16_t transaction_id;
+  // (mandatory)
+  uint32_t lmf_measurement_id;
+  // IE 9.2.1 (mandatory)
+  nrppa_cause_t cause;
+} nrppa_measurement_failure_t;
 
 #endif // NRPPA_MESSAGES_TYPES_H_

--- a/openair2/COMMON/nrppa_messages_types.h
+++ b/openair2/COMMON/nrppa_messages_types.h
@@ -9,6 +9,7 @@
 
 #define NRPPA_TRP_INFORMATION_REQ(mSGpTR) (mSGpTR)->ittiMsg.nrppa_trp_information_req
 #define NRPPA_TRP_INFORMATION_RESP(mSGpTR) (mSGpTR)->ittiMsg.nrppa_trp_information_resp
+#define NRPPA_TRP_INFORMATION_FAILURE(mSGpTR) (mSGpTR)->ittiMsg.nrppa_trp_information_failure
 #define NRPPA_POSITIONING_INFORMATION_REQ(mSGpTR) (mSGpTR)->ittiMsg.nrppa_positioning_information_req
 #define NRPPA_POSITIONING_INFORMATION_RESP(mSGpTR) (mSGpTR)->ittiMsg.nrppa_positioning_information_resp
 #define NRPPA_POSITIONING_ACTIVATION_REQ(mSGpTR) (mSGpTR)->ittiMsg.nrppa_positioning_activation_req
@@ -735,6 +736,18 @@ typedef struct nrppa_measurement_response_list_s {
   uint32_t measurement_response_list_length;
 } nrppa_measurement_response_list_t;
 
+typedef enum nrppa_cause_type_e {
+  NRPPA_CAUSE_NOTHING, /* No components present */
+  NRPPA_CAUSE_RADIO_NETWORK,
+  NRPPA_CAUSE_PROTOCOL,
+  NRPPA_CAUSE_MISC,
+} nrppa_cause_type_t;
+
+typedef struct nrppa_cause_e {
+  nrppa_cause_type_t type;
+  uint8_t value;
+} nrppa_cause_t;
+
 typedef struct nrppa_trp_information_req_s {
   // IE 9.2.4 (mandatory)
   uint16_t transaction_id;
@@ -751,6 +764,13 @@ typedef struct nrppa_trp_information_resp_s {
   // mandatory
   nrppa_trp_information_list_t trp_information_list;
 } nrppa_trp_information_resp_t;
+
+typedef struct nrppa_trp_information_failure_s {
+  // IE 9.2.4 (mandatory)
+  uint16_t transaction_id;
+  // IE 9.2.1 (mandatory)
+  nrppa_cause_t cause;
+} nrppa_trp_information_failure_t;
 
 typedef struct nrppa_positioning_information_req_s {
   // IE 9.2.4 (mandatory)

--- a/openair2/F1AP/f1ap_cu_positioning.c
+++ b/openair2/F1AP/f1ap_cu_positioning.c
@@ -46,6 +46,22 @@ int CU_handle_TRP_INFORMATION_RESPONSE(instance_t instance, sctp_assoc_t assoc_i
   return 0;
 }
 
+int CU_handle_TRP_INFORMATION_FAILURE(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu)
+{
+  f1ap_trp_information_failure_t fail = {0};
+  if (!decode_trp_information_failure(pdu, &fail)) {
+    LOG_E(F1AP, "cannot decode F1 TRP Information Failure\n");
+    free_trp_information_failure(&fail);
+    return -1;
+  }
+
+  MessageDef *msg_p = itti_alloc_new_message(TASK_DU_F1, 0, F1AP_TRP_INFORMATION_FAILURE);
+  msg_p->ittiMsgHeader.originInstance = assoc_id;
+  F1AP_TRP_INFORMATION_FAILURE(msg_p) = fail;
+  itti_send_msg_to_task(TASK_RRC_GNB, instance, msg_p);
+  return 0;
+}
+
 int CU_send_POSITIONING_INFORMATION_REQUEST(sctp_assoc_t assoc_id, f1ap_positioning_information_req_t *req)
 {
   F1AP_F1AP_PDU_t *pdu = encode_positioning_information_req(req);

--- a/openair2/F1AP/f1ap_cu_positioning.c
+++ b/openair2/F1AP/f1ap_cu_positioning.c
@@ -175,3 +175,19 @@ int CU_handle_POSITIONING_MEASUREMENT_RESPONSE(instance_t instance, sctp_assoc_t
   itti_send_msg_to_task(TASK_RRC_GNB, instance, msg_p);
   return 0;
 }
+
+int CU_handle_POSITIONING_MEASUREMENT_FAILURE(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu)
+{
+  f1ap_positioning_measurement_failure_t fail = {0};
+  if (!decode_positioning_measurement_failure(pdu, &fail)) {
+    LOG_E(F1AP, "cannot decode F1 Positioning Measurement Failure\n");
+    free_positioning_measurement_failure(&fail);
+    return -1;
+  }
+
+  MessageDef *msg_p = itti_alloc_new_message(TASK_DU_F1, 0, F1AP_POSITIONING_MEASUREMENT_FAILURE);
+  msg_p->ittiMsgHeader.originInstance = assoc_id;
+  F1AP_POSITIONING_MEASUREMENT_FAILURE(msg_p) = fail;
+  itti_send_msg_to_task(TASK_RRC_GNB, instance, msg_p);
+  return 0;
+}

--- a/openair2/F1AP/f1ap_cu_positioning.h
+++ b/openair2/F1AP/f1ap_cu_positioning.h
@@ -6,6 +6,7 @@
 
 int CU_send_TRP_INFORMATION_REQUEST(sctp_assoc_t assoc_id, f1ap_trp_information_req_t *req);
 int CU_handle_TRP_INFORMATION_RESPONSE(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu);
+int CU_handle_TRP_INFORMATION_FAILURE(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu);
 int CU_send_POSITIONING_INFORMATION_REQUEST(sctp_assoc_t assoc_id, f1ap_positioning_information_req_t *req);
 int CU_handle_POSITIONING_INFORMATION_RESPONSE(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu);
 int CU_send_POSITIONING_ACTIVATION_REQUEST(sctp_assoc_t assoc_id, f1ap_positioning_activation_req_t *req);

--- a/openair2/F1AP/f1ap_cu_positioning.h
+++ b/openair2/F1AP/f1ap_cu_positioning.h
@@ -13,5 +13,6 @@ int CU_send_POSITIONING_ACTIVATION_REQUEST(sctp_assoc_t assoc_id, f1ap_positioni
 int CU_handle_POSITIONING_ACTIVATION_RESPONSE(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu);
 int CU_send_POSITIONING_MEASUREMENT_REQUEST(sctp_assoc_t assoc_id, f1ap_positioning_measurement_req_t *req);
 int CU_handle_POSITIONING_MEASUREMENT_RESPONSE(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu);
+int CU_handle_POSITIONING_MEASUREMENT_FAILURE(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu);
 
 #endif /* F1AP_CU_POSITIONING_H_ */

--- a/openair2/F1AP/f1ap_du_positioning.c
+++ b/openair2/F1AP/f1ap_du_positioning.c
@@ -152,3 +152,20 @@ int DU_send_POSITIONING_MEASUREMENT_RESPONSE(sctp_assoc_t assoc_id, f1ap_positio
   ASN_STRUCT_FREE(asn_DEF_F1AP_F1AP_PDU, pdu);
   return 0;
 }
+
+int DU_send_POSITIONING_MEASUREMENT_FAILURE(sctp_assoc_t assoc_id, f1ap_positioning_measurement_failure_t *fail)
+{
+  F1AP_F1AP_PDU_t *pdu = encode_positioning_measurement_failure(fail);
+
+  uint8_t *buffer = NULL;
+  uint32_t len = 0;
+  if (f1ap_encode_pdu(pdu, &buffer, &len) < 0) {
+    LOG_E(F1AP, "Failed to encode F1 Positioning Measurement Failure\n");
+    ASN_STRUCT_FREE(asn_DEF_F1AP_F1AP_PDU, pdu);
+    return -1;
+  }
+
+  f1ap_itti_send_sctp_data_req(assoc_id, buffer, len);
+  ASN_STRUCT_FREE(asn_DEF_F1AP_F1AP_PDU, pdu);
+  return 0;
+}

--- a/openair2/F1AP/f1ap_du_positioning.c
+++ b/openair2/F1AP/f1ap_du_positioning.c
@@ -40,6 +40,23 @@ int DU_send_TRP_INFORMATION_RESPONSE(sctp_assoc_t assoc_id, f1ap_trp_information
   return 0;
 }
 
+int DU_send_TRP_INFORMATION_FAILURE(sctp_assoc_t assoc_id, f1ap_trp_information_failure_t *fail)
+{
+  F1AP_F1AP_PDU_t *pdu = encode_trp_information_failure(fail);
+
+  uint8_t *buffer = NULL;
+  uint32_t len = 0;
+  if (f1ap_encode_pdu(pdu, &buffer, &len) < 0) {
+    LOG_E(F1AP, "Failed to encode F1 TRP INFORMATION FAILURE\n");
+    ASN_STRUCT_FREE(asn_DEF_F1AP_F1AP_PDU, pdu);
+    return -1;
+  }
+
+  f1ap_itti_send_sctp_data_req(assoc_id, buffer, len);
+  ASN_STRUCT_FREE(asn_DEF_F1AP_F1AP_PDU, pdu);
+  return 0;
+}
+
 int DU_handle_POSITIONING_INFORMATION_REQUEST(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu)
 {
   f1ap_positioning_information_req_t req = {0};

--- a/openair2/F1AP/f1ap_du_positioning.h
+++ b/openair2/F1AP/f1ap_du_positioning.h
@@ -13,5 +13,6 @@ int DU_handle_POSITIONING_ACTIVATION_REQUEST(instance_t instance, sctp_assoc_t a
 int DU_send_POSITIONING_ACTIVATION_RESPONSE(sctp_assoc_t assoc_id, f1ap_positioning_activation_resp_t *resp);
 int DU_handle_POSITIONING_MEASUREMENT_REQUEST(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu);
 int DU_send_POSITIONING_MEASUREMENT_RESPONSE(sctp_assoc_t assoc_id, f1ap_positioning_measurement_resp_t *resp);
+int DU_send_POSITIONING_MEASUREMENT_FAILURE(sctp_assoc_t assoc_id, f1ap_positioning_measurement_failure_t *fail);
 
 #endif /* F1AP_DU_POSITIONING_H_ */

--- a/openair2/F1AP/f1ap_du_positioning.h
+++ b/openair2/F1AP/f1ap_du_positioning.h
@@ -6,6 +6,7 @@
 
 int DU_handle_TRP_INFORMATION_REQUEST(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu);
 int DU_send_TRP_INFORMATION_RESPONSE(sctp_assoc_t assoc_id, f1ap_trp_information_resp_t *resp);
+int DU_send_TRP_INFORMATION_FAILURE(sctp_assoc_t assoc_id, f1ap_trp_information_failure_t *fail);
 int DU_handle_POSITIONING_INFORMATION_REQUEST(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu);
 int DU_send_POSITIONING_INFORMATION_RESPONSE(sctp_assoc_t assoc_id, f1ap_positioning_information_resp_t *resp);
 int DU_handle_POSITIONING_ACTIVATION_REQUEST(instance_t instance, sctp_assoc_t assoc_id, uint32_t stream, F1AP_F1AP_PDU_t *pdu);

--- a/openair2/F1AP/f1ap_du_task.c
+++ b/openair2/F1AP/f1ap_du_task.c
@@ -189,6 +189,10 @@ void *F1AP_DU_task(void *arg)
         DU_send_TRP_INFORMATION_RESPONSE(assoc_id, &F1AP_TRP_INFORMATION_RESP(msg));
         break;
 
+      case F1AP_TRP_INFORMATION_FAILURE:
+        DU_send_TRP_INFORMATION_FAILURE(assoc_id, &F1AP_TRP_INFORMATION_FAILURE(msg));
+        break;
+
       case F1AP_POSITIONING_INFORMATION_RESP:
         DU_send_POSITIONING_INFORMATION_RESPONSE(assoc_id, &F1AP_POSITIONING_INFORMATION_RESP(msg));
         break;

--- a/openair2/F1AP/f1ap_du_task.c
+++ b/openair2/F1AP/f1ap_du_task.c
@@ -205,6 +205,10 @@ void *F1AP_DU_task(void *arg)
         DU_send_POSITIONING_MEASUREMENT_RESPONSE(assoc_id, &F1AP_POSITIONING_MEASUREMENT_RESP(msg));
         break;
 
+      case F1AP_POSITIONING_MEASUREMENT_FAILURE:
+        DU_send_POSITIONING_MEASUREMENT_FAILURE(assoc_id, &F1AP_POSITIONING_MEASUREMENT_FAILURE(msg));
+        break;
+
       case TERMINATE_MESSAGE:
         LOG_W(F1AP, " *** Exiting F1AP thread\n");
         itti_exit_task();

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -58,6 +58,7 @@
 #include "gnb_config_common.h"
 #include "positioning_nr_paramdef.h"
 #include "f1ap_cu_task.h"
+#include "openair3/NRPPA/nrppa_gNB_config.h"
 
 static int DEFBANDS[] = {7};
 static int DEFENBS[] = {0};
@@ -1819,6 +1820,7 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg)
 
       // triggers also PHY initialization in case we have L1 via FAPI
       nr_mac_config_scc(RC.nrmac[j], scc, &config);
+      RC.nrmac[j]->positioning_config = RCconfig_nr_positioning();
     } //  for (j=0;j<RC.nb_nr_macrlc_inst;j++)
 
     uint64_t gnb_du_id = 0;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -1815,6 +1815,14 @@ void handle_nr_srs_toa_vendor_ext_measurements(const module_id_t module_id,
   positioning_config_t *positioning_config = mac->positioning_config;
   if (positioning_config == NULL) {
     LOG_E(NR_MAC, "No TRPs configured for positioning in the configuration file\n");
+    f1ap_positioning_measurement_failure_t fail = {.transaction_id = req->transaction_id,
+                                                   .lmf_measurement_id = req->lmf_measurement_id,
+                                                   .ran_measurement_id = req->ran_measurement_id};
+    fail.cause = F1AP_CAUSE_RADIO_NETWORK;
+    mac->mac_rrc.positioning_measurement_failure(&fail);
+    // since we suppport 1 measurement report per positioning request, we deactive the UE after sending failure message
+    rm_pos_act_ue_context(mac, rnti);
+    mac->pos_meas_info.active = false;
     return;
   }
   const f1ap_trp_measurement_request_list_t *req_list = &req->trp_measurement_request_list;
@@ -1838,7 +1846,14 @@ void handle_nr_srs_toa_vendor_ext_measurements(const module_id_t module_id,
 
   if (num_ta != num_trps) {
     LOG_E(NR_MAC, "Number of TRPs doesn't match with number of ToAs\n");
-    // send positioning measurement failure
+    f1ap_positioning_measurement_failure_t fail = {.transaction_id = req->transaction_id,
+                                                   .lmf_measurement_id = req->lmf_measurement_id,
+                                                   .ran_measurement_id = req->ran_measurement_id};
+    fail.cause = F1AP_CAUSE_RADIO_NETWORK;
+    mac->mac_rrc.positioning_measurement_failure(&fail);
+    // since we suppport 1 measurement report per positioning request, we deactive the UE after sending failure message
+    rm_pos_act_ue_context(mac, rnti);
+    mac->pos_meas_info.active = false;
     return;
   }
 
@@ -1847,6 +1862,8 @@ void handle_nr_srs_toa_vendor_ext_measurements(const module_id_t module_id,
       generate_pos_measurement_result(&req->pos_measurement_quantities, num_trps, trp_ids_list, mu, ta_offset_nsec, frame, slot);
   mac->mac_rrc.positioning_measurement_response(&resp);
   free_positioning_measurement_resp(&resp);
+  // We suppport 1 measurement report per positioning request (no periodic measurement report support)
+  // We deactive the UE after sending measurement report
   rm_pos_act_ue_context(mac, rnti);
   mac->pos_meas_info.active = false;
 }

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -1812,7 +1812,11 @@ void handle_nr_srs_toa_vendor_ext_measurements(const module_id_t module_id,
       break;
   }
 
-  positioning_config_t positioning_config = RCconfig_nr_positioning();
+  positioning_config_t *positioning_config = mac->positioning_config;
+  if (positioning_config == NULL) {
+    LOG_E(NR_MAC, "No TRPs configured for positioning in the configuration file\n");
+    return;
+  }
   const f1ap_trp_measurement_request_list_t *req_list = &req->trp_measurement_request_list;
   uint32_t req_list_len = req_list->trp_measurement_request_list_length;
   f1ap_trp_measurement_request_item_t *req_item = req_list->trp_measurement_request_item;
@@ -1821,8 +1825,8 @@ void handle_nr_srs_toa_vendor_ext_measurements(const module_id_t module_id,
 
   // Count the number of relavent TRPs
   for (int i = 0; i < req_list_len; i++) {
-    for (int j = 0; j < positioning_config.num_trp; j++) {
-      if (req_item[i].tRPID == positioning_config.trps[j].id) {
+    for (int j = 0; j < positioning_config->num_trp; j++) {
+      if (req_item[i].tRPID == positioning_config->trps[j].id) {
         if (num_trps < MAX_NUM_MEASURE_TRPS) {
           trp_ids_list[num_trps] = req_item[i].tRPID;
           num_trps++;

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
@@ -1145,10 +1145,14 @@ void f1_paging(const f1ap_paging_t *paging)
 
 void trp_information_request(const f1ap_trp_information_req_t *req)
 {
-  positioning_config_t positioning_config = RCconfig_nr_positioning();
-  uint8_t NumTRPs = positioning_config.num_trp;
-  f1ap_trp_information_resp_t resp = {0};
   gNB_MAC_INST *mac = RC.nrmac[0];
+  positioning_config_t *positioning_config = mac->positioning_config;
+  if (positioning_config == NULL) {
+    LOG_E(NR_PHY, "No TRPs configured for positioning in the configuration file\n");
+    return;
+  }
+  uint8_t NumTRPs = positioning_config->num_trp;
+  f1ap_trp_information_resp_t resp = {0};
 
   resp.transaction_id = req->transaction_id;
   // Check if the TRP_ID matches with the list sent in the trp information request
@@ -1160,7 +1164,7 @@ void trp_information_request(const f1ap_trp_information_req_t *req)
         calloc_or_fail(trp_list_length, sizeof(*resp.trp_information_list.trp_information_item));
     for (int i = 0; i < trp_list_length; i++) {
       for (int j = 0; j < NumTRPs; j++) {
-        if (positioning_config.trps[j].id == req->trp_list.trp_list_item[i].trp_id) {
+        if (positioning_config->trps[j].id == req->trp_list.trp_list_item[i].trp_id) {
           resp.trp_information_list.trp_information_item[trp_resp_len].trp_id = req->trp_list.trp_list_item[i].trp_id;
           trp_resp_len++;
         }
@@ -1172,8 +1176,8 @@ void trp_information_request(const f1ap_trp_information_req_t *req)
         calloc_or_fail(NumTRPs, sizeof(*resp.trp_information_list.trp_information_item));
     for (int i = 0; i < NumTRPs; i++) {
       f1ap_trp_information_t *trp_info_item = &resp.trp_information_list.trp_information_item[i];
-      trp_info_item->trp_id = positioning_config.trps[i].id;
-      create_trp_info_item(req, trp_info_item, &positioning_config, i);
+      trp_info_item->trp_id = positioning_config->trps[i].id;
+      create_trp_info_item(req, trp_info_item, positioning_config, i);
     }
     resp.trp_information_list.trp_information_item_length = NumTRPs;
   }

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
@@ -1149,6 +1149,9 @@ void trp_information_request(const f1ap_trp_information_req_t *req)
   positioning_config_t *positioning_config = mac->positioning_config;
   if (positioning_config == NULL) {
     LOG_E(NR_PHY, "No TRPs configured for positioning in the configuration file\n");
+    f1ap_trp_information_failure_t fail = {.transaction_id = req->transaction_id};
+    fail.cause = F1AP_CAUSE_RADIO_NETWORK;
+    mac->mac_rrc.trp_information_failure(&fail);
     return;
   }
   uint8_t NumTRPs = positioning_config->num_trp;

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul.h
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul.h
@@ -26,6 +26,7 @@ typedef void (*trp_information_failure_func_t)(const f1ap_trp_information_failur
 typedef void (*positioning_information_response_func_t)(const f1ap_positioning_information_resp_t *resp);
 typedef void (*positioning_activation_response_func_t)(const f1ap_positioning_activation_resp_t *resp);
 typedef void (*positioning_measurement_response_func_t)(const f1ap_positioning_measurement_resp_t *resp);
+typedef void (*positioning_measurement_failure_func_t)(const f1ap_positioning_measurement_failure_t *failure);
 
 struct nr_mac_rrc_ul_if_s;
 void mac_rrc_ul_direct_init(struct nr_mac_rrc_ul_if_s *mac_rrc);

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul.h
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul.h
@@ -22,6 +22,7 @@ typedef void (*ue_context_release_complete_func_t)(const f1ap_ue_context_rel_cpl
 
 typedef void (*initial_ul_rrc_message_transfer_func_t)(module_id_t module_id, const f1ap_initial_ul_rrc_message_t *ul_rrc);
 typedef void (*trp_information_response_func_t)(const f1ap_trp_information_resp_t *resp);
+typedef void (*trp_information_failure_func_t)(const f1ap_trp_information_failure_t *fail);
 typedef void (*positioning_information_response_func_t)(const f1ap_positioning_information_resp_t *resp);
 typedef void (*positioning_activation_response_func_t)(const f1ap_positioning_activation_resp_t *resp);
 typedef void (*positioning_measurement_response_func_t)(const f1ap_positioning_measurement_resp_t *resp);

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul_direct.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul_direct.c
@@ -117,6 +117,14 @@ static void trp_information_response_direct(const f1ap_trp_information_resp_t *r
   itti_send_msg_to_task(TASK_RRC_GNB, 0, msg);
 }
 
+static void trp_information_failure_direct(const f1ap_trp_information_failure_t *fail)
+{
+  MessageDef *msg = itti_alloc_new_message(TASK_MAC_GNB, 0, F1AP_TRP_INFORMATION_FAILURE);
+  msg->ittiMsgHeader.originInstance = -1; // means monolithic
+  F1AP_TRP_INFORMATION_FAILURE(msg) = cp_trp_information_failure(fail);
+  itti_send_msg_to_task(TASK_RRC_GNB, 0, msg);
+}
+
 static void positioning_information_response_direct(const f1ap_positioning_information_resp_t *resp)
 {
   MessageDef *msg = itti_alloc_new_message(TASK_MAC_GNB, 0, F1AP_POSITIONING_INFORMATION_RESP);
@@ -154,6 +162,7 @@ void mac_rrc_ul_direct_init(struct nr_mac_rrc_ul_if_s *mac_rrc)
   mac_rrc->ue_context_release_complete = ue_context_release_complete_direct;
   mac_rrc->initial_ul_rrc_message_transfer = initial_ul_rrc_message_transfer_direct;
   mac_rrc->trp_information_response = trp_information_response_direct;
+  mac_rrc->trp_information_failure = trp_information_failure_direct;
   mac_rrc->positioning_information_response = positioning_information_response_direct;
   mac_rrc->positioning_activation_response = positioning_activation_response_direct;
   mac_rrc->positioning_measurement_response = positioning_measurement_response_direct;

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul_direct.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul_direct.c
@@ -149,6 +149,14 @@ static void positioning_measurement_response_direct(const f1ap_positioning_measu
   itti_send_msg_to_task(TASK_RRC_GNB, 0, msg);
 }
 
+static void positioning_measurement_failure_direct(const f1ap_positioning_measurement_failure_t *fail)
+{
+  MessageDef *msg = itti_alloc_new_message(TASK_MAC_GNB, 0, F1AP_POSITIONING_MEASUREMENT_FAILURE);
+  msg->ittiMsgHeader.originInstance = -1; // means monolithic
+  F1AP_POSITIONING_MEASUREMENT_FAILURE(msg) = cp_positioning_measurement_failure(fail);
+  itti_send_msg_to_task(TASK_RRC_GNB, 0, msg);
+}
+
 void mac_rrc_ul_direct_init(struct nr_mac_rrc_ul_if_s *mac_rrc)
 {
   mac_rrc->f1_reset = f1_reset_du_initiated_direct;
@@ -166,4 +174,5 @@ void mac_rrc_ul_direct_init(struct nr_mac_rrc_ul_if_s *mac_rrc)
   mac_rrc->positioning_information_response = positioning_information_response_direct;
   mac_rrc->positioning_activation_response = positioning_activation_response_direct;
   mac_rrc->positioning_measurement_response = positioning_measurement_response_direct;
+  mac_rrc->positioning_measurement_failure = positioning_measurement_failure_direct;
 }

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul_f1ap.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul_f1ap.c
@@ -131,6 +131,13 @@ static void trp_information_response_f1ap(const f1ap_trp_information_resp_t *res
   itti_send_msg_to_task(TASK_DU_F1, 0, msg);
 }
 
+static void trp_information_failure_f1ap(const f1ap_trp_information_failure_t *fail)
+{
+  MessageDef *msg = itti_alloc_new_message(TASK_MAC_GNB, 0, F1AP_TRP_INFORMATION_FAILURE);
+  F1AP_TRP_INFORMATION_FAILURE(msg) = cp_trp_information_failure(fail);
+  itti_send_msg_to_task(TASK_DU_F1, 0, msg);
+}
+
 static void positioning_information_response_f1ap(const f1ap_positioning_information_resp_t *resp)
 {
   MessageDef *msg = itti_alloc_new_message(TASK_MAC_GNB, 0, F1AP_POSITIONING_INFORMATION_RESP);
@@ -165,6 +172,7 @@ void mac_rrc_ul_f1ap_init(struct nr_mac_rrc_ul_if_s *mac_rrc)
   mac_rrc->ue_context_release_complete = ue_context_release_complete_f1ap;
   mac_rrc->initial_ul_rrc_message_transfer = initial_ul_rrc_message_transfer_f1ap;
   mac_rrc->trp_information_response = trp_information_response_f1ap;
+  mac_rrc->trp_information_failure = trp_information_failure_f1ap;
   mac_rrc->positioning_information_response = positioning_information_response_f1ap;
   mac_rrc->positioning_activation_response = positioning_activation_response_f1ap;
   mac_rrc->positioning_measurement_response = positioning_measurement_response_f1ap;

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul_f1ap.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_ul_f1ap.c
@@ -159,6 +159,13 @@ static void positioning_measurement_response_f1ap(const f1ap_positioning_measure
   itti_send_msg_to_task(TASK_DU_F1, 0, msg);
 }
 
+static void positioning_measurement_failure_f1ap(const f1ap_positioning_measurement_failure_t *fail)
+{
+  MessageDef *msg = itti_alloc_new_message(TASK_MAC_GNB, 0, F1AP_POSITIONING_MEASUREMENT_FAILURE);
+  F1AP_POSITIONING_MEASUREMENT_FAILURE(msg) = cp_positioning_measurement_failure(fail);
+  itti_send_msg_to_task(TASK_DU_F1, 0, msg);
+}
+
 void mac_rrc_ul_f1ap_init(struct nr_mac_rrc_ul_if_s *mac_rrc)
 {
   mac_rrc->f1_reset = f1_reset_du_initiated_f1ap;
@@ -176,5 +183,6 @@ void mac_rrc_ul_f1ap_init(struct nr_mac_rrc_ul_if_s *mac_rrc)
   mac_rrc->positioning_information_response = positioning_information_response_f1ap;
   mac_rrc->positioning_activation_response = positioning_activation_response_f1ap;
   mac_rrc->positioning_measurement_response = positioning_measurement_response_f1ap;
+  mac_rrc->positioning_measurement_failure = positioning_measurement_failure_f1ap;
 }
 

--- a/openair2/LAYER2/NR_MAC_gNB/main.c
+++ b/openair2/LAYER2/NR_MAC_gNB/main.c
@@ -359,6 +359,7 @@ void mac_top_destroy_gNB(gNB_MAC_INST *mac)
   if (mac->f1_config.setup_resp)
     free_f1ap_setup_response(mac->f1_config.setup_resp);
   free(mac->f1_config.setup_resp);
+  free(mac->positioning_config);
 }
 
 void nr_mac_send_f1_setup_req(void)

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -1336,6 +1336,7 @@ typedef struct gNB_MAC_INST_s {
 
   seq_arr_t pos_act_ue_arr;
   positioning_measurement_info_t pos_meas_info;
+  positioning_config_t *positioning_config;
 } gNB_MAC_INST;
 
 #endif /*__LAYER2_NR_MAC_GNB_H__ */

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -792,6 +792,7 @@ typedef struct nr_mac_rrc_ul_if_s {
   ue_context_release_complete_func_t ue_context_release_complete;
   initial_ul_rrc_message_transfer_func_t initial_ul_rrc_message_transfer;
   trp_information_response_func_t trp_information_response;
+  trp_information_failure_func_t trp_information_failure;
   positioning_information_response_func_t positioning_information_response;
   positioning_activation_response_func_t positioning_activation_response;
   positioning_measurement_response_func_t positioning_measurement_response;

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -796,6 +796,7 @@ typedef struct nr_mac_rrc_ul_if_s {
   positioning_information_response_func_t positioning_information_response;
   positioning_activation_response_func_t positioning_activation_response;
   positioning_measurement_response_func_t positioning_measurement_response;
+  positioning_measurement_failure_func_t positioning_measurement_failure;
 } nr_mac_rrc_ul_if_t;
 
 typedef struct measgap_config {

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -3831,6 +3831,10 @@ void *rrc_gnb_task(void *args_p)
         free_trp_information_resp(&F1AP_TRP_INFORMATION_RESP(msg_p));
         break;
 
+      case F1AP_TRP_INFORMATION_FAILURE:
+        rrc_CU_process_trp_information_failure(&F1AP_TRP_INFORMATION_FAILURE(msg_p));
+        break;
+
       case NRPPA_POSITIONING_INFORMATION_REQ:
         rrc_gNB_process_positioning_information_request(RC.nrrrc[instance], &NRPPA_POSITIONING_INFORMATION_REQ(msg_p));
         break;

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -3864,6 +3864,10 @@ void *rrc_gnb_task(void *args_p)
         free_positioning_measurement_resp(&F1AP_POSITIONING_MEASUREMENT_RESP(msg_p));
         break;
 
+      case F1AP_POSITIONING_MEASUREMENT_FAILURE:
+        rrc_CU_process_positioning_measurement_failure(&F1AP_POSITIONING_MEASUREMENT_FAILURE(msg_p));
+        break;
+
       default:
         LOG_E(NR_RRC, "[gNB %ld] Received unexpected message %s\n", instance, msg_name_p);
         break;

--- a/openair2/RRC/NR/rrc_gNB_NRPPA.c
+++ b/openair2/RRC/NR/rrc_gNB_NRPPA.c
@@ -1277,3 +1277,37 @@ void rrc_CU_process_positioning_measurement_response(f1ap_positioning_measuremen
   LOG_I(NR_RRC, "Sending NRPPA_MEASUREMENT_RESP to TASK_NRPPA\n");
   itti_send_msg_to_task(TASK_NRPPA, 0, msg_resp);
 }
+
+static nrppa_cause_t f1ap2nrppa_encode_cause(f1ap_Cause_t cause, long cause_value)
+{
+  nrppa_cause_t nrppa_cause = {0};
+  switch (cause) {
+    case F1AP_CAUSE_NOTHING:
+      nrppa_cause.type = NRPPA_CAUSE_NOTHING;
+      break;
+    case F1AP_CAUSE_RADIO_NETWORK:
+      nrppa_cause.type = NRPPA_CAUSE_RADIO_NETWORK;
+      break;
+    case F1AP_CAUSE_PROTOCOL:
+      nrppa_cause.type = NRPPA_CAUSE_PROTOCOL;
+      break;
+    case F1AP_CAUSE_MISC:
+      nrppa_cause.type = NRPPA_CAUSE_MISC;
+      break;
+    default:
+      AssertFatal(false, "Illegal Cause\n");
+      break;
+  }
+  nrppa_cause.value = cause_value;
+  return nrppa_cause;
+}
+
+void rrc_CU_process_trp_information_failure(f1ap_trp_information_failure_t *f1ap_msg)
+{
+  MessageDef *msg_fail = itti_alloc_new_message(TASK_RRC_GNB, 0, NRPPA_TRP_INFORMATION_FAILURE);
+  nrppa_trp_information_failure_t *nrppa_msg = &NRPPA_TRP_INFORMATION_FAILURE(msg_fail);
+  nrppa_msg->transaction_id = f1ap_msg->transaction_id;
+  nrppa_msg->cause = f1ap2nrppa_encode_cause(f1ap_msg->cause, f1ap_msg->cause_value);
+  LOG_I(NR_RRC, "Sending NRPPA_TRP_INFORMATION_FAILURE to TASK_NRPPA\n");
+  itti_send_msg_to_task(TASK_NRPPA, 0, msg_fail);
+}

--- a/openair2/RRC/NR/rrc_gNB_NRPPA.c
+++ b/openair2/RRC/NR/rrc_gNB_NRPPA.c
@@ -1311,3 +1311,14 @@ void rrc_CU_process_trp_information_failure(f1ap_trp_information_failure_t *f1ap
   LOG_I(NR_RRC, "Sending NRPPA_TRP_INFORMATION_FAILURE to TASK_NRPPA\n");
   itti_send_msg_to_task(TASK_NRPPA, 0, msg_fail);
 }
+
+void rrc_CU_process_positioning_measurement_failure(f1ap_positioning_measurement_failure_t *f1ap_msg)
+{
+  MessageDef *msg_fail = itti_alloc_new_message(TASK_RRC_GNB, 0, NRPPA_MEASUREMENT_FAILURE);
+  nrppa_measurement_failure_t *nrppa_msg = &NRPPA_MEASUREMENT_FAILURE(msg_fail);
+  nrppa_msg->transaction_id = f1ap_msg->transaction_id;
+  nrppa_msg->lmf_measurement_id = f1ap_msg->lmf_measurement_id;
+  nrppa_msg->cause = f1ap2nrppa_encode_cause(f1ap_msg->cause, f1ap_msg->cause_value);
+  LOG_I(NR_RRC, "Sending NRPPA_MEASUREMENT_FAILURE to TASK_NRPPA\n");
+  itti_send_msg_to_task(TASK_NRPPA, 0, msg_fail);
+}

--- a/openair2/RRC/NR/rrc_gNB_NRPPA.h
+++ b/openair2/RRC/NR/rrc_gNB_NRPPA.h
@@ -17,5 +17,6 @@ void rrc_gNB_process_positioning_activation_request(gNB_RRC_INST *rrc, const nrp
 void rrc_CU_process_positioning_activation_response(f1ap_positioning_activation_resp_t *f1ap_msg);
 void rrc_gNB_process_positioning_measurement_request(gNB_RRC_INST *rrc, const nrppa_measurement_req_t *msg);
 void rrc_CU_process_positioning_measurement_response(f1ap_positioning_measurement_resp_t *f1ap_msg);
+void rrc_CU_process_trp_information_failure(f1ap_trp_information_failure_t *f1ap_msg);
 
 #endif /* RRC_GNB_NRPPA_H_ */

--- a/openair2/RRC/NR/rrc_gNB_NRPPA.h
+++ b/openair2/RRC/NR/rrc_gNB_NRPPA.h
@@ -18,5 +18,6 @@ void rrc_CU_process_positioning_activation_response(f1ap_positioning_activation_
 void rrc_gNB_process_positioning_measurement_request(gNB_RRC_INST *rrc, const nrppa_measurement_req_t *msg);
 void rrc_CU_process_positioning_measurement_response(f1ap_positioning_measurement_resp_t *f1ap_msg);
 void rrc_CU_process_trp_information_failure(f1ap_trp_information_failure_t *f1ap_msg);
+void rrc_CU_process_positioning_measurement_failure(f1ap_positioning_measurement_failure_t *f1ap_msg);
 
 #endif /* RRC_GNB_NRPPA_H_ */

--- a/openair3/NRPPA/CMakeLists.txt
+++ b/openair3/NRPPA/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_subdirectory(MESSAGES)
 
 add_library(nrppa
+  nrppa_common.c
   nrppa_gNB.c
   nrppa_gNB_config.c
   nrppa_gNB_handlers.c

--- a/openair3/NRPPA/nrppa_common.c
+++ b/openair3/NRPPA/nrppa_common.c
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include "nrppa_common.h"
+
+NRPPA_Cause_t encode_nrppa_cause(nrppa_cause_t cause)
+{
+  NRPPA_Cause_t nrppa_cause = {0};
+  switch (cause.type) {
+    case NRPPA_CAUSE_RADIO_NETWORK:
+      nrppa_cause.present = NRPPA_Cause_PR_radioNetwork;
+      nrppa_cause.choice.radioNetwork = cause.value;
+      break;
+    case NRPPA_CAUSE_PROTOCOL:
+      nrppa_cause.present = NRPPA_Cause_PR_protocol;
+      nrppa_cause.choice.protocol = cause.value;
+      break;
+    case NRPPA_CAUSE_MISC:
+      nrppa_cause.present = NRPPA_Cause_PR_misc;
+      nrppa_cause.choice.misc = cause.value;
+      break;
+    case NRPPA_CAUSE_NOTHING:
+    default:
+      AssertFatal(false, "unknown cause value %d\n", cause.type);
+      break;
+  }
+  return nrppa_cause;
+}

--- a/openair3/NRPPA/nrppa_common.h
+++ b/openair3/NRPPA/nrppa_common.h
@@ -13,6 +13,8 @@
 #include "NRPPA_TRPInformationItem.h"
 #include "NRPPA_SRSCarrier-List.h"
 #include "NRPPA_SRSType.h"
+#include "common/5g_platform_types.h"
+#include "openair2/COMMON/nrppa_messages_types.h"
 
 #define NRPPA_FIND_PROTOCOLIE_BY_ID(IE_TYPE, ie, container, IE_ID, mandatory)                                                  \
   do {                                                                                                                         \
@@ -45,5 +47,6 @@ typedef struct nrppa_gnb_ue_info_s {
 } nrppa_gnb_ue_info_t;
 
 typedef int (*nrppa_message_decoded_callback)(nrppa_gnb_ue_info_t *nrppa_msg_info, const NRPPA_NRPPA_PDU_t *pdu);
+NRPPA_Cause_t encode_nrppa_cause(nrppa_cause_t cause);
 
 #endif /* NRPPA_COMMON_H_ */

--- a/openair3/NRPPA/nrppa_gNB.c
+++ b/openair3/NRPPA/nrppa_gNB.c
@@ -57,6 +57,9 @@ void *nrppa_gNB_process_itti_msg(void *notUsed)
       case NRPPA_MEASUREMENT_RESP:
         nrppa_gNB_measurement_response(instance, received_msg);
         break;
+      case NRPPA_MEASUREMENT_FAILURE:
+        nrppa_gNB_measurement_failure(instance, received_msg);
+        break;
       default:
         LOG_E(NRPPA, "Received unhandled message: %d:%s\n", ITTI_MSG_ID(received_msg), ITTI_MSG_NAME(received_msg));
         break;

--- a/openair3/NRPPA/nrppa_gNB.c
+++ b/openair3/NRPPA/nrppa_gNB.c
@@ -45,6 +45,9 @@ void *nrppa_gNB_process_itti_msg(void *notUsed)
       case NRPPA_TRP_INFORMATION_RESP:
         nrppa_gNB_trp_information_response(instance, received_msg);
         break;
+      case NRPPA_TRP_INFORMATION_FAILURE:
+        nrppa_gNB_trp_information_failure(instance, received_msg);
+        break;
       case NRPPA_POSITIONING_INFORMATION_RESP:
         nrppa_gNB_positioning_information_response(instance, received_msg);
         break;

--- a/openair3/NRPPA/nrppa_gNB_config.c
+++ b/openair3/NRPPA/nrppa_gNB_config.c
@@ -9,9 +9,9 @@
 #include "common/config/config_userapi.h"
 #include "common/utils/LOG/log.h"
 
-positioning_config_t RCconfig_nr_positioning(void)
+positioning_config_t *RCconfig_nr_positioning(void)
 {
-  positioning_config_t positioning_config = {0};
+  positioning_config_t *positioning_config = NULL;
   paramdef_t positioning_params_desc[] = POSITIONING_PARAMS_DESC;
   int num_params = sizeofArray(positioning_params_desc);
   GET_PARAMS_LIST(POSITIONING_ParamList, POSITIONING_Params, POSITIONING_PARAMS_DESC, CONFIG_STRING_POSITIONING_CONFIG, NULL);
@@ -21,8 +21,7 @@ positioning_config_t RCconfig_nr_positioning(void)
 
     uint8_t num_trp = *gpd(params, num_params, CONFIG_STRING_POSITIONING_NUM_TRPS)->uptr;
     if (num_trp == 0) {
-      LOG_E(NR_PHY, "No TRP configuration found..!!!\n");
-      return positioning_config;
+      return NULL;
     } else if (num_trp > MAX_NUM_TRPs) {
       AssertFatal(false, "Exceeded MAX number of TRPs\n");
     }
@@ -37,13 +36,14 @@ positioning_config_t RCconfig_nr_positioning(void)
       AssertFatal(false, "Mismatch in the number of TRPs with the number of ids, x-axis, y-axis, z-axis, units\n");
     }
 
-    positioning_config.num_trp = num_trp;
+    positioning_config = calloc_or_fail(1, sizeof(positioning_config_t));
+    positioning_config->num_trp = num_trp;
     for (int l = 0; l < num_trp; l++) {
-      positioning_config.trps[l].id = gpd(params, num_params, CONFIG_STRING_POSITIONING_TRP_IDS_LIST)->uptr[l];
-      positioning_config.trps[l].x_axis = gpd(params, num_params, CONFIG_STRING_POSITIONING_TRP_X_AXIS_LIST)->uptr[l];
-      positioning_config.trps[l].y_axis = gpd(params, num_params, CONFIG_STRING_POSITIONING_TRP_Y_AXIS_LIST)->uptr[l];
-      positioning_config.trps[l].z_axis = gpd(params, num_params, CONFIG_STRING_POSITIONING_TRP_Z_AXIS_LIST)->uptr[l];
-      positioning_config.trps[l].unit = gpd(params, num_params, CONFIG_STRING_POSITIONING_TRP_UNIT_LIST)->uptr[l];
+      positioning_config->trps[l].id = gpd(params, num_params, CONFIG_STRING_POSITIONING_TRP_IDS_LIST)->uptr[l];
+      positioning_config->trps[l].x_axis = gpd(params, num_params, CONFIG_STRING_POSITIONING_TRP_X_AXIS_LIST)->uptr[l];
+      positioning_config->trps[l].y_axis = gpd(params, num_params, CONFIG_STRING_POSITIONING_TRP_Y_AXIS_LIST)->uptr[l];
+      positioning_config->trps[l].z_axis = gpd(params, num_params, CONFIG_STRING_POSITIONING_TRP_Z_AXIS_LIST)->uptr[l];
+      positioning_config->trps[l].unit = gpd(params, num_params, CONFIG_STRING_POSITIONING_TRP_UNIT_LIST)->uptr[l];
       }
   } else {
     LOG_I(NR_PHY, "No " CONFIG_STRING_POSITIONING_CONFIG " configuration found..!!\n");

--- a/openair3/NRPPA/nrppa_gNB_config.h
+++ b/openair3/NRPPA/nrppa_gNB_config.h
@@ -7,7 +7,7 @@
 
 #include "common/utils/nr/nr_common.h"
 
-positioning_config_t RCconfig_nr_positioning(void);
+positioning_config_t *RCconfig_nr_positioning(void);
 void dump_positioning_config(const positioning_config_t *positioning_config);
 
 #endif /* GNB_CONFIG_POSITIONING_H_ */

--- a/openair3/NRPPA/nrppa_gNB_location_information_transfer.c
+++ b/openair3/NRPPA/nrppa_gNB_location_information_transfer.c
@@ -1360,3 +1360,73 @@ int nrppa_gNB_positioning_activation_response(instance_t instance, MessageDef *m
   free(buffer);
   return length;
 }
+
+int nrppa_gNB_trp_information_failure(instance_t instance, MessageDef *msg_p)
+{
+  DevAssert(msg_p);
+  nrppa_trp_information_failure_t *fail = &NRPPA_TRP_INFORMATION_FAILURE(msg_p);
+  nrppa_gNB_ue_context_t *ue_info = nrppa_detach_ue_context(fail->transaction_id);
+
+  if (ue_info->gNB_ue_ngap_id != 0 && ue_info->amf_ue_ngap_id != 0) {
+    LOG_E(NRPPA, "Illegal gNB_ue_ngap_id %d and amf_ue_ngap_id %ld\n", ue_info->gNB_ue_ngap_id, ue_info->amf_ue_ngap_id);
+    nrppa_free_ue_context(ue_info);
+    return -1;
+  }
+
+  LOG_I(NRPPA,
+        "Received TRP Information Failure from RRC with transaction_id=%u and gNB_ue_ngap_id %u\n",
+        ue_info->transaction_id,
+        ue_info->gNB_ue_ngap_id);
+
+  NRPPA_NRPPA_PDU_t pdu = {0};
+
+  // IE: 9.2.3 Message Type : mandatory
+  pdu.present = NRPPA_NRPPA_PDU_PR_unsuccessfulOutcome;
+  asn1cCalloc(pdu.choice.unsuccessfulOutcome, head);
+  head->procedureCode = NRPPA_ProcedureCode_id_tRPInformationExchange;
+  head->criticality = NRPPA_Criticality_reject;
+  head->value.present = NRPPA_UnsuccessfulOutcome__value_PR_TRPInformationFailure;
+
+  // IE 9.2.4 nrppatransactionID : mandatory
+  head->nrppatransactionID = fail->transaction_id;
+  NRPPA_TRPInformationFailure_t *out = &head->value.choice.TRPInformationFailure;
+
+  // IE 9.2.1 Cause : mandatory
+  asn1cSequenceAdd(out->protocolIEs.list, NRPPA_TRPInformationFailure_IEs_t, ie);
+  ie->id = NRPPA_ProtocolIE_ID_id_Cause;
+  ie->criticality = NRPPA_Criticality_ignore;
+  ie->value.present = NRPPA_TRPInformationFailure_IEs__value_PR_Cause;
+  ie->value.choice.Cause = encode_nrppa_cause(fail->cause);
+
+  LOG_I(NRPPA, "Calling encoder for TRP Information Failure \n");
+
+  if (LOG_DEBUGFLAG(DEBUG_ASN1)) {
+    xer_fprint(stdout, &asn_DEF_NRPPA_NRPPA_PDU, &pdu);
+  }
+
+  // Encode NRPPA message
+  uint8_t *buffer = NULL;
+  uint32_t length = 0;
+  if (nrppa_gNB_encode_pdu(&pdu, &buffer, &length) < 0) {
+    LOG_E(NRPPA, "Failed to encode Uplink NRPPa TRP Information Failure\n");
+    nrppa_free_ue_context(ue_info);
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NRPPA_NRPPA_PDU, &pdu);
+    return -1;
+  }
+
+  MessageDef *msg = itti_alloc_new_message(TASK_NRPPA, 0, NGAP_UPLINKNONUEASSOCIATEDNRPPA);
+  ngap_uplink_non_ue_associated_nrppa_t *ULNRPPA = &NGAP_UPLINKNONUEASSOCIATEDNRPPA(msg);
+
+  // Routing ID
+  ULNRPPA->routing_id = create_byte_array(ue_info->routing_id.len, ue_info->routing_id.buf);
+
+  // NRPPA PDU
+  ULNRPPA->nrppa_pdu = create_byte_array(length, buffer);
+
+  // Forward the NRPPA PDU to NGAP
+  itti_send_msg_to_task(TASK_NGAP, instance, msg);
+  nrppa_free_ue_context(ue_info);
+  free(buffer);
+  return length;
+  return 0;
+}

--- a/openair3/NRPPA/nrppa_gNB_location_information_transfer.h
+++ b/openair3/NRPPA/nrppa_gNB_location_information_transfer.h
@@ -22,5 +22,6 @@ int nrppa_gNB_handle_positioning_activation_request(nrppa_gnb_ue_info_t *nrppa_m
 void decode_nrppa_srstype(NRPPA_SRSType_t *srs_type, nrppa_srs_type_t *out);
 void free_nrppa_positioning_activation_request(nrppa_positioning_activation_req_t *msg);
 int nrppa_gNB_positioning_activation_response(instance_t instance, MessageDef *msg_p);
+int nrppa_gNB_trp_information_failure(instance_t instance, MessageDef *msg_p);
 
 #endif /* NRPPA_GNB_POSITIONING_PROCEDURES_H_ */

--- a/openair3/NRPPA/nrppa_gNB_measurement_information_transfer.c
+++ b/openair3/NRPPA/nrppa_gNB_measurement_information_transfer.c
@@ -1124,3 +1124,84 @@ int nrppa_gNB_measurement_response(instance_t instance, MessageDef *msg_p)
   free(buffer);
   return length;
 }
+
+int nrppa_gNB_measurement_failure(instance_t instance, MessageDef *msg_p)
+{
+  DevAssert(msg_p);
+  nrppa_measurement_failure_t *fail = &NRPPA_MEASUREMENT_FAILURE(msg_p);
+  nrppa_gNB_ue_context_t *ue_info = nrppa_detach_ue_context(fail->transaction_id);
+
+  if (ue_info->gNB_ue_ngap_id != 0 && ue_info->amf_ue_ngap_id != 0) {
+    LOG_E(NRPPA, "Illegal gNB_ue_ngap_id %d and amf_ue_ngap_id %ld\n", ue_info->gNB_ue_ngap_id, ue_info->amf_ue_ngap_id);
+    nrppa_free_ue_context(ue_info);
+    return -1;
+  }
+
+  LOG_I(NRPPA,
+        "Received measurement failure info from RRC with transaction_id %u and gNB_ue_ngap_id %u\n",
+        ue_info->transaction_id,
+        ue_info->gNB_ue_ngap_id);
+
+  // Prepare NRPPA TRP Information transfer Response
+  NRPPA_NRPPA_PDU_t pdu = {0};
+
+  // IE: 9.2.3 Message Type : mandatory
+  pdu.present = NRPPA_NRPPA_PDU_PR_unsuccessfulOutcome;
+  asn1cCalloc(pdu.choice.unsuccessfulOutcome, head);
+  head->procedureCode = NRPPA_ProcedureCode_id_Measurement;
+  head->criticality = NRPPA_Criticality_reject;
+  head->value.present = NRPPA_UnsuccessfulOutcome__value_PR_MeasurementFailure;
+
+  // IE 9.2.4 nrppatransactionID : mandatory
+  head->nrppatransactionID = fail->transaction_id;
+  NRPPA_MeasurementFailure_t *out = &head->value.choice.MeasurementFailure;
+
+  // IE LMF Measurement ID : mandatory
+  {
+    asn1cSequenceAdd(out->protocolIEs.list, NRPPA_MeasurementFailure_IEs_t, ie);
+    ie->id = NRPPA_ProtocolIE_ID_id_LMF_Measurement_ID;
+    ie->criticality = NRPPA_Criticality_reject;
+    ie->value.present = NRPPA_MeasurementFailure_IEs__value_PR_Measurement_ID;
+    ie->value.choice.Measurement_ID = fail->lmf_measurement_id;
+  }
+
+  // IE Cause : mandatory
+  {
+    asn1cSequenceAdd(out->protocolIEs.list, NRPPA_MeasurementFailure_IEs_t, ie);
+    ie->id = NRPPA_ProtocolIE_ID_id_Cause;
+    ie->criticality = NRPPA_Criticality_reject;
+    ie->value.present = NRPPA_MeasurementFailure_IEs__value_PR_Cause;
+    ie->value.choice.Cause = encode_nrppa_cause(fail->cause);
+  }
+
+  LOG_I(NRPPA, "Calling encoder for Measurement Failure \n");
+
+  if (LOG_DEBUGFLAG(DEBUG_ASN1)) {
+    xer_fprint(stdout, &asn_DEF_NRPPA_NRPPA_PDU, &pdu);
+  }
+
+  // Encode NRPPA message
+  uint8_t *buffer = NULL;
+  uint32_t length = 0;
+  if (nrppa_gNB_encode_pdu(&pdu, &buffer, &length) < 0) {
+    LOG_E(NRPPA, "Failed to encode Uplink NRPPa Measurement Failure\n");
+    nrppa_free_ue_context(ue_info);
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_NRPPA_NRPPA_PDU, &pdu);
+    return -1;
+  }
+
+  MessageDef *msg = itti_alloc_new_message(TASK_NRPPA, 0, NGAP_UPLINKNONUEASSOCIATEDNRPPA);
+  ngap_uplink_non_ue_associated_nrppa_t *ULNRPPA = &NGAP_UPLINKNONUEASSOCIATEDNRPPA(msg);
+
+  // Routing ID
+  ULNRPPA->routing_id = create_byte_array(ue_info->routing_id.len, ue_info->routing_id.buf);
+
+  // NRPPa PDU
+  ULNRPPA->nrppa_pdu = create_byte_array(length, buffer);
+
+  // Forward the NRPPA PDU to NGAP
+  itti_send_msg_to_task(TASK_NGAP, instance, msg);
+  nrppa_free_ue_context(ue_info);
+  free(buffer);
+  return length;
+}

--- a/openair3/NRPPA/nrppa_gNB_measurement_information_transfer.h
+++ b/openair3/NRPPA/nrppa_gNB_measurement_information_transfer.h
@@ -13,5 +13,6 @@ void free_nrppa_measurement_request(nrppa_measurement_req_t *msg);
 int nrppa_gNB_measurement_response(instance_t instance, MessageDef *msg_p);
 NRPPA_TRP_MeasurementResponseList_t encode_trp_measurement_reponse_list(nrppa_measurement_response_list_t *in_list);
 void free_nrppa_measurement_resp(nrppa_measurement_resp_t *msg);
+int nrppa_gNB_measurement_failure(instance_t instance, MessageDef *msg_p);
 
 #endif /* NRPPA_GNB_MEASUREMENT_INFORMATION_TRANSFER_H_ */

--- a/tests/nr-cu-nrppa/nr-cu-nrppa.c
+++ b/tests/nr-cu-nrppa/nr-cu-nrppa.c
@@ -28,6 +28,7 @@ uint16_t mcc = 1;
 uint16_t mnc = 1;
 uint8_t mnc_len = 2;
 int NB_UE_INST = 1;
+positioning_config_t *positioning_config = NULL;
 
 void exit_function(const char *file, const char *function, const int line, const char *s, const int assert)
 {
@@ -77,20 +78,19 @@ configmodule_interface_t *uniqCfg = NULL;
 
 static nrppa_trp_information_resp_t fill_trp_resp(uint8_t transaction_id)
 {
-  positioning_config_t positioning_config = RCconfig_nr_positioning();
-  dump_positioning_config(&positioning_config);
+  dump_positioning_config(positioning_config);
   nrppa_trp_information_resp_t resp = {0};
   resp.transaction_id = transaction_id;
 
   nrppa_trp_information_list_t *list = &resp.trp_information_list;
-  uint32_t trp_info_item_len = positioning_config.num_trp;
+  uint32_t trp_info_item_len = positioning_config->num_trp;
   list->trp_information_item_length = trp_info_item_len;
   list->trp_information_item = calloc_or_fail(trp_info_item_len, sizeof(*list->trp_information_item));
 
   uint8_t resp_item_len = 3;
   for (int i = 0; i < trp_info_item_len; i++) {
     nrppa_trp_information_t *tRPInformation = &list->trp_information_item[i];
-    tRPInformation->trp_id = positioning_config.trps[i].id;
+    tRPInformation->trp_id = positioning_config->trps[i].id;
     nrppa_trp_information_type_response_list_t *resp_list = &tRPInformation->trp_information_type_response_list;
     resp_list->trp_information_type_response_item_length = resp_item_len;
     nrppa_trp_information_type_response_item_t *resp_item = calloc_or_fail(resp_item_len, sizeof(*resp_item));
@@ -122,12 +122,12 @@ static nrppa_trp_information_resp_t fill_trp_resp(uint8_t transaction_id)
     referencePointType->present = NRPPA_TRP_REFERENCE_POINT_TYPE_PR_TRPPOSITION_RELATIVE_CARTESIAN;
     nrppa_relative_cartesian_location_t *trp_pos_cart = &referencePointType->choice.trp_position_relative_cartesian;
     // 0 = millimeter
-    trp_pos_cart->xyz_unit = positioning_config.trps[i].unit;
+    trp_pos_cart->xyz_unit = positioning_config->trps[i].unit;
 
     // random reference cartesian coordinates in millimeter
-    trp_pos_cart->xvalue = positioning_config.trps[i].x_axis;
-    trp_pos_cart->yvalue = positioning_config.trps[i].y_axis;
-    trp_pos_cart->zvalue = positioning_config.trps[i].z_axis;
+    trp_pos_cart->xvalue = positioning_config->trps[i].x_axis;
+    trp_pos_cart->yvalue = positioning_config->trps[i].y_axis;
+    trp_pos_cart->zvalue = positioning_config->trps[i].z_axis;
     // testing random values for uncertainity and confidence
     trp_pos_cart->location_uncertainty.horizontal_uncertainty = i + 1;
     trp_pos_cart->location_uncertainty.horizontal_confidence = i + 2;
@@ -422,19 +422,18 @@ static nrppa_positioning_information_resp_t fill_position_information_resp(uint1
 
 static nrppa_measurement_resp_t fill_measurement_response(uint16_t transaction_id, uint32_t lmf_measurement_id)
 {
-  positioning_config_t positioning_config = RCconfig_nr_positioning();
   nrppa_measurement_resp_t resp = {0};
   resp.transaction_id = transaction_id;
   resp.lmf_measurement_id = lmf_measurement_id;
   resp.ran_measurement_id = 1;
   resp.measurement_response_list = calloc_or_fail(1, sizeof(*resp.measurement_response_list));
-  uint32_t meas_response_list_len = positioning_config.num_trp;
+  uint32_t meas_response_list_len = positioning_config->num_trp;
   resp.measurement_response_list->measurement_response_list_length = meas_response_list_len;
   resp.measurement_response_list->measurement_response_item =
       calloc_or_fail(meas_response_list_len, sizeof(*resp.measurement_response_list->measurement_response_item));
   for (int i = 0; i < meas_response_list_len; i++) {
     nrppa_measurement_response_item_t *meas_response_item = &resp.measurement_response_list->measurement_response_item[i];
-    meas_response_item->trp_id = positioning_config.trps[i].id;
+    meas_response_item->trp_id = positioning_config->trps[i].id;
 
     nrppa_measurement_result_t *MeasurementResult = &meas_response_item->measurement_result;
     uint32_t meas_result_length = 4;
@@ -652,6 +651,12 @@ int main(int argc, char **argv)
   }
   logInit();
 
+  positioning_config = RCconfig_nr_positioning();
+  if (positioning_config == NULL) {
+    LOG_E(NRPPA, "No TRPs configured for positioning in the configuration file.\n");
+    exit(EXIT_FAILURE);
+  }
+
   nas_init_nrue(NB_UE_INST);
 
   set_softmodem_sighandler();
@@ -691,6 +696,7 @@ int main(int argc, char **argv)
   itti_wait_tasks_end(NULL);
 
   logClean();
+  free(positioning_config);
   printf("Bye.\n");
   return 0;
 }


### PR DESCRIPTION
Call RCconfig_nr_positioning() only during initialization and store it in the MAC. This avoids repeated reading of the configuration from the config file.

This PR also introduces end-to-end implementation of `TRP information failure` and `positioning measurement failure` for error handling