### PR TITLE
Correctly handle IPv4/IPv6 in sctp_handle_new_association_req_multi()

### DIFF
--- a/openair3/SCTP/sctp_eNB_task.c
+++ b/openair3/SCTP/sctp_eNB_task.c
@@ -238,49 +238,50 @@ sctp_handle_new_association_req_multi(
     if ((sctp_new_association_req_p->remote_address.ipv6 != 0) ||
             (sctp_new_association_req_p->remote_address.ipv4 != 0)) {
         uint8_t address_index = 0;
-        uint8_t used_address  = sctp_new_association_req_p->remote_address.ipv6 +
-                                sctp_new_association_req_p->remote_address.ipv4;
-        struct sockaddr_in addr[used_address];
+        const net_ip_address_t *remote = &sctp_new_association_req_p->remote_address;
+        uint8_t used_address  = remote->ipv6 + remote->ipv4;
+        struct sockaddr_storage addr[used_address];
 
-        memset(addr, 0, used_address * sizeof(struct sockaddr_in));
+        memset(addr, 0, used_address * sizeof(*addr));
 
-        if (sctp_new_association_req_p->remote_address.ipv6 == 1) {
-            if (inet_pton(AF_INET6, sctp_new_association_req_p->remote_address.ipv6_address,
-                          &addr[address_index].sin_addr.s_addr) != 1) {
+        if (remote->ipv6 == 1) {
+            struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)&addr[address_index];
+            if (inet_pton(AF_INET6, remote->ipv6_address, &sa6->sin6_addr.s6_addr) != 1) {
                 SCTP_ERROR("Failed to convert ipv6 address %*s to network type\n",
-                           (int)strlen(sctp_new_association_req_p->remote_address.ipv6_address),
-                           sctp_new_association_req_p->remote_address.ipv6_address);
+                           (int)strlen(remote->ipv6_address),
+                           remote->ipv6_address);
                 //close(sd);
                 //return;
                 exit_fun("sctp_handle_new_association_req_multi fatal: inet_pton error");
             }
 
             SCTP_DEBUG("Converted ipv6 address %*s to network type\n",
-                       (int)strlen(sctp_new_association_req_p->remote_address.ipv6_address),
-                       sctp_new_association_req_p->remote_address.ipv6_address);
+                       (int)strlen(remote->ipv6_address),
+                       remote->ipv6_address);
 
-            addr[address_index].sin_family = AF_INET6;
-            addr[address_index].sin_port   = htons(sctp_new_association_req_p->port);
+            sa6->sin6_family = AF_INET6;
+            sa6->sin6_port   = htons(sctp_new_association_req_p->port);
             address_index++;
         }
 
-        if (sctp_new_association_req_p->remote_address.ipv4 == 1) {
-            if (inet_pton(AF_INET, sctp_new_association_req_p->remote_address.ipv4_address,
-                          &addr[address_index].sin_addr.s_addr) != 1) {
+        if (remote->ipv4 == 1) {
+            struct sockaddr_in *sa = (struct sockaddr_in *)&addr[address_index];
+            if (inet_pton(AF_INET, remote->ipv4_address,
+                          &sa->sin_addr.s_addr) != 1) {
                 SCTP_ERROR("Failed to convert ipv4 address %*s to network type\n",
-                           (int)strlen(sctp_new_association_req_p->remote_address.ipv4_address),
-                           sctp_new_association_req_p->remote_address.ipv4_address);
+                           (int)strlen(remote->ipv4_address),
+                           remote->ipv4_address);
                 //close(sd);
                 //return;
                 exit_fun("sctp_handle_new_association_req_multi fatal: inet_pton error");
             }
 
             SCTP_DEBUG("Converted ipv4 address %*s to network type\n",
-                       (int)strlen(sctp_new_association_req_p->remote_address.ipv4_address),
-                       sctp_new_association_req_p->remote_address.ipv4_address);
+                       (int)strlen(remote->ipv4_address),
+                       remote->ipv4_address);
 
-            addr[address_index].sin_family = AF_INET;
-            addr[address_index].sin_port   = htons(sctp_new_association_req_p->port);
+            sa->sin_family = AF_INET;
+            sa->sin_port   = htons(sctp_new_association_req_p->port);
             address_index++;
         }
 


### PR DESCRIPTION
The immediate problem in this code is a warning

    inlined from ‘sctp_handle_new_association_req_multi’ at /home/user/openairinterface5g/openair3/SCTP/sctp_eNB_task.c:248:17:
    /usr/include/x86_64-linux-gnu/bits/inet-fortified.h:58:10: warning: call to ‘__inet_pton_chk_warn’ declared with attribute warning: inet_pton called with a destination buffer size too small [-Wattribute-warning]

(which I cannot reproduce myself). This is because inet_pton() writes an IPv6 address into an IPv4 .sin_addr.s_addr. Handle this by defining the address as a sockaddr_storage to hold both IPv4/IPv6 address, and cast to the correct types, to handle that warning.

I am not convinced that this works beyond IPv4. First of all, my sctp_connectx man page says

> If sd is an IPv4 socket, the addresses passed must be IPv4 addresses.
> If sd is an IPv6 socket, the addresses passed can be either IPv4 or IPv6
> addresses.

In this function heer, we don't know that. So passing IPv6 might fail because we used IPv4 previously. We probably also have no test anywhere for IPv6.

Closes: #433

Test plan:
- [x] Ensure that CI tests using SCTP_MULTI_REQ (mostly 4G, I think) pass.