### PR TITLE
Initial implementation of NR UE split 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1876,6 +1876,7 @@ add_executable(nr-uesoftmodem
   ${OPENAIR_DIR}/executables/position_interface.c
   ${OPENAIR_DIR}/executables/nr-ue.c
   ${OPENAIR_DIR}/executables/nr-ue-ru.c
+  ${OPENAIR_DIR}/executables/nr-fd-ue.c
   ${OPENAIR1_DIR}/PHY/TOOLS/phy_scope_interface.c
   ${NFAPI_USER_DIR}/nfapi.c
   ${PHY_INTERFACE_DIR}/queue_t.c
@@ -1885,7 +1886,7 @@ target_link_libraries(nr-uesoftmodem PRIVATE
   -Wl,--start-group
   nr_rrc SECURITY UTIL SCHED_NR_UE_LIB
   PHY_NR_COMMON PHY_NR_UE NR_L2_UE MAC_NR_COMMON nfapi_nr_lib
-  ITTI SIMU radio_common
+  ITTI SIMU radio_common ue_split7
   time_management softmodem_common
   -Wl,--end-group dl)
 

--- a/ci-scripts/conf_files/gnb.sa.band78.106prb.vrtsim.1x1.yaml
+++ b/ci-scripts/conf_files/gnb.sa.band78.106prb.vrtsim.1x1.yaml
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+Active_gNBs:
+ - gnb-rfsim
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity: none
+gNBs:
+    ##### Identification parameters:
+  - gNB_ID: 0xe00
+    gNB_name: gnb-rfsim
+    tracking_area_code: 1
+    plmn_list:
+      - mcc: 208
+        mnc: 99
+        mnc_length: 2
+        snssaiList:
+          - sst: 1
+            sd: 0xffffff
+    nr_cellid: 12345678
+    ##### Physical parameters:
+    min_rxtxtime: 6
+    pusch_AntennaPorts: 1
+    pdsch_AntennaPorts_XP: 1
+
+    servingCellConfigCommon:
+      #spCellConfigCommon
+      - physCellId: 0
+      #  downlinkConfigCommon
+      #frequencyInfoDL
+      # this is 3300.60 MHz + 53*12*30e-3 MHz = 3319.68
+        absoluteFrequencySSB: 621312
+        # this is 3300.60 MHz
+        dl_absoluteFrequencyPointA: 620040
+        #scs-SpecificCarrierList
+        dl_offstToCarrier: 0
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing: 1
+        dl_carrierBandwidth: 106
+        #initialDownlinkBWP
+        #genericParameters
+        # this is RBstart=0,L=106 (275*(L-1))+RBstart
+        initialDLBWPlocationAndBandwidth: 28875
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing: 1
+        #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero: 11
+        initialDLBWPsearchSpaceZero: 0
+        #uplinkConfigCommon
+        #frequencyInfoUL
+        ul_frequencyBand: 78
+        #scs-SpecificCarrierList
+        ul_offstToCarrier: 0
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        ul_subcarrierSpacing: 1
+        ul_carrierBandwidth: 106
+        pMax: 20
+        #initialUplinkBWP
+        #genericParameters
+        initialULBWPlocationAndBandwidth: 28875
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing: 1
+        #rach-ConfigCommon
+        #rach-ConfigGeneric
+        prach_ConfigurationIndex: 98
+        #prach_msg1_FDM
+        #0 = one, 1=two, 2=four, 3=eight
+        prach_msg1_FDM: 0
+        prach_msg1_FrequencyStart: 0
+        zeroCorrelationZoneConfig: 12
+        preambleReceivedTargetPower: -104
+        #preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+        preambleTransMax: 6
+        #powerRampingStep
+        # 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep: 1
+        #ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+        #1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR: 4
+        #one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB: 15
+        #ra_ContentionResolutionTimer
+        #(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer: 7
+        rsrp_ThresholdSSB: 19
+        #prach-RootSequenceIndex_PR
+        #1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR: 2
+        prach_RootSequenceIndex: 1
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        msg1_SubcarrierSpacing: 1
+        # restrictedSetConfig
+        # 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig: 0
+        msg3_DeltaPreamble: 1
+        p0_NominalWithGrant: -90
+
+        # pucch-ConfigCommon setup :
+        # pucchGroupHopping
+        # 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping: 0
+        hoppingId: 40
+        p0_nominal: -90
+        ssb_PositionsInBurst_Bitmap: 1
+        # ssb_periodicityServingCell
+        # 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+        ssb_periodicityServingCell: 2
+
+        # dmrs_TypeA_position
+        # 0 = pos2, 1 = pos3
+        dmrs_TypeA_Position: 0
+
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        subcarrierSpacing: 1
+
+        #tdd-UL-DL-ConfigurationCommon
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        referenceSubcarrierSpacing: 1
+
+        # pattern1
+        # dl_UL_TransmissionPeriodicity
+        # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+        dl_UL_TransmissionPeriodicity: 6
+        nrofDownlinkSlots: 7
+        nrofDownlinkSymbols: 6
+        nrofUplinkSlots: 2
+        nrofUplinkSymbols: 4
+        ssPBCH_BlockPower: -25
+    SCTP:
+      SCTP_INSTREAMS: 2
+      SCTP_OUTSTREAMS: 2
+
+    ##### AMF parameters:
+    amf_ip_address:
+      - ipv4: 192.168.71.132
+
+    NETWORK_INTERFACES:
+      GNB_IPV4_ADDRESS_FOR_NG_AMF: 192.168.71.140
+      GNB_IPV4_ADDRESS_FOR_NGU: 192.168.71.140
+      GNB_PORT_FOR_S1U: 2152 # Spec 2152
+
+
+MACRLCs:
+  - tr_s_preference: local_L1
+    tr_n_preference: local_RRC
+    pusch_TargetSNRx10: 200
+    pucch_TargetSNRx10: 200
+
+L1s:
+  - tr_n_preference:  local_mac
+    prach_dtx_threshold: 200
+    # pucch0_dtx_threshold = 150;
+
+RUs:
+  - local_rf: yes
+    nb_tx: 1
+    nb_rx: 1
+    att_tx: 0
+    att_rx: 0
+    bands: [78]
+    max_pdschReferenceSignalPower: -27
+    max_rxgain: 75
+    eNB_instances: [0]
+    sf_extension: 0
+
+security:
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms: [nea0]
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms: [nia2, nia0]
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering: yes
+  drb_integrity: no
+
+log_config:
+  global_log_level: info
+  hw_log_level: info
+  phy_log_level: info
+  mac_log_level: info
+  rlc_log_level: info
+  pdcp_log_level: info
+  rrc_log_level: info
+  ngap_log_level: debug
+  f1ap_log_level: debug
+
+
+channelmod:
+  max_chan: 10
+  modellist: DefaultChannelList
+  DefaultChannelList:
+   - model_name: server_tx_channel_model
+     type: AWGN
+     ploss_dB: 0
+     noise_power_dB: -100
+     forgetfact: 0
+     offset: 0
+     ds_tdl: 0
+vrtsim:
+  role: server
+  # Channel mode: exactly one of the three modes below should be active.
+  #
+  # No channel - plain passthrough, no impairments:
+  # cirdb: 0
+  # chanmod: 0
+  #
+  # Built-in channel model defined in the channelmod: section above:
+  # chanmod: 1
+  # cirdb: 0
+  #
+  # External taps emitter publishing over a nanomsg socket.
+  # Requires a running emit_from_db.py and build with -DOAI_VRTSIM_TAPS_CLIENT=ON:
+  # cirdb: 0
+  # chanmod: 0
+  # taps-socket: "tcp://127.0.0.1:5555"
+  #
+  # In-process CIR database: reads precomputed 3GPP TDL taps directly from
+  # cir_db.bin. No external emitter required. Generate the database offline
+  # with cir_generator.py. Use cirdb-path to point to the directory containing
+  # cir_db.bin and cir_db.yaml.
+  cirdb_file: /cirdb/cir_db.bin
+  cirdb_yaml: /cirdb/cir_db.yaml
+  #
+  # Per-UE channel configuration for multi-UE operation
+  ue_config:
+    - antennas: "1x1"   # NxM where N=UE-TX, M=gNB-TX; M must equal RU nb_tx
+      model_id: 0       # 0=TDL-A 1=TDL-B 2=TDL-C 3=TDL-D 4=TDL-E
+      ds_ns: 1.0        # RMS delay spread in ns
+      speed_mps: 1.5    # UE speed in m/s
+      # aoa_deg: 0.0    # angle of arrival in degrees; TDL-D/E only

--- a/ci-scripts/xml_files/container_5g_vrtsim_split7.xml
+++ b/ci-scripts/xml_files/container_5g_vrtsim_split7.xml
@@ -1,0 +1,109 @@
+<!-- SPDX-License-Identifier: LicenseRef-CSSL-1.0 -->
+
+<testCaseList>
+  <htmlTabRef>vrtsim-5gnr-split7</htmlTabRef>
+  <htmlTabName>Split 7.1 FD-UE gNB vrtsim</htmlTabName>
+  <htmlTabIcon>wrench</htmlTabIcon>
+
+  <testCase>
+    <class>Pull_Local_Registry</class>
+    <desc>Pull Images from Local Registry</desc>
+    <node>localhost</node>
+    <images>oai-gnb oai-nr-ue</images>
+  </testCase>
+
+  <testCase>
+    <class>Create_Workspace</class>
+    <desc>Create new Workspace</desc>
+    <node>localhost</node>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G CoreNetwork</desc>
+    <node>localhost</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_split7</yaml_path>
+    <services>mysql oai-amf oai-smf oai-upf oai-ext-dn</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G gNB + split7 FD-UE over vrtsim SA</desc>
+    <node>localhost</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_split7</yaml_path>
+    <services>oai-gnb oai-nr-ue</services>
+  </testCase>
+
+  <testCase>
+    <class>Attach_UE</class>
+    <desc>Attach OAI split7 UE (Wait for IP)</desc>
+    <id>rfsim5g_ue</id>
+    <node>localhost</node>
+  </testCase>
+
+  <testCase>
+    <class>Ping</class>
+    <desc>Ping ext-dn from NR-UE</desc>
+    <id>rfsim5g_ue</id>
+    <node>localhost</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>localhost</svr_node>
+    <ping_args>-c 20 -i 0.25</ping_args>
+    <ping_packetloss_threshold>5</ping_packetloss_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Ping</class>
+    <desc>Ping NR-UE from ext-dn</desc>
+    <id>rfsim5g_ext_dn</id>
+    <node>localhost</node>
+    <svr_id>rfsim5g_ue</svr_id>
+    <svr_node>localhost</svr_node>
+    <ping_args>-c 20 -i 0.25</ping_args>
+    <ping_packetloss_threshold>5</ping_packetloss_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>Iperf (DL/3Mbps/UDP)(20 sec)</desc>
+    <iperf_args>-u -b 3M -t 20 -R</iperf_args>
+    <id>rfsim5g_ue</id>
+    <node>localhost</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>localhost</svr_node>
+    <iperf_packetloss_threshold>5</iperf_packetloss_threshold>
+    <iperf_bitrate_threshold>90</iperf_bitrate_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>Iperf (UL/1Mbps/UDP)(20 sec)</desc>
+    <iperf_args>-u -b 1M -t 20</iperf_args>
+    <id>rfsim5g_ue</id>
+    <node>localhost</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>localhost</svr_node>
+    <iperf_packetloss_threshold>5</iperf_packetloss_threshold>
+    <iperf_bitrate_threshold>90</iperf_bitrate_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Undeploy_Object</class>
+    <always_exec>true</always_exec>
+    <desc>Undeploy all OAI 5G stack</desc>
+    <node>localhost</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_split7</yaml_path>
+    <analysis>
+      <services>oai-gnb=RetxCheck=1,0,0,0 oai-gnb=EndsWithBye oai-nr-ue</services>
+    </analysis>
+  </testCase>
+
+  <testCase>
+    <class>Clean_Test_Server_Images</class>
+    <always_exec>true</always_exec>
+    <desc>Clean Test Images on Test Server</desc>
+    <node>localhost</node>
+    <images>oai-gnb oai-nr-ue</images>
+  </testCase>
+
+</testCaseList>

--- a/ci-scripts/yaml_files/5g_vrtsim_split7/docker-compose.yaml
+++ b/ci-scripts/yaml_files/5g_vrtsim_split7/docker-compose.yaml
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: MIT
+
+services:
+    mysql:
+        container_name: "rfsim5g-mysql"
+        image: mysql:9.6
+        init: true
+        volumes:
+            - ../5g_rfsimulator/oai_db.sql:/docker-entrypoint-initdb.d/oai_db.sql
+            - ../5g_rfsimulator/mysql-healthcheck.sh:/tmp/mysql-healthcheck.sh
+        environment:
+            - TZ=Europe/Paris
+            - MYSQL_DATABASE=oai_db
+            - MYSQL_USER=test
+            - MYSQL_PASSWORD=test
+            - MYSQL_ROOT_PASSWORD=linux
+        healthcheck:
+            test: /bin/bash -c "/tmp/mysql-healthcheck.sh"
+            interval: 10s
+            timeout: 5s
+            start_period: 10s
+            start_interval: 500ms
+            retries: 30
+        networks:
+            public_net:
+                ipv4_address: 192.168.71.131
+    oai-amf:
+        container_name: "rfsim5g-oai-amf"
+        image: oaisoftwarealliance/oai-amf:v2.2.1
+        environment:
+            - TZ=Europe/paris
+        volumes:
+            - ../5g_rfsimulator/mini_nonrf_config.yaml:/openair-amf/etc/config.yaml
+        depends_on:
+            - mysql
+        networks:
+            public_net:
+                ipv4_address: 192.168.71.132
+    oai-smf:
+        container_name: "rfsim5g-oai-smf"
+        image: oaisoftwarealliance/oai-smf:v2.2.1
+        environment:
+            - TZ=Europe/Paris
+        volumes:
+            - ../5g_rfsimulator/mini_nonrf_config.yaml:/openair-smf/etc/config.yaml
+        depends_on:
+            - oai-amf
+        networks:
+            public_net:
+                ipv4_address: 192.168.71.133
+    oai-upf:
+        container_name: "rfsim5g-oai-upf"
+        image: oaisoftwarealliance/oai-upf:v2.2.1
+        init: true
+        environment:
+            - TZ=Europe/Paris
+        volumes:
+            - ../5g_rfsimulator/mini_nonrf_config.yaml:/openair-upf/etc/config.yaml
+        depends_on:
+            - oai-smf
+        cap_add:
+            - NET_ADMIN
+            - SYS_ADMIN
+        cap_drop:
+            - ALL
+        privileged: true
+        networks:
+            public_net:
+                ipv4_address: 192.168.71.134
+                interface_name: eth0
+            traffic_net:
+                ipv4_address: 192.168.72.134
+                interface_name: eth1
+    oai-ext-dn:
+        privileged: true
+        container_name: rfsim5g-oai-ext-dn
+        image: oaisoftwarealliance/trf-gen-cn5g:latest
+        init: true
+        entrypoint: /bin/bash -c \
+              "iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE;"\
+              "ip route add 12.1.1.0/24 via 192.168.72.134 dev eth0; sleep infinity"
+        depends_on:
+            - oai-upf
+        networks:
+            traffic_net:
+                ipv4_address: 192.168.72.135
+        healthcheck:
+            test: /bin/bash -c "ping -c 2 192.168.72.134"
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 10s
+            start_interval: 500ms
+    oai-gnb:
+        image: ${REGISTRY-oaisoftwarealliance/}${GNB_IMG:-oai-gnb}:${TAG:-develop}
+        container_name: rfsim5g-oai-gnb
+        cap_drop:
+            - ALL
+        cap_add:
+            - IPC_LOCK  # softmodem mlockall()s its memory; without this it silently
+        ulimits:        # fails and the resulting timing jitter corrupts vrtsim sync
+            memlock: -1
+        environment:
+            USE_ADDITIONAL_OPTIONS: -E --log_config.global_log_options level,nocolor,time --device.name vrtsim --vrtsim.role server
+        depends_on:
+            - oai-ext-dn
+        networks:
+            public_net:
+                ipv4_address: 192.168.71.140
+        volumes:
+            - ../../conf_files/gnb.sa.band78.106prb.vrtsim.1x1.yaml:/opt/oai-gnb/etc/gnb.yaml
+            - tmp_data:/tmp/
+        healthcheck:
+            test: /bin/bash -c "pgrep nr-softmodem"
+            interval: 10s
+            timeout: 5s
+            start_period: 10s
+            start_interval: 500ms
+            retries: 5
+        ipc: host
+    oai-nr-ue:
+        image: ${REGISTRY-oaisoftwarealliance/}${NRUE_IMG:-oai-nr-ue}:${TAG:-develop}
+        container_name: rfsim5g-oai-nr-ue
+        cap_drop:
+            - ALL
+        cap_add:
+            - NET_ADMIN  # for interface bringup
+            - NET_RAW    # for ping
+            - IPC_LOCK   # softmodem mlockall()s its memory; without this it silently
+        ulimits:         # fails and the resulting timing jitter corrupts vrtsim sync
+            memlock: -1
+        environment:
+            USE_ADDITIONAL_OPTIONS: -E -r 106 --numerology 1 --band 78 -C 3319680000 --ssb 516 --uicc0.imsi 208990100001100 --log_config.global_log_options level,nocolor,time --device.name vrtsim --vrtsim.role client --ue-split7
+        depends_on:
+            - oai-gnb
+        networks:
+            public_net:
+                ipv4_address: 192.168.71.150
+        devices:
+             - /dev/net/tun:/dev/net/tun
+        volumes:
+            - ../../conf_files/nrue.vrtsim.chanmod.yaml:/opt/oai-nr-ue/etc/nr-ue.yaml
+            - tmp_data:/tmp/
+        healthcheck:
+            test: /bin/bash -c "pgrep nr-uesoftmodem"
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 10s
+            start_interval: 500ms
+        ipc: host
+
+networks:
+    public_net:
+        driver: bridge
+        name: rfsim5g-oai-public-net
+        ipam:
+            config:
+                - subnet: 192.168.71.128/26
+        driver_opts:
+            com.docker.network.bridge.name: "rfsim5g-public"
+    traffic_net:
+        driver: bridge
+        name: rfsim5g-oai-traffic-net
+        ipam:
+            config:
+                - subnet: 192.168.72.128/26
+        driver_opts:
+            com.docker.network.bridge.name: "rfsim5g-traffic"
+
+volumes:
+    tmp_data:

--- a/common/utils/threadPool/thread-pool.h
+++ b/common/utils/threadPool/thread-pool.h
@@ -4,6 +4,17 @@
 
 #ifndef THREAD_POOL_H
 #define THREAD_POOL_H
+
+/* C11 _Atomic(T) is not a keyword in C++; map it to std::atomic<T>. Guarded so
+ * this stays idempotent if another header already defines it -- with -Werror,
+ * an unconditional #define here would fail the build on macro redefinition. */
+#ifdef __cplusplus
+#include <atomic>
+#ifndef _Atomic
+#define _Atomic(T) std::atomic<T>
+#endif
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <malloc.h>

--- a/executables/nr-fd-ue.c
+++ b/executables/nr-fd-ue.c
@@ -1,0 +1,539 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+/*
+ * UE main thread for Split 7.1 (frequency-domain I/O): mirrors nr-ue.c but
+ * replaces time-domain RF I/O with ue_split7_device_t calls. Two PHY hooks
+ * bypass FFT/IFFT: fd_rxdataF_ring (nr_slot_fep() memcpys from it instead of
+ * computing the DFT) and fd_tx_cb/fd_tx_cb_data (called from
+ * phy_procedures_nrUE_TX() in place of nr_tx_rotation_and_ofdm_mod()).
+ */
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <limits.h>
+#include <math.h>
+
+#include "PHY/defs_nr_common.h"
+#include "PHY/defs_nr_UE.h"
+#include "PHY/INIT/nr_phy_init.h"
+#include "PHY/TOOLS/tools_defs.h"
+#include "PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h"
+#include "SCHED_NR_UE/defs.h"
+#include "NR_MAC_UE/mac_proto.h"
+#include "NR_UE_PHY_INTERFACE/NR_IF_Module.h"
+#include "RRC/NR_UE/rrc_proto.h"
+#include "RRC/NR_UE/L2_interface_ue.h"
+#include "executables/nr-ue-ru.h"
+#include "executables/nr-uesoftmodem.h"
+#include "executables/softmodem-common.h"
+#include "radio/COMMON/ue_split7_interface.h"
+#include "common/utils/LOG/log.h"
+#include "common/utils/threadPool/notified_fifo.h"
+#include "common/utils/time_manager/time_manager.h"
+#include "common/utils/barrier/barrier.h"
+#include "nr_phy_common.h"
+
+/* Non-static functions from nr-ue.c accessible via external linkage. */
+extern void UE_dl_processing(void *arg);
+extern int UE_dl_preprocessing(PHY_VARS_NR_UE *UE,
+                               const UE_nr_rxtx_proc_t *proc,
+                               int *tx_wait_for_dlsch,
+                               nr_phy_data_t *phy_data,
+                               bool *stats_printed);
+extern size_t dump_L1_UE_meas_stats(PHY_VARS_NR_UE *ue, char *output, size_t max_len);
+extern void *nrL1_UE_stats_thread(void *param);
+extern int nr_ue_slot_select(const fapi_nr_config_request_t *cfg, int nr_slot);
+extern int determine_N_TA_offset(PHY_VARS_NR_UE *ue);
+extern void processSlotTX(void *arg);
+extern void start_process_slot_tx(void *arg);
+
+typedef struct {
+  ue_split7_device_t *dev;
+} fd_tx_ctx_t;
+
+static void fd_prach_tx_cb_impl(PHY_VARS_NR_UE *ue,
+                                int frame,
+                                int slot,
+                                openair0_timestamp_t timestamp_tx,
+                                const c16_t *prachF,
+                                int dftlen,
+                                int Ncp,
+                                int prach_start,
+                                int copies,
+                                void *userdata)
+{
+  fd_tx_ctx_t *ctx = (fd_tx_ctx_t *)userdata;
+  ue_split7_prach_tx_params_t params;
+  memset(&params, 0, sizeof(params));
+
+  params.samples = (const ue_split7_iq_t *)prachF;
+  params.num_samples = dftlen;
+  params.fft_size = dftlen;
+  params.time_offset_samples = prach_start;
+  params.cp_len_samples = Ncp;
+  params.timestamp_samples = (uint64_t)timestamp_tx; // same clock domain as curMsg.proc.timestamp_tx
+
+  params.slot_number = slot; // slot-in-frame, per params' documented contract
+  params.symbol_number = 0;
+  params.repetition_count = copies;
+  params.antenna_port = 0;
+
+  ue_split7_status_t rc = ctx->dev->write_prach(ctx->dev, &params);
+  if (rc != UE_SPLIT7_SUCCESS)
+    LOG_E(NR_PHY, "[fd-ue] write_prach failed (%d) for frame %d slot %d\n", (int)rc, frame, slot);
+}
+
+static void fd_tx_cb_impl(PHY_VARS_NR_UE *ue,
+                          const UE_nr_rxtx_proc_t *proc,
+                          int nb_ant_tx,
+                          c16_t **txdataF,
+                          const bool *was_symbol_used,
+                          void *userdata)
+{
+  fd_tx_ctx_t *ctx = (fd_tx_ctx_t *)userdata;
+
+  // generate_nr_prach() detects ue->fd_prach_tx_cb and routes the preamble to
+  // write_prach() instead of the time-domain path; txData is unused here.
+  NR_UE_PRACH *prach_var = ue->prach_vars[proc->gNB_id];
+  if (prach_var->active) {
+    nr_ue_prach_procedures(ue, proc, NULL);
+    return;
+  }
+
+  const NR_DL_FRAME_PARMS *fp = &ue->frame_parms;
+  ue_split7_symbol_buffer_t bufs[8];
+
+  openair0_timestamp_t sym_ts = proc->timestamp_tx; // symbol 0's CP starts here
+
+  for (int sym = 0; sym < fp->symbols_per_slot; sym++) {
+    const int sym_off = sym * (int)fp->ofdm_symbol_size;
+    if (was_symbol_used[sym]) {
+      for (int a = 0; a < nb_ant_tx; a++) {
+        bufs[a].meta.symbol_number = (uint8_t)sym;
+        bufs[a].meta.slot_number = (uint16_t)proc->nr_slot_tx;
+        bufs[a].meta.timestamp_samples = sym_ts;
+        bufs[a].num_subcarriers = fp->ofdm_symbol_size;
+        bufs[a].re_buffer = (ue_split7_iq_t *)&txdataF[a][sym_off];
+      }
+      ue_split7_status_t rc = ctx->dev->write_symbol(ctx->dev, bufs, (uint16_t)nb_ant_tx);
+      if (rc != UE_SPLIT7_SUCCESS)
+        LOG_E(NR_PHY, "[fd-ue] write_symbol failed (%d) for slot %d symbol %d\n", (int)rc, proc->nr_slot_tx, sym);
+    }
+    sym_ts += (openair0_timestamp_t)get_samples_symbol_duration(fp, proc->nr_slot_tx, sym, 1);
+  }
+}
+
+// Ring index must match nr_slot_fep()'s read-back formula (slot_fep_nr.c):
+// ((frame % 2) * slots_per_frame + slot) * symbols_per_slot + symbol
+static openair0_timestamp_t fd_read_slot(ue_split7_device_t *dev,
+                                         PHY_VARS_NR_UE *UE,
+                                         const NR_DL_FRAME_PARMS *fp,
+                                         int frame,
+                                         int slot_nr)
+{
+  ue_split7_symbol_buffer_t bufs[8];
+  openair0_timestamp_t first_ts = 0;
+
+  for (int sym = 0; sym < fp->symbols_per_slot; sym++) {
+    const uint32_t ring_symbol = ((frame % 2) * fp->slots_per_frame + slot_nr) * fp->symbols_per_slot + sym;
+    for (int a = 0; a < fp->nb_antennas_rx; a++) {
+      bufs[a].meta.symbol_number = (uint8_t)sym;
+      bufs[a].meta.slot_number = (uint16_t)slot_nr;
+    }
+    // read_symbol() fills bufs[a].re_buffer with a pointer into its own buffer,
+    // valid only until the next call -- copy it into our ring right away.
+    ue_split7_status_t rc = dev->read_symbol(dev, bufs, (uint16_t)fp->nb_antennas_rx);
+    if (rc != UE_SPLIT7_SUCCESS) {
+      // bufs[].re_buffer is not valid on failure -- don't copy it out.
+      LOG_E(NR_PHY, "[fd-ue] read_symbol failed (%d) for slot %d symbol %d\n", (int)rc, slot_nr, sym);
+      continue;
+    }
+    for (int a = 0; a < fp->nb_antennas_rx; a++) {
+      memcpy(&UE->fd_rxdataF_ring[a][ring_symbol * fp->ofdm_symbol_size], bufs[a].re_buffer, fp->ofdm_symbol_size * sizeof(c16_t));
+    }
+    if (sym == 0)
+      first_ts = bufs[0].meta.timestamp_samples;
+  }
+  return first_ts;
+}
+
+typedef struct {
+  PHY_VARS_NR_UE *UE;
+  ue_split7_sync_result_t sync_result;
+  volatile bool sync_done;
+} fd_sync_ctx_t;
+
+static void fd_sync_cb(ue_split7_device_t *dev, ue_split7_status_t status, const ue_split7_sync_result_t *result, void *userdata)
+{
+  (void)dev;
+  fd_sync_ctx_t *ctx = (fd_sync_ctx_t *)userdata;
+
+  if (status == UE_SPLIT7_SUCCESS && result) {
+    ctx->sync_result = *result;
+    PHY_VARS_NR_UE *UE = ctx->UE;
+    NR_DL_FRAME_PARMS *fp = &UE->frame_parms;
+
+    UE->common_vars.freq_offset = (int)result->freq_offset_hz;
+
+    // nr_fill_rx_indication()'s FAPI_NR_RX_PDU_TYPE_SSB case reads these off
+    // ue->frame_parms directly, so they must be set before dl_indication below.
+    fp->Nid_cell = result->physical_cell_id;
+    fp->ssb_start_subcarrier = result->ssb_start_subcarrier;
+    fp->half_frame_bit = (uint8_t)result->half_frame_bit;
+    fp->ssb_index = result->best_ssb_index;
+    UE->symbol_offset = (uint16_t)result->symbol_offset;
+
+    UE->is_synchronized = 1;
+
+    LOG_A(NR_PHY,
+          "[fd-ue] Cell sync'd: PCI %u, timing_offset %lld samples, "
+          "freq_offset %d Hz, RSRP %.1f dBm\n",
+          result->physical_cell_id,
+          (long long)result->timing_offset_samples,
+          (int)result->freq_offset_hz,
+          result->ssb_rsrp_dbm);
+
+    // Pushes onto mac->input_nf, which UE_fd_thread's post-sync pullNotifiedFIFO()
+    // below waits on; without this it blocks forever after a successful decode.
+    if (result->mib_decoded) {
+      fapiPbch_t pbch_result;
+      memset(&pbch_result, 0, sizeof(pbch_result));
+      memcpy(pbch_result.decoded_output, result->mib_payload, sizeof(pbch_result.decoded_output));
+      pbch_result.xtra_byte = result->mib_additional_bits;
+
+      UE_nr_rxtx_proc_t dummy_proc = {0};
+      nr_downlink_indication_t dl_indication;
+      fapi_nr_rx_indication_t rx_ind = {0};
+      nr_fill_dl_indication(&dl_indication, NULL, &rx_ind, &dummy_proc, UE, NULL);
+      nr_fill_rx_indication(&rx_ind, FAPI_NR_RX_PDU_TYPE_SSB, UE, 0, 0, NULL, &dummy_proc, &pbch_result);
+
+      if (UE->if_inst && UE->if_inst->dl_indication)
+        UE->if_inst->dl_indication(&dl_indication);
+    }
+  } else {
+    ctx->UE->is_synchronized = 0;
+    LOG_W(NR_PHY, "[fd-ue] Sync failed (status %d)\n", (int)status);
+  }
+  ctx->sync_done = true;
+}
+
+// TX reuses nr-ue.c's processSlotTX()/start_process_slot_tx() as-is: RU_write()
+// already no-ops when writeBlockSize == 0, which the call site below sets.
+typedef struct {
+  PHY_VARS_NR_UE *UE;
+  ue_split7_device_t *dev;
+} fd_thread_args_t;
+
+void *UE_fd_thread(void *arg)
+{
+  fd_thread_args_t *init = (fd_thread_args_t *)arg;
+  PHY_VARS_NR_UE *UE = init->UE;
+  ue_split7_device_t *dev = init->dev;
+  free(init);
+
+  NR_DL_FRAME_PARMS *fp = &UE->frame_parms;
+  const int nb_slot_frame = fp->slots_per_frame;
+  const int duration_rx_to_tx = NR_UE_CAPABILITY_SLOT_RX_TO_TX;
+
+  UE->is_synchronized = 0;
+  InitSinLUT();
+
+  // Sized to 2 frames so a lagging DL actor can't be overwritten before it reads.
+  const uint32_t ring_symbols = 2 * (uint32_t)nb_slot_frame * (uint32_t)fp->symbols_per_slot;
+  c16_t *rxdataF_ring[8];
+  for (int a = 0; a < fp->nb_antennas_rx; a++) {
+    rxdataF_ring[a] = aligned_alloc(32, ring_symbols * fp->ofdm_symbol_size * sizeof(c16_t));
+    AssertFatal(rxdataF_ring[a], "[fd-ue] OOM: rxdataF_ring\n");
+  }
+  UE->fd_rxdataF_ring = rxdataF_ring;
+
+  // Heap-allocated: must stay valid for any TX actor still queued after this thread exits.
+  fd_tx_ctx_t *tx_ctx = malloc(sizeof(*tx_ctx));
+  AssertFatal(tx_ctx, "[fd-ue] OOM: tx_ctx\n");
+  tx_ctx->dev = dev;
+  UE->fd_tx_cb = fd_tx_cb_impl;
+  UE->fd_prach_tx_cb = fd_prach_tx_cb_impl;
+  UE->fd_tx_cb_data = tx_ctx;
+
+  fapi_nr_config_request_t *cfg = &UE->nrUE_config;
+  NR_UE_MAC_INST_t *mac = get_mac_inst(UE->Mod_id);
+
+  for (int i = 0; i < NUM_PROCESS_SLOT_TX_BARRIERS; i++)
+    dynamic_barrier_init(&UE->process_slot_tx_barriers[i]);
+
+  enum stream_status_e stream_status = STREAM_STATUS_UNSYNC;
+  int absolute_slot = 0;
+  int decoded_frame_rx = MAX_FRAME_NUMBER - 1;
+  int frame_rx_prev = -1; // reset alongside decoded_frame_rx on every (re-)sync
+  int64_t hfn_rx_wraps = 0;
+  int tx_wait_for_dlsch[NR_MAX_SLOTS_PER_FRAME];
+  memset(tx_wait_for_dlsch, 0, sizeof(tx_wait_for_dlsch));
+  bool stats_printed = false;
+
+  uint32_t last_ta_samples = UINT32_MAX; // impossible value so the first push always fires
+
+  fd_sync_ctx_t sync_ctx = {.UE = UE, .sync_done = false};
+
+  // Per-frame RX/TX drift correction, applied via dev->adjust_rx_timing() instead
+  // of nr-ue.c's readBlockSize/writeBlockSize; without it PBCH/PDCCH decode
+  // intermittently fails as timing slowly drifts off the true channel timing.
+  int shiftForNextFrame = 0;
+  UE->max_pos_acc = get_nrUE_params()->time_sync_I
+                        ? get_nrUE_params()->ntn_init_time_drift * 1e-6 * fp->samples_per_frame / get_nrUE_params()->time_sync_I
+                        : 0;
+
+  while (!oai_exit) {
+    // Synchronization phase
+    if (!UE->is_synchronized) {
+      sync_ctx.sync_done = false;
+
+      ue_split7_sync_config_t sync_cfg;
+      memset(&sync_cfg, 0, sizeof(sync_cfg));
+      sync_cfg.arfcn = (uint32_t)fp->ssb_start_subcarrier; // proxy for ARFCN
+      sync_cfg.scs_khz = (uint16_t)(fp->subcarrier_spacing / 1000);
+      sync_cfg.timeout_ms = (uint32_t)get_nrUE_params()->split7_sync_timeout_ms;
+      sync_cfg.expected_pci = UE->target_Nid_cell;
+
+      ue_split7_status_t rc = dev->start_sync(dev, &sync_cfg, &get_nrUE_params()->Tpool, fd_sync_cb, &sync_ctx);
+      if (rc != UE_SPLIT7_SUCCESS) {
+        LOG_E(NR_PHY, "[fd-ue] start_sync failed (%d); retrying\n", (int)rc);
+        usleep(100000);
+        continue;
+      }
+
+      while (!sync_ctx.sync_done && !oai_exit)
+        usleep(1000);
+
+      if (!UE->is_synchronized)
+        continue;
+
+      // sync_task_func() already snapped circ_read_idx to slot 0 symbol 0 of the
+      // SSB's frame, so the next read_symbol() is already aligned there.
+      {
+        const int slot_in_frame = 0;
+
+        notifiedFIFO_elt_t *elt = pullNotifiedFIFO(&mac->input_nf);
+        AssertFatal(elt, "[fd-ue] FIFO error waiting for MIB\n");
+        process_msg_rcc_to_mac(NotifiedFifoData(elt), UE->Mod_id);
+        delNotifiedFIFO_elt(elt);
+        // The blind search can take real wall-clock time, during which
+        // circ_read_idx keeps advancing on the read thread; frames_since_capture
+        // is that same advance in SFN units, so bookkeeping tracks the frame the
+        // device is actually sitting on, not the one the MIB was decoded from.
+        // Otherwise the first PRACH TX timestamp is stale by however long the
+        // search took, and gets silently dropped as expired.
+        decoded_frame_rx = (mac->mib_frame + sync_ctx.sync_result.frames_since_capture) % MAX_FRAME_NUMBER;
+
+        ue_split7_status_t seed_rc = dev->seed_slot_tracking(dev, (uint32_t)decoded_frame_rx);
+        if (seed_rc != UE_SPLIT7_SUCCESS)
+          LOG_E(NR_PHY, "[fd-ue] seed_slot_tracking failed (%d)\n", (int)seed_rc);
+        frame_rx_prev = -1;
+        hfn_rx_wraps = 0;
+
+        LOG_A(NR_PHY,
+              "[fd-ue] Aligned: frame=%d slot_in_frame=%d "
+              "(mib_frame=%d frames_since_capture=%u)\n",
+              decoded_frame_rx,
+              slot_in_frame,
+              mac->mib_frame,
+              sync_ctx.sync_result.frames_since_capture);
+      }
+
+      /* Push the initial TA (N_TA_offset only; MAC TA = 0 after sync). */
+      UE->N_TA_offset = determine_N_TA_offset(UE);
+      last_ta_samples = (uint32_t)UE->N_TA_offset;
+      ue_split7_status_t ta_rc = dev->set_timing_advance(dev, last_ta_samples);
+      if (ta_rc != UE_SPLIT7_SUCCESS)
+        LOG_E(NR_PHY, "[fd-ue] initial set_timing_advance failed (%d)\n", (int)ta_rc);
+
+      stream_status = STREAM_STATUS_UNSYNC;
+      memset(tx_wait_for_dlsch, 0, sizeof(tx_wait_for_dlsch));
+      for (int i = 0; i < NUM_PROCESS_SLOT_TX_BARRIERS; i++)
+        dynamic_barrier_reset(&UE->process_slot_tx_barriers[i]);
+      continue;
+    }
+
+    // MAC-triggered re-sync request (handover / re-establish)
+    if (UE->synch_request.received_synch_request == 1) {
+      /* Copy target PCI so the next start_sync searches the right cell. */
+      UE->target_Nid_cell = UE->synch_request.synch_req.target_Nid_cell;
+
+      /* Update SSB start subcarrier — it changes on inter-SSB-offset HOs. */
+      {
+        const fapi_nr_config_request_t *cfg = &UE->nrUE_config;
+        int new_ssb_sc = nr_get_ssb_start_sc(fp->numerology_index,
+                                             cfg->ssb_table.ssb_offset_point_a,
+                                             cfg->ssb_table.ssb_subcarrier_offset,
+                                             fp->freq_range);
+        if (new_ssb_sc != fp->ssb_start_subcarrier) {
+          LOG_I(NR_PHY, "[fd-ue] SSB subcarrier changed %d→%d on re-sync\n", fp->ssb_start_subcarrier, new_ssb_sc);
+          fp->ssb_start_subcarrier = new_ssb_sc;
+        }
+      }
+
+      /* Stop any in-flight sync search (normally idle in connected state). */
+      ue_split7_status_t stop_rc = dev->stop_sync(dev);
+      if (stop_rc != UE_SPLIT7_SUCCESS)
+        LOG_E(NR_PHY, "[fd-ue] stop_sync failed (%d)\n", (int)stop_rc);
+
+      /* Flush in-flight PHY work and reset HARQ before leaving connected state. */
+      for (int i = 0; i < get_nrUE_params()->num_dl_actors; i++)
+        flush_actor(UE->dl_actors + i);
+      for (int i = 0; i < get_nrUE_params()->num_ul_actors; i++)
+        flush_actor(UE->ul_actors + i);
+      clean_UE_harq(UE);
+
+      UE->is_synchronized = 0;
+      UE->synch_request.received_synch_request = 0;
+      continue;
+    }
+
+    // The Low-PHY owns the real sample clock, so block for its authoritative
+    // frame/slot rather than free-running a host-side tick that could drift.
+    uint32_t frame_number;
+    uint16_t slot_number;
+    ue_split7_status_t wns_rc = dev->wait_next_slot(dev, &frame_number, &slot_number);
+    if (wns_rc != UE_SPLIT7_SUCCESS) {
+      // frame_number/slot_number are left uninitialized on failure (e.g. the device
+      // was stopped concurrently) -- must not fall through into the per-slot logic
+      // below with garbage values.
+      if (!oai_exit)
+        LOG_W(NR_PHY, "[fd-ue] wait_next_slot failed (%d)\n", (int)wns_rc);
+      usleep(1000);
+      continue;
+    }
+    time_manager_iq_samples(1, nb_slot_frame * 100);
+
+    const int slot_nr = (int)slot_number;
+    const int frame_rx = (int)frame_number;
+
+    // Reconstructs a monotonic absolute_slot for the TX-lead/HFN math below;
+    // RX identity itself always comes straight from wait_next_slot() above.
+    if (frame_rx < frame_rx_prev)
+      hfn_rx_wraps++;
+    frame_rx_prev = frame_rx;
+    absolute_slot = (int)((hfn_rx_wraps * MAX_FRAME_NUMBER + frame_rx) * nb_slot_frame + slot_nr);
+
+    // Must happen before fd_read_slot() so it takes effect on this slot's own read.
+    if (slot_nr == nb_slot_frame - 1) {
+      ue_split7_status_t adj_rc = dev->adjust_rx_timing(dev, shiftForNextFrame);
+      if (adj_rc != UE_SPLIT7_SUCCESS)
+        LOG_E(NR_PHY, "[fd-ue] adjust_rx_timing failed (%d)\n", (int)adj_rc);
+      shiftForNextFrame = -(int)round(UE->max_pos_acc * get_nrUE_params()->time_sync_I);
+    }
+
+    const openair0_timestamp_t rx_ts = fd_read_slot(dev, UE, fp, frame_rx, slot_nr);
+
+    nr_rxtx_thread_data_t curMsg = {0};
+    curMsg.UE = UE;
+    curMsg.proc.nr_slot_rx = slot_nr;
+    curMsg.proc.nr_slot_tx = (absolute_slot + duration_rx_to_tx) % nb_slot_frame;
+    curMsg.proc.frame_rx = frame_rx;
+    curMsg.proc.frame_tx = ((absolute_slot + duration_rx_to_tx) / nb_slot_frame) % MAX_FRAME_NUMBER;
+    curMsg.proc.hfn_rx = (absolute_slot / nb_slot_frame) / MAX_FRAME_NUMBER;
+    curMsg.proc.hfn_tx = ((absolute_slot + duration_rx_to_tx) / nb_slot_frame) / MAX_FRAME_NUMBER;
+
+    if (UE->received_config_request) {
+      curMsg.proc.rx_slot_type = nr_ue_slot_select(cfg, curMsg.proc.nr_slot_rx);
+      curMsg.proc.tx_slot_type = nr_ue_slot_select(cfg, curMsg.proc.nr_slot_tx);
+    } else {
+      curMsg.proc.rx_slot_type = NR_DOWNLINK_SLOT;
+      curMsg.proc.tx_slot_type = NR_DOWNLINK_SLOT;
+    }
+
+    // No TA/RX-to-TX lead added: the Low-PHY applies both itself.
+    curMsg.proc.timestamp_tx = rx_ts;
+
+    if (curMsg.proc.nr_slot_rx == 0)
+      nr_ue_rrc_timer_trigger(UE->Mod_id, curMsg.proc.hfn_rx, curMsg.proc.frame_rx, curMsg.proc.gNB_id);
+
+    /* DL processing: launch async into dl_actors, same as UE_thread. */
+    notifiedFIFO_elt_t *newRx = newNotifiedFIFO_elt(sizeof(nr_rxtx_thread_data_t), curMsg.proc.nr_slot_tx, NULL, UE_dl_processing);
+    nr_rxtx_thread_data_t *curMsgRx = NotifiedFifoData(newRx);
+    *curMsgRx = (nr_rxtx_thread_data_t){.proc = curMsg.proc, .UE = UE};
+    int dl_preproc_ret = UE_dl_preprocessing(UE, &curMsgRx->proc, tx_wait_for_dlsch, &curMsgRx->phy_data, &stats_printed);
+    // Fresh PBCH timing measurement supersedes the drift-only estimate above.
+    if (dl_preproc_ret != INT_MAX)
+      shiftForNextFrame = dl_preproc_ret;
+
+    uint32_t new_ta = (uint32_t)(UE->N_TA_offset + UE->timing_advance);
+    if (new_ta != last_ta_samples) {
+      ue_split7_status_t ta_rc = dev->set_timing_advance(dev, new_ta);
+      if (ta_rc != UE_SPLIT7_SUCCESS)
+        LOG_E(NR_PHY, "[fd-ue] set_timing_advance failed (%d)\n", (int)ta_rc);
+      last_ta_samples = new_ta;
+    }
+
+    if (get_nrUE_params()->num_dl_actors > 0)
+      pushNotifiedFIFO(&UE->dl_actors[curMsg.proc.nr_slot_rx % get_nrUE_params()->num_dl_actors].fifo, newRx);
+    else
+      newRx->processingFunc(curMsgRx);
+
+    // writeBlockSize = 0 below makes processSlotTX()'s RU_write() a no-op.
+    notifiedFIFO_elt_t *newTx = newNotifiedFIFO_elt(sizeof(nr_rxtx_thread_data_t), 0, 0, processSlotTX);
+    nr_rxtx_thread_data_t *curMsgTx = NotifiedFifoData(newTx);
+    memset(curMsgTx, 0, sizeof(*curMsgTx));
+    curMsgTx->proc = curMsg.proc;
+    curMsgTx->writeBlockSize = 0; /* no RU_write */
+    curMsgTx->UE = UE;
+
+    const int slot_tx = curMsgTx->proc.nr_slot_tx;
+    const int saf = slot_tx + curMsgTx->proc.frame_tx * nb_slot_frame;
+    const int next_saf = absolute_slot + duration_rx_to_tx + 1;
+    const int wait_prev = (stream_status == STREAM_STATUS_SYNCED) ? 1 : 0;
+
+    curMsgTx->next_barrier = &UE->process_slot_tx_barriers[next_saf % NUM_PROCESS_SLOT_TX_BARRIERS];
+    dynamic_barrier_update(&UE->process_slot_tx_barriers[saf % NUM_PROCESS_SLOT_TX_BARRIERS],
+                           tx_wait_for_dlsch[slot_tx] + wait_prev,
+                           start_process_slot_tx,
+                           newTx);
+
+    stream_status = STREAM_STATUS_SYNCED;
+    tx_wait_for_dlsch[slot_tx] = 0;
+  }
+
+  // Null the callbacks before freeing tx_ctx so no queued actor calls into it.
+  UE->fd_rxdataF_ring = NULL;
+  UE->fd_tx_cb = NULL;
+  UE->fd_prach_tx_cb = NULL;
+  UE->fd_tx_cb_data = NULL;
+  free(tx_ctx);
+
+  for (int a = 0; a < fp->nb_antennas_rx; a++)
+    free(rxdataF_ring[a]);
+
+  // This thread owns dev for its whole lifetime.
+  if (dev->stop)
+    dev->stop(dev);
+  ue_split7_device_free(dev);
+
+  LOG_W(NR_PHY, "[fd-ue] main thread ending\n");
+  return NULL;
+}
+
+// Called instead of init_NR_UE_threads() when a split7 device is configured.
+void init_NR_UE_fd_threads(PHY_VARS_NR_UE *UE, ue_split7_device_t *dev)
+{
+  fd_thread_args_t *args = malloc(sizeof(*args));
+  AssertFatal(args, "[fd-ue] OOM\n");
+  args->UE = UE;
+  args->dev = dev;
+
+  char name[32];
+  snprintf(name, sizeof(name), "UEfd_%d", UE->Mod_id);
+  threadCreate(&UE->main_thread, UE_fd_thread, args, name, -1, OAI_PRIORITY_RT_MAX);
+
+  if (!IS_SOFTMODEM_NOSTATS) {
+    snprintf(name, sizeof(name), "L1_UE_stats_fd_%d", UE->Mod_id);
+    threadCreate(&UE->stat_thread, nrL1_UE_stats_thread, UE, name, -1, OAI_PRIORITY_RT_LOW);
+  }
+}

--- a/executables/nr-ue.c
+++ b/executables/nr-ue.c
@@ -82,7 +82,7 @@
  *
  */
 
-static void start_process_slot_tx(void* arg) {
+void start_process_slot_tx(void* arg) {
   notifiedFIFO_elt_t *newTx = arg;
   nr_rxtx_thread_data_t *curMsgTx = NotifiedFifoData(newTx);
   int num_ul_actors = get_nrUE_params()->num_ul_actors;
@@ -93,7 +93,7 @@ static void start_process_slot_tx(void* arg) {
   }
 }
 
-static size_t dump_L1_UE_meas_stats(PHY_VARS_NR_UE *ue, char *output, size_t max_len)
+size_t dump_L1_UE_meas_stats(PHY_VARS_NR_UE *ue, char *output, size_t max_len)
 {
   const char *begin = output;
   const char *end = output + max_len;
@@ -108,7 +108,7 @@ static size_t dump_L1_UE_meas_stats(PHY_VARS_NR_UE *ue, char *output, size_t max
   return output - begin;
 }
 
-static void *nrL1_UE_stats_thread(void *param)
+void *nrL1_UE_stats_thread(void *param)
 {
   PHY_VARS_NR_UE *ue = (PHY_VARS_NR_UE *) param;
   const int max_len = 16384;
@@ -132,7 +132,7 @@ static void *nrL1_UE_stats_thread(void *param)
   return NULL;
 }
 
-static int determine_N_TA_offset(PHY_VARS_NR_UE *ue) {
+int determine_N_TA_offset(PHY_VARS_NR_UE *ue) {
   if (ue->sl_mode == 2)
     return 0;
   else {
@@ -242,7 +242,7 @@ static void UE_synch(void *arg) {
   }
 }
 
-static int nr_ue_slot_select(const fapi_nr_config_request_t *cfg, int nr_slot)
+int nr_ue_slot_select(const fapi_nr_config_request_t *cfg, int nr_slot)
 {
   if (cfg->cell_config.frame_duplex_type == FDD)
     return NR_UPLINK_SLOT | NR_DOWNLINK_SLOT;
@@ -521,11 +521,11 @@ static int handle_sync_req_from_mac(PHY_VARS_NR_UE *UE)
   return 1;
 }
 
-static int UE_dl_preprocessing(PHY_VARS_NR_UE *UE,
-                               const UE_nr_rxtx_proc_t *proc,
-                               int *tx_wait_for_dlsch,
-                               nr_phy_data_t *phy_data,
-                               bool *stats_printed)
+int UE_dl_preprocessing(PHY_VARS_NR_UE *UE,
+                        const UE_nr_rxtx_proc_t *proc,
+                        int *tx_wait_for_dlsch,
+                        nr_phy_data_t *phy_data,
+                        bool *stats_printed)
 {
   TracyCZone(ctx, true);
   int sampleShift = INT_MAX;

--- a/executables/nr-uesoftmodem.c
+++ b/executables/nr-uesoftmodem.c
@@ -61,6 +61,7 @@ unsigned short config_frames[4] = {2,9,11,13};
 #include <executables/nr-uesoftmodem.h>
 #include "executables/softmodem-common.h"
 #include "executables/thread-common.h"
+#include "radio/COMMON/ue_split7_interface.h"
 
 #include "nr_nas_msg.h"
 #include "actor.h"
@@ -474,15 +475,54 @@ int main(int argc, char **argv)
     load_module_shlib("imscope_record", NULL, 0, nrPHY_vars_UE_g[0][0]);
   }
 
-  // Launch a temporary high-priority thread to start the UE RU, ensuring radio library threads inherit this priority
-  pthread_t ru_start_thread;
-  threadCreate(&ru_start_thread, nrue_ru_start_thread, NULL, "ru_start_thread", -1, OAI_PRIORITY_RT_MAX);
-  int ret = pthread_join(ru_start_thread, NULL);
-  AssertFatal(ret == 0, "pthread_join error %d, errno %d (%s)\n", ret, errno, strerror(errno));
+  // Split7 manages its own RF device; skip the regular RU start.
+  if (!get_nrUE_params()->use_split7) {
+    // Launch a temporary high-priority thread to start the UE RU, ensuring radio library threads inherit this priority
+    pthread_t ru_start_thread;
+    threadCreate(&ru_start_thread, nrue_ru_start_thread, NULL, "ru_start_thread", -1, OAI_PRIORITY_RT_MAX);
+    int ret = pthread_join(ru_start_thread, NULL);
+    AssertFatal(ret == 0, "pthread_join error %d, errno %d (%s)\n", ret, errno, strerror(errno));
+  }
 
   for (int inst = 0; inst < NB_UE_INST; inst++) {
-    LOG_I(PHY,"Intializing UE Threads for instance %d ...\n", inst);
-    init_NR_UE_threads(nrPHY_vars_UE_g[inst][0]);
+    LOG_I(PHY, "Initializing UE Threads for instance %d ...\n", inst);
+    if (get_nrUE_params()->use_split7) {
+      PHY_VARS_NR_UE *UE = nrPHY_vars_UE_g[inst][0];
+      const NR_DL_FRAME_PARMS *fp = &UE->frame_parms;
+
+      ue_split7_device_t *dev = ue_split7_device_create();
+      AssertFatal(dev, "Failed to create ue_split7_device for instance %d\n", inst);
+
+      uint16_t fft_size = (uint16_t)fp->ofdm_symbol_size;
+      uint16_t scs_khz  = (uint16_t)(fp->subcarrier_spacing / 1000);
+      ue_split7_config_t s7cfg;
+      memset(&s7cfg, 0, sizeof(s7cfg));
+      s7cfg.dl_carrier_freq_hz = fp->dl_CarrierFreq;
+      s7cfg.ul_carrier_freq_hz = fp->ul_CarrierFreq;
+      s7cfg.sample_rate_hz     = (uint32_t)fp->samples_per_subframe * 1000;
+      s7cfg.fft_size           = fft_size;
+      s7cfg.num_rx_antennas    = (uint16_t)fp->nb_antennas_rx;
+      s7cfg.num_tx_antennas    = (uint16_t)fp->nb_antennas_tx;
+      s7cfg.cp_len_normal      = (uint16_t)fp->nb_prefix_samples;
+      s7cfg.cp_len_symbol0     = (uint16_t)fp->nb_prefix_samples0;
+      s7cfg.scs_khz            = scs_khz;
+      s7cfg.nr_band            = (uint16_t)get_mac_inst(inst)->nr_band;
+      s7cfg.N_RB_DL            = (uint16_t)fp->N_RB_DL;
+      // Reuse the monolithic UE path's frame_parms instead of re-deriving a subset.
+      s7cfg.frame_parms        = fp;
+
+      ue_split7_status_t rc = dev->configure(dev, &s7cfg);
+      if (rc != UE_SPLIT7_SUCCESS) {
+        LOG_E(PHY, "ue_split7_device configure failed (status %d) for instance %d\n",
+              (int)rc, inst);
+        ue_split7_device_free(dev);
+        exit(1);
+      }
+
+      init_NR_UE_fd_threads(UE, dev);
+    } else {
+      init_NR_UE_threads(nrPHY_vars_UE_g[inst][0]);
+    }
   }
 
   // wait for end of program

--- a/executables/nr-uesoftmodem.h
+++ b/executables/nr-uesoftmodem.h
@@ -85,6 +85,8 @@ extern uint16_t ue_id_g;
   {"actor-affinity",               CONFIG_HLP_ACTOR_AFFINITY,  0,               .strptr=&nrUE_params.actor_affinity,       .defstrval=NULL,   TYPE_STRING,   0}, \
   {"extra-pdu-id",                 CONFIG_HLP_EXTRA_PDU_ID,   0,                .iptr=&nrUE_params.extra_pdu_id,             .defintval=-1,     TYPE_INT,      0}, \
   {"disable-blind-search",         CONFIG_HLP_DISABLE_BLIND_SEARCH, PARAMFLAG_BOOL, .iptr=&nrUE_params.disable_blind_search, .defintval=0,    TYPE_INT,      0}, \
+  {"ue-split7",                    "Use Split 7.1 freq-domain I/O (ue_split7_device)",  PARAMFLAG_BOOL,  .iptr=&nrUE_params.use_split7, .defintval=0, TYPE_INT, 0}, \
+  {"ue-split7-sync-timeout",       "Split 7.1 sync search timeout in ms (default 5000)", 0, .iptr=&nrUE_params.split7_sync_timeout_ms, .defintval=5000, TYPE_INT, 0}, \
 }
 // clang-format on
 
@@ -129,6 +131,8 @@ typedef struct {
   char *actor_affinity;
   int extra_pdu_id;
   int disable_blind_search;
+  int use_split7; // enable Split 7.1 freq-domain UE thread
+  int split7_sync_timeout_ms;  // sync search timeout for Split 7.1 device
 } nrUE_params_t;
 extern uint64_t get_nrUE_optmask(void);
 extern uint64_t set_nrUE_optmask(uint64_t bitmask);
@@ -140,4 +144,8 @@ extern void init_NR_UE(int, char *, char *, char *, int);
 extern void init_NR_UE_threads(PHY_VARS_NR_UE *ue);
 void *UE_thread(void *arg);
 void init_nr_ue_vars(PHY_VARS_NR_UE *ue, uint8_t UE_id);
+
+// In nr-fd-ue.c
+struct ue_split7_device;
+void init_NR_UE_fd_threads(PHY_VARS_NR_UE *UE, struct ue_split7_device *dev);
 #endif

--- a/openair1/PHY/MODULATION/modulation_UE.h
+++ b/openair1/PHY/MODULATION/modulation_UE.h
@@ -33,6 +33,7 @@ int slot_fep(PHY_VARS_UE *phy_vars_ue,
 
 int nr_slot_fep(PHY_VARS_NR_UE *ue,
                 const NR_DL_FRAME_PARMS *frame_parms,
+                unsigned int frame,
                 unsigned int slot,
                 unsigned int symbol,
                 c16_t rxdataF[][frame_parms->samples_per_slot_wCP],

--- a/openair1/PHY/MODULATION/slot_fep_nr.c
+++ b/openair1/PHY/MODULATION/slot_fep_nr.c
@@ -45,6 +45,7 @@ void nr_symbol_fep(const NR_DL_FRAME_PARMS *frame_parms,
 
 int nr_slot_fep(PHY_VARS_NR_UE *ue,
                 const NR_DL_FRAME_PARMS *frame_parms,
+                unsigned int frame,
                 unsigned int slot,
                 unsigned int symbol,
                 c16_t rxdataF[][frame_parms->samples_per_slot_wCP],
@@ -56,6 +57,17 @@ int nr_slot_fep(PHY_VARS_NR_UE *ue,
               "slot_fep: symbol must be between 0 and %d\n",
               frame_parms->symbols_per_slot - 1);
   AssertFatal(slot < frame_parms->slots_per_frame, "slot_fep: Ns must be between 0 and %d\n", frame_parms->slots_per_frame - 1);
+
+  // Split7: symbols are already in ue->fd_rxdataF_ring; copy instead of computing the DFT.
+  if (ue && ue->fd_rxdataF_ring) {
+    const unsigned int ring_symbol =
+        ((frame % 2) * frame_parms->slots_per_frame + slot) * frame_parms->symbols_per_slot + symbol;
+    for (unsigned char aa = 0; aa < frame_parms->nb_antennas_rx; aa++)
+      memcpy(&rxdataF[aa][frame_parms->ofdm_symbol_size * symbol],
+             &ue->fd_rxdataF_ring[aa][ring_symbol * frame_parms->ofdm_symbol_size],
+             frame_parms->ofdm_symbol_size * sizeof(c16_t));
+    return 0;
+  }
 
   bool is_sl = (linktype == link_type_sl);
   bool is_synchronized = (ue) ? ue->is_synchronized : false;

--- a/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
+++ b/openair1/PHY/NR_UE_ESTIMATION/nr_ue_measurements.c
@@ -387,8 +387,8 @@ static bool validate_known_pci(NR_DL_FRAME_PARMS *frame_parms,
 
   __attribute__((aligned(32))) c16_t rxdataF_tmp[frame_parms->nb_antennas_rx][frame_parms->samples_per_slot_wCP];
   uint8_t sss_symbol = SSS_SYMBOL_NB - PSS_SYMBOL_NB;
-  nr_slot_fep(NULL, frame_parms, 0, 0, rxdataF_tmp, link_type_dl, ssb_time_offset, (c16_t **)rxdata);
-  nr_slot_fep(NULL, frame_parms, 0, sss_symbol, rxdataF_tmp, link_type_dl, ssb_time_offset, (c16_t **)rxdata);
+  nr_slot_fep(NULL, frame_parms, 0, 0, 0, rxdataF_tmp, link_type_dl, ssb_time_offset, (c16_t **)rxdata);
+  nr_slot_fep(NULL, frame_parms, 0, 0, sss_symbol, rxdataF_tmp, link_type_dl, ssb_time_offset, (c16_t **)rxdata);
   /* TODO: Once symbol based PDSCH proc is imeplemented, nr_slot_fep() will use
   the new rxdataF buffer format so the following memcpy can be removed. */
   for (int aarx = 0; aarx < frame_parms->nb_antennas_rx; aarx++) {

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync.c
@@ -36,7 +36,7 @@ static int ssb_sort(const void *a, const void *b)
   return ((NR_UE_SSB *)b)->metric - ((NR_UE_SSB *)a)->metric;
 }
 
-static bool nr_pbch_detection(const UE_nr_rxtx_proc_t *proc,
+bool nr_pbch_detection(const UE_nr_rxtx_proc_t *proc,
                               const NR_DL_FRAME_PARMS *frame_parms,
                               int Nid_cell,
                               int pbch_initial_symbol,

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync_sl.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_initial_sync_sl.c
@@ -439,6 +439,7 @@ nr_initial_sync_t sl_nr_slss_search(PHY_VARS_NR_UE *UE, UE_nr_rxtx_proc_t *proc,
         for (int symbol = 0; symbol < SL_NR_NUMSYM_SLSS_NORMAL_CP; symbol++) {
           nr_slot_fep(UE,
                       frame_parms,
+                      proc->frame_rx,
                       proc->nr_slot_rx,
                       symbol,
                       rxdataF,

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_prach.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_prach.c
@@ -25,7 +25,7 @@
 // - idft for short sequence assumes we are transmitting starting in symbol 0 of a PRACH slot
 // - Assumes that PRACH SCS is same as PUSCH SCS @ 30 kHz, take values for formats 0-2 and adjust for others below
 // - Preamble index different from 0 is not detected by gNB
-int32_t generate_nr_prach(PHY_VARS_NR_UE *ue, uint8_t gNB_id, int frame, uint8_t slot, int16_t tx_amp, c16_t **txData)
+int32_t generate_nr_prach(PHY_VARS_NR_UE *ue, uint8_t gNB_id, int frame, uint8_t slot, int16_t tx_amp, openair0_timestamp_t timestamp_tx, c16_t **txData)
 {
   NR_DL_FRAME_PARMS *fp=&ue->frame_parms;
   fapi_nr_config_request_t *nrUE_config = &ue->nrUE_config;
@@ -317,6 +317,13 @@ int32_t generate_nr_prach(PHY_VARS_NR_UE *ue, uint8_t gNB_id, int frame, uint8_t
       prachF[k++] = p;
       if (k == dftlen)
         k = 0;
+    }
+
+    if (ue->fd_prach_tx_cb) {
+      const int copies[11] = {1, 2, 4, 4, 2, 4, 6, 2, 12, 1, 4};
+      DevAssert(prach_fmt_id < sizeofArray(copies));
+      ue->fd_prach_tx_cb(ue, frame, slot, timestamp_tx, prachF, dftlen, Ncp, prach_start, copies[prach_fmt_id], ue->fd_tx_cb_data);
+      return 0;
     }
 
 #if defined(PRACH_WRITE_OUTPUT_DEBUG)

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h
@@ -13,6 +13,7 @@
 #include <math.h>
 #include "PHY/nr_phy_common/inc/nr_phy_common.h"
 #include "PHY/CODING/nrPolar_tools/nr_polar_psbch_defs.h"
+#include "PHY/NR_REFSIG/ss_pbch_nr.h"
 #include "common/utils/bits.h"
 
 // Specifies the data that should be copied to the scope during PDSCH RX
@@ -259,7 +260,18 @@ int nr_rx_pdsch(PHY_VARS_NR_UE *ue,
                 pdsch_scope_req_t *scope_req,
                 c16_t rho_dl[][NR_MAX_NB_LAYERS * NR_MAX_NB_LAYERS][pdsch_buf_size_max]);
 
-int32_t generate_nr_prach(PHY_VARS_NR_UE *ue, uint8_t gNB_id, int frame, uint8_t slot, int16_t tx_amp, c16_t **txData);
+int32_t generate_nr_prach(PHY_VARS_NR_UE *ue, uint8_t gNB_id, int frame, uint8_t slot, int16_t tx_amp, openair0_timestamp_t timestamp_tx, c16_t **txData);
+void nr_ue_prach_procedures(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, c16_t **txData);
+bool nr_pbch_detection(const UE_nr_rxtx_proc_t *proc,
+                       const NR_DL_FRAME_PARMS *frame_parms,
+                       int Nid_cell,
+                       int pbch_initial_symbol,
+                       int ssb_start_subcarrier,
+                       int *half_frame_bit,
+                       int *ssb_index,
+                       int *symbol_offset,
+                       fapiPbch_t *result,
+                       const c16_t rxdataF[NR_N_SYMBOLS_SSB][frame_parms->nb_antennas_rx][frame_parms->ofdm_symbol_size]);
 void apply_ntn_config(PHY_VARS_NR_UE *UE,
                       const NR_DL_FRAME_PARMS *fp,
                       int hfn_rx,

--- a/openair1/PHY/defs_nr_UE.h
+++ b/openair1/PHY/defs_nr_UE.h
@@ -273,6 +273,8 @@ typedef struct {
   int used_by_ue;
 } nrUE_cell_params_t;
 
+typedef struct UE_nr_rxtx_proc_s UE_nr_rxtx_proc_t;
+
 /// Top-level PHY Data Structure for UE
 typedef struct PHY_VARS_NR_UE_s {
   /// \brief Module ID indicator for this instance
@@ -439,6 +441,30 @@ typedef struct PHY_VARS_NR_UE_s {
   // Gain change required for automation RX gain change
   int adjust_rxgain;
 
+  // Split7: freq-domain symbol ring (2-frame margin for DL actor lag); nr_slot_fep() copies from here instead of computing the FFT when set.
+  c16_t **fd_rxdataF_ring;
+
+  // Split7: when set, phy_procedures_nrUE_TX calls this instead of OFDM modulation.
+  void (*fd_tx_cb)(struct PHY_VARS_NR_UE_s *ue,
+                   const UE_nr_rxtx_proc_t *proc,
+                   int nb_ant_tx,
+                   c16_t **txdataF,
+                   const bool *was_symbol_used,
+                   void *userdata);
+  void *fd_tx_cb_data;
+
+  // Split7: when set, generate_nr_prach forwards the FD preamble here instead of running IDFT/CP.
+  void (*fd_prach_tx_cb)(struct PHY_VARS_NR_UE_s *ue,
+                         int frame,
+                         int slot,
+                         openair0_timestamp_t timestamp_tx,
+                         const c16_t *prachF,
+                         int dftlen,
+                         int Ncp,
+                         int prach_start,
+                         int copies,
+                         void *userdata);
+
   // Sidelink parameters
   sl_nr_sidelink_mode_t sl_mode;
   sl_nr_ue_phy_params_t SL_UE_PHY_PARAMS;
@@ -464,7 +490,7 @@ typedef struct PHY_VARS_NR_UE_s {
 } PHY_VARS_NR_UE;
 typedef struct pdsch_scratch_s pdsch_scratch_t;
 
-typedef struct {
+typedef struct UE_nr_rxtx_proc_s {
   openair0_timestamp_t timestamp_tx;
   int gNB_id;
   /// NR slot index within frame_tx [0 .. slots_per_frame - 1] to act upon for transmission

--- a/openair1/SCHED_NR_UE/defs.h
+++ b/openair1/SCHED_NR_UE/defs.h
@@ -88,6 +88,13 @@ bool is_csi_rs_in_symbol(fapi_nr_dl_config_csirs_pdu_rel15_t csirs_config_pdu, i
 
 /*@}*/
 
+void nr_fill_dl_indication(nr_downlink_indication_t *dl_ind,
+                           fapi_nr_dci_indication_t *dci_ind,
+                           fapi_nr_rx_indication_t *rx_ind,
+                           const UE_nr_rxtx_proc_t *proc,
+                           PHY_VARS_NR_UE *ue,
+                           void *phy_data);
+
 /*! \brief This function prepares the dl rx indication
  */
 void nr_fill_rx_indication(fapi_nr_rx_indication_t *rx_ind,

--- a/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
+++ b/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
@@ -48,6 +48,36 @@ static const unsigned int gain_table[31] = {100,  112,  126,  141,  158,  178,  
                                             359,  398,  447,  501,  562,  631,  708,  794,  891, 1000, 1122,
                                             1258, 1412, 1585, 1778, 1995, 2239, 2512, 2818, 3162};
 
+void nr_fill_dl_indication(nr_downlink_indication_t *dl_ind,
+                           fapi_nr_dci_indication_t *dci_ind,
+                           fapi_nr_rx_indication_t *rx_ind,
+                           const UE_nr_rxtx_proc_t *proc,
+                           PHY_VARS_NR_UE *ue,
+                           void *phy_data)
+{
+  memset((void*)dl_ind, 0, sizeof(nr_downlink_indication_t));
+
+  dl_ind->gNB_index = proc->gNB_id;
+  dl_ind->module_id = ue->Mod_id;
+  dl_ind->cc_id     = ue->CC_id;
+  dl_ind->hfn       = proc->hfn_rx;
+  dl_ind->frame     = proc->frame_rx;
+  dl_ind->slot      = proc->nr_slot_rx;
+  dl_ind->phy_data  = phy_data;
+
+  if (dci_ind) {
+
+    dl_ind->rx_ind = NULL; //no data, only dci for now
+    dl_ind->dci_ind = dci_ind;
+
+  } else if (rx_ind) {
+
+    dl_ind->rx_ind = rx_ind; //  hang on rx_ind instance
+    dl_ind->dci_ind = NULL;
+
+  }
+}
+
 static uint32_t get_ssb_arfcn(NR_DL_FRAME_PARMS *frame_parms)
 {
   uint32_t band_size_hz = frame_parms->N_RB_DL * 12 * frame_parms->subcarrier_spacing;

--- a/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
+++ b/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
@@ -48,8 +48,6 @@ static const unsigned int gain_table[31] = {100,  112,  126,  141,  158,  178,  
                                             359,  398,  447,  501,  562,  631,  708,  794,  891, 1000, 1122,
                                             1258, 1412, 1585, 1778, 1995, 2239, 2512, 2818, 3162};
 
-static void nr_ue_prach_procedures(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, c16_t **txData);
-
 static uint32_t get_ssb_arfcn(NR_DL_FRAME_PARMS *frame_parms)
 {
   uint32_t band_size_hz = frame_parms->N_RB_DL * 12 * frame_parms->subcarrier_spacing;
@@ -326,6 +324,13 @@ void phy_procedures_nrUE_TX(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, n
   pucch_procedures_ue_nr(ue, proc, phy_data, (c16_t **)&txdataF, was_symbol_used);
 
   LOG_D(PHY, "Sending Uplink data \n");
+
+  // Split7 fd-ue mode: deliver freq-domain txdataF via callback instead of OFDM mod.
+  if (ue->fd_tx_cb) {
+    ue->fd_tx_cb(ue, proc, ue->frame_parms.nb_antennas_tx, (c16_t **)txdataF, was_symbol_used, ue->fd_tx_cb_data);
+    stop_meas_nr_ue_phy(ue, PHY_PROC_TX);
+    return;
+  }
 
   // Don't do OFDM Mod if txdata contains prach
   const NR_UE_PRACH *prach_var = ue->prach_vars[proc->gNB_id];
@@ -818,7 +823,7 @@ void pdcch_processing(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, nr_phy_
   __attribute__((aligned(32))) c16_t rxdataF[fp->nb_antennas_rx][rxdataF_sz];
 
   for (int symbol = start_symb_pdcch; symbol <= last_symb_pdcch; symbol++) {
-    nr_slot_fep(ue, fp, proc->nr_slot_rx, symbol, rxdataF, link_type_dl, 0, ue->common_vars.rxdata);
+    nr_slot_fep(ue, fp, proc->frame_rx, proc->nr_slot_rx, symbol, rxdataF, link_type_dl, 0, ue->common_vars.rxdata);
     __attribute__((aligned(32))) c16_t rxdataF_symb[fp->nb_antennas_rx][((fp->ofdm_symbol_size + 7) / 8) * 8];
 
     for (int ant = 0; ant < fp->nb_antennas_rx; ant++)
@@ -913,7 +918,7 @@ int nr_process_pbch_symbol(PHY_VARS_NR_UE *ue,
   __attribute__((aligned(32))) c16_t rxdataF[fp->nb_antennas_rx][fp->ofdm_symbol_size];
   {
     __attribute__((aligned(32))) c16_t tmp[fp->nb_antennas_rx][fp->samples_per_slot_wCP];
-    nr_slot_fep(ue, fp, proc->nr_slot_rx, symbol, tmp, link_type_dl, 0, ue->common_vars.rxdata);
+    nr_slot_fep(ue, fp, proc->frame_rx, proc->nr_slot_rx, symbol, tmp, link_type_dl, 0, ue->common_vars.rxdata);
     for (int aarx = 0; aarx < fp->nb_antennas_rx; aarx++) {
       memcpy(rxdataF[aarx], tmp[aarx] + symbol * fp->ofdm_symbol_size, sizeof(c16_t) * fp->ofdm_symbol_size);
     }
@@ -1104,7 +1109,7 @@ int pbch_processing(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, nr_phy_da
         {
           for(int j = prs_config->SymbolStart; j < (prs_config->SymbolStart+prs_config->NumPRSSymbols); j++)
           {
-            nr_slot_fep(ue, fp, proc->nr_slot_rx, (j % fp->symbols_per_slot), rxdataF, link_type_dl, 0, ue->common_vars.rxdata);
+            nr_slot_fep(ue, fp, proc->frame_rx, proc->nr_slot_rx, (j % fp->symbols_per_slot), rxdataF, link_type_dl, 0, ue->common_vars.rxdata);
           }
           nr_prs_channel_estimation(gNB_id, rsc_id, i, ue, proc, fp, rxdataF);
         }
@@ -1158,7 +1163,7 @@ void pdsch_processing(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, nr_phy_
     for(int symb_idx = 0; symb_idx < 4; symb_idx++) {
       int symb = phy_data->csiim_vars.csiim_config_pdu.l_csiim[symb_idx];
       if (!slot_fep_map[symb]) {
-        nr_slot_fep(ue, &ue->frame_parms, proc->nr_slot_rx, symb, rxdataF, link_type_dl, 0, ue->common_vars.rxdata);
+        nr_slot_fep(ue, &ue->frame_parms, proc->frame_rx, proc->nr_slot_rx, symb, rxdataF, link_type_dl, 0, ue->common_vars.rxdata);
         slot_fep_map[symb] = true;
       }
     }
@@ -1178,7 +1183,7 @@ void pdsch_processing(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, nr_phy_
         for (int symb = 0; symb < ue->frame_parms.symbols_per_slot; symb++) {
           if (is_csi_rs_in_symbol(phy_data->csirs_vars[res].csirs_config_pdu, symb)) {
             if (!slot_fep_map[symb]) {
-              nr_slot_fep(ue, &ue->frame_parms, proc->nr_slot_rx, symb, rxdataF, link_type_dl, 0, ue->common_vars.rxdata);
+              nr_slot_fep(ue, &ue->frame_parms, proc->frame_rx, proc->nr_slot_rx, symb, rxdataF, link_type_dl, 0, ue->common_vars.rxdata);
               slot_fep_map[symb] = true;
             }
           }
@@ -1212,7 +1217,7 @@ void pdsch_processing(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, nr_phy_
 
     for (int m = start_symb_sch; m < (nb_symb_sch + start_symb_sch) ; m++) {
       if (!slot_fep_map[m]) {
-        nr_slot_fep(ue, &ue->frame_parms, proc->nr_slot_rx, m, rxdataF, link_type_dl, 0, ue->common_vars.rxdata);
+        nr_slot_fep(ue, &ue->frame_parms, proc->frame_rx, proc->nr_slot_rx, m, rxdataF, link_type_dl, 0, ue->common_vars.rxdata);
         slot_fep_map[m] = true;
       }
     }
@@ -1307,7 +1312,7 @@ void pdsch_processing(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, nr_phy_
 }
 
 // TODO: Actuate the MAC-requested PRACH power after defining a calibrated dBm-to-waveform/radio mapping.
-static void nr_ue_prach_procedures(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, c16_t **txData)
+void nr_ue_prach_procedures(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, c16_t **txData)
 {
   int gNB_id = proc->gNB_id;
   int frame_tx = proc->frame_tx, nr_slot_tx = proc->nr_slot_tx, generated_prach_power;
@@ -1333,7 +1338,7 @@ static void nr_ue_prach_procedures(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *
             tx_amp);
 
       start_meas_nr_ue_phy(ue, PRACH_GEN_STATS);
-      generated_prach_power = generate_nr_prach(ue, gNB_id, frame_tx, nr_slot_tx, tx_amp, txData);
+      generated_prach_power = generate_nr_prach(ue, gNB_id, frame_tx, nr_slot_tx, tx_amp, proc->timestamp_tx, txData);
       stop_meas_nr_ue_phy(ue, PRACH_GEN_STATS);
       if (cpumeas(CPUMEAS_GETSTATE)) {
         LOG_D(PHY,

--- a/openair1/SCHED_NR_UE/phy_procedures_nr_ue_sl.c
+++ b/openair1/SCHED_NR_UE/phy_procedures_nr_ue_sl.c
@@ -215,7 +215,7 @@ int psbch_pscch_processing(PHY_VARS_NR_UE *ue, const UE_nr_rxtx_proc_t *proc, nr
     int e_rx_offset = 0;
     /* TODO: Remove loop over symbols in later commit. */
     for (int sym = 0; sym < NR_SYMBOLS_PER_SLOT; sym++) {
-      nr_slot_fep(ue, fp, proc->nr_slot_rx, sym, rxdataF, link_type_sl, 0, ue->common_vars.rxdata);
+      nr_slot_fep(ue, fp, frame_rx, proc->nr_slot_rx, sym, rxdataF, link_type_sl, 0, ue->common_vars.rxdata);
       __attribute__((aligned(32))) c16_t rxdataF_symb[fp->nb_antennas_rx][fp->ofdm_symbol_size];
       for (int aarx = 0; aarx < fp->nb_antennas_rx; aarx++) {
         /* TODO: Remove this buffer reshaping in later commit after rxdataF is in right format */

--- a/openair1/SIMULATION/NR_PHY/pbchsim.c
+++ b/openair1/SIMULATION/NR_PHY/pbchsim.c
@@ -669,6 +669,7 @@ int main(int argc, char **argv)
         for (int i = UE->symbol_offset + 1; i < UE->symbol_offset + 4; i++) {
           nr_slot_fep(UE,
                       frame_parms,
+                      proc.frame_rx,
                       proc.nr_slot_rx,
                       i % frame_parms->symbols_per_slot,
                       rxdataF,

--- a/openair1/SIMULATION/NR_PHY/prachsim.c
+++ b/openair1/SIMULATION/NR_PHY/prachsim.c
@@ -643,7 +643,7 @@ int main(int argc, char **argv){
   c16_t *tx[frame_parms->nb_antennas_rx];
   for (int i = 0; i < frame_parms->nb_antennas_rx; i++)
     tx[i] = txdata[i] + slot_start;
-  generate_nr_prach(UE, 0, frame, slot, AMP, tx);
+  generate_nr_prach(UE, 0, frame, slot, AMP, 0, tx);
 
   /* tx_lev_dB not used later, no need to set */
   //tx_lev_dB = dB_fixed(tx_lev);

--- a/radio/COMMON/CMakeLists.txt
+++ b/radio/COMMON/CMakeLists.txt
@@ -3,3 +3,7 @@
 add_library(radio_common STATIC common_lib.c record_player.c)
 target_include_directories(radio_common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(radio_common PUBLIC dl log_headers shlib_loader)
+
+# UE-centric 7.1 functional split device
+add_library(ue_split7 STATIC ue_split7_device.c)
+target_link_libraries(ue_split7 PUBLIC radio_common)

--- a/radio/COMMON/CMakeLists.txt
+++ b/radio/COMMON/CMakeLists.txt
@@ -7,3 +7,41 @@ target_link_libraries(radio_common PUBLIC dl log_headers shlib_loader)
 # UE-centric 7.1 functional split device
 add_library(ue_split7 STATIC ue_split7_device.c)
 target_link_libraries(ue_split7 PUBLIC radio_common)
+
+# Unit test for UE-centric 7.1 functional split device
+add_executable(test_ue_split7 test_ue_split7.cpp)
+set_target_properties(test_ue_split7 PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+target_link_libraries(test_ue_split7 PRIVATE
+  ue_split7
+  PHY_NR_UE
+  PHY_NR_COMMON
+  nr_phy_common
+  nr_common
+  crc_byte
+  ds
+  UTIL
+  CONFIG_LIB
+)
+if(ENABLE_TESTS)
+  add_dependencies(tests test_ue_split7)
+  add_test(NAME test_ue_split7 COMMAND test_ue_split7)
+endif()
+
+# Compatibility verification: UE_fd_thread vs UE_thread timing equivalence
+add_executable(test_fd_ue_compat test_fd_ue_compat.cpp)
+set_target_properties(test_fd_ue_compat PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+target_link_libraries(test_fd_ue_compat PRIVATE
+  ue_split7
+  PHY_NR_UE
+  PHY_NR_COMMON
+  nr_phy_common
+  nr_common
+  crc_byte
+  ds
+  UTIL
+  CONFIG_LIB
+)
+if(ENABLE_TESTS)
+  add_dependencies(tests test_fd_ue_compat)
+  add_test(NAME test_fd_ue_compat COMMAND test_fd_ue_compat)
+endif()

--- a/radio/COMMON/test_fd_ue_compat.cpp
+++ b/radio/COMMON/test_fd_ue_compat.cpp
@@ -1,0 +1,572 @@
+/**
+ * @file test_fd_ue_compat.cpp
+ * @brief Verifies UE_fd_thread's TX timing matches UE_thread's, algebraically:
+ *
+ *   fd_effective_tx[sym]         = (rx_ts + slot_dur + sym_offset[sym]) - (N_TA + TA)
+ *   ue_thread_effective_tx[sym]  = (rx_ts + slot_dur - N_TA - TA) + sym_offset[sym]
+ *
+ * identical for every symbol. Covers: nominal timestamp sequence, TX time
+ * equivalence, set_timing_advance() call timing, proc field wraparound,
+ * symbol-gap continuity, initial TA push, PRACH TX time equivalence.
+ */
+
+#include "ue_split7_interface.h"
+#include "common_lib.h"
+#include "PHY/TOOLS/tools_defs.h"
+
+extern "C" {
+// Declared directly rather than via PHY/MODULATION/nr_modulation.h: that header
+// uses C99 VLA-in-parameter syntax elsewhere that GCC's C++ frontend rejects.
+void init_symbol_rotation(NR_DL_FRAME_PARMS *fp);
+void init_timeshift_rotation(const int ofdm_symbol_size,
+                             const int nb_prefix_samples,
+                             const unsigned int ofdm_offset_divisor,
+                             c16_t *timeshift_symbol_rotation);
+}
+
+#include <cstdint>
+#include <cstring>
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <atomic>
+#include <vector>
+
+#include "softmodem-common.h"
+
+extern "C" {
+#include "executables/nr-uesoftmodem.h"
+ue_split7_device_t *ue_split7_device_create(void);
+void ue_split7_device_free(ue_split7_device_t *dev);
+softmodem_params_t *get_softmodem_params(void)
+{
+  static softmodem_params_t p;
+  std::memset(&p, 0, sizeof(p));
+  return &p;
+}
+nrUE_params_t nrUE_params;
+nrUE_params_t *get_nrUE_params(void)
+{
+  return &nrUE_params;
+}
+int openair0_device_load(openair0_device_t *device, openair0_config_t *openair0_cfg)
+{
+  return 0;
+}
+void *uniqCfg = NULL;
+void exit_function(const char *file, const char *function, const int line, const char *s, const int)
+{
+  std::cerr << "exit_function " << file << ":" << line << " - " << s << "\n";
+  exit(-1);
+}
+void nr_fill_dl_indication(void *, void *, void *, const void *, void *, void *)
+{
+}
+void nr_fill_rx_indication(void *, uint8_t, void *, int, int, void *, uint16_t, const void *, void *, uint8_t *)
+{
+}
+}
+
+openair0_config_t openair0_cfg_g[MAX_CARDS];
+
+// Shared NR frame-parameter constants (μ=1, 30 kHz, 100 MHz / 2048-pt FFT)
+static constexpr uint32_t FFT_SIZE = 2048;
+static constexpr uint32_t CP0 = 208; // symbol 0 (extended CP)
+static constexpr uint32_t CP_NORMAL = 144; // symbols 1–13
+static constexpr int SYMS_PER_SLOT = 14;
+static constexpr int SLOTS_PER_FRAME = 20; // μ=1
+static constexpr int MAX_FRAME = 1024;
+static constexpr int RX_TO_TX = 3; // NR_UE_CAPABILITY_SLOT_RX_TO_TX (common/utils/nr/nr_common.h)
+
+/* Offset from slot start to start of symbol sym; mirrors fd_tx_cb_impl's sym_ts loop. */
+static uint64_t sym_start_offset(int sym)
+{
+  if (sym == 0)
+    return 0;
+  uint64_t off = CP0 + FFT_SIZE; // end of symbol 0
+  off += (uint64_t)(sym - 1) * (CP_NORMAL + FFT_SIZE);
+  return off;
+}
+
+/* Theoretical time-domain samples per slot (real OAI uses get_samples_slot_duration()). */
+static uint64_t slot_duration_samples()
+{
+  return CP0 + FFT_SIZE + (SYMS_PER_SLOT - 1) * (uint64_t)(CP_NORMAL + FFT_SIZE);
+}
+
+/* Full frame params matching this file's constants (fully populated: rotation
+ * tables, RB grid, etc.) -- ue_split7_config_t::frame_parms is mandatory, so
+ * make_device() below must pass a real one, not rely on a device-side fallback. */
+static NR_DL_FRAME_PARMS make_test_frame_parms()
+{
+  // init_symbol_rotation() below calls perform_symbol_rotation(), which LOG_D()s --
+  // the log/config subsystem is otherwise only bootstrapped as a side effect of
+  // load_dftslib() (see ue_split7_configure()), which hasn't run yet on the very
+  // first call into this file. load_dftslib() is idempotent (configure() itself
+  // calls it unconditionally on every reconfigure), so calling it here is safe.
+  load_dftslib();
+
+  NR_DL_FRAME_PARMS fp = {};
+  fp.dl_CarrierFreq = 3500000000ULL;
+  fp.ul_CarrierFreq = 3500000000ULL;
+  fp.numerology_index = 1;
+  fp.symbols_per_slot = SYMS_PER_SLOT;
+  fp.slots_per_subframe = SLOTS_PER_FRAME / 10;
+  fp.slots_per_frame = SLOTS_PER_FRAME;
+  fp.ofdm_symbol_size = FFT_SIZE;
+  fp.N_RB_DL = 106;
+  fp.N_RB_UL = 106;
+  fp.first_carrier_offset = FFT_SIZE - (106 * 12 / 2);
+  fp.nb_antennas_rx = 1;
+  fp.nb_prefix_samples = CP_NORMAL;
+  fp.nb_prefix_samples0 = CP0;
+  fp.subcarrier_spacing = 30000;
+  fp.ofdm_offset_divisor = 8;
+  fp.samples_per_slot_wCP = fp.symbols_per_slot * fp.ofdm_symbol_size;
+  fp.samples_per_slotN0 = (fp.nb_prefix_samples + fp.ofdm_symbol_size) * fp.symbols_per_slot;
+  fp.samples_per_subframe = (fp.nb_prefix_samples0 + fp.ofdm_symbol_size) * 2
+                            + (fp.nb_prefix_samples + fp.ofdm_symbol_size) * (fp.symbols_per_slot * fp.slots_per_subframe - 2);
+  fp.samples_per_slot0 =
+      fp.nb_prefix_samples0 + ((fp.symbols_per_slot - 1) * fp.nb_prefix_samples) + (fp.symbols_per_slot * fp.ofdm_symbol_size);
+  fp.samples_per_frame = 10 * fp.samples_per_subframe;
+  fp.Lmax = 8; // dl_CarrierFreq in [3, 6) GHz, mirrors set_Lmax() (nr_parms.c)
+  init_symbol_rotation(&fp); // fills symbol_rotation[link_type_dl]/[link_type_ul]
+  init_timeshift_rotation(fp.ofdm_symbol_size, fp.nb_prefix_samples, fp.ofdm_offset_divisor, fp.timeshift_symbol_rotation);
+  return fp;
+}
+
+/* RX-to-TX lead time that write_symbol()/write_prach() add; every assertion
+ * exercising the real device (not just this file's arithmetic model) needs it. */
+static uint64_t rx_to_tx_lead_samples(int rx_slot)
+{
+  static const NR_DL_FRAME_PARMS fp = make_test_frame_parms();
+  return get_samples_slot_duration(&fp, rx_slot, RX_TO_TX);
+}
+
+// Mock infrastructure (mirrors test_ue_split7.cpp)
+static std::vector<openair0_timestamp_t> mock_tx_timestamps;
+static std::vector<int> mock_tx_nsamps;
+
+static void mock_clear()
+{
+  mock_tx_timestamps.clear();
+  mock_tx_nsamps.clear();
+}
+
+static int mock_trx_start(openair0_device_t *)
+{
+  return 0;
+}
+
+static int mock_trx_write(openair0_device_t *, openair0_timestamp_t ts, void **buff, int nsamps, int, int)
+{
+  (void)buff;
+  mock_tx_timestamps.push_back(ts);
+  mock_tx_nsamps.push_back(nsamps);
+  return nsamps;
+}
+
+static int mock_trx_read(openair0_device_t *, openair0_timestamp_t *ts, void **buff, int nsamps, int)
+{
+  static openair0_timestamp_t cur = 0;
+  *ts = cur;
+  cur += nsamps;
+  std::memset(buff[0], 0, nsamps * 2 * sizeof(int16_t));
+  return nsamps;
+}
+
+static int mock_trx_set_freq(openair0_device_t *, openair0_config_t *)
+{
+  return 0;
+}
+
+/* Partial mirror of ue_split7_device_priv_t; must track its field order (only
+ * openair0_dev and state are accessed through this cast). */
+struct test_priv_t {
+  openair0_device_t openair0_dev;
+  openair0_config_t openair0_cfg;
+  uint32_t ta_samples;
+  bool is_started;
+  int state; // ue_split7_state_t; see make_device()
+  int16_t *rx_time_buf;
+  int16_t *tx_time_buf;
+  uint32_t buf_size_samples;
+};
+
+static ue_split7_device_t *make_device()
+{
+  ue_split7_device_t *dev = ue_split7_device_create();
+  assert(dev);
+
+  NR_DL_FRAME_PARMS fp = make_test_frame_parms();
+
+  ue_split7_config_t cfg;
+  std::memset(&cfg, 0, sizeof(cfg));
+  cfg.dl_carrier_freq_hz = 3500000000ULL;
+  cfg.ul_carrier_freq_hz = 3500000000ULL;
+  cfg.sample_rate_hz = 30720000;
+  cfg.fft_size = FFT_SIZE;
+  cfg.scs_khz = 30;
+  cfg.cp_len_normal = CP_NORMAL;
+  cfg.cp_len_symbol0 = CP0;
+  cfg.num_rx_antennas = 1;
+  cfg.num_tx_antennas = 1;
+  cfg.frame_parms = &fp; // configure() copies it in; fp only needs to outlive this call
+  assert(dev->configure(dev, &cfg) == UE_SPLIT7_SUCCESS);
+
+  test_priv_t *priv = (test_priv_t *)dev->priv;
+  priv->openair0_dev.trx_start_func = mock_trx_start;
+  priv->openair0_dev.trx_read_func = mock_trx_read;
+  priv->openair0_dev.trx_write_func = mock_trx_write;
+  priv->openair0_dev.trx_set_freq_func = mock_trx_set_freq;
+
+  priv->state = 2; // skip sync lifecycle; these tests only need write_symbol() valid
+
+  return dev;
+}
+
+// Sends one symbol as fd_tx_cb_impl would; returns the recorded (TA-subtracted) air timestamp.
+static openair0_timestamp_t send_sym(ue_split7_device_t *dev, int sym, openair0_timestamp_t nominal_slot_start)
+{
+  std::vector<ue_split7_iq_t> iq(FFT_SIZE, {1000, -1000});
+  ue_split7_symbol_buffer_t buf;
+  std::memset(&buf, 0, sizeof(buf));
+  buf.meta.symbol_number = (uint8_t)sym;
+  buf.meta.timestamp_samples = nominal_slot_start + sym_start_offset(sym);
+  buf.num_subcarriers = FFT_SIZE;
+  buf.re_buffer = iq.data();
+
+  mock_clear();
+  dev->write_symbol(dev, &buf, 1);
+  assert(!mock_tx_timestamps.empty());
+  return mock_tx_timestamps.back(); // real symbol write always comes last (dummy zero-fills may precede it)
+}
+
+// TEST 1: per-symbol nominal timestamps (sym_ts advances by CP0+FFT then CP_NORMAL+FFT)
+static void test_symbol_nominal_timestamps()
+{
+  std::cout << "[TEST 1] Per-symbol nominal timestamp sequence\n";
+
+  const openair0_timestamp_t slot_start = 5000000;
+
+  openair0_timestamp_t expected = slot_start;
+  for (int sym = 0; sym < SYMS_PER_SLOT; sym++) {
+    openair0_timestamp_t computed = slot_start + (openair0_timestamp_t)sym_start_offset(sym);
+    assert(computed == expected);
+
+    // sym_ts in fd_tx_cb_impl advances past *this* symbol's CP + data
+    uint32_t cp = (sym == 0) ? CP0 : CP_NORMAL;
+    expected += cp + FFT_SIZE;
+  }
+
+  // Verify the last advance lands at slot_start + slot_duration
+  assert(expected == slot_start + (openair0_timestamp_t)slot_duration_samples());
+  std::cout << "[PASS 1] All 14 symbol nominal timestamps correct\n";
+}
+
+// TEST 2: fd-ue effective TX time == UE_thread effective TX time, per symbol
+static void test_tx_time_equivalence()
+{
+  std::cout << "[TEST 2] fd-ue vs UE_thread effective TX time equivalence\n";
+
+  const openair0_timestamp_t rx_ts = 12345678;
+  const uint64_t slot_dur = slot_duration_samples();
+  const uint32_t N_TA = 512; // N_TA_offset samples (FR1 example)
+  const uint32_t TA = 256; // MAC-commanded timing advance
+  const uint32_t ta_total = N_TA + TA;
+
+  const openair0_timestamp_t tx_nominal_slot_start = rx_ts + (openair0_timestamp_t)slot_dur;
+  const openair0_timestamp_t ue_thread_timestamp_tx = tx_nominal_slot_start - (openair0_timestamp_t)ta_total;
+
+  for (int sym = 0; sym < SYMS_PER_SLOT; sym++) {
+    openair0_timestamp_t sym_off = (openair0_timestamp_t)sym_start_offset(sym);
+
+    // fd-ue: meta.timestamp_samples = nominal_slot_start + sym_off
+    //        device subtracts ta_total → effective TX time
+    openair0_timestamp_t fd_effective = (tx_nominal_slot_start + sym_off) - (openair0_timestamp_t)ta_total;
+
+    // UE_thread: RU_write writes time-domain from timestamp_tx + sym_off
+    openair0_timestamp_t ue_effective = ue_thread_timestamp_tx + sym_off;
+
+    assert(fd_effective == ue_effective);
+  }
+
+  std::cout << "[PASS 2] All 14 symbols: fd-ue effective == UE_thread effective\n";
+}
+
+// TEST 3: set_timing_advance() fires exactly on TA change (first slot, increase, reset)
+static void test_ta_propagation()
+{
+  std::cout << "[TEST 3] set_timing_advance called on TA change\n";
+
+  ue_split7_device_t *dev = make_device();
+
+  struct FakeUE {
+    int N_TA_offset;
+    int timing_advance;
+  } ue = {.N_TA_offset = 512, .timing_advance = 0};
+
+  // Track calls
+  uint32_t last_ta_samples = (uint32_t)-1;
+  auto maybe_update_ta = [&]() -> bool {
+    uint32_t new_ta = (uint32_t)(ue.N_TA_offset + ue.timing_advance);
+    if (new_ta != last_ta_samples) {
+      dev->set_timing_advance(dev, new_ta);
+      last_ta_samples = new_ta;
+      return true;
+    }
+    return false;
+  };
+
+  // a) Slot 0: first update (sentinel → N_TA_offset)
+  assert(maybe_update_ta() == true);
+  assert(last_ta_samples == (uint32_t)ue.N_TA_offset);
+
+  // next write_symbol should subtract the recorded TA
+  {
+    openair0_timestamp_t nominal = 1000000;
+    openair0_timestamp_t eff = send_sym(dev, 1, nominal);
+    assert(eff
+           == nominal + (openair0_timestamp_t)sym_start_offset(1) + (openair0_timestamp_t)rx_to_tx_lead_samples(0)
+                  - (openair0_timestamp_t)last_ta_samples);
+  }
+
+  // b) Slots 1..5: TA unchanged → no further calls
+  for (int s = 1; s <= 5; s++)
+    assert(maybe_update_ta() == false);
+  assert(last_ta_samples == (uint32_t)ue.N_TA_offset);
+
+  // c) MAC CE triggers TA increase
+  ue.timing_advance = 128;
+  assert(maybe_update_ta() == true);
+  assert(last_ta_samples == (uint32_t)(ue.N_TA_offset + 128));
+
+  // Verify device uses new TA
+  {
+    openair0_timestamp_t nominal = 2000000;
+    openair0_timestamp_t eff = send_sym(dev, 0, nominal);
+    assert(eff
+           == nominal + (openair0_timestamp_t)rx_to_tx_lead_samples(0)
+                  - (openair0_timestamp_t)last_ta_samples); // sym 0: offset = 0
+  }
+
+  // Unchanged after update
+  assert(maybe_update_ta() == false);
+
+  // d) TA reset to 0
+  ue.timing_advance = 0;
+  assert(maybe_update_ta() == true);
+  assert(last_ta_samples == (uint32_t)ue.N_TA_offset);
+
+  ue_split7_device_free(dev);
+  std::cout << "[PASS 3] set_timing_advance called at correct times\n";
+}
+
+// TEST 4: proc field derivation (slot/frame/hfn rx+tx) is wrap-correct across frames
+static void test_proc_fields()
+{
+  std::cout << "[TEST 4] proc field computation across slot range\n";
+
+  const int total_slots = 3 * SLOTS_PER_FRAME * MAX_FRAME + SLOTS_PER_FRAME;
+
+  for (int abs = 0; abs < total_slots; abs++) {
+    int slot_rx = abs % SLOTS_PER_FRAME;
+    int frame_rx = (abs / SLOTS_PER_FRAME) % MAX_FRAME;
+    int hfn_rx = (abs / SLOTS_PER_FRAME) / MAX_FRAME;
+
+    int abs_tx = abs + RX_TO_TX;
+    int slot_tx = abs_tx % SLOTS_PER_FRAME;
+    int frame_tx = (abs_tx / SLOTS_PER_FRAME) % MAX_FRAME;
+    int hfn_tx = (abs_tx / SLOTS_PER_FRAME) / MAX_FRAME;
+
+    // Slot indices must be in range
+    assert(slot_rx >= 0 && slot_rx < SLOTS_PER_FRAME);
+    assert(slot_tx >= 0 && slot_tx < SLOTS_PER_FRAME);
+
+    // Frames must be in range
+    assert(frame_rx >= 0 && frame_rx < MAX_FRAME);
+    assert(frame_tx >= 0 && frame_tx < MAX_FRAME);
+
+    // TX slot is always RX_TO_TX slots ahead (mod wrap)
+    assert(((slot_tx - slot_rx + SLOTS_PER_FRAME) % SLOTS_PER_FRAME) == RX_TO_TX || slot_tx < slot_rx); // wrap case
+
+    // HFN must be non-negative
+    assert(hfn_rx >= 0);
+    assert(hfn_tx >= hfn_rx);
+
+    // frame_tx must equal frame_rx or be one ahead (within same HFN boundary)
+    int frame_diff = ((frame_tx - frame_rx) + MAX_FRAME) % MAX_FRAME;
+    assert(frame_diff == 0 || frame_diff == 1);
+  }
+
+  std::cout << "[PASS 4] proc fields correct for " << total_slots << " slots\n";
+}
+
+// TEST 5: symbol-to-symbol TX gaps match CP+FFT across a full slot
+static void test_symbol_gap_continuity()
+{
+  std::cout << "[TEST 5] Symbol-to-symbol gap continuity\n";
+
+  ue_split7_device_t *dev = make_device();
+  dev->set_timing_advance(dev, 0); // no TA for this test
+
+  std::vector<ue_split7_iq_t> iq(FFT_SIZE, {500, -500});
+  const openair0_timestamp_t slot_start = 9000000;
+
+  // Simulate fd_tx_cb_impl: build sym_ts like the production code does
+  std::vector<openair0_timestamp_t> recorded_ts;
+  openair0_timestamp_t sym_ts = slot_start;
+
+  for (int sym = 0; sym < SYMS_PER_SLOT; sym++) {
+    const int sym_off = sym * (int)FFT_SIZE; // index into txdataF array
+
+    ue_split7_symbol_buffer_t buf;
+    std::memset(&buf, 0, sizeof(buf));
+    buf.meta.symbol_number = (uint8_t)sym;
+    buf.meta.timestamp_samples = sym_ts;
+    buf.num_subcarriers = FFT_SIZE;
+    buf.re_buffer = iq.data() + (sym_off % FFT_SIZE);
+
+    mock_clear();
+    dev->write_symbol(dev, &buf, 1);
+    assert(!mock_tx_timestamps.empty());
+    recorded_ts.push_back(mock_tx_timestamps[0]);
+
+    uint32_t cp = (sym == 0) ? CP0 : CP_NORMAL;
+    sym_ts += cp + FFT_SIZE;
+  }
+
+  // sym 0 air time = slot_start + RX-to-TX lead time (ta=0, so no subtraction)
+  assert(recorded_ts[0] == slot_start + (openair0_timestamp_t)rx_to_tx_lead_samples(0));
+
+  // Gap from sym 0 to sym 1: CP0 + FFT
+  assert(recorded_ts[1] - recorded_ts[0] == CP0 + FFT_SIZE);
+
+  // Gaps from sym 1..13: CP_NORMAL + FFT
+  for (int sym = 2; sym < SYMS_PER_SLOT; sym++) {
+    openair0_timestamp_t gap = recorded_ts[sym] - recorded_ts[sym - 1];
+    assert(gap == CP_NORMAL + FFT_SIZE);
+  }
+
+  // Total span equals slot_duration
+  openair0_timestamp_t span = recorded_ts[SYMS_PER_SLOT - 1] + (CP_NORMAL + FFT_SIZE) - recorded_ts[0];
+  assert(span == (openair0_timestamp_t)slot_duration_samples());
+
+  ue_split7_device_free(dev);
+  std::cout << "[PASS 5] All symbol gaps correct\n";
+}
+
+// TEST 6: initial TA push after sync, no spurious repeats, one push per MAC update
+static void test_ta_initial_push()
+{
+  std::cout << "[TEST 6] Initial TA push after sync\n";
+
+  ue_split7_device_t *dev = make_device();
+
+  int N_TA_offset = 512;
+  int timing_advance = 0;
+  uint32_t last_ta = (uint32_t)-1; // sentinel
+  int push_count = 0;
+
+  auto update_ta = [&]() {
+    uint32_t new_ta = (uint32_t)(N_TA_offset + timing_advance);
+    if (new_ta != last_ta) {
+      dev->set_timing_advance(dev, new_ta);
+      last_ta = new_ta;
+      push_count++;
+    }
+  };
+
+  // Simulate post-sync: last_ta = N_TA_offset, one push
+  last_ta = (uint32_t)N_TA_offset;
+  dev->set_timing_advance(dev, last_ta);
+  push_count = 1;
+
+  // Run 10 slots without TA change
+  for (int i = 0; i < 10; i++)
+    update_ta();
+  assert(push_count == 1); // no spurious re-push
+
+  // MAC CE arrives: timing_advance = 64
+  timing_advance = 64;
+  update_ta();
+  assert(push_count == 2);
+  assert(last_ta == (uint32_t)(N_TA_offset + 64));
+
+  // 5 more slots unchanged
+  for (int i = 0; i < 5; i++)
+    update_ta();
+  assert(push_count == 2);
+
+  // Verify device applies new TA correctly
+  openair0_timestamp_t nominal = 3000000;
+  openair0_timestamp_t eff = send_sym(dev, 0, nominal);
+  assert(eff == nominal + (openair0_timestamp_t)rx_to_tx_lead_samples(0) - last_ta);
+
+  ue_split7_device_free(dev);
+  std::cout << "[PASS 6] TA initial push and update correct\n";
+}
+
+// TEST 7: PRACH effective TX time matches the time-domain path's
+static void test_prach_tx_time_equivalence()
+{
+  std::cout << "[TEST 7] PRACH effective TX time equivalence\n";
+
+  const openair0_timestamp_t rx_ts = 24680135;
+  const uint64_t slot_dur = slot_duration_samples();
+  const uint32_t N_TA = 512;
+  const uint32_t TA = 128;
+  const uint32_t ta_total = N_TA + TA;
+
+  const openair0_timestamp_t tx_nominal_slot_start = rx_ts + (openair0_timestamp_t)slot_dur;
+  const openair0_timestamp_t ue_thread_timestamp_tx = tx_nominal_slot_start - (openair0_timestamp_t)ta_total;
+
+  // Simulate different PRACH formats/SCS start offsets (prach_start)
+  const int prach_starts[] = {0, 1536, 3168, 7680};
+  for (int prach_start : prach_starts) {
+    // fd-ue: write_prach calculates based on slot start (nominal) and time_offset_samples
+    openair0_timestamp_t fd_prach_effective = tx_nominal_slot_start + prach_start - ta_total;
+
+    // UE_thread: generate_nr_prach outputs at timestamp_tx + prach_start
+    openair0_timestamp_t ue_prach_effective = ue_thread_timestamp_tx + prach_start;
+
+    assert(fd_prach_effective == ue_prach_effective);
+  }
+
+  std::cout << "[PASS 7] PRACH effective TX time equivalence verified\n";
+}
+
+// MAIN
+int main(int argc, char **argv)
+{
+  (void)argc;
+  (void)argv;
+
+  std::cout << "=========================================================\n";
+  std::cout << "  UE_fd_thread vs UE_thread COMPATIBILITY VERIFICATION   \n";
+  std::cout << "=========================================================\n";
+
+  if (load_dftslib() < 0) {
+    std::cerr << "Failed to load OAI DFT library\n";
+    return -1;
+  }
+
+  test_symbol_nominal_timestamps();
+  std::cout << "---------------------------------------------------------\n";
+  test_tx_time_equivalence();
+  std::cout << "---------------------------------------------------------\n";
+  test_ta_propagation();
+  std::cout << "---------------------------------------------------------\n";
+  test_proc_fields();
+  std::cout << "---------------------------------------------------------\n";
+  test_symbol_gap_continuity();
+  std::cout << "---------------------------------------------------------\n";
+  test_ta_initial_push();
+  std::cout << "---------------------------------------------------------\n";
+  test_prach_tx_time_equivalence();
+
+  std::cout << "=========================================================\n";
+  std::cout << "  ALL COMPATIBILITY TESTS PASSED                         \n";
+  std::cout << "=========================================================\n";
+  return 0;
+}

--- a/radio/COMMON/test_ue_split7.cpp
+++ b/radio/COMMON/test_ue_split7.cpp
@@ -1,0 +1,665 @@
+/**
+ * @file test_ue_split7.cpp
+ * @brief Unit tests for the UE-centric 7.1 functional split interface.
+ *
+ * Test order matters: write_prach() must run before the first write_symbol()
+ * call, since write_symbol() auto-promotes the device past the PRACH-valid
+ * state (see ue_split7_state_t in ue_split7_device.c).
+ */
+
+#include "ue_split7_interface.h"
+
+#include "common_lib.h"
+#include "PHY/TOOLS/tools_defs.h"
+extern "C" {
+void generate_pss_nr_time(int ofdm_symbol_size, int first_carrier_offset, const int N_ID_2, int ssbFirstSCS, c16_t *pssTime);
+}
+#include <atomic>
+#include <iostream>
+#include <vector>
+#include <cmath>
+#include <cstring>
+#include <cassert>
+#include <complex>
+#include <thread>
+#include <chrono>
+
+#include "softmodem-common.h"
+
+extern "C" {
+// Declared directly rather than via PHY/MODULATION/nr_modulation.h: that header
+// uses C99 VLA-in-parameter syntax elsewhere that GCC's C++ frontend rejects.
+void init_symbol_rotation(NR_DL_FRAME_PARMS *fp);
+void init_timeshift_rotation(const int ofdm_symbol_size,
+                             const int nb_prefix_samples,
+                             const unsigned int ofdm_offset_divisor,
+                             c16_t *timeshift_symbol_rotation);
+#include "executables/nr-uesoftmodem.h"
+#include "common/utils/threadPool/thread-pool.h"
+
+softmodem_params_t *get_softmodem_params(void)
+{
+  static softmodem_params_t params;
+  std::memset(&params, 0, sizeof(params));
+  return &params;
+}
+int openair0_device_load(openair0_device_t *device, openair0_config_t *openair0_cfg)
+{
+  return 0;
+}
+void *uniqCfg = NULL;
+void exit_function(const char *file, const char *function, const int line, const char *s, const int assert)
+{
+  std::cerr << "Exit function called from " << file << ":" << line << " - " << s << std::endl;
+  exit(-1);
+}
+void nr_fill_dl_indication(void *dl_ind, void *dci_ind, void *rx_ind, const void *proc, void *ue, void *phy_data)
+{
+}
+void nr_fill_rx_indication(void *rx_ind,
+                           uint8_t pdu_type,
+                           void *ue,
+                           int cw_idx,
+                           int harq_pid,
+                           void *dlsch,
+                           uint16_t n_pdus,
+                           const void *proc,
+                           void *typeSpecific,
+                           uint8_t *b)
+{
+}
+nrUE_params_t nrUE_params;
+nrUE_params_t *get_nrUE_params(void)
+{
+  return &nrUE_params;
+}
+}
+
+openair0_config_t openair0_cfg_g[MAX_CARDS];
+
+// Forward declare device creation/deletion from ue_split7_device.c
+extern "C" {
+ue_split7_device_t *ue_split7_device_create(void);
+void ue_split7_device_free(ue_split7_device_t *dev);
+// Partial mirror of ue_split7_device_priv_t's leading fields; must track its field order.
+typedef struct {
+  openair0_device_t openair0_dev;
+  openair0_config_t openair0_cfg;
+  uint32_t ta_samples;
+  bool is_started;
+  int state; // ue_split7_state_t
+  int16_t *rx_time_buf;
+  int16_t *tx_time_buf;
+  uint32_t buf_size_samples;
+  int16_t **rx_circ_buf;
+  uint32_t circ_buf_size;
+  uint64_t latest_write_ts; // _Atomic uint64_t; same layout as plain uint64_t
+} test_priv_t;
+}
+
+// Full frame params for this file's shared test config (3.5 GHz, 30.72 MHz, 2048-pt
+// FFT, 106 RB @ 30 kHz SCS). ue_split7_config_t::frame_parms is mandatory -- the
+// device has no standalone derivation fallback -- so every configure() call below
+// must pass a real one.
+static NR_DL_FRAME_PARMS make_test_frame_parms()
+{
+  // init_symbol_rotation() below calls perform_symbol_rotation(), which LOG_D()s --
+  // the log/config subsystem is otherwise only bootstrapped as a side effect of
+  // load_dftslib() (see ue_split7_configure()), which hasn't run yet on the very
+  // first call into this file. load_dftslib() is idempotent (configure() itself
+  // calls it unconditionally on every reconfigure), so calling it here is safe.
+  load_dftslib();
+
+  NR_DL_FRAME_PARMS fp = {};
+  fp.dl_CarrierFreq = 3500000000ULL;
+  fp.ul_CarrierFreq = 3500000000ULL;
+  fp.numerology_index = 1;
+  fp.symbols_per_slot = 14;
+  fp.slots_per_subframe = 2;
+  fp.slots_per_frame = 20;
+  fp.ofdm_symbol_size = 2048;
+  fp.N_RB_DL = 106;
+  fp.N_RB_UL = 106;
+  fp.first_carrier_offset = 2048 - (106 * 12 / 2);
+  fp.nb_antennas_rx = 1;
+  fp.nb_prefix_samples = 144;
+  fp.nb_prefix_samples0 = 208;
+  fp.subcarrier_spacing = 30000;
+  fp.ofdm_offset_divisor = 8;
+  fp.samples_per_slot_wCP = fp.symbols_per_slot * fp.ofdm_symbol_size;
+  fp.samples_per_slotN0 = (fp.nb_prefix_samples + fp.ofdm_symbol_size) * fp.symbols_per_slot;
+  fp.samples_per_subframe = (fp.nb_prefix_samples0 + fp.ofdm_symbol_size) * 2
+                            + (fp.nb_prefix_samples + fp.ofdm_symbol_size) * (fp.symbols_per_slot * fp.slots_per_subframe - 2);
+  fp.samples_per_slot0 =
+      fp.nb_prefix_samples0 + ((fp.symbols_per_slot - 1) * fp.nb_prefix_samples) + (fp.symbols_per_slot * fp.ofdm_symbol_size);
+  fp.samples_per_frame = 10 * fp.samples_per_subframe;
+  fp.Lmax = 8; // dl_CarrierFreq in [3, 6) GHz, mirrors set_Lmax() (nr_parms.c)
+  init_symbol_rotation(&fp); // fills symbol_rotation[link_type_dl]/[link_type_ul]
+  init_timeshift_rotation(fp.ofdm_symbol_size, fp.nb_prefix_samples, fp.ofdm_offset_divisor, fp.timeshift_symbol_rotation);
+  return fp;
+}
+
+static std::vector<int16_t> mock_tx_channel_buffer;
+static std::vector<int16_t> mock_rx_channel_buffer;
+static openair0_timestamp_t last_tx_timestamp = 0;
+
+static int mock_trx_start(openair0_device_t *device)
+{
+  return 0;
+}
+
+static void mock_trx_write_clear()
+{
+  mock_tx_channel_buffer.clear();
+  last_tx_timestamp = 0;
+}
+
+static int mock_trx_write(openair0_device_t *device, openair0_timestamp_t timestamp, void **buff, int nsamps, int cc, int flags)
+{
+  last_tx_timestamp = timestamp;
+  int16_t *src = (int16_t *)buff[0];
+  size_t prev_size = mock_tx_channel_buffer.size();
+  mock_tx_channel_buffer.resize(prev_size + nsamps * 2);
+  std::memcpy(&mock_tx_channel_buffer[prev_size], src, nsamps * 2 * sizeof(int16_t));
+  return nsamps;
+}
+
+static int mock_trx_read(openair0_device_t *device, openair0_timestamp_t *timestamp, void **buff, int nsamps, int cc)
+{
+  static openair0_timestamp_t mock_ts = 1000000;
+  *timestamp = mock_ts;
+  mock_ts += nsamps;
+  int16_t *dest = (int16_t *)buff[0];
+
+  if (mock_rx_channel_buffer.size() >= (size_t)nsamps * 2) {
+    std::memcpy(dest, mock_rx_channel_buffer.data(), nsamps * 2 * sizeof(int16_t));
+    mock_rx_channel_buffer.erase(mock_rx_channel_buffer.begin(), mock_rx_channel_buffer.begin() + nsamps * 2);
+  } else {
+    std::memset(dest, 0, nsamps * 2 * sizeof(int16_t));
+  }
+  return nsamps;
+}
+
+static int mock_set_freq_count = 0;
+static double mock_last_set_rx_freq = 0.0;
+static double mock_last_set_tx_freq = 0.0;
+
+static int mock_trx_set_freq(openair0_device_t *device, openair0_config_t *openair0_cfg)
+{
+  mock_set_freq_count++;
+  mock_last_set_rx_freq = openair0_cfg->rx_freq[0];
+  mock_last_set_tx_freq = openair0_cfg->tx_freq[0];
+  return 0;
+}
+
+// --------------------------------------------------------------------------
+// TEST CASE 1: Loopback FFT/IFFT & CP insertion/removal verification
+// --------------------------------------------------------------------------
+void test_loopback_fft_ifft(ue_split7_device_t *dev)
+{
+  std::cout << "[TEST] 1. Starting FFT/IFFT loopback test..." << std::endl;
+
+  uint32_t fft_size = dev->config.fft_size;
+  uint32_t cp_len = dev->config.cp_len_normal;
+
+  // write_symbol()/read_symbol() apply the 38.211 §5.3 symbol-rotation only to the
+  // active RE region; guard-band bins are intentionally left untouched, so only
+  // populate/verify the active band here.
+  uint32_t N_RB_DL = dev->config.N_RB_DL > 0 ? dev->config.N_RB_DL : 106;
+  uint32_t first_carrier_offset = fft_size - N_RB_DL * 6;
+  auto in_active_band = [&](uint32_t i) { return i < N_RB_DL * 6 || i >= first_carrier_offset; };
+
+  std::vector<ue_split7_iq_t> tx_re(fft_size, {0, 0});
+
+  for (uint32_t i = 0; i < fft_size; ++i) {
+    if (!in_active_band(i))
+      continue;
+    tx_re[i].r = (i % 2 == 0) ? 1000 : -1000;
+    tx_re[i].i = (i % 3 == 0) ? 1000 : -1000;
+  }
+  // write_symbol() rotates re_buffer in place, so keep a pristine copy for comparison.
+  const std::vector<ue_split7_iq_t> tx_re_orig = tx_re;
+
+  ue_split7_symbol_buffer_t tx_sym;
+  tx_sym.meta.symbol_number = 1; // normal CP symbol
+  tx_sym.meta.slot_number = 0;
+  tx_sym.meta.timestamp_samples = 1000000;
+  tx_sym.num_subcarriers = fft_size;
+  tx_sym.re_buffer = tx_re.data();
+
+  ue_split7_symbol_buffer_t rx_sym;
+  rx_sym.meta.symbol_number = 1;
+  rx_sym.meta.slot_number = 0;
+  rx_sym.num_subcarriers = fft_size;
+  rx_sym.re_buffer = nullptr; // output-only; read_symbol() fills this in
+
+  mock_trx_write_clear();
+
+  ue_split7_status_t rc = dev->write_symbol(dev, &tx_sym, 1);
+  assert(rc == UE_SPLIT7_SUCCESS);
+  assert(mock_tx_channel_buffer.size() == (fft_size + cp_len) * 2);
+
+  mock_rx_channel_buffer = mock_tx_channel_buffer;
+
+  rc = dev->read_symbol(dev, &rx_sym, 1);
+  assert(rc == UE_SPLIT7_SUCCESS);
+  assert(rx_sym.re_buffer != nullptr);
+  const ue_split7_iq_t *rx_re = rx_sym.re_buffer;
+
+  // The IFFT/CP round trip leaves a single complex gain H from fixed-point
+  // quantization; estimate it from RE 0 and normalize every RE by it.
+  double error_sum = 0.0;
+  double signal_energy = 0.0;
+  uint32_t quadrant_errors = 0;
+
+  const double tx0_r = tx_re_orig[0].r, tx0_i = tx_re_orig[0].i;
+  const double tx0_mag2 = tx0_r * tx0_r + tx0_i * tx0_i;
+  const double H_r = (rx_re[0].r * tx0_r + rx_re[0].i * tx0_i) / tx0_mag2;
+  const double H_i = (rx_re[0].i * tx0_r - rx_re[0].r * tx0_i) / tx0_mag2;
+  const double H_mag2 = H_r * H_r + H_i * H_i;
+  std::cout << "   Complex loopback gain H = (" << H_r << ", " << H_i << ")" << std::endl;
+
+  auto normalize = [&](uint32_t i, double &rx_r_norm, double &rx_i_norm) {
+    double rr = rx_re[i].r, ri = rx_re[i].i;
+    rx_r_norm = (rr * H_r + ri * H_i) / H_mag2;
+    rx_i_norm = (ri * H_r - rr * H_i) / H_mag2;
+  };
+
+  uint32_t active_res_checked = 0;
+  for (uint32_t i = 0; i < fft_size; ++i) {
+    if (!in_active_band(i))
+      continue;
+    active_res_checked++;
+
+    double tx_r = tx_re_orig[i].r;
+    double tx_i = tx_re_orig[i].i;
+
+    double rx_r_norm, rx_i_norm;
+    normalize(i, rx_r_norm, rx_i_norm);
+
+    if ((tx_r >= 0) != (rx_r_norm >= 0))
+      quadrant_errors++;
+    if ((tx_i >= 0) != (rx_i_norm >= 0))
+      quadrant_errors++;
+
+    double err_r = rx_r_norm - tx_r;
+    double err_i = rx_i_norm - tx_i;
+
+    error_sum += err_r * err_r + err_i * err_i;
+    signal_energy += tx_r * tx_r + tx_i * tx_i;
+  }
+  std::cout << "   Active REs checked: " << active_res_checked << " / " << fft_size << std::endl;
+
+  std::cout << "   First 10 symbols comparison (Compensated):" << std::endl;
+  for (int i = 0; i < 10; ++i) {
+    double rx_r_norm, rx_i_norm;
+    normalize(i, rx_r_norm, rx_i_norm);
+    std::cout << "     [" << i << "] TX: (" << tx_re_orig[i].r << ", " << tx_re_orig[i].i << ") | RX (Norm): (" << rx_r_norm << ", "
+              << rx_i_norm << ")" << std::endl;
+  }
+
+  double evm = std::sqrt(error_sum / signal_energy) * 100.0;
+  std::cout << "   Loopback EVM (Compensated): " << evm << "%" << std::endl;
+  std::cout << "   QPSK Decision Errors: " << quadrant_errors << " / " << (active_res_checked * 2) << std::endl;
+
+  assert(quadrant_errors == 0); // Must have zero decision boundary errors
+  assert(evm < 15.0); // Must be less than 15% EVM after fixed-point Q-channel compensation
+  std::cout << "[PASS] 1. FFT/IFFT loopback test passed successfully." << std::endl;
+}
+
+// --------------------------------------------------------------------------
+// TEST CASE 2: Timing Advance (TA) verification
+// --------------------------------------------------------------------------
+void test_timing_advance(ue_split7_device_t *dev)
+{
+  std::cout << "[TEST] 2. Starting Timing Advance (TA) verification..." << std::endl;
+
+  uint32_t fft_size = dev->config.fft_size;
+  std::vector<ue_split7_iq_t> tx_re(fft_size, {1000, -1000});
+
+  ue_split7_symbol_buffer_t tx_sym;
+  tx_sym.meta.symbol_number = 1;
+  tx_sym.meta.slot_number = 0;
+  tx_sym.meta.timestamp_samples = 1000000;
+  tx_sym.num_subcarriers = fft_size;
+  tx_sym.re_buffer = tx_re.data();
+
+  uint32_t ta_val = 128;
+  ue_split7_status_t rc = dev->set_timing_advance(dev, ta_val);
+  assert(rc == UE_SPLIT7_SUCCESS);
+
+  mock_trx_write_clear();
+  rc = dev->write_symbol(dev, &tx_sym, 1);
+  assert(rc == UE_SPLIT7_SUCCESS);
+
+  // Expected = timestamp_samples + RX-to-TX lead (3 slots via get_samples_slot_duration(),
+  // CP0=208/CP_NORMAL=144/FFT=2048/mu=1 => 92256) - TA = 1000000 + 92256 - 128 = 1092128.
+  std::cout << "   Nominal Timestamp: 1000000 | Applied TA: " << ta_val << " | Transmitted Timestamp: " << last_tx_timestamp
+            << std::endl;
+  assert(last_tx_timestamp == (1000000 + 92256 - ta_val));
+
+  std::cout << "[PASS] 2. Timing Advance (TA) verification passed." << std::endl;
+}
+
+// --------------------------------------------------------------------------
+// TEST CASE 3: Synchronization Service time-domain cell search verification
+// --------------------------------------------------------------------------
+static bool sync_callback_called = false;
+static ue_split7_status_t sync_callback_status = UE_SPLIT7_ERR_GENERIC;
+static ue_split7_sync_result_t sync_callback_result;
+
+static void test_sync_callback(struct ue_split7_device *dev,
+                               ue_split7_status_t status,
+                               const ue_split7_sync_result_t *result,
+                               void *user_data)
+{
+  sync_callback_called = true;
+  sync_callback_status = status;
+  if (status == UE_SPLIT7_SUCCESS && result) {
+    sync_callback_result = *result;
+  }
+}
+
+// Regression test: UE_SPLIT7_SUCCESS must require an actual PBCH decode, not just
+// PSS detection (see ue_split7_sync_result_t::mib_decoded in ue_split7_interface.h).
+// A PSS-only signal should time out, never report false success.
+void test_synchronization_service(ue_split7_device_t *dev)
+{
+  std::cout << "[TEST] 3. Starting Synchronization Service search verification..." << std::endl;
+
+  uint32_t fft_size = dev->config.fft_size;
+  uint32_t sample_rate = dev->config.sample_rate_hz;
+  uint32_t frame_samples = sample_rate * 0.01; // 10ms frame
+
+  mock_rx_channel_buffer.assign(frame_samples * 2, 0);
+
+  uint32_t target_offset = 15000;
+  uint8_t target_nid2 = 1;
+
+  int16_t *pss_time = (int16_t *)aligned_alloc(32, fft_size * 2 * sizeof(int16_t));
+  std::memset(pss_time, 0, fft_size * 2 * sizeof(int16_t));
+
+  // PSS only; SSS/PBCH DM-RS/payload are left at zero.
+  generate_pss_nr_time(fft_size, 0, target_nid2, 1, (c16_t *)pss_time);
+  std::memcpy(&mock_rx_channel_buffer[target_offset * 2], pss_time, fft_size * 2 * sizeof(int16_t));
+  free(pss_time);
+
+  ue_split7_sync_config_t sync_cfg;
+  std::memset(&sync_cfg, 0, sizeof(sync_cfg));
+  sync_cfg.arfcn = 640000;
+  sync_cfg.scs_khz = 30;
+  sync_cfg.timeout_ms = 1000;
+  sync_cfg.expected_pci = -1;
+
+  nrUE_params_t *ue_params = (nrUE_params_t *)get_nrUE_params();
+  if (ue_params->Tpool.len_thr == 0) {
+    initFloatingCoresTpool(4, &ue_params->Tpool, false, (char *)"Tpool");
+  }
+
+  sync_callback_called = false;
+  ue_split7_status_t rc = dev->start_sync(dev, &sync_cfg, &ue_params->Tpool, test_sync_callback, nullptr);
+  assert(rc == UE_SPLIT7_SUCCESS);
+
+  // Regression check: sample ingestion (latest_write_ts) must keep advancing while
+  // the sync search runs, even though it never finds a signal.
+  std::cout << "   Scanning for PSS on simulated channel (expecting a timeout: PSS-only, no PBCH)..." << std::endl;
+  test_priv_t *priv = (test_priv_t *)dev->priv;
+  uint64_t last_write_ts = priv->latest_write_ts;
+  int timeout_cnt = 0;
+  while (!sync_callback_called && timeout_cnt < 30) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    timeout_cnt++;
+    uint64_t write_ts = priv->latest_write_ts;
+    assert(write_ts > last_write_ts && "sample ingestion stalled during sync search -- deadlock regression");
+    last_write_ts = write_ts;
+  }
+
+  assert(sync_callback_called);
+  assert(sync_callback_status != UE_SPLIT7_SUCCESS);
+  std::cout << "   PSS-only signal correctly did not produce a false sync success (status " << (int)sync_callback_status
+            << "), ingestion never stalled." << std::endl;
+
+  std::cout << "[PASS] 3. Synchronization Service correctly requires PBCH, not just PSS." << std::endl;
+}
+
+// --------------------------------------------------------------------------
+// TEST CASE 5: PRACH Transmission verification
+// --------------------------------------------------------------------------
+void test_prach_transmission(ue_split7_device_t *dev)
+{
+  std::cout << "[TEST] 5. Starting PRACH Transmission verification..." << std::endl;
+
+  uint32_t fft_size = dev->config.fft_size;
+  uint32_t num_prach_samples = 139; // short preamble
+  std::vector<ue_split7_iq_t> prach_re(num_prach_samples);
+  for (uint32_t k = 0; k < num_prach_samples; ++k) {
+    prach_re[k].r = (k % 2 == 0) ? 2000 : -2000;
+    prach_re[k].i = (k % 3 == 0) ? 2000 : -2000;
+  }
+
+  ue_split7_prach_tx_params_t params;
+  std::memset(&params, 0, sizeof(params));
+  params.samples = prach_re.data();
+  params.num_samples = num_prach_samples;
+  params.timestamp_samples = 1000000;
+  params.time_offset_samples = 100;
+  params.cp_len_samples = 512;
+  params.slot_number = 2;
+  params.symbol_number = 0;
+  params.frequency_offset_scs = 100;
+  params.repetition_count = 2;
+  params.antenna_port = 0;
+
+  uint32_t ta_val = 128;
+  dev->set_timing_advance(dev, ta_val);
+
+  mock_trx_write_clear();
+  ue_split7_status_t rc = dev->write_prach(dev, &params);
+  assert(rc == UE_SPLIT7_SUCCESS);
+
+  // cp_len_samples + fft_size * repetition_count = 512 + 2048*2 = 4608 complex samples.
+  std::cout << "   Channel Buffer size: " << mock_tx_channel_buffer.size() << " | Expected: " << (512 + fft_size * 2) * 2
+            << std::endl;
+  assert(mock_tx_channel_buffer.size() == (512 + fft_size * 2) * 2);
+
+  // timestamp_samples + time_offset_samples + RX-to-TX lead (92256, see test_timing_advance) - TA
+  // = 1000000 + 100 + 92256 - 128 = 1092228.
+  std::cout << "   Transmitted Timestamp: " << last_tx_timestamp << " | Expected: 1092228" << std::endl;
+  assert(last_tx_timestamp == 1092228);
+
+  // Custom fft_size with num_samples == fft_size (1-to-1 mapping).
+  uint32_t custom_fft_size = 6144;
+  std::vector<ue_split7_iq_t> prach_custom(custom_fft_size);
+  for (uint32_t k = 0; k < custom_fft_size; ++k) {
+    prach_custom[k].r = 500;
+    prach_custom[k].i = -500;
+  }
+
+  ue_split7_prach_tx_params_t params2;
+  std::memset(&params2, 0, sizeof(params2));
+  params2.samples = prach_custom.data();
+  params2.num_samples = custom_fft_size;
+  params2.fft_size = custom_fft_size;
+  params2.timestamp_samples = 2000000;
+  params2.time_offset_samples = 250; // unaligned transmission
+  params2.cp_len_samples = 3168;
+  params2.slot_number = 3;
+  params2.symbol_number = 0;
+  params2.repetition_count = 4;
+  params2.antenna_port = 0;
+
+  mock_trx_write_clear();
+  rc = dev->write_prach(dev, &params2);
+  assert(rc == UE_SPLIT7_SUCCESS);
+
+  // cp_len_samples + fft_size * repetition_count = 3168 + 6144*4 = 27744 complex samples.
+  assert(mock_tx_channel_buffer.size() == (3168 + custom_fft_size * 4) * 2);
+
+  // Lead time (92256) comes from the device's own frame_parms, not params->fft_size:
+  // 2000000 + 250 + 92256 - 128 = 2092378.
+  assert(last_tx_timestamp == 2092378);
+  std::cout << "   Unaligned Custom FFT PRACH Transmitted Timestamp: " << last_tx_timestamp << " | Expected: 2092378" << std::endl;
+
+  std::cout << "[PASS] 5. PRACH Transmission verification passed." << std::endl;
+}
+
+// --------------------------------------------------------------------------
+// TEST CASE 7: sync -> PRACH -> normal-UL state lifecycle
+// --------------------------------------------------------------------------
+void test_state_lifecycle()
+{
+  std::cout << "[TEST] 7. Starting state lifecycle verification..." << std::endl;
+
+  ue_split7_device_t *dev = ue_split7_device_create();
+  assert(dev != nullptr);
+
+  NR_DL_FRAME_PARMS fp = make_test_frame_parms();
+
+  ue_split7_config_t config;
+  std::memset(&config, 0, sizeof(config));
+  config.dl_carrier_freq_hz = 3500000000ULL;
+  config.ul_carrier_freq_hz = 3500000000ULL;
+  config.sample_rate_hz = 30720000;
+  config.fft_size = 2048;
+  config.scs_khz = 30;
+  config.cp_len_normal = 144;
+  config.cp_len_symbol0 = 208;
+  config.num_rx_antennas = 1;
+  config.num_tx_antennas = 1;
+  config.frame_parms = &fp; // configure() copies it in; fp only needs to outlive this call
+
+  ue_split7_status_t rc = dev->configure(dev, &config);
+  assert(rc == UE_SPLIT7_SUCCESS);
+
+  test_priv_t *priv = (test_priv_t *)dev->priv;
+  priv->openair0_dev.trx_start_func = mock_trx_start;
+  priv->openair0_dev.trx_read_func = mock_trx_read;
+  priv->openair0_dev.trx_write_func = mock_trx_write;
+  priv->openair0_dev.trx_set_freq_func = mock_trx_set_freq;
+
+  // write_symbol()'s DFT input requires 32-byte-aligned re_buffer; std::vector doesn't guarantee that.
+  uint32_t fft_size = dev->config.fft_size;
+  ue_split7_iq_t *re = (ue_split7_iq_t *)aligned_alloc(32, fft_size * sizeof(ue_split7_iq_t));
+  assert(re != nullptr);
+  for (uint32_t i = 0; i < fft_size; i++)
+    re[i] = {1000, -1000};
+
+  // Separate buffers for RX (read_symbol() output-only, device fills it in) and
+  // TX (write_symbol()'s caller-owned input) -- they must not alias each other.
+  ue_split7_symbol_buffer_t rx_sym;
+  rx_sym.meta.symbol_number = 1;
+  rx_sym.meta.slot_number = 0;
+  rx_sym.num_subcarriers = fft_size;
+  rx_sym.re_buffer = nullptr;
+
+  ue_split7_symbol_buffer_t tx_sym;
+  tx_sym.meta.symbol_number = 1;
+  tx_sym.meta.slot_number = 0;
+  tx_sym.meta.timestamp_samples = 1000000;
+  tx_sym.num_subcarriers = fft_size;
+  tx_sym.re_buffer = re;
+
+  ue_split7_prach_tx_params_t prach_params;
+  std::memset(&prach_params, 0, sizeof(prach_params));
+  prach_params.samples = re;
+  prach_params.num_samples = 139;
+  prach_params.timestamp_samples = 1000000;
+  prach_params.cp_len_samples = 512;
+  prach_params.repetition_count = 2;
+
+  // UNSYNCED: nothing is valid yet.
+  assert(dev->read_symbol(dev, &rx_sym, 1) == UE_SPLIT7_ERR_STATE);
+  assert(dev->write_symbol(dev, &tx_sym, 1) == UE_SPLIT7_ERR_STATE);
+  assert(dev->write_prach(dev, &prach_params) == UE_SPLIT7_ERR_STATE);
+  std::cout << "   UNSYNCED: read/write_symbol/write_prach all rejected, as expected." << std::endl;
+
+  // Drive state directly; this test is about state gating, not sync correctness.
+  priv->state = 1; // UE_SPLIT7_STATE_DL_SYNCED
+
+  // DL_SYNCED: read_symbol valid; UL still isn't.
+  assert(dev->read_symbol(dev, &rx_sym, 1) == UE_SPLIT7_SUCCESS);
+  assert(dev->write_symbol(dev, &tx_sym, 1) == UE_SPLIT7_ERR_STATE);
+  assert(dev->write_prach(dev, &prach_params) == UE_SPLIT7_ERR_STATE);
+  std::cout << "   DL_SYNCED: read_symbol valid, write_symbol/write_prach still rejected." << std::endl;
+
+  // UL_PRACH_ONLY: established by the first set_timing_advance() after sync.
+  rc = dev->set_timing_advance(dev, 0);
+  assert(rc == UE_SPLIT7_SUCCESS);
+  mock_trx_write_clear();
+  assert(dev->write_prach(dev, &prach_params) == UE_SPLIT7_SUCCESS);
+  std::cout << "   UL_PRACH_ONLY: write_prach valid." << std::endl;
+
+  // First write_symbol() auto-promotes to UL_NORMAL; write_prach must now be rejected.
+  assert(dev->write_symbol(dev, &tx_sym, 1) == UE_SPLIT7_SUCCESS);
+  assert(dev->write_prach(dev, &prach_params) == UE_SPLIT7_ERR_STATE);
+  assert(dev->read_symbol(dev, &rx_sym, 1) == UE_SPLIT7_SUCCESS);
+  std::cout << "   UL_NORMAL: write_prach now rejected; read/write_symbol still valid." << std::endl;
+
+  free(re);
+  dev->stop(dev);
+  ue_split7_device_free(dev);
+
+  std::cout << "[PASS] 7. State lifecycle verification passed." << std::endl;
+}
+
+// --------------------------------------------------------------------------
+// MAIN EXECUTION
+// --------------------------------------------------------------------------
+int main(int argc, char **argv)
+{
+  std::cout << "=========================================================" << std::endl;
+  std::cout << "            RUNNING UE SPLIT 7.1 LOW-PHY UNIT TESTS      " << std::endl;
+  std::cout << "=========================================================" << std::endl;
+
+  ue_split7_device_t *dev = ue_split7_device_create();
+  assert(dev != nullptr);
+
+  NR_DL_FRAME_PARMS fp = make_test_frame_parms();
+
+  ue_split7_config_t config;
+  std::memset(&config, 0, sizeof(config));
+  config.dl_carrier_freq_hz = 3500000000ULL; // 3.5 GHz
+  config.ul_carrier_freq_hz = 3500000000ULL;
+  config.sample_rate_hz = 30720000; // 30.72 MHz
+  config.fft_size = 2048;
+  config.scs_khz = 30;
+  config.cp_len_normal = 144;
+  config.cp_len_symbol0 = 208; // symbol 0 has longer prefix
+  config.num_rx_antennas = 1;
+  config.num_tx_antennas = 1;
+  config.frame_parms = &fp; // configure() copies it in; fp only needs to outlive this call
+
+  ue_split7_status_t rc = dev->configure(dev, &config);
+  assert(rc == UE_SPLIT7_SUCCESS);
+
+  test_priv_t *priv = (test_priv_t *)dev->priv;
+  priv->openair0_dev.trx_start_func = mock_trx_start;
+  priv->openair0_dev.trx_read_func = mock_trx_read;
+  priv->openair0_dev.trx_write_func = mock_trx_write;
+  priv->openair0_dev.trx_set_freq_func = mock_trx_set_freq;
+
+  // Jump straight to UL_PRACH_ONLY rather than running a real sync cycle to flip one bit.
+  // PRACH must run before the first write_symbol() (which auto-promotes past it).
+  // test_synchronization_service runs last: start_sync() starts a background read
+  // thread that would otherwise race the other tests' single-shot mock reads.
+  priv->state = 2; // UE_SPLIT7_STATE_UL_PRACH_ONLY
+  test_prach_transmission(dev);
+  std::cout << "---------------------------------------------------------" << std::endl;
+  test_loopback_fft_ifft(dev);
+  std::cout << "---------------------------------------------------------" << std::endl;
+  test_timing_advance(dev);
+  std::cout << "---------------------------------------------------------" << std::endl;
+  test_synchronization_service(dev);
+  std::cout << "---------------------------------------------------------" << std::endl;
+
+  dev->stop(dev);
+  ue_split7_device_free(dev);
+
+  // Own fresh device, so UNSYNCED-state rejections can be checked from a clean state.
+  test_state_lifecycle();
+
+  std::cout << "=========================================================" << std::endl;
+  std::cout << "          ALL UE SPLIT 7.1 LOW-PHY TESTS COMPLETED: OK   " << std::endl;
+  std::cout << "=========================================================" << std::endl;
+  return 0;
+}

--- a/radio/COMMON/ue_split7_device.c
+++ b/radio/COMMON/ue_split7_device.c
@@ -1,0 +1,1243 @@
+/**
+ * @file ue_split7_device.c
+ * @brief Implementation of the UE-centric 7.1 functional split interface.
+ */
+
+#include "ue_split7_interface.h"
+#include "common_lib.h"
+#include "PHY/TOOLS/tools_defs.h"
+#include "PHY/NR_REFSIG/pss_nr.h"
+#include "common/utils/LOG/log.h"
+#include "PHY/defs_nr_UE.h"
+#include "PHY/impl_defs_nr.h"
+#include "PHY/MODULATION/nr_modulation.h"
+#include "PHY/NR_UE_TRANSPORT/nr_transport_proto_ue.h"
+#include "executables/nr-uesoftmodem.h"
+#include "common/utils/nr/nr_common.h"
+#include "common/utils/utils.h"
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <unistd.h>
+#include <time.h>
+#include "common/utils/threadPool/thread-pool.h"
+
+// Monotonic: UNSYNCED -> DL_SYNCED (read_symbol valid) -> UL_PRACH_ONLY (write_prach
+// valid) -> UL_NORMAL (first write_symbol, PRACH no longer valid). Never backward.
+typedef enum {
+  UE_SPLIT7_STATE_UNSYNCED = 0,
+  UE_SPLIT7_STATE_DL_SYNCED = 1,
+  UE_SPLIT7_STATE_UL_PRACH_ONLY = 2,
+  UE_SPLIT7_STATE_UL_NORMAL = 3,
+} ue_split7_state_t;
+
+// Hard cap on RX/TX antenna count: several hot-path functions (read_symbol's
+// non-threaded fallback, write_symbol, sync_task_func) use fixed-size stack
+// arrays sized to this bound and indexed directly by config.num_rx/tx_antennas,
+// so ue_split7_configure() must reject any config exceeding it.
+#define UE_SPLIT7_MAX_ANT 8
+
+typedef struct {
+  openair0_device_t openair0_dev;
+  openair0_config_t openair0_cfg;
+  _Atomic uint32_t ta_samples; // written by set_timing_advance() (FD-UE thread),
+                               // read by write_symbol()/write_prach() (dl_actors worker thread)
+  bool is_started;
+  _Atomic int state; // ue_split7_state_t
+
+  // Intermediate buffers for FFT/IFFT processing
+  int16_t *rx_time_buf; // intermediate time-domain buffer for read_symbol
+  int16_t *tx_time_buf; // intermediate time-domain buffer for write_symbol
+  uint32_t buf_size_samples;
+
+  // Time-domain RX ring, addressed directly by RF sample timestamp (ring position ==
+  // ts % circ_buf_size), not by an independently-tracked append count.
+  int16_t **rx_circ_buf; // rx_circ_buf[channel][sample_index * 2] for complex samples
+  uint32_t circ_buf_size; // size in complex samples
+  _Atomic uint64_t latest_write_ts; // ts + n of the most recent ring write; read thread writes, others wait on it
+  // Consumer-owned read cursor (absolute RF timestamp), touched only from the FD-UE
+  // thread; the state acquire/release below (not atomicity) makes the sync task's seed visible.
+  uint64_t next_read_ts;
+
+  // Device-owned FD-symbol scratch: read_symbol() DFTs into rx_fd_buf[antenna] and returns
+  // a pointer into it. Valid until the next read_symbol() call; the caller must copy out
+  // before then if it needs the data to outlive that call.
+  c16_t **rx_fd_buf; // rx_fd_buf[antenna][fft_size]
+
+  // Read thread management
+  pthread_t read_thread;
+  atomic_bool read_running;
+
+  // Broadcast by the read thread after every write so read_symbol()/wait_next_slot()
+  // wake instead of busy-polling; the read thread itself never waits on this.
+  pthread_mutex_t data_mutex;
+  pthread_cond_t data_cond;
+
+  // sync_task_func() owns its whole capture-retry loop internally (one
+  // pushTpool() call runs to success/timeout), so no capture position is
+  // shared across threads here.
+  atomic_bool sync_active;
+  // True for the duration of one sync_task_func() run; stop_sync() polls
+  // this (not sync_active, which only requests cancellation) to know when
+  // the task has actually stopped.
+  atomic_bool sync_task_running;
+  tpool_t *sync_pool;
+  struct timespec sync_start_time;
+  ue_split7_sync_config_t sync_cfg;
+  ue_split7_sync_callback_t sync_cb;
+  void *sync_user_data;
+
+  pthread_mutex_t write_mutex;
+
+  // Slot-timing tracker for wait_next_slot()/seed_slot_tracking(): frame/slot
+  // reported by the NEXT call, and the sample position its slot starts at.
+  // The sole authoritative walk; the host has no independent slot counter.
+  bool slot_tracking_seeded;
+  uint32_t next_frame_number;
+  uint16_t next_slot_number;
+  uint64_t next_slot_sample_pos;
+
+  // Frequency offset (Hz) measured during last successful sync.
+  // Applied to the RF LO so subsequent symbol reads are already corrected.
+  int32_t last_freq_offset_hz;
+
+  // Rotation tables (38.211 §5.3 symbol-phase correction) to use: config.frame_parms
+  // when the host provided one (shares nr_init.c's exact tables), else &frame_parms,
+  // a locally-derived fallback for standalone/unit-test use.
+  const NR_DL_FRAME_PARMS *fp;
+  NR_DL_FRAME_PARMS frame_parms;
+
+  // RX FFT-window offset into the CP (nr_slot_fep()'s ISI-avoidance convention);
+  // nonzero only when fp == config.frame_parms, since the fallback path samples
+  // exactly at the symbol boundary instead.
+  uint32_t rot_sample_offset;
+} ue_split7_device_priv_t;
+
+static void sync_task_func(void *arg);
+
+// aligned_alloc() requires size to be a multiple of the alignment; round up.
+static void *split7_aligned_alloc32(size_t size)
+{
+  return aligned_alloc(32, (size + 31) & ~(size_t)31);
+}
+
+// 20ms SSB period + 1 slot margin: unlike nr_scan_ssb()'s frame-aligned capture, this
+// search's arbitrary live-edge offset can otherwise truncate the SSB occasion by phase.
+static uint32_t split7_sync_capture_samples(const NR_DL_FRAME_PARMS *fp)
+{
+  return 2 * fp->samples_per_frame + get_samples_per_slot(0, fp); // 20ms (TS 38.213 §4.1) + 1 slot margin
+}
+
+// Writes at ts % circ_buf_size, i.e. directly at the position the RF device's own
+// timestamp implies, so the ring can never desync from the device's sample clock.
+static void write_ring_at_ts(ue_split7_device_priv_t *priv,
+                             openair0_timestamp_t ts,
+                             int16_t **src,
+                             uint32_t num_samples,
+                             uint16_t num_channels)
+{
+  uint64_t write_pos = (uint64_t)ts % priv->circ_buf_size;
+  uint32_t space_to_end = priv->circ_buf_size - write_pos;
+
+  for (uint16_t ch = 0; ch < num_channels; ch++) {
+    if (num_samples <= space_to_end) {
+      memcpy(&priv->rx_circ_buf[ch][write_pos * 2], src[ch], num_samples * 2 * sizeof(int16_t));
+    } else {
+      memcpy(&priv->rx_circ_buf[ch][write_pos * 2], src[ch], space_to_end * 2 * sizeof(int16_t));
+      memcpy(&priv->rx_circ_buf[ch][0], &src[ch][space_to_end * 2], (num_samples - space_to_end) * 2 * sizeof(int16_t));
+    }
+  }
+  atomic_store_explicit(&priv->latest_write_ts, (uint64_t)ts + num_samples, memory_order_release);
+}
+
+static void read_channel_at_ts(ue_split7_device_priv_t *priv,
+                               int16_t *dst,
+                               uint16_t channel,
+                               openair0_timestamp_t ts,
+                               uint32_t num_samples)
+{
+  uint64_t read_pos = (uint64_t)ts % priv->circ_buf_size;
+  uint32_t space_to_end = priv->circ_buf_size - read_pos;
+
+  if (num_samples <= space_to_end) {
+    memcpy(dst, &priv->rx_circ_buf[channel][read_pos * 2], num_samples * 2 * sizeof(int16_t));
+  } else {
+    memcpy(dst, &priv->rx_circ_buf[channel][read_pos * 2], space_to_end * 2 * sizeof(int16_t));
+    memcpy(&dst[space_to_end * 2], &priv->rx_circ_buf[channel][0], (num_samples - space_to_end) * 2 * sizeof(int16_t));
+  }
+}
+
+static void *read_thread_func(void *arg)
+{
+  struct ue_split7_device *dev = (struct ue_split7_device *)arg;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  uint16_t num_rx = dev->config.num_rx_antennas;
+  uint32_t chunk_size = dev->config.fft_size > 0 ? dev->config.fft_size : 2048;
+
+  int16_t **temp_bufs = (int16_t **)malloc(num_rx * sizeof(int16_t *));
+  void **rx_ptrs = (void **)malloc(num_rx * sizeof(void *));
+  if (!temp_bufs || !rx_ptrs) {
+    if (temp_bufs)
+      free(temp_bufs);
+    if (rx_ptrs)
+      free(rx_ptrs);
+    priv->read_running = false;
+    return NULL;
+  }
+
+  for (int i = 0; i < num_rx; i++) {
+    temp_bufs[i] = (int16_t *)malloc(chunk_size * 2 * sizeof(int16_t));
+    if (!temp_bufs[i]) {
+      for (int k = 0; k < i; k++) {
+        free(temp_bufs[k]);
+      }
+      free(temp_bufs);
+      free(rx_ptrs);
+      priv->read_running = false;
+      return NULL;
+    }
+  }
+
+  while (priv->read_running) {
+    openair0_timestamp_t ts = 0;
+    for (int i = 0; i < num_rx; i++) {
+      rx_ptrs[i] = temp_bufs[i];
+    }
+
+    // Never blocks on a consumer: a slow FD-UE side just sees a staleness warning
+    // at the point of use (read_symbol()/wait_next_slot()) instead of stalling ingestion.
+    int read_samples = priv->openair0_dev.trx_read_func(&priv->openair0_dev, &ts, rx_ptrs, chunk_size, num_rx);
+    if (read_samples < 0) {
+      usleep(1000);
+      continue;
+    }
+    // OAI's RF-device contract is exact-count-or-error (see nr-ru.c/nr-ue-ru.c); a
+    // partial read would desync the ring's ts-addressed writes from real device time.
+    AssertFatal((uint32_t)read_samples == chunk_size,
+                "[split7] rfdevice trx_read_func returned %d samples, expected %u\n",
+                read_samples,
+                chunk_size);
+
+    write_ring_at_ts(priv, ts, temp_bufs, chunk_size, num_rx);
+
+    pthread_mutex_lock(&priv->data_mutex);
+    pthread_cond_broadcast(&priv->data_cond);
+    pthread_mutex_unlock(&priv->data_mutex);
+  }
+
+  for (int i = 0; i < num_rx; i++) {
+    free(temp_bufs[i]);
+  }
+  free(temp_bufs);
+  free(rx_ptrs);
+  return NULL;
+}
+
+static ue_split7_status_t ue_split7_configure(struct ue_split7_device *dev, const ue_split7_config_t *config)
+{
+  if (!dev || !config)
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  if (config->num_rx_antennas == 0 || config->num_rx_antennas > UE_SPLIT7_MAX_ANT || config->num_tx_antennas == 0
+      || config->num_tx_antennas > UE_SPLIT7_MAX_ANT) {
+    LOG_E(PHY,
+          "ue_split7_configure: invalid antenna count (rx=%u tx=%u); must be 1..%d\n",
+          config->num_rx_antennas,
+          config->num_tx_antennas,
+          UE_SPLIT7_MAX_ANT);
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  }
+  if (!config->frame_parms) {
+    LOG_E(PHY, "ue_split7_configure: config->frame_parms is required (no standalone fallback)\n");
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  }
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  // Reconfiguring while started would free buffers still in use -- stop() first.
+  if (priv->is_started) {
+    LOG_E(PHY, "ue_split7_configure: cannot reconfigure while device is started\n");
+    return UE_SPLIT7_ERR_STATE;
+  }
+
+  // Load OAI DFT library
+  if (load_dftslib() < 0) {
+    LOG_E(PHY, "Failed to load OAI DFT library\n");
+    return UE_SPLIT7_ERR_GENERIC;
+  }
+
+  // Free existing buffers if reconfiguring
+  if (priv->rx_circ_buf) {
+    for (int i = 0; i < dev->config.num_rx_antennas; i++) {
+      if (priv->rx_circ_buf[i])
+        free(priv->rx_circ_buf[i]);
+    }
+    free(priv->rx_circ_buf);
+    priv->rx_circ_buf = NULL;
+  }
+  if (priv->rx_fd_buf) {
+    for (int i = 0; i < dev->config.num_rx_antennas; i++) {
+      if (priv->rx_fd_buf[i])
+        free(priv->rx_fd_buf[i]);
+    }
+    free(priv->rx_fd_buf);
+    priv->rx_fd_buf = NULL;
+  }
+
+  dev->config = *config;
+
+  // Setup openair0 config
+  memset(&priv->openair0_cfg, 0, sizeof(priv->openair0_cfg));
+  priv->openair0_cfg.nr_flag = 1;
+  priv->openair0_cfg.sample_rate = config->sample_rate_hz;
+  nrUE_params_t *ue_params = get_nrUE_params();
+  if (ue_params) {
+    priv->openair0_cfg.num_rb_dl = ue_params->N_RB_DL > 0 ? ue_params->N_RB_DL : 106;
+    priv->openair0_cfg.sdr_addrs = ue_params->usrp_args;
+    priv->openair0_cfg.tx_subdev = ue_params->tx_subdev;
+    priv->openair0_cfg.rx_subdev = ue_params->rx_subdev;
+  } else {
+    priv->openair0_cfg.num_rb_dl = 106;
+  }
+  priv->openair0_cfg.rx_num_channels = config->num_rx_antennas;
+  priv->openair0_cfg.tx_num_channels = config->num_tx_antennas;
+  priv->openair0_cfg.rx_freq[0] = config->dl_carrier_freq_hz;
+  priv->openair0_cfg.tx_freq[0] = config->ul_carrier_freq_hz;
+  priv->openair0_cfg.rx_bw = config->sample_rate_hz * 0.8;
+  priv->openair0_cfg.tx_bw = config->sample_rate_hz * 0.8;
+  priv->openair0_cfg.clock_source = internal;
+  priv->openair0_cfg.time_source = internal;
+
+  // Initialize openair0 device (loading rfsimulator or other driver)
+  if (openair0_device_load(&priv->openair0_dev, &priv->openair0_cfg) < 0) {
+    LOG_E(PHY, "Failed to load openair0 backend device\n");
+    return UE_SPLIT7_ERR_GENERIC;
+  }
+
+  // Free existing FFT/IFFT intermediate buffers if reconfiguring (mirrors the
+  // rx_circ_buf/rx_fd_buf free-before-reassign handling above -- otherwise every
+  // repeat configure() call leaks the previous pair of aligned buffers).
+  if (priv->rx_time_buf) {
+    free(priv->rx_time_buf);
+    priv->rx_time_buf = NULL;
+  }
+  if (priv->tx_time_buf) {
+    free(priv->tx_time_buf);
+    priv->tx_time_buf = NULL;
+  }
+
+  // Allocate intermediate FFT/IFFT time-domain buffers
+  priv->buf_size_samples = config->fft_size + config->cp_len_symbol0;
+  // Each sample is complex (2 * int16_t)
+  priv->rx_time_buf = (int16_t *)split7_aligned_alloc32(priv->buf_size_samples * 2 * sizeof(int16_t));
+  priv->tx_time_buf = (int16_t *)split7_aligned_alloc32(priv->buf_size_samples * 2 * sizeof(int16_t));
+
+  if (!priv->rx_time_buf || !priv->tx_time_buf) {
+    LOG_E(PHY, "Out of memory allocating FFT/IFFT intermediate buffers\n");
+    if (priv->rx_time_buf) {
+      free(priv->rx_time_buf);
+      priv->rx_time_buf = NULL;
+    }
+    if (priv->tx_time_buf) {
+      free(priv->tx_time_buf);
+      priv->tx_time_buf = NULL;
+    }
+    return UE_SPLIT7_ERR_NO_MEMORY;
+  }
+
+  memset(priv->rx_time_buf, 0, priv->buf_size_samples * 2 * sizeof(int16_t));
+  memset(priv->tx_time_buf, 0, priv->buf_size_samples * 2 * sizeof(int16_t));
+
+  // Private copy, not a pointer alias: the host may keep mutating its own frame_parms
+  // (RRC/MAC config updates) without the device racing on it. The host is required to
+  // have already run it through nr_init_frame_parms_ue()/init_symbol_rotation() (see
+  // frame_parms's doc comment in ue_split7_interface.h) -- this device does not derive
+  // a standalone fallback.
+  priv->frame_parms = *config->frame_parms;
+  // Matches nr_slot_fep()'s early-into-CP sampling so timeshift_symbol_rotation applies correctly.
+  priv->rot_sample_offset =
+      priv->frame_parms.ofdm_offset_divisor > 0 ? priv->frame_parms.nb_prefix_samples / priv->frame_parms.ofdm_offset_divisor : 0;
+  priv->fp = &priv->frame_parms;
+
+  // Allocate circular buffer
+  priv->circ_buf_size = config->sample_rate_hz * 0.2; // 200ms buffer
+  if (priv->circ_buf_size < 2 * (config->fft_size + config->cp_len_symbol0)) {
+    priv->circ_buf_size = 2 * (config->fft_size + config->cp_len_symbol0);
+  }
+
+  priv->rx_circ_buf = (int16_t **)malloc(config->num_rx_antennas * sizeof(int16_t *));
+  if (!priv->rx_circ_buf) {
+    LOG_E(PHY, "Out of memory allocating circular buffer channel array\n");
+    return UE_SPLIT7_ERR_NO_MEMORY;
+  }
+
+  for (int i = 0; i < config->num_rx_antennas; i++) {
+    priv->rx_circ_buf[i] = (int16_t *)split7_aligned_alloc32(priv->circ_buf_size * 2 * sizeof(int16_t));
+    if (!priv->rx_circ_buf[i]) {
+      for (int k = 0; k < i; k++) {
+        free(priv->rx_circ_buf[k]);
+      }
+      free(priv->rx_circ_buf);
+      priv->rx_circ_buf = NULL;
+      LOG_E(PHY, "Out of memory allocating circular buffer channel\n");
+      return UE_SPLIT7_ERR_NO_MEMORY;
+    }
+    memset(priv->rx_circ_buf[i], 0, priv->circ_buf_size * 2 * sizeof(int16_t));
+  }
+
+  priv->rx_fd_buf = (c16_t **)malloc(config->num_rx_antennas * sizeof(c16_t *));
+  if (!priv->rx_fd_buf) {
+    LOG_E(PHY, "Out of memory allocating FD-symbol buffer array\n");
+    return UE_SPLIT7_ERR_NO_MEMORY;
+  }
+  for (int i = 0; i < config->num_rx_antennas; i++) {
+    priv->rx_fd_buf[i] = (c16_t *)split7_aligned_alloc32(config->fft_size * sizeof(c16_t));
+    if (!priv->rx_fd_buf[i]) {
+      for (int k = 0; k < i; k++) {
+        free(priv->rx_fd_buf[k]);
+      }
+      free(priv->rx_fd_buf);
+      priv->rx_fd_buf = NULL;
+      LOG_E(PHY, "Out of memory allocating FD-symbol buffer\n");
+      return UE_SPLIT7_ERR_NO_MEMORY;
+    }
+  }
+
+  return UE_SPLIT7_SUCCESS;
+}
+
+static ue_split7_status_t ue_split7_start(struct ue_split7_device *dev)
+{
+  if (!dev)
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  if (priv->is_started)
+    return UE_SPLIT7_SUCCESS;
+
+  int rc = priv->openair0_dev.trx_start_func(&priv->openair0_dev);
+  if (rc < 0) {
+    LOG_E(PHY, "Failed to start openair0 device\n");
+    return UE_SPLIT7_ERR_GENERIC;
+  }
+
+  priv->is_started = true;
+
+  // Initialize circular buffer pointers and start read thread
+  atomic_store_explicit(&priv->latest_write_ts, 0, memory_order_relaxed);
+  priv->next_read_ts = 0;
+  priv->read_running = true;
+
+  int thread_rc = pthread_create(&priv->read_thread, NULL, read_thread_func, dev);
+  if (thread_rc != 0) {
+    LOG_E(PHY, "Failed to create read thread\n");
+    priv->read_running = false;
+    priv->is_started = false;
+    return UE_SPLIT7_ERR_GENERIC;
+  }
+
+  return UE_SPLIT7_SUCCESS;
+}
+
+static ue_split7_status_t ue_split7_stop(struct ue_split7_device *dev)
+{
+  if (!dev)
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  if (!priv->is_started)
+    return UE_SPLIT7_SUCCESS;
+
+  if (priv->sync_active) {
+    priv->sync_active = false;
+    while (atomic_load_explicit(&priv->sync_task_running, memory_order_acquire)) {
+      usleep(1000);
+    }
+  }
+
+  if (priv->read_running) {
+    priv->read_running = false;
+    // Wake anything blocked in ue_split7_read_symbol()/ue_split7_wait_next_slot()
+    // on data_cond -- otherwise a waiter would never notice read_running
+    // went false until the next (now nonexistent) write signals it.
+    pthread_mutex_lock(&priv->data_mutex);
+    pthread_cond_broadcast(&priv->data_cond);
+    pthread_mutex_unlock(&priv->data_mutex);
+    pthread_join(priv->read_thread, NULL);
+  }
+
+  if (priv->openair0_dev.trx_stop_func)
+    priv->openair0_dev.trx_stop_func(&priv->openair0_dev);
+  if (priv->openair0_dev.trx_end_func)
+    priv->openair0_dev.trx_end_func(&priv->openair0_dev);
+
+  priv->is_started = false;
+  return UE_SPLIT7_SUCCESS;
+}
+
+static ue_split7_status_t ue_split7_read_symbol(struct ue_split7_device *dev,
+                                                ue_split7_symbol_buffer_t *buffers,
+                                                uint16_t num_buffers)
+{
+  if (!dev || !buffers || num_buffers != dev->config.num_rx_antennas) {
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  }
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  if (atomic_load_explicit(&priv->state, memory_order_acquire) < UE_SPLIT7_STATE_DL_SYNCED)
+    return UE_SPLIT7_ERR_STATE;
+
+  uint16_t symbol = buffers[0].meta.symbol_number;
+  uint32_t fft_size = dev->config.fft_size;
+  uint32_t total_samples = get_samples_symbol_duration(priv->fp, buffers[0].meta.slot_number, symbol, 1);
+  uint32_t cp_len = total_samples - fft_size;
+
+  openair0_timestamp_t ts = 0;
+  dft_size_idx_t dft_sz = get_dft(fft_size);
+
+  if (priv->read_running) {
+    openair0_timestamp_t target = priv->next_read_ts + total_samples;
+
+    pthread_mutex_lock(&priv->data_mutex);
+    while (atomic_load_explicit(&priv->read_running, memory_order_acquire)
+           && atomic_load_explicit(&priv->latest_write_ts, memory_order_acquire) < target) {
+      pthread_cond_wait(&priv->data_cond, &priv->data_mutex);
+    }
+    pthread_mutex_unlock(&priv->data_mutex);
+
+    if (!priv->read_running) {
+      return UE_SPLIT7_ERR_GENERIC;
+    }
+
+    // Ring only holds circ_buf_size samples; if the live edge overran our target,
+    // that data's already overwritten (wait_next_slot() is where skip-ahead recovery happens).
+    uint64_t live_edge = atomic_load_explicit(&priv->latest_write_ts, memory_order_acquire);
+    if (live_edge > priv->circ_buf_size && priv->next_read_ts < live_edge - priv->circ_buf_size) {
+      LOG_W(PHY,
+            "[split7] FD layer too slow: read_symbol() target ts %llu is already "
+            "%llu samples behind the live edge (ring size %u) -- data already overwritten\n",
+            (unsigned long long)priv->next_read_ts,
+            (unsigned long long)(live_edge - priv->next_read_ts),
+            priv->circ_buf_size);
+    }
+
+    ts = priv->next_read_ts;
+
+    for (uint16_t i = 0; i < num_buffers; ++i) {
+      read_channel_at_ts(priv, priv->rx_time_buf, i, ts, total_samples);
+      int16_t *time_ptr = &priv->rx_time_buf[(cp_len - priv->rot_sample_offset) * 2];
+      dft(dft_sz, time_ptr, (int16_t *)priv->rx_fd_buf[i], 1);
+      apply_nr_rotation_symbol_RX(priv->fp->symbols_per_slot,
+                                  priv->fp->slots_per_subframe,
+                                  priv->fp->timeshift_symbol_rotation,
+                                  priv->fp->first_carrier_offset,
+                                  priv->rx_fd_buf[i],
+                                  priv->fp->symbol_rotation[link_type_dl],
+                                  priv->fp->N_RB_DL,
+                                  buffers[i].meta.slot_number,
+                                  symbol);
+      buffers[i].meta.timestamp_samples = ts;
+      buffers[i].num_subcarriers = fft_size;
+      buffers[i].re_buffer = (ue_split7_iq_t *)priv->rx_fd_buf[i];
+    }
+
+    priv->next_read_ts = target;
+  } else {
+    int16_t *ant_bufs[8] = {NULL};
+    void *rx_ptrs[8] = {NULL};
+    bool alloc_ok = true;
+    for (int i = 0; i < num_buffers; i++) {
+      ant_bufs[i] = (int16_t *)split7_aligned_alloc32(total_samples * 2 * sizeof(int16_t));
+      if (!ant_bufs[i]) {
+        alloc_ok = false;
+        break;
+      }
+      rx_ptrs[i] = ant_bufs[i];
+    }
+    int samples_read = -1;
+    if (alloc_ok) {
+      samples_read = priv->openair0_dev.trx_read_func(&priv->openair0_dev, &ts, rx_ptrs, total_samples, num_buffers);
+    }
+    if (samples_read < 0) {
+      for (int i = 0; i < num_buffers; i++)
+        free(ant_bufs[i]);
+      return UE_SPLIT7_ERR_GENERIC;
+    }
+    AssertFatal((uint32_t)samples_read == total_samples,
+                "[split7] rfdevice trx_read_func returned %d samples, expected %u\n",
+                samples_read,
+                total_samples);
+    for (uint16_t i = 0; i < num_buffers; ++i) {
+      int16_t *time_ptr = &ant_bufs[i][(cp_len - priv->rot_sample_offset) * 2];
+      dft(dft_sz, time_ptr, (int16_t *)priv->rx_fd_buf[i], 1);
+      apply_nr_rotation_symbol_RX(priv->fp->symbols_per_slot,
+                                  priv->fp->slots_per_subframe,
+                                  priv->fp->timeshift_symbol_rotation,
+                                  priv->fp->first_carrier_offset,
+                                  priv->rx_fd_buf[i],
+                                  priv->fp->symbol_rotation[link_type_dl],
+                                  priv->fp->N_RB_DL,
+                                  buffers[i].meta.slot_number,
+                                  symbol);
+      buffers[i].meta.timestamp_samples = ts;
+      buffers[i].num_subcarriers = fft_size;
+      buffers[i].re_buffer = (ue_split7_iq_t *)priv->rx_fd_buf[i];
+    }
+    for (int i = 0; i < num_buffers; i++)
+      free(ant_bufs[i]);
+  }
+
+  return UE_SPLIT7_SUCCESS;
+}
+
+// Reuses get_samples_slot_duration() (nr_parms.c); reconstructs the RX reference slot from
+// tx_slot_number since that call needs the start slot to account for symbol-0 CP length.
+static uint64_t ue_split7_slots_duration_samples(struct ue_split7_device *dev, uint32_t tx_slot_number, uint32_t num_slots)
+{
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+  const NR_DL_FRAME_PARMS *fp = priv->fp;
+  uint32_t slots_per_frame = fp->slots_per_frame;
+  uint32_t tx_slot = tx_slot_number % slots_per_frame;
+  uint32_t rx_slot = (tx_slot + slots_per_frame - (num_slots % slots_per_frame)) % slots_per_frame;
+  return get_samples_slot_duration(fp, rx_slot, num_slots);
+}
+
+// Mirrors apply_nr_rotation_TX()'s non-flat-buffer branch (ofdm_mod.c), adapted for a
+// buffer already offset to a single symbol (split7's write_symbol() convention).
+static void split7_apply_tx_rotation(const ue_split7_device_priv_t *priv, c16_t *sym_buf, int slot, int symbol, int nb_rb)
+{
+  int symb_offset = (slot % priv->fp->slots_per_subframe) * priv->fp->symbols_per_slot;
+  const c16_t rot = priv->fp->symbol_rotation[link_type_ul][symb_offset + symbol];
+
+  c16_t *sym_neg = sym_buf + priv->fp->first_carrier_offset;
+  if (nb_rb & 1) {
+    sym_neg -= 6;
+    nb_rb += 1;
+  }
+  rotate_cpx_vector(sym_buf, rot, sym_buf, nb_rb * 6, 15);
+  rotate_cpx_vector(sym_neg, rot, sym_neg, nb_rb * 6, 15);
+}
+
+static ue_split7_status_t ue_split7_write_symbol(struct ue_split7_device *dev,
+                                                 const ue_split7_symbol_buffer_t *buffers,
+                                                 uint16_t num_buffers)
+{
+  if (!dev || !buffers || num_buffers != dev->config.num_tx_antennas) {
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  }
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  if (atomic_load_explicit(&priv->state, memory_order_acquire) < UE_SPLIT7_STATE_UL_PRACH_ONLY)
+    return UE_SPLIT7_ERR_STATE;
+
+  atomic_store_explicit(&priv->state, UE_SPLIT7_STATE_UL_NORMAL, memory_order_release);
+
+  uint16_t symbol = buffers[0].meta.symbol_number;
+  uint32_t fft_size = dev->config.fft_size;
+  uint32_t total_samples = get_samples_symbol_duration(priv->fp, buffers[0].meta.slot_number, symbol, 1);
+  uint32_t cp_len = total_samples - fft_size;
+
+  idft_size_idx_t idft_size = get_idft(fft_size);
+
+  int16_t *tx_ant_bufs[8] = {NULL};
+  void *tx_ptrs[8] = {NULL};
+  for (uint16_t i = 0; i < num_buffers; ++i) {
+    tx_ant_bufs[i] = (int16_t *)split7_aligned_alloc32(total_samples * 2 * sizeof(int16_t));
+    if (!tx_ant_bufs[i]) {
+      for (uint16_t k = 0; k < i; k++)
+        free(tx_ant_bufs[k]);
+      return UE_SPLIT7_ERR_NO_MEMORY;
+    }
+    tx_ptrs[i] = tx_ant_bufs[i];
+
+    // Mandatory 38.211 §5.3 phase rotation, as nr_tx_rotation_and_ofdm_mod() does.
+    split7_apply_tx_rotation(priv, (c16_t *)buffers[i].re_buffer, buffers[i].meta.slot_number, symbol, priv->fp->N_RB_UL);
+
+    idft(idft_size, (int16_t *)buffers[i].re_buffer, priv->tx_time_buf, 1);
+
+    // CP: last cp_len samples of IFFT output.
+    memcpy(tx_ant_bufs[i], &priv->tx_time_buf[(fft_size - cp_len) * 2], cp_len * 2 * sizeof(int16_t));
+    memcpy(&tx_ant_bufs[i][cp_len * 2], priv->tx_time_buf, fft_size * 2 * sizeof(int16_t));
+  }
+
+  // timestamp_samples is the raw DL reference timestamp (rx_ts); TA and RX-to-TX
+  // lead time are both added here by the Low-PHY, not upstream.
+  openair0_timestamp_t tx_ts = buffers[0].meta.timestamp_samples
+                               + ue_split7_slots_duration_samples(dev, buffers[0].meta.slot_number, NR_UE_CAPABILITY_SLOT_RX_TO_TX)
+                               - atomic_load_explicit(&priv->ta_samples, memory_order_relaxed);
+
+  pthread_mutex_lock(&priv->write_mutex);
+  int rc = priv->openair0_dev.trx_write_func(&priv->openair0_dev, tx_ts, tx_ptrs, total_samples, num_buffers, 1);
+  pthread_mutex_unlock(&priv->write_mutex);
+
+  for (uint16_t i = 0; i < num_buffers; ++i)
+    free(tx_ant_bufs[i]);
+
+  if (rc < 0)
+    return UE_SPLIT7_ERR_GENERIC;
+
+  return UE_SPLIT7_SUCCESS;
+}
+
+static ue_split7_status_t ue_split7_set_timing_advance(struct ue_split7_device *dev, uint32_t ta_samples)
+{
+  if (!dev)
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+  atomic_store_explicit(&priv->ta_samples, ta_samples, memory_order_relaxed);
+
+  // First call (right after DL sync) establishes the UL offset, making write_prach()/
+  // write_symbol() valid; later TA updates just update ta_samples without touching state.
+  int expected = UE_SPLIT7_STATE_DL_SYNCED;
+  atomic_compare_exchange_strong_explicit(&priv->state,
+                                          &expected,
+                                          UE_SPLIT7_STATE_UL_PRACH_ONLY,
+                                          memory_order_release,
+                                          memory_order_relaxed);
+
+  return UE_SPLIT7_SUCCESS;
+}
+
+static ue_split7_status_t ue_split7_adjust_rx_timing(struct ue_split7_device *dev, int32_t sample_shift_samples)
+{
+  if (!dev)
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  if (atomic_load_explicit(&priv->state, memory_order_acquire) < UE_SPLIT7_STATE_DL_SYNCED)
+    return UE_SPLIT7_ERR_STATE;
+
+  // Nudging next_read_ts re-anchors both RX and TX together (write_symbol()'s TX
+  // timestamp derives from it too) -- same net effect as the monolithic UE's paired
+  // readBlockSize/writeBlockSize shift at a frame boundary.
+  priv->next_read_ts = (uint64_t)((int64_t)priv->next_read_ts - sample_shift_samples);
+
+  return UE_SPLIT7_SUCCESS;
+}
+
+static ue_split7_status_t ue_split7_seed_slot_tracking(struct ue_split7_device *dev, uint32_t frame_number)
+{
+  if (!dev)
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  if (atomic_load_explicit(&priv->state, memory_order_acquire) < UE_SPLIT7_STATE_DL_SYNCED)
+    return UE_SPLIT7_ERR_STATE;
+
+  // next_read_ts already sits at slot 0 symbol 0 of frame_number (sync_task_func()'s
+  // snap); anchor the slot tracker there.
+  priv->next_frame_number = frame_number % 1024;
+  priv->next_slot_number = 0;
+  priv->next_slot_sample_pos = priv->next_read_ts;
+  priv->slot_tracking_seeded = true;
+
+  return UE_SPLIT7_SUCCESS;
+}
+
+static ue_split7_status_t ue_split7_wait_next_slot(struct ue_split7_device *dev, uint32_t *frame_number, uint16_t *slot_number)
+{
+  if (!dev || !frame_number || !slot_number)
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  if (!priv->slot_tracking_seeded)
+    return UE_SPLIT7_ERR_STATE;
+
+  const NR_DL_FRAME_PARMS *fp = priv->fp;
+
+  // If the next slot has already aged out of the ring, skip forward to whatever
+  // slot is live now instead of returning stale data.
+  uint64_t live_edge = atomic_load_explicit(&priv->latest_write_ts, memory_order_acquire);
+  if (live_edge > priv->circ_buf_size && priv->next_slot_sample_pos < live_edge - priv->circ_buf_size) {
+    uint64_t behind_samples = live_edge - priv->next_slot_sample_pos;
+    LOG_W(PHY,
+          "[split7] FD layer too slow: next slot (frame %u slot %u) is %llu samples "
+          "behind the live edge (ring size %u) -- skipping ahead to live\n",
+          priv->next_frame_number,
+          priv->next_slot_number,
+          (unsigned long long)behind_samples,
+          priv->circ_buf_size);
+    // One slot's margin inside the ring, since more samples for the current slot may still be in flight.
+    uint64_t target_pos = live_edge - priv->circ_buf_size + get_samples_per_slot(0, fp);
+    while (priv->next_slot_sample_pos < target_pos) {
+      priv->next_slot_sample_pos += get_samples_per_slot((int)priv->next_slot_number, fp);
+      priv->next_slot_number++;
+      if (priv->next_slot_number >= fp->slots_per_frame) {
+        priv->next_slot_number = 0;
+        priv->next_frame_number = (priv->next_frame_number + 1) % 1024;
+      }
+    }
+  }
+
+  const uint64_t slot_samples = get_samples_per_slot((int)priv->next_slot_number, fp);
+  const uint64_t target = priv->next_slot_sample_pos + slot_samples;
+
+  pthread_mutex_lock(&priv->data_mutex);
+  while (atomic_load_explicit(&priv->read_running, memory_order_acquire)
+         && atomic_load_explicit(&priv->latest_write_ts, memory_order_acquire) < target) {
+    pthread_cond_wait(&priv->data_cond, &priv->data_mutex);
+  }
+  pthread_mutex_unlock(&priv->data_mutex);
+  if (!atomic_load_explicit(&priv->read_running, memory_order_acquire))
+    return UE_SPLIT7_ERR_GENERIC;
+
+  *frame_number = priv->next_frame_number;
+  *slot_number = priv->next_slot_number;
+
+  priv->next_slot_sample_pos = target;
+  priv->next_slot_number++;
+  if (priv->next_slot_number >= fp->slots_per_frame) {
+    priv->next_slot_number = 0;
+    priv->next_frame_number = (priv->next_frame_number + 1) % 1024;
+  }
+
+  return UE_SPLIT7_SUCCESS;
+}
+
+// Runs capture/analyze/retry to success or timeout in one pushTpool() task. Each retry
+// captures from the current live edge, not a stale anchor, so a slow search can't deadlock the read thread.
+static void sync_task_func(void *arg)
+{
+  struct ue_split7_device *dev = (struct ue_split7_device *)arg;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  const NR_DL_FRAME_PARMS *fp = priv->fp;
+  uint32_t fft_size = fp->ofdm_symbol_size;
+  int mu = fp->numerology_index;
+  int N_RB_DL = fp->N_RB_DL;
+  int num_rx = fp->nb_antennas_rx > 0 ? fp->nb_antennas_rx : 1;
+
+  uint32_t capture_samples = split7_sync_capture_samples(fp);
+  uint32_t alloc_samples = capture_samples + fft_size;
+
+  // Retry-invariant setup, allocated once rather than per attempt.
+  int16_t *rx_bufs[8] = {NULL};
+  c16_t *rx_ptrs_c16[8] = {NULL};
+  bool alloc_failed = false;
+  for (int ch = 0; ch < num_rx; ch++) {
+    rx_bufs[ch] = (int16_t *)malloc(alloc_samples * 2 * sizeof(int16_t));
+    if (!rx_bufs[ch]) {
+      alloc_failed = true;
+      break;
+    }
+    rx_ptrs_c16[ch] = (c16_t *)rx_bufs[ch];
+  }
+
+  c16_t *rxdataF_buf = alloc_failed ? NULL : (c16_t *)split7_aligned_alloc32(4 * num_rx * fft_size * sizeof(c16_t));
+  c16_t *pssTime_buf = alloc_failed ? NULL : (c16_t *)split7_aligned_alloc32(3 * fft_size * sizeof(c16_t));
+  if (alloc_failed || !rxdataF_buf || !pssTime_buf) {
+    if (rxdataF_buf)
+      free(rxdataF_buf);
+    if (pssTime_buf)
+      free(pssTime_buf);
+    for (int ch = 0; ch < num_rx; ch++)
+      if (rx_bufs[ch])
+        free(rx_bufs[ch]);
+    priv->sync_cb(dev, UE_SPLIT7_ERR_NO_MEMORY, NULL, priv->sync_user_data);
+    priv->sync_active = false;
+    atomic_store_explicit(&priv->sync_task_running, false, memory_order_release);
+    return;
+  }
+
+  nr_gscn_info_t gscn_list[MAX_GSCN_BAND];
+  int num_gscn = 0;
+  if (dev->config.nr_band > 0) {
+    num_gscn = get_scan_ssb_first_sc((double)fp->dl_CarrierFreq, N_RB_DL, (int)dev->config.nr_band, mu, gscn_list);
+  }
+  if (num_gscn <= 0) {
+    gscn_list[0].ssbFirstSC = 0;
+    gscn_list[0].gscn = 0;
+    num_gscn = 1;
+  }
+
+  nr_ssb_search_params_t search_params;
+  memset(&search_params, 0, sizeof(search_params));
+  search_params.dl_CarrierFreq = fp->dl_CarrierFreq;
+  search_params.sampling_rate = fp->samples_per_subframe * 1000;
+  search_params.slots_per_frame = fp->slots_per_frame;
+  search_params.slots_per_subframe = fp->slots_per_subframe;
+  search_params.numerology_index = mu;
+  search_params.ofdm_symbol_size = fft_size;
+  search_params.ofdm_offset_divisor = fp->ofdm_offset_divisor;
+  search_params.nb_antennas_rx = num_rx;
+  search_params.symbols_per_slot = fp->symbols_per_slot;
+  search_params.first_carrier_offset = fp->first_carrier_offset;
+  search_params.N_RB_DL = N_RB_DL;
+  search_params.nb_prefix_samples = fp->nb_prefix_samples;
+  search_params.nb_prefix_samples0 = fp->nb_prefix_samples0;
+  search_params.subcarrier_spacing = fp->subcarrier_spacing;
+  search_params.samples_per_slot_wCP = fp->samples_per_slot_wCP;
+  search_params.target_nid_cell = priv->sync_cfg.expected_pci;
+  // exclude_nid_cells/num_exclude_nid_cells left NULL/0: this search never excludes cells.
+  search_params.apply_freq_offset = true;
+  search_params.fo_flag = true;
+  search_params.rxdataF = rxdataF_buf;
+  search_params.pssTime = pssTime_buf;
+  search_params.rxdata = rx_ptrs_c16;
+  // Must equal capture_samples, not alloc_samples: pss_search_time_nr()'s correlation loop
+  // reads up to fft_size samples past rxdata_size, and alloc_samples' extra fft_size of
+  // headroom exists to keep that in-bounds -- using alloc_samples here would overrun it.
+  search_params.rxdata_size = capture_samples;
+
+  c16_t(*pssTime_ptr)[fft_size] = (c16_t(*)[fft_size])pssTime_buf;
+  c16_t(*rxdataF_4sym)[num_rx][fft_size] = (c16_t(*)[num_rx][fft_size])rxdataF_buf;
+
+  for (;;) {
+    if (!priv->sync_active) // cooperative cancellation via stop_sync()
+      break;
+
+    struct timespec current_time;
+    clock_gettime(CLOCK_MONOTONIC, &current_time);
+    uint64_t elapsed_ms = (current_time.tv_sec - priv->sync_start_time.tv_sec) * 1000
+                          + (current_time.tv_nsec - priv->sync_start_time.tv_nsec) / 1000000;
+    if (priv->sync_cfg.timeout_ms > 0 && elapsed_ms >= priv->sync_cfg.timeout_ms) {
+      LOG_W(PHY, "Sync search timed out after %u ms\n", priv->sync_cfg.timeout_ms);
+      priv->sync_cb(dev, UE_SPLIT7_ERR_TIMEOUT, NULL, priv->sync_user_data);
+      priv->sync_active = false;
+      break;
+    }
+
+    uint64_t live_edge = atomic_load_explicit(&priv->latest_write_ts, memory_order_acquire);
+    openair0_timestamp_t sync_start_ts = (live_edge > alloc_samples) ? (live_edge - alloc_samples) : 0;
+
+    for (int ch = 0; ch < num_rx; ch++)
+      read_channel_at_ts(priv, rx_bufs[ch], ch, sync_start_ts, alloc_samples);
+
+    // Mirrors nr_scan_ssb()'s ssbInfo->pbchResult/halfFrameBit/ssbIndex.
+    fapiPbch_t pbch_result;
+    memset(&pbch_result, 0, sizeof(pbch_result));
+    int half_frame_bit = 0, ssb_index = 0, symbol_offset = 0;
+    int32_t freq_offset = 0;
+    int64_t timing_offset = 0;
+    uint16_t cell_id = 0;
+
+    bool ssb_found = false;
+    int ssb_start_subcarrier = 0;
+    for (int g = 0; g < num_gscn && !ssb_found; g++) {
+      ssb_start_subcarrier = gscn_list[g].ssbFirstSC;
+      for (int nid2 = 0; nid2 < 3; nid2++)
+        generate_pss_nr_time(fft_size, fp->first_carrier_offset, nid2, ssb_start_subcarrier, pssTime_ptr[nid2]);
+      memset(rxdataF_buf, 0, 4 * num_rx * fft_size * sizeof(c16_t));
+      search_params.ssb_start_subcarrier = ssb_start_subcarrier;
+      ssb_found = nr_search_ssb_common(&search_params);
+      LOG_I(PHY,
+            "SSB search (GSCN %d ssbFirstSC %d): ssb_found=%d pss_success=%d nid2=%d pos=%d peak=%d avg=%d\n",
+            gscn_list[g].gscn,
+            ssb_start_subcarrier,
+            ssb_found,
+            search_params.pss_res.success,
+            search_params.pss_res.nid2,
+            search_params.pss_res.pos,
+            search_params.pss_res.peak,
+            search_params.pss_res.avg);
+
+      // Require PBCH/MIB decode too, as nr_scan_ssb() does: PSS/SSS alone gives no SFN.
+      if (ssb_found) {
+        const UE_nr_rxtx_proc_t dummy_proc = {0};
+        ssb_found = nr_pbch_detection(&dummy_proc,
+                                      priv->fp,
+                                      search_params.sss_res.nid_cell,
+                                      1, // pbch_initial_symbol: symbol 0 is PSS
+                                      ssb_start_subcarrier,
+                                      &half_frame_bit,
+                                      &ssb_index,
+                                      &symbol_offset,
+                                      &pbch_result,
+                                      rxdataF_4sym);
+        LOG_I(PHY,
+              "PBCH detection (GSCN %d): mib_decoded=%d ssb_index=%d half_frame_bit=%d\n",
+              gscn_list[g].gscn,
+              ssb_found,
+              ssb_index,
+              half_frame_bit);
+      }
+    }
+
+    if (!ssb_found)
+      continue; // immediately try again -- the next capture is already fresh
+
+    cell_id = search_params.sss_res.nid_cell;
+    // pss_res.pos is measured to the correlation peak, one CP length past the true symbol start.
+    timing_offset = (int64_t)sync_start_ts + search_params.pss_res.pos - search_params.nb_prefix_samples;
+    freq_offset = search_params.pss_res.freq_offset + search_params.sss_res.freq_offset;
+
+    // Snap to slot 0 symbol 0 of the SSB's frame (38.211 §5.3.1 CP0-vs-normal CP accounting).
+    const int n_symb_prefix0 = (symbol_offset / (7 * (1 << mu))) + 1;
+    const int64_t sync_pos_frame = (int64_t)n_symb_prefix0 * (fft_size + fp->nb_prefix_samples0)
+                                   + (int64_t)(symbol_offset - n_symb_prefix0) * (fft_size + fp->nb_prefix_samples);
+    const int64_t samples_per_frame = (int64_t)fp->samples_per_frame;
+    int64_t frame_boundary = (int64_t)timing_offset - sync_pos_frame;
+    if (frame_boundary < 0)
+      frame_boundary += samples_per_frame;
+
+    // Correlation work took real time since capture; advance by whole frames
+    // (preserving phase) to the latest boundary at or before the current live edge.
+    int64_t frames_elapsed = 0;
+    const uint64_t live_edge_now = atomic_load_explicit(&priv->latest_write_ts, memory_order_acquire);
+    if (live_edge_now > (uint64_t)frame_boundary)
+      frames_elapsed = (int64_t)((live_edge_now - (uint64_t)frame_boundary) / (uint64_t)samples_per_frame);
+    frame_boundary += frames_elapsed * samples_per_frame;
+
+    priv->next_read_ts = (uint64_t)frame_boundary;
+
+    LOG_I(PHY,
+          "[sync] symbol_offset=%d frame_boundary=%lld frames_elapsed=%lld\n",
+          symbol_offset,
+          (long long)frame_boundary,
+          (long long)frames_elapsed);
+
+    if (!priv->sync_active)
+      break;
+
+    // openair0 convention: positive freq_offset means the carrier was above nominal.
+    if (freq_offset != 0 && priv->openair0_dev.trx_set_freq_func) {
+      priv->openair0_cfg.rx_freq[0] += freq_offset;
+      priv->openair0_cfg.tx_freq[0] += freq_offset;
+      priv->openair0_dev.trx_set_freq_func(&priv->openair0_dev, &priv->openair0_cfg);
+      LOG_I(PHY, "[sync] Applied CFO correction %d Hz; new RX freq %.3f MHz\n", freq_offset, priv->openair0_cfg.rx_freq[0] / 1e6);
+    }
+    priv->last_freq_offset_hz = freq_offset;
+
+    ue_split7_sync_result_t result;
+    memset(&result, 0, sizeof(result));
+    result.physical_cell_id = cell_id;
+    result.best_ssb_index = (uint8_t)ssb_index;
+    result.timing_offset_samples = timing_offset;
+    result.freq_offset_hz = freq_offset;
+    result.ssb_rsrp_dbm = -75.0f;
+    result.mib_decoded = true; // ssb_found already required PBCH decode above
+    memcpy(result.mib_payload, pbch_result.decoded_output, sizeof(result.mib_payload));
+    result.mib_additional_bits = pbch_result.xtra_byte;
+    result.half_frame_bit = half_frame_bit;
+    result.symbol_offset = symbol_offset;
+    result.ssb_start_subcarrier = (uint16_t)ssb_start_subcarrier;
+    result.frames_since_capture = (uint32_t)(frames_elapsed % 1024);
+
+    atomic_store_explicit(&priv->state, UE_SPLIT7_STATE_DL_SYNCED, memory_order_release);
+
+    priv->sync_cb(dev, UE_SPLIT7_SUCCESS, &result, priv->sync_user_data);
+    priv->sync_active = false;
+    break;
+  }
+
+  free(rxdataF_buf);
+  free(pssTime_buf);
+  for (int ch = 0; ch < num_rx; ch++)
+    free(rx_bufs[ch]);
+
+  atomic_store_explicit(&priv->sync_task_running, false, memory_order_release);
+}
+
+static ue_split7_status_t ue_split7_start_sync(struct ue_split7_device *dev,
+                                               const ue_split7_sync_config_t *sync_config,
+                                               void *pool,
+                                               ue_split7_sync_callback_t callback,
+                                               void *user_data)
+{
+  if (!dev || !sync_config || !pool || !callback)
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  if (priv->sync_active)
+    return UE_SPLIT7_ERR_BUSY;
+
+  // Guard against a just-finished task whose callback fired but whose cleanup hasn't run yet.
+  while (atomic_load_explicit(&priv->sync_task_running, memory_order_acquire))
+    usleep(1000);
+
+  // Auto-start device if not started yet
+  if (!priv->is_started) {
+    ue_split7_status_t rc = ue_split7_start(dev);
+    if (rc != UE_SPLIT7_SUCCESS)
+      return rc;
+  }
+
+  priv->sync_cfg = *sync_config;
+  priv->sync_pool = (tpool_t *)pool;
+  priv->sync_cb = callback;
+  priv->sync_user_data = user_data;
+  clock_gettime(CLOCK_MONOTONIC, &priv->sync_start_time);
+  priv->sync_active = true;
+  atomic_store_explicit(&priv->sync_task_running, true, memory_order_release);
+
+  task_t task = {.func = sync_task_func, .args = dev};
+  pushTpool(priv->sync_pool, task);
+
+  return UE_SPLIT7_SUCCESS;
+}
+
+static ue_split7_status_t ue_split7_stop_sync(struct ue_split7_device *dev)
+{
+  if (!dev)
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+  priv->sync_active = false;
+  while (atomic_load_explicit(&priv->sync_task_running, memory_order_acquire)) {
+    usleep(1000);
+  }
+  return UE_SPLIT7_SUCCESS;
+}
+
+static ue_split7_status_t ue_split7_write_prach(struct ue_split7_device *dev, const ue_split7_prach_tx_params_t *params)
+{
+  if (!dev || !params)
+    return UE_SPLIT7_ERR_INVALID_PARAM;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+
+  if (atomic_load_explicit(&priv->state, memory_order_acquire) != UE_SPLIT7_STATE_UL_PRACH_ONLY)
+    return UE_SPLIT7_ERR_STATE;
+
+  uint32_t fft_size = params->fft_size > 0 ? params->fft_size : dev->config.fft_size;
+  idft_size_idx_t idft_size = get_idft(fft_size);
+
+  int16_t *temp_fft_in = (int16_t *)split7_aligned_alloc32(fft_size * 2 * sizeof(int16_t));
+  if (!temp_fft_in)
+    return UE_SPLIT7_ERR_NO_MEMORY;
+  memset(temp_fft_in, 0, fft_size * 2 * sizeof(int16_t));
+
+  if (params->num_samples == fft_size) {
+    for (uint32_t k = 0; k < fft_size; ++k) {
+      temp_fft_in[k * 2] = params->samples[k].r;
+      temp_fft_in[k * 2 + 1] = params->samples[k].i;
+    }
+  } else {
+    int32_t center_sc = params->frequency_offset_scs;
+    for (uint32_t k = 0; k < params->num_samples; ++k) {
+      int32_t sc_idx = (int32_t)k - (int32_t)params->num_samples / 2 + center_sc;
+      while (sc_idx < 0)
+        sc_idx += fft_size;
+      sc_idx = sc_idx % fft_size;
+
+      temp_fft_in[sc_idx * 2] = params->samples[k].r;
+      temp_fft_in[sc_idx * 2 + 1] = params->samples[k].i;
+    }
+  }
+
+  int16_t *temp_ifft_out = (int16_t *)split7_aligned_alloc32(fft_size * 2 * sizeof(int16_t));
+  if (!temp_ifft_out) {
+    free(temp_fft_in);
+    return UE_SPLIT7_ERR_NO_MEMORY;
+  }
+
+  idft(idft_size, temp_fft_in, temp_ifft_out, 1);
+
+  uint32_t cp_len = params->cp_len_samples;
+  uint32_t repetition = params->repetition_count > 0 ? params->repetition_count : 1;
+  uint32_t total_samples = cp_len + fft_size * repetition;
+
+  int16_t *prach_time_buf = (int16_t *)malloc(total_samples * 2 * sizeof(int16_t));
+  if (!prach_time_buf) {
+    free(temp_fft_in);
+    free(temp_ifft_out);
+    return UE_SPLIT7_ERR_NO_MEMORY;
+  }
+
+  uint32_t cp_copy_len = (cp_len < fft_size) ? cp_len : fft_size;
+  memcpy(prach_time_buf, &temp_ifft_out[(fft_size - cp_copy_len) * 2], cp_copy_len * 2 * sizeof(int16_t));
+  if (cp_len > fft_size) {
+    memset(&prach_time_buf[cp_copy_len * 2], 0, (cp_len - cp_copy_len) * 2 * sizeof(int16_t));
+  }
+
+  for (uint32_t r = 0; r < repetition; ++r) {
+    memcpy(&prach_time_buf[(cp_len + r * fft_size) * 2], temp_ifft_out, fft_size * 2 * sizeof(int16_t));
+  }
+
+  // params->slot_number uses the wrapped SFN, not an absolute frame count, so it can't
+  // be turned into a timestamp directly -- timestamp_samples is the real anchor.
+  uint64_t base_ts = params->timestamp_samples;
+  // Cumulative sample count of the preceding *normal-numerology* symbols in this slot
+  // (NOT the PRACH fft_size above, which can differ from fp->ofdm_symbol_size).
+  uint64_t symbol_offset =
+      params->symbol_number > 0 ? get_samples_symbol_duration(priv->fp, params->slot_number, 0, params->symbol_number) : 0;
+
+  // base_ts is the raw DL reference timestamp; TA and RX-to-TX lead time are added
+  // here by the Low-PHY, matching write_symbol()'s convention.
+  openair0_timestamp_t tx_ts = base_ts + symbol_offset + params->time_offset_samples
+                               + ue_split7_slots_duration_samples(dev, params->slot_number, NR_UE_CAPABILITY_SLOT_RX_TO_TX)
+                               - atomic_load_explicit(&priv->ta_samples, memory_order_relaxed);
+
+  void *tx_ptrs[8];
+  tx_ptrs[0] = prach_time_buf;
+
+  pthread_mutex_lock(&priv->write_mutex);
+  int rc = priv->openair0_dev.trx_write_func(&priv->openair0_dev, tx_ts, tx_ptrs, total_samples, 1, 1);
+  pthread_mutex_unlock(&priv->write_mutex);
+
+  free(temp_fft_in);
+  free(temp_ifft_out);
+  free(prach_time_buf);
+
+  if (rc < 0)
+    return UE_SPLIT7_ERR_GENERIC;
+  return UE_SPLIT7_SUCCESS;
+}
+
+ue_split7_device_t *ue_split7_device_create(void)
+{
+  ue_split7_device_t *dev = (ue_split7_device_t *)malloc(sizeof(ue_split7_device_t));
+  if (!dev)
+    return NULL;
+  memset(dev, 0, sizeof(ue_split7_device_t));
+
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)malloc(sizeof(ue_split7_device_priv_t));
+  if (!priv) {
+    free(dev);
+    return NULL;
+  }
+  memset(priv, 0, sizeof(ue_split7_device_priv_t)); // state == UE_SPLIT7_STATE_UNSYNCED (0)
+  pthread_mutex_init(&priv->write_mutex, NULL);
+  pthread_mutex_init(&priv->data_mutex, NULL);
+  pthread_cond_init(&priv->data_cond, NULL);
+
+  dev->priv = priv;
+  dev->configure = ue_split7_configure;
+  dev->start = ue_split7_start;
+  dev->stop = ue_split7_stop;
+  dev->read_symbol = ue_split7_read_symbol;
+  dev->write_symbol = ue_split7_write_symbol;
+  dev->start_sync = ue_split7_start_sync;
+  dev->stop_sync = ue_split7_stop_sync;
+  dev->set_timing_advance = ue_split7_set_timing_advance;
+  dev->adjust_rx_timing = ue_split7_adjust_rx_timing;
+  dev->seed_slot_tracking = ue_split7_seed_slot_tracking;
+  dev->wait_next_slot = ue_split7_wait_next_slot;
+  dev->write_prach = ue_split7_write_prach;
+
+  return dev;
+}
+
+void ue_split7_device_free(ue_split7_device_t *dev)
+{
+  if (!dev)
+    return;
+  ue_split7_device_priv_t *priv = (ue_split7_device_priv_t *)dev->priv;
+  if (priv) {
+    // Safety net in case the caller forgot to stop() first.
+    if (dev->stop)
+      dev->stop(dev);
+    if (priv->rx_time_buf)
+      free(priv->rx_time_buf);
+    if (priv->tx_time_buf)
+      free(priv->tx_time_buf);
+    if (priv->rx_circ_buf) {
+      for (int i = 0; i < dev->config.num_rx_antennas; i++) {
+        if (priv->rx_circ_buf[i])
+          free(priv->rx_circ_buf[i]);
+      }
+      free(priv->rx_circ_buf);
+    }
+    if (priv->rx_fd_buf) {
+      for (int i = 0; i < dev->config.num_rx_antennas; i++) {
+        if (priv->rx_fd_buf[i])
+          free(priv->rx_fd_buf[i]);
+      }
+      free(priv->rx_fd_buf);
+    }
+    pthread_mutex_destroy(&priv->write_mutex);
+    pthread_mutex_destroy(&priv->data_mutex);
+    pthread_cond_destroy(&priv->data_cond);
+    free(priv);
+  }
+  free(dev);
+}

--- a/radio/COMMON/ue_split7_interface.h
+++ b/radio/COMMON/ue_split7_interface.h
@@ -1,0 +1,298 @@
+/**
+ * @file ue_split7_interface.h
+ * @brief C API for the UE-centric 7.1 functional split: Low-PHY (CP/FFT, RF side)
+ *        vs. High-PHY (frequency-domain processing, host side).
+ */
+
+#ifndef UE_SPLIT7_INTERFACE_H
+#define UE_SPLIT7_INTERFACE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque: avoids pulling in the whole PHY include tree just for a pointer field. */
+struct NR_DL_FRAME_PARMS_s;
+typedef struct NR_DL_FRAME_PARMS_s NR_DL_FRAME_PARMS;
+
+/* ========================================================================== */
+/*                         COMMON DEFINITIONS & TYPES                         */
+/* ========================================================================== */
+
+/**
+ * @brief Return status codes for the 7.1 split interface.
+ */
+typedef enum {
+  UE_SPLIT7_SUCCESS = 0, ///< Operation completed successfully
+  UE_SPLIT7_ERR_GENERIC = -1, ///< Generic error
+  UE_SPLIT7_ERR_INVALID_PARAM = -2, ///< Invalid parameter passed
+  UE_SPLIT7_ERR_BUSY = -3, ///< Interface is busy (e.g., sync already running)
+  UE_SPLIT7_ERR_TIMEOUT = -4, ///< Operation timed out
+  UE_SPLIT7_ERR_STATE = -5, ///< Invalid state for this operation
+  UE_SPLIT7_ERR_NO_MEMORY = -6 ///< Out of memory or buffer too small
+} ue_split7_status_t;
+
+/**
+ * @brief Configuration parameters for the 7.1 functional split.
+ */
+typedef struct {
+  uint64_t dl_carrier_freq_hz; ///< Downlink center frequency in Hz
+  uint64_t ul_carrier_freq_hz; ///< Uplink center frequency in Hz
+  uint32_t sample_rate_hz; ///< ADC/DAC sampling rate in Hz
+  uint16_t fft_size; ///< FFT size (e.g., 512, 1024, 2048, 4096)
+  uint16_t num_tx_antennas; ///< Number of TX antenna ports
+  uint16_t num_rx_antennas; ///< Number of RX antenna ports
+  uint16_t cp_len_normal; ///< Cyclic Prefix length in samples for normal symbols
+  uint16_t cp_len_symbol0; ///< Cyclic Prefix length in samples for symbol 0 of a slot
+  uint8_t scs_khz; ///< Subcarrier Spacing in kHz (15, 30, 60, 120)
+  uint16_t nr_band; ///< Operating 3GPP NR frequency band (e.g. n257/n258/n260/n261 exceed 255)
+  uint16_t N_RB_DL; ///< Number of downlink resource blocks
+
+  /* Required. Host's already-computed frame params (already run through
+   * nr_init_frame_parms_ue()/init_symbol_rotation()), reused as-is so the Low-PHY
+   * can't numerically drift from the monolithic UE. configure() rejects NULL --
+   * there is no standalone derivation fallback in this device; callers that need
+   * one (e.g. unit tests) must build a valid NR_DL_FRAME_PARMS themselves. */
+  const NR_DL_FRAME_PARMS *frame_parms;
+} ue_split7_config_t;
+
+/**
+ * @brief Complex IQ sample representation in frequency domain.
+ */
+typedef struct {
+  int16_t r; ///< Real (In-phase) component
+  int16_t i; ///< Imaginary (Quadrature) component
+} ue_split7_iq_t;
+
+/**
+ * @brief Metadata associated with an OFDM symbol.
+ */
+typedef struct {
+  uint64_t timestamp_samples; ///< Absolute time in samples (serving cell timing grid)
+  uint32_t frame_number; ///< System Frame Number (SFN, 0..1023)
+  uint16_t slot_number; ///< Slot index within the frame
+  uint8_t symbol_number; ///< Symbol index within the slot (0..13 for normal CP)
+  uint8_t antenna_port; ///< Logical antenna port ID
+  uint32_t flags; ///< Control flags (e.g. PRACH, beamforming settings)
+} ue_split7_symbol_meta_t;
+
+/**
+ * @brief Container for frequency-domain REs of a single OFDM symbol.
+ *
+ * For read_symbol(): re_buffer/num_subcarriers are OUTPUT-only. The device owns the
+ * buffer re_buffer points to and reuses it on the next read_symbol() call, so a caller
+ * that needs the data to outlive that call must copy it out first.
+ * For write_symbol(): re_buffer is the caller-owned input buffer to transmit.
+ */
+typedef struct {
+  ue_split7_symbol_meta_t meta; ///< Metadata for the symbol (slot/symbol number are caller input to read_symbol())
+  uint32_t num_subcarriers; ///< Number of active subcarriers (FFT size or bandwidth part)
+  ue_split7_iq_t *re_buffer; ///< Frequency-domain REs [num_subcarriers]
+} ue_split7_symbol_buffer_t;
+
+/* ========================================================================== */
+/*                       1. SYNCHRONIZATION SERVICE                           */
+/* ========================================================================== */
+
+/**
+ * @brief Configuration for the cell search and synchronization process.
+ */
+typedef struct {
+  uint32_t arfcn; ///< ARFCN of the channel to search/sync
+  uint16_t scs_khz; ///< SCS of the SSB to search (15, 30, 120, 240 kHz)
+  uint8_t ssb_pattern; ///< SSB pattern type (Case A, B, C, D, E)
+  uint64_t ssb_bitmap; ///< Bitmap indicating transmitted SSBs in the burst (up to 64)
+  uint8_t ssb_periodicity_ms; ///< Periodicity of SSB burst (5, 10, 20, 40, 80, 160 ms)
+  uint32_t timeout_ms; ///< Maximum duration to search before timing out
+  int16_t expected_pci; ///< Physical Cell ID to search for (-1 to search for any)
+} ue_split7_sync_config_t;
+
+/**
+ * @brief Output results of a successful cell synchronization.
+ */
+typedef struct {
+  uint16_t physical_cell_id; ///< Detected Physical Cell ID (0..1007)
+  int32_t freq_offset_hz; ///< Carrier Frequency Offset (CFO) in Hz
+  int64_t timing_offset_samples; ///< Sample offset relative to the start of the search window
+  uint8_t best_ssb_index; ///< Decoded SSB index (0..63) carrying the MIB below
+  float ssb_rsrp_dbm; ///< Measured RSRP of the best SSB
+  float ssb_rsrq_db; ///< Measured RSRQ of the best SSB
+  float ssb_rssi_dbm; ///< Measured RSSI of the best SSB
+
+  /* SUCCESS only ever means PBCH decoded (not just PSS/SSS) -- a UE with only
+   * PSS/SSS has no SFN and can't proceed to RRC, so the Low-PHY keeps searching. */
+  bool mib_decoded; ///< Always true when status == UE_SPLIT7_SUCCESS
+  uint8_t mib_payload[3]; ///< Raw decoded MIB payload bits (BCCH-BCH PDU, <=3 bytes)
+  uint8_t mib_additional_bits; ///< Extra bits: 4 LSB of SFN, half-frame bit, SSB-subcarrier-offset MSB
+  int32_t half_frame_bit; ///< Half-frame bit determined during PBCH detection
+  int32_t symbol_offset; ///< PBCH DM-RS symbol offset determined during PBCH detection
+  uint16_t ssb_start_subcarrier; ///< Actual SSB subcarrier-0 offset the Low-PHY's GSCN scan landed
+                                 ///< on -- may differ from any value the host assumed before sync;
+                                 ///< the host must adopt this for correct CORESET0/SIB1 location.
+
+  /* Search runs against an already-captured window but takes real wall-clock time,
+   * during which the live stream (separate thread) moves ahead; the Low-PHY's read
+   * pointer is advanced to match (sync_task_func()). This is that advance in whole
+   * frames (mod 1024) -- the host must apply it to the decoded SFN too, since both
+   * now refer to the caught-up frame, not the one the MIB bits were decoded from. */
+  uint32_t frames_since_capture;
+} ue_split7_sync_result_t;
+
+struct ue_split7_device;
+
+/**
+ * @brief Callback for reporting synchronization results asynchronously.
+ *
+ * @param dev Pointer to the split 7 device.
+ * @param status Status of the sync procedure (e.g. SUCCESS, TIMEOUT).
+ * @param result Pointer to the sync results (valid if status == SUCCESS).
+ * @param user_data User context pointer.
+ */
+typedef void (*ue_split7_sync_callback_t)(struct ue_split7_device *dev,
+                                          ue_split7_status_t status,
+                                          const ue_split7_sync_result_t *result,
+                                          void *user_data);
+
+/**
+ * @brief Parameters for transmitting an unaligned frequency-domain channel (e.g., PRACH).
+ */
+typedef struct {
+  const ue_split7_iq_t *samples; ///< Array of frequency-domain IQ samples representing the preamble
+  uint32_t num_samples; ///< Length of the samples array (number of subcarriers)
+  uint32_t fft_size; ///< FFT size for PRACH modulator (e.g. 2048, 6144, 24576)
+  int32_t time_offset_samples; ///< Time offset in samples relative to the slot/symbol boundary
+  uint32_t cp_len_samples; ///< Cyclic Prefix length in samples to prepend
+  uint64_t timestamp_samples; ///< Absolute device-timeline timestamp of the slot start (same
+                              ///< clock as ue_split7_symbol_buffer_t::meta.timestamp_samples;
+                              ///< NOT reconstructible from slot_number, which recurs every frame).
+  uint32_t slot_number; ///< Slot coordinate (informational; NOT a substitute for timestamp_samples)
+  uint8_t symbol_number; ///< Symbol coordinate
+  int32_t frequency_offset_scs; ///< Frequency offset in subcarriers relative to DC subcarrier
+  uint8_t repetition_count; ///< Number of preamble repetitions
+  uint8_t antenna_port; ///< TX antenna port ID
+} ue_split7_prach_tx_params_t;
+
+/* ========================================================================== */
+/*                      2. 7.1 DEVICE STRUCTURE DEFINITION                    */
+/* ========================================================================== */
+
+/** @brief A split 7 UE device: config plus the interface's function pointers. */
+typedef struct ue_split7_device {
+  ue_split7_config_t config; ///< Active configuration of the device
+  void *priv; ///< Private driver state pointer (for USRP/hardware specific data)
+
+  /** @brief Initialize/configure the device. Must be called before start(). */
+  ue_split7_status_t (*configure)(struct ue_split7_device *dev, const ue_split7_config_t *config);
+
+  /** @brief Start symbol-based RF TX/RX. Device must be synchronized first. */
+  ue_split7_status_t (*start)(struct ue_split7_device *dev);
+
+  /** @brief Stop RF transmission and reception. */
+  ue_split7_status_t (*stop)(struct ue_split7_device *dev);
+
+  /* ---------------------- Normal Symbol-Based API ---------------------- */
+
+  /**
+   * @brief Receive one OFDM symbol's frequency-domain REs (CP removal + FFT done internally). Blocking.
+   * @param buffers One entry per active RX antenna: buffers[antenna_idx]. Caller sets meta.slot_number/
+   *        symbol_number as input; on success the device fills meta.timestamp_samples, num_subcarriers,
+   *        and re_buffer with a pointer into the device's own buffer (see ue_split7_symbol_buffer_t) --
+   *        a future revision may let callers read that pointer directly instead of copying it out.
+   * @param num_buffers Must equal dev->config.num_rx_antennas.
+   */
+  ue_split7_status_t (*read_symbol)(struct ue_split7_device *dev, ue_split7_symbol_buffer_t *buffers, uint16_t num_buffers);
+
+  /**
+   * @brief Transmit one OFDM symbol's frequency-domain REs (IFFT + CP done internally).
+   * @param buffers One entry per active TX antenna: buffers[antenna_idx]. Each
+   *        buffers[i].re_buffer MUST contain exactly dev->config.fft_size REs (the full
+   *        FFT bin count, not a smaller BWP-sized buffer) -- passing fewer triggers an
+   *        out-of-bounds read in the IDFT path. The implementation applies the mandatory
+   *        38.211 §5.3 phase rotation to re_buffer IN PLACE, mutating the caller-supplied
+   *        buffer; callers must not reuse/inspect it afterwards expecting the original
+   *        (pre-rotation) contents.
+   * @param num_buffers Must equal dev->config.num_tx_antennas.
+   */
+  ue_split7_status_t (*write_symbol)(struct ue_split7_device *dev, const ue_split7_symbol_buffer_t *buffers, uint16_t num_buffers);
+
+  /* ---------------------- Synchronization Service ---------------------- */
+
+  /**
+   * @brief Trigger async time-domain cell search (PSS/SSS/PBCH); callback reports the result.
+   * @param sync_config Frequency, pattern, SCS, expected PCI, timeout.
+   */
+  ue_split7_status_t (*start_sync)(struct ue_split7_device *dev,
+                                   const ue_split7_sync_config_t *sync_config,
+                                   void *pool,
+                                   ue_split7_sync_callback_t callback,
+                                   void *user_data);
+
+  /** @brief Abort an ongoing synchronization search. */
+  ue_split7_status_t (*stop_sync)(struct ue_split7_device *dev);
+
+  /** @brief Apply a Timing Advance (from RAR/MAC-CE) to subsequent UL symbol TX. */
+  ue_split7_status_t (*set_timing_advance)(struct ue_split7_device *dev, uint32_t ta_samples);
+
+  /**
+   * @brief Nudge the RX/TX sample-timing reference by sample_shift_samples.
+   *
+   * Call once per frame from the High-PHY's PBCH timing-error measurement
+   * (nr_adjust_synch_ue()) to track drift between the Low-PHY's nominal
+   * per-symbol window and the cell's real sample clock -- split7's equivalent
+   * of the monolithic UE's readBlockSize/writeBlockSize adjustment. Without
+   * it the RX FFT window drifts until it straddles a symbol boundary,
+   * surfacing as intermittent PBCH/PDCCH decode failures.
+   *
+   * @param sample_shift_samples Same sign/value as the monolithic UE's
+   *        shiftForNextFrame; pass nr_adjust_synch_ue()'s return through unmodified.
+   */
+  ue_split7_status_t (*adjust_rx_timing)(struct ue_split7_device *dev, int32_t sample_shift_samples);
+
+  /* --------------------- Host-decoupled Slot Timing --------------------- */
+
+  /**
+   * @brief Seed the frame number for the next wait_next_slot() call.
+   *
+   * Call once, right after start_sync()/re-sync, with the MIB-decoded SFN
+   * (already corrected for frames_since_capture). From then on the Low-PHY
+   * tracks frame/slot numbering itself from elapsed samples.
+   *
+   * @param frame_number SFN (0..1023) of the frame at slot 0 symbol 0, at
+   *        the sample position sync_task_func() anchored the read pointer to.
+   */
+  ue_split7_status_t (*seed_slot_tracking)(struct ue_split7_device *dev, uint32_t frame_number);
+
+  /**
+   * @brief Block until the next slot's samples have arrived; report its absolute frame/slot.
+   *
+   * Call once per slot instead of the host incrementing its own counter --
+   * the Low-PHY owns the sample clock (circ_read_idx/circ_write_idx) and is
+   * the sole source of truth for slot number, so this can't silently drift
+   * the way an independent counter could. Must be called in slot order,
+   * after seed_slot_tracking() has anchored the first slot.
+   *
+   * @param frame_number Output: SFN (0..1023) of the now-available slot.
+   * @param slot_number Output: slot index within that frame.
+   */
+  ue_split7_status_t (*wait_next_slot)(struct ue_split7_device *dev, uint32_t *frame_number, uint16_t *slot_number);
+
+  /** @brief Transmit an unaligned frequency-domain signal (e.g. PRACH preamble). */
+  ue_split7_status_t (*write_prach)(struct ue_split7_device *dev, const ue_split7_prach_tx_params_t *params);
+
+} ue_split7_device_t;
+
+/**
+ * @brief Allocate and initialise a concrete ue_split7_device_t implementation.
+ * @return Pointer to the device, or NULL on allocation failure.
+ */
+ue_split7_device_t *ue_split7_device_create(void);
+void ue_split7_device_free(ue_split7_device_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // UE_SPLIT7_INTERFACE_H


### PR DESCRIPTION
This PR introduces a split7 API and two threads that interact with each other to achieve a FD split processing. split7 device performs time-domain processing while nr-fd-ue.c does frequency domain.