### PR TITLE
fix(NR_UE): implement T304 expiry per TS 38.331 5.3.5.8.3

### DIFF
--- a/common/utils/telnetsrv/telnetsrv_ciUE.c
+++ b/common/utils/telnetsrv/telnetsrv_ciUE.c
@@ -75,7 +75,7 @@ int force_rlf(char *buf, int debug, telnet_printfunc_t prnt)
   UNUSED(buf);
   UNUSED(prnt);
   NR_UE_RRC_INST_t *rrc = get_NR_UE_rrc_inst(0);
-  handle_rlf_detection(rrc);
+  handle_rlf_detection(rrc, NR_ReestablishmentCause_otherFailure);
   return 0;
 }
 

--- a/openair2/COMMON/rrc_messages_types.h
+++ b/openair2/COMMON/rrc_messages_types.h
@@ -464,6 +464,10 @@ typedef struct {
 
 typedef struct {
   nr_mac_ra_start_cause_t cause;
+  // Set together with NR_MAC_RA_START_REESTABLISHMENT when re-establishment was triggered by T304
+  // expiry (TS 38.331 5.3.5.8.3): MAC must revert its common/BWP0/PHY config -- already switched to
+  // the (unreachable) target PCell -- back to the source PCell, using its own ho_source_scc snapshot.
+  bool revert_to_ho_source;
 } nr_mac_rrc_start_ra_t;
 
 enum payload_type {

--- a/openair2/LAYER2/NR_MAC_UE/config_ue.c
+++ b/openair2/LAYER2/NR_MAC_UE/config_ue.c
@@ -2040,7 +2040,7 @@ void nr_rrc_mac_config_req_paging_ue_id(module_id_t module_id, uint64_t fiveG_S_
   pthread_mutex_unlock(&mac->if_mutex);
 }
 
-static void nr_mac_start_ra(NR_UE_MAC_INST_t *mac, module_id_t module_id, nr_mac_ra_start_cause_t cause)
+static void nr_mac_start_ra(NR_UE_MAC_INST_t *mac, module_id_t module_id, nr_mac_ra_start_cause_t cause, bool revert_to_ho_source)
 {
   switch (cause) {
     case NR_MAC_RA_START_SETUP:
@@ -2051,6 +2051,51 @@ static void nr_mac_start_ra(NR_UE_MAC_INST_t *mac, module_id_t module_id, nr_mac
       mac->state = UE_PERFORMING_RA;
       break;
     case NR_MAC_RA_START_REESTABLISHMENT: {
+      if (revert_to_ho_source && mac->ho_source_scc) {
+        // TS 38.331 5.3.5.8.3: T304 (handover) failure -- revert the common/BWP0/PHY config that
+        // handle_reconfiguration_with_sync() switched to the (unreachable) target PCell, back to
+        // the source PCell, replaying the same derivation it originally used to apply it.
+        NR_ServingCellConfigCommon_t *scc = mac->ho_source_scc;
+        if (scc->physCellId)
+          mac->physCellId = *scc->physCellId;
+        mac->dmrs_TypeA_Position = scc->dmrs_TypeA_Position;
+        UPDATE_IE(mac->tdd_UL_DL_ConfigurationCommon, scc->tdd_UL_DL_ConfigurationCommon, NR_TDD_UL_DL_ConfigCommon_t);
+        config_common_ue(mac, scc, 0, 0, 0);
+        build_ssb_list(mac);
+        if (scc->downlinkConfigCommon)
+          configure_common_BWP_dl(mac, 0, scc->downlinkConfigCommon->initialDownlinkBWP);
+        if (scc->uplinkConfigCommon)
+          configure_common_BWP_ul(mac, 0, scc->uplinkConfigCommon->initialUplinkBWP);
+        asn1cFreeStruc(asn_DEF_NR_ServingCellConfigCommon, mac->servingCellConfigCommon);
+        mac->servingCellConfigCommon = mac->ho_source_scc; // ownership transferred, don't free scc itself below
+        mac->ho_source_scc = NULL;
+        mac->if_module->phy_config_request(&mac->phy_config);
+      } else if (revert_to_ho_source && mac->ho_source_phy.valid) {
+        // Fallback: no full ho_source_scc snapshot available -- typically because this was the
+        // UE's first ever handover, whose source common config came from SIB1-based camping
+        // (config_common_ue_sa(), a different ASN.1 type) rather than a prior
+        // reconfigurationWithSync. Directly restore the plain scalars that drive the PHY resync
+        // (see handle_sync_req_from_mac() in executables/nr-ue.c), so PHY still targets the
+        // correct source cell/frequency. TDD/BWP0/RACH-common config stay target-derived until
+        // SIB1 is reacquired on the source cell.
+        mac->physCellId = mac->ho_source_phy.physCellId;
+        mac->phy_config.config_req.carrier_config.dl_frequency = mac->ho_source_phy.dl_frequency;
+        mac->phy_config.config_req.carrier_config.uplink_frequency = mac->ho_source_phy.uplink_frequency;
+        mac->phy_config.config_req.ssb_table.ssb_offset_point_a = mac->ho_source_phy.ssb_offset_point_a;
+        mac->phy_config.config_req.ssb_table.ssb_subcarrier_offset = mac->ho_source_phy.ssb_subcarrier_offset;
+        mac->if_module->phy_config_request(&mac->phy_config);
+      } else if (revert_to_ho_source) {
+        LOG_E(NR_MAC,
+              "T304 expiry re-establishment requested a revert to the source PCell, but no source config (full or "
+              "scalar) was snapshotted -- resyncing with the (stale) current common config\n");
+      }
+      mac->ho_source_phy.valid = false; // snapshot consumed (or was never valid for this RA start)
+      // TS 38.331 5.3.5.8.3 / TS 38.321: discard dedicated (CFRA) preambles and msgA PUSCH
+      // resources from rach-ConfigDedicated -- reset_mac_inst() below only clears RA state, not this.
+      if (mac->ra.rach_ConfigDedicated) {
+        asn1cFreeStruc(asn_DEF_NR_RACH_ConfigDedicated, mac->ra.rach_ConfigDedicated);
+        mac->ra.rach_ConfigDedicated = NULL;
+      }
       fapi_nr_synch_request_t sync_req = {.target_Nid_cell = mac->physCellId, .ssb_bw_scan = false};
       reset_mac_inst(mac);
       nr_ue_mac_default_configs(mac);
@@ -2072,13 +2117,13 @@ static void nr_mac_start_ra(NR_UE_MAC_INST_t *mac, module_id_t module_id, nr_mac
 }
 
 /** @brief All RRC-initiated RA entry points */
-void nr_rrc_mac_start_ra(module_id_t module_id, nr_mac_ra_start_cause_t cause)
+void nr_rrc_mac_start_ra(module_id_t module_id, nr_mac_ra_start_cause_t cause, bool revert_to_ho_source)
 {
   NR_UE_MAC_INST_t *mac = get_mac_inst(module_id);
   int ret = pthread_mutex_lock(&mac->if_mutex);
   AssertFatal(!ret, "mutex failed %d\n", ret);
 
-  nr_mac_start_ra(mac, module_id, cause);
+  nr_mac_start_ra(mac, module_id, cause, revert_to_ho_source);
 
   ret = pthread_mutex_unlock(&mac->if_mutex);
   AssertFatal(!ret, "mutex failed %d\n", ret);
@@ -2180,6 +2225,31 @@ static void handle_reconfiguration_with_sync(NR_UE_MAC_INST_t *mac,
 
   if (reconfWithSync->spCellConfigCommon) {
     NR_ServingCellConfigCommon_t *scc = reconfWithSync->spCellConfigCommon;
+
+    // Snapshot the (source PCell's) common config that's about to be overwritten below, so that
+    // it can be re-applied if this handover's T304 expires (TS 38.331 5.3.5.8.3 "revert back to
+    // the UE configuration used in the source PCell"), see the NR_MAC_RA_START_REESTABLISHMENT
+    // case of nr_mac_start_ra(). Nothing to snapshot on the very first ServingCellConfigCommon
+    // application (initial connection, not a handover).
+    if (mac->servingCellConfigCommon) {
+      asn1cFreeStruc(asn_DEF_NR_ServingCellConfigCommon, mac->ho_source_scc);
+      mac->ho_source_scc = mac->servingCellConfigCommon;
+      mac->servingCellConfigCommon = NULL;
+    }
+    int copy_result = asn_copy(&asn_DEF_NR_ServingCellConfigCommon, (void **)&mac->servingCellConfigCommon, scc);
+    AssertFatal(copy_result == 0, "unable to copy NR_ServingCellConfigCommon_t\n");
+
+    // Also snapshot the plain PHY-resync scalars unconditionally (see ho_source_phy in
+    // mac_defs.h): unlike ho_source_scc above, these are always available on T304 expiry, even
+    // for the UE's first ever handover, so PHY can always be pointed back at the right source
+    // cell/frequency (see handle_sync_req_from_mac() in executables/nr-ue.c).
+    mac->ho_source_phy.valid = true;
+    mac->ho_source_phy.physCellId = mac->physCellId;
+    mac->ho_source_phy.dl_frequency = mac->phy_config.config_req.carrier_config.dl_frequency;
+    mac->ho_source_phy.uplink_frequency = mac->phy_config.config_req.carrier_config.uplink_frequency;
+    mac->ho_source_phy.ssb_offset_point_a = mac->phy_config.config_req.ssb_table.ssb_offset_point_a;
+    mac->ho_source_phy.ssb_subcarrier_offset = mac->phy_config.config_req.ssb_table.ssb_subcarrier_offset;
+
     if (scc->physCellId)
       mac->physCellId = *scc->physCellId;
     mac->dmrs_TypeA_Position = scc->dmrs_TypeA_Position;

--- a/openair2/LAYER2/NR_MAC_UE/mac_defs.h
+++ b/openair2/LAYER2/NR_MAC_UE/mac_defs.h
@@ -39,6 +39,7 @@
 #include "NR_ServingCellConfig.h"
 #include "NR_MeasConfig.h"
 #include "NR_ServingCellConfigCommonSIB.h"
+#include "NR_ServingCellConfigCommon.h"
 
 /* position_t */
 #include "executables/position_interface.h"
@@ -570,6 +571,32 @@ typedef struct NR_UE_MAC_INST_s {
   NR_UL_TIME_ALIGNMENT_t ul_time_alignment;
   NR_TDD_UL_DL_ConfigCommon_t *tdd_UL_DL_ConfigurationCommon;
   frame_structure_t frame_structure;
+
+  /// Clone of the ServingCellConfigCommon currently in effect (the one config_common_ue() last
+  /// applied), kept around solely so that the next handover can snapshot it into ho_source_scc.
+  NR_ServingCellConfigCommon_t *servingCellConfigCommon;
+  /// Snapshot of the source PCell's ServingCellConfigCommon, taken right before a handover
+  /// (reconfigurationWithSync) overwrites the common/BWP0/PHY config with the target's. Consumed
+  /// (and freed) to revert the common config back to the source PCell upon T304 expiry
+  /// (TS 38.331 5.3.5.8.3), see the NR_MAC_RA_START_REESTABLISHMENT case of nr_mac_start_ra().
+  /// Only available when servingCellConfigCommon was already set, i.e. this isn't the UE's first
+  /// ever handover (a UE's initial common config comes from SIB1 via config_common_ue_sa(), a
+  /// different ASN.1 type -- see ho_source_phy below for the fallback that covers that case too).
+  NR_ServingCellConfigCommon_t *ho_source_scc;
+  /// Fallback source-PCell snapshot: just the plain scalars that actually drive the PHY resync
+  /// (see handle_sync_req_from_mac() in executables/nr-ue.c) -- physCellId, DL/UL frequency, SSB
+  /// location. Unlike ho_source_scc above, these are taken unconditionally on every handover
+  /// (regardless of whether the current common config came from SIB1-based camping or a prior
+  /// dedicated reconfigurationWithSync), so they're always available to at least point PHY back
+  /// at the right cell/frequency on T304 expiry, even when the fuller ho_source_scc isn't.
+  struct {
+    bool valid;
+    long physCellId;
+    uint32_t dl_frequency;
+    uint32_t uplink_frequency;
+    uint16_t ssb_offset_point_a;
+    uint8_t ssb_subcarrier_offset;
+  } ho_source_phy;
 
   /* Random Access */
   /// CRNTI

--- a/openair2/LAYER2/NR_MAC_UE/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_UE/mac_proto.h
@@ -67,7 +67,7 @@ void nr_rrc_mac_config_req_mib(module_id_t module_id, int cc_idP, NR_MIB_t *mibP
 void nr_rrc_mac_sched_sib(module_id_t module_id, int sched_sib);
 void nr_rrc_mac_config_req_sib1(module_id_t module_id, int cc_idP, NR_SIB1_t *sib1, bool can_start_ra);
 void nr_rrc_mac_config_req_paging_ue_id(module_id_t module_id, uint64_t fiveG_S_TMSI);
-void nr_rrc_mac_start_ra(module_id_t module_id, nr_mac_ra_start_cause_t cause);
+void nr_rrc_mac_start_ra(module_id_t module_id, nr_mac_ra_start_cause_t cause, bool revert_to_ho_source);
 
 struct position; /* forward declaration */
 void nr_rrc_mac_config_other_sib(module_id_t module_id, NR_SIB19_r17_t *sib19_r17, int hfn, int frame, bool can_start_ra);

--- a/openair2/RRC/NR_UE/L2_interface_ue.c
+++ b/openair2/RRC/NR_UE/L2_interface_ue.c
@@ -145,7 +145,7 @@ void process_msg_rcc_to_mac(nr_mac_rrc_message_t *msg, int instance_id)
                                   msg->payload.config_other_sib.can_start_ra);
     } break;
     case NR_MAC_RRC_START_RA:
-      nr_rrc_mac_start_ra(instance_id, msg->payload.start_ra.cause);
+      nr_rrc_mac_start_ra(instance_id, msg->payload.start_ra.cause, msg->payload.start_ra.revert_to_ho_source);
       break;
     case NR_MAC_RRC_SCHED_SIB:
       nr_rrc_mac_sched_sib(instance_id, msg->payload.sched_sib.get_sib);

--- a/openair2/RRC/NR_UE/rrc_UE.c
+++ b/openair2/RRC/NR_UE/rrc_UE.c
@@ -137,6 +137,13 @@ static void nr_rrc_trigger_mac_ra(NR_UE_RRC_INST_t *rrc, nr_mac_ra_start_cause_t
   nr_mac_rrc_message_t rrc_msg = {0};
   rrc_msg.payload_type = NR_MAC_RRC_START_RA;
   rrc_msg.payload.start_ra.cause = cause;
+  if (cause == NR_MAC_RA_START_REESTABLISHMENT && rrc->ho_source.valid) {
+    // This re-establishment was triggered by T304 expiry (handle_t304_expiry() already reverted
+    // rrc->phyCellID/rnti/etc. from the snapshot below): tell MAC to revert its own common/BWP0/PHY
+    // config back to the source PCell too, TS 38.331 5.3.5.8.3.
+    rrc_msg.payload.start_ra.revert_to_ho_source = true;
+    rrc->ho_source.valid = false; // snapshot consumed
+  }
   nr_rrc_send_msg_to_mac(rrc, &rrc_msg);
 }
 
@@ -958,6 +965,20 @@ static void nr_rrc_process_reconfigurationWithSync(NR_UE_RRC_INST_t *rrc,
     return;
   }
 
+  // Snapshot the source PCell's identity/security state before it gets overwritten below by the
+  // target's, so that it can be restored if T304 expires (TS 38.331 5.3.5.8.3 "revert back to the
+  // UE configuration used in the source PCell"). Only meaningful when AS security is active: this
+  // is what nr_rrc_process_reconfigurationWithSync() and 5.3.7 re-establishment require anyway.
+  if (rrc->as_security_activated) {
+    rrc->ho_source.valid = true;
+    rrc->ho_source.phyCellID = rrc->phyCellID;
+    rrc->ho_source.rnti = rrc->rnti;
+    rrc->ho_source.arfcn_ssb = rrc->arfcn_ssb;
+    memcpy(rrc->ho_source.kgnb, rrc->kgnb, sizeof(rrc->ho_source.kgnb));
+    memcpy(rrc->ho_source.nh, rrc->nh, sizeof(rrc->ho_source.nh));
+    rrc->ho_source.nhcc = rrc->nhcc;
+  }
+
   // Clear neighbor cell lists from measurement objects during handover
   rrcPerNB_t *rrcNB = &rrc->perNB[gNB_index];
   for (int i = 0; i < MAX_MEAS_OBJ; i++) {
@@ -1027,7 +1048,7 @@ static bool nr_rrc_cellgroup_configuration(NR_UE_RRC_INST_t *rrc, NR_CellGroupCo
   if (!check_cellgroup_config(cgConfig)) {
     // if we received a configuration not supported or with some wrong combination
     // we call the function for RLF (re-establishment if security is activated, going to IDLE otherwise)
-    handle_rlf_detection(rrc);
+    handle_rlf_detection(rrc, NR_ReestablishmentCause_otherFailure);
     return false;
   }
   NR_SpCellConfig_t *spCellConfig = cgConfig->spCellConfig;
@@ -1100,7 +1121,7 @@ static bool nr_rrc_ue_process_masterCellGroup(NR_UE_RRC_INST_t *rrc,
     LOG_E(NR_RRC, "CellGroupConfig decode error\n");
     // if the ASN1 decoding fails for the received CellGroup configuration
     // we call the function for RLF (re-establishment if security is activated, going to IDLE otherwise)
-    handle_rlf_detection(rrc);
+    handle_rlf_detection(rrc, NR_ReestablishmentCause_otherFailure);
     return false;
   }
   if (LOG_DEBUGFLAG(DEBUG_ASN1)) {
@@ -1711,7 +1732,7 @@ static void nr_rrc_ue_process_rrcReconfiguration(NR_UE_RRC_INST_t *rrc, int gNB_
           SEQUENCE_free(&asn_DEF_NR_CellGroupConfig, (void *)cellGroupConfig, 1);
           // if the ASN1 decoding fails for the received CellGroup configuration
           // we call the function for RLF (re-establishment if security is activated, going to IDLE otherwise)
-          handle_rlf_detection(rrc);
+          handle_rlf_detection(rrc, NR_ReestablishmentCause_otherFailure);
         } else {
           if (LOG_DEBUGFLAG(DEBUG_ASN1))
             xer_fprint(stdout, &asn_DEF_NR_CellGroupConfig, (const void *) cellGroupConfig);
@@ -3253,7 +3274,7 @@ static void nr_rrc_handle_ra_indication(NR_UE_RRC_INST_t *rrc, bool ra_succeeded
         && !nr_timer_is_active(&timers->T304)
         && !nr_timer_is_active(&timers->T311)
         && !nr_timer_is_active(&timers->T319))
-      handle_rlf_detection(rrc);
+      handle_rlf_detection(rrc, NR_ReestablishmentCause_otherFailure);
   }
 }
 
@@ -3359,7 +3380,7 @@ void *rrc_nrue(void *notUsed)
 
   case NR_RRC_MAC_VERIFY:
     LOG_W(NR_RRC, "L2 verification of RRC consistency failed\n");
-    handle_rlf_detection(rrc);
+    handle_rlf_detection(rrc, NR_ReestablishmentCause_otherFailure);
     break;
 
   case NR_RRC_MAC_INAC_IND:
@@ -3374,7 +3395,7 @@ void *rrc_nrue(void *notUsed)
           "[UE %ld ID %d] Received indication that RLC reached max retransmissions\n",
           instance,
           NR_RRC_RLC_MAXRTX(msg_p).ue_id);
-    handle_rlf_detection(rrc);
+    handle_rlf_detection(rrc, NR_ReestablishmentCause_otherFailure);
     break;
 
   case NR_RRC_MAC_MSG3_IND:
@@ -3634,9 +3655,10 @@ void handle_RRCRelease(NR_UE_RRC_INST_t *rrc)
   asn1cFreeStruc(asn_DEF_NR_RRCRelease, rrc->RRCRelease);
 }
 
-void handle_rlf_detection(NR_UE_RRC_INST_t *rrc)
+void handle_rlf_detection(NR_UE_RRC_INST_t *rrc, NR_ReestablishmentCause_t reestab_cause)
 {
-  // 5.3.10.3 in 38.331
+  // 5.3.7.1: a UE in RRC_CONNECTED, for which AS security has been activated with SRB2 and at
+  // least one DRB setup, may initiate re-establishment; otherwise it goes directly to RRC_IDLE.
   bool srb2 = rrc->Srb[2] != RB_NOT_PRESENT;
   bool any_drb = false;
   for (int i = 0; i < MAX_DRBS_PER_UE; i++) {
@@ -3647,11 +3669,31 @@ void handle_rlf_detection(NR_UE_RRC_INST_t *rrc)
   }
 
   if (rrc->as_security_activated && srb2 && any_drb) // initiate the connection re-establishment procedure
-    nr_rrc_initiate_rrcReestablishment(rrc, NR_ReestablishmentCause_otherFailure);
+    nr_rrc_initiate_rrcReestablishment(rrc, reestab_cause);
   else {
     NR_Release_Cause_t cause = rrc->as_security_activated ? RRC_CONNECTION_FAILURE : OTHER;
     nr_rrc_going_to_IDLE(rrc, cause, NULL);
   }
+}
+
+/** @brief T304 (MCG) expiry: TS 38.331 5.3.5.8.3 "T304 expiry (Reconfiguration with sync Failure)".
+ * DAPS is not supported in this implementation, so only the non-DAPS branch applies: revert back to
+ * the source PCell's identity/security context (RRC-level; MAC reverts its own common/BWP0/PHY
+ * config symmetrically, see nr_rrc_trigger_mac_ra()) and initiate re-establishment (5.3.7). Releasing
+ * dedicated CFRA preambles/msgA PUSCH resources happens at MAC as part of that re-establishment
+ * trigger. VarRLF-Report is not implemented anywhere in this codebase (same as for every other RLF
+ * trigger), so it's skipped here too. */
+void handle_t304_expiry(NR_UE_RRC_INST_t *rrc)
+{
+  if (rrc->ho_source.valid) {
+    rrc->phyCellID = rrc->ho_source.phyCellID;
+    rrc->rnti = rrc->ho_source.rnti;
+    rrc->arfcn_ssb = rrc->ho_source.arfcn_ssb;
+    memcpy(rrc->kgnb, rrc->ho_source.kgnb, sizeof(rrc->kgnb));
+    memcpy(rrc->nh, rrc->ho_source.nh, sizeof(rrc->nh));
+    rrc->nhcc = rrc->ho_source.nhcc;
+  }
+  handle_rlf_detection(rrc, NR_ReestablishmentCause_handoverFailure);
 }
 
 void nr_rrc_going_to_IDLE(NR_UE_RRC_INST_t *rrc,
@@ -3726,6 +3768,8 @@ void nr_rrc_going_to_IDLE(NR_UE_RRC_INST_t *rrc,
   memset(rrc->kgnb, 0, sizeof(rrc->kgnb));
   rrc->integrityProtAlgorithm = 0;
   rrc->cipheringAlgorithm = 0;
+  // discard any pending source-PCell snapshot: it's only valid within the connection that took it
+  rrc->ho_source.valid = false;
 
   // release all radio resources, including release of the RLC entity,
   // the MAC configuration and the associated PDCP entity

--- a/openair2/RRC/NR_UE/rrc_defs.h
+++ b/openair2/RRC/NR_UE/rrc_defs.h
@@ -241,6 +241,19 @@ typedef struct NR_UE_RRC_INST_s {
   uint8_t nh[32];
   uint64_t nhcc;
 
+  /// Snapshot of the source PCell's identity/security state, taken right before a received
+  /// reconfigurationWithSync (handover command) starts mutating it. Used to revert back to the
+  /// source PCell upon T304 expiry, as mandated by TS 38.331 5.3.5.8.3.
+  struct {
+    bool valid;
+    uint32_t phyCellID;
+    rnti_t rnti;
+    long arfcn_ssb;
+    uint8_t kgnb[32];
+    uint8_t nh[32];
+    uint64_t nhcc;
+  } ho_source;
+
   bool detach_after_release;
   NR_timer_t release_timer;
   NR_RRCRelease_t *RRCRelease;

--- a/openair2/RRC/NR_UE/rrc_proto.h
+++ b/openair2/RRC/NR_UE/rrc_proto.h
@@ -38,7 +38,8 @@ void *rrc_nrue_task(void *args_p);
 void *rrc_nrue(void *args_p);
 
 void nr_rrc_handle_timers(NR_UE_RRC_INST_t *rrc);
-void handle_rlf_detection(NR_UE_RRC_INST_t *rrc);
+void handle_rlf_detection(NR_UE_RRC_INST_t *rrc, NR_ReestablishmentCause_t reestab_cause);
+void handle_t304_expiry(NR_UE_RRC_INST_t *rrc);
 void handle_302_expired_stopped(NR_UE_RRC_INST_t *rrc);
 
 int get_from_lte_ue_fd();

--- a/openair2/RRC/NR_UE/rrc_timers_and_constants.c
+++ b/openair2/RRC/NR_UE/rrc_timers_and_constants.c
@@ -195,12 +195,8 @@ void nr_rrc_handle_timers(NR_UE_RRC_INST_t *rrc)
 
   bool t304_expired = nr_timer_tick(&timers->T304);
   if(t304_expired) {
-    LOG_W(NR_RRC, "[UE %ld] Timer T304 expired\n", rrc->ue_id);
-    // TODO
-    // For T304 of MCG, in case of the handover from NR or intra-NR
-    // handover, initiate the RRC re-establishment procedure;
-    // In case of handover to NR, perform the actions defined in the
-    // specifications applicable for the source RAT.
+    LOG_W(NR_RRC, "[UE %ld] Timer T304 expired! Reconfiguration with sync (handover) failed\n", rrc->ue_id);
+    handle_t304_expiry(rrc);
   }
 
   bool t310_expired = nr_timer_tick(&timers->T310);
@@ -208,7 +204,7 @@ void nr_rrc_handle_timers(NR_UE_RRC_INST_t *rrc)
     LOG_W(NR_RRC, "[UE %ld] Timer T310 expired\n", rrc->ue_id);
     // handle detection of radio link failure
     // as described in 5.3.10.3 of 38.331
-    handle_rlf_detection(rrc);
+    handle_rlf_detection(rrc, NR_ReestablishmentCause_otherFailure);
   }
 
   bool t311_expired = nr_timer_tick(&timers->T311);


### PR DESCRIPTION
## Problem

T304 (reconfiguration-with-sync / handover) expiry was a dead stub: the timer ticked correctly and was started/stopped correctly, but on expiry nothing happened beyond a log line — no re-establishment, no fallback.
A UE whose handover RA never completed to the target cell just hung indefinitely, retrying RA against a target it could no longer reach.

## Fix

Implements TS 38.331 §5.3.5.8.3 (MCG, non-DAPS branch — DAPS isn't supported elsewhere in this codebase, so that's the only applicable branch): on T304 expiry, revert to the source PCell's identity/security/PHY config and initiate re-establishment (§5.3.7), instead of leaving the UE stuck on the failed target.

This touches three layers, since the target's config gets applied destructively (no "undo" state) at three different places on
`reconfigurationWithSync` reception:

- **RRC**: `handle_t304_expiry()` reverts `phyCellID`/`rnti`/`arfcn_ssb`/`kgnb`/`nh`/`nhcc` from a snapshot taken right before
  `reconfigurationWithSync` overwrites them, then calls  `handle_rlf_detection()` (now parameterized with `NR_ReestablishmentCause_t`, so this path correctly signals `handoverFailure` instead of the generic `otherFailure` every other RLF trigger uses). This matters concretely: §5.3.7.4 requires the `RRCReestablishmentRequest`'s `c-RNTI`/`physCellId`/`shortMAC-I` to be computed from the *source* PCell's context, not whatever's currently cached (which is the target's).
- **MAC**: mirrors the revert for common/BWP0/PHY config, which otherwise leaves PHY resyncing to the same unreachable target cell/frequency in a loop. Two-tier snapshot: a full `ServingCellConfigCommon` clone when a prior dedicated one exists (covers TDD config, BWP0, SSB list, RACH common config), plus an always-available scalar fallback (PCI, DL/UL
  frequency, SSB location) for the common case of a UE's *first* handover, where the source config came from SIB1-based camping rather than a prior `reconfigurationWithSync` — a gap only found by testing in rfsim and tracing the PHY resync log chain back to its trigger.
- **Bonus fix**: dedicated CFRA/msgA-PUSCH RACH resources (`rach_ConfigDedicated`) were never freed on re-establishment (any cause, not just T304) — fixed alongside, since it's the same code path.

Scoped deliberately out: DAPS handling (unsupported), and `VarRLF-Report` (not implemented anywhere in this codebase for any RLF trigger, so skipping it here isn't a new gap).

## Testing

Verified in rfsim: forced a handover failure (T304 expiry) and confirmed the UE now falls back to searching for the source PCell/frequency instead of looping RA attempts against the unreachable target.

## Known follow-up (not in this PR)

When only the scalar fallback is available (UE's first handover), TDD/BWP0/RACH-common config stay target-derived after the revert — only PCI/frequency/SSB location are restored. If source and target differ there, RA could still fail for a different reason post-resync. ("ensure valid and up to date system information") suggests forcing a fresh SIB1 reacquisition after this resync as the proper fix, rather than snapshotting more state.