### PR TITLE
mac: fix HARQ-ACK PUCCH resource selection (TS 38.213 9.2.1)

### DIFF
--- a/openair2/LAYER2/NR_MAC_UE/mac_defs.h
+++ b/openair2/LAYER2/NR_MAC_UE/mac_defs.h
@@ -380,6 +380,8 @@ typedef struct {
   bool active;
   bool ack_received;
   uint8_t  pucch_resource_indicator;
+  /* use pucch-ResourceCommon table (TS 38.213 9.2.1) for this HARQ-ACK */
+  bool pucch_resource_common;
   frame_t ul_frame;
   int ul_slot;
   uint8_t ack;

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_procedures.c
@@ -432,6 +432,12 @@ int8_t nr_ue_process_dci_freq_dom_resource_assignment(nfapi_nr_ue_pusch_pdu_t *p
   return 0;
 }
 
+/* TS 38.213 9.2.3: UE has PUCCH-ResourceSet configured in PUCCH-Config */
+static inline bool nr_ue_has_dedicated_pucch_resource_set(const NR_PUCCH_Config_t *cfg)
+{
+  return cfg && cfg->resourceSetToAddModList && cfg->resourceSetToAddModList->list.array[0];
+}
+
 static void set_harq_status(NR_UE_MAC_INST_t *mac,
                             uint8_t pucch_id,
                             uint8_t harq_id,
@@ -445,9 +451,11 @@ static void set_harq_status(NR_UE_MAC_INST_t *mac,
                             int slot)
 {
   NR_UE_DL_HARQ_STATUS_t *current_harq = &mac->dl_harq_info[harq_id][cw_id];
+  const NR_PUCCH_Config_t *pucch_Config = mac->current_UL_BWP ? mac->current_UL_BWP->pucch_Config : NULL;
   current_harq->active = true;
   current_harq->ack_received = false;
   current_harq->pucch_resource_indicator = pucch_id;
+  current_harq->pucch_resource_common = !nr_ue_has_dedicated_pucch_resource_set(pucch_Config);
   current_harq->n_CCE = n_CCE;
   current_harq->N_CCE = N_CCE;
   current_harq->dai_cumul = 0;
@@ -2380,6 +2388,7 @@ bool get_downlink_ack(NR_UE_MAC_INST_t *mac, frame_t frame, int slot, PUCCH_sche
   uint32_t dai_total[NR_DL_MAX_NB_CW][NR_MAX_HARQ_PROCESSES] = {{0},{0}}; /* for multiple cells */
   int number_harq_feedback = 0;
   uint32_t dai_max = 0;
+  bool pucch_common = false;
 
   NR_UE_DL_BWP_t *current_DL_BWP = mac->current_DL_BWP;
   NR_UE_UL_BWP_t *current_UL_BWP = mac->current_UL_BWP;
@@ -2448,6 +2457,8 @@ bool get_downlink_ack(NR_UE_MAC_INST_t *mac, frame_t frame, int slot, PUCCH_sche
             pucch->harq_ack_pucch_res_ind = temp_ind;
             pucch->n_CCE = current_harq->n_CCE;
             pucch->N_CCE = current_harq->N_CCE;
+            if (current_harq->pucch_resource_common)
+              pucch_common = true;
             LOG_D(NR_MAC,"%4d.%2d Sent %d ack on harq pid %d\n", frame, slot, current_harq->ack, dl_harq_pid);
           }
         }
@@ -2529,7 +2540,7 @@ bool get_downlink_ack(NR_UE_MAC_INST_t *mac, frame_t frame, int slot, PUCCH_sche
   }
 
   NR_PUCCH_Config_t *pucch_Config = current_UL_BWP ? current_UL_BWP->pucch_Config : NULL;
-  if (!(pucch_Config && pucch_Config->resourceSetToAddModList && pucch_Config->resourceSetToAddModList->list.array[0]))
+  if (pucch_common || !nr_ue_has_dedicated_pucch_resource_set(pucch_Config))
     configure_initial_pucch(pucch, res_ind, current_UL_BWP->pucch_ConfigCommon->pucch_ResourceCommon);
   else {
     int resource_set_id = find_pucch_resource_set(pucch_Config, O_ACK);


### PR DESCRIPTION
When a UE without dedicated PUCCH receives a DCI, the gNB encodes the 3-bit PUCCH Resource Indicator (PRI) against the common resource table (TS 38.213 9.2.1, pucch-ResourceCommon): `r_PUCCH = floor(2*n_CCE/N_CCE) + 2*delta_PRI`, mapping to format 0 at the last symbols of the slot.

RRCSetup carries masterCellGroup inside its PDSCH payload. The UE applies the dedicated PUCCH-Config from that CellGroup immediately upon decoding (TS 38.331 5.3.3.4), which is correct.

During tests with OCUDU DU it was found that with k1=7, the config change is effective at MAC before the k1 slot. get_downlink_ack() was then re-interpreting the same PRI bits against the newly installed resourceSetToAddModList (TS 38.213 9.2.3), pointing the UE at a different PUCCH resource (dedicated format 0, symbols 0-2), while the DU was still listening on the common resource (symbols 12-14). Logs were showing energy on the scheduled resource was zero: `sinr=-inf, HARQ NACK`. On NACK the DU was then retransmitting a new MAC PDU, with UE processing RRCSetup a second time, leading to a new RRCSetupComplete, new NGAP Initial UE message, AMF assigning two UE contexts, and CU dropping PDU session establishment due to AMF UE NGAP ID mismatch.

TS 38.213 9.2.1 says:
> "If a UE does not have dedicated PUCCH resource configuration, provided by PUCCH-ResourceSet in PUCCH-Config, a PUCCH resource set is provided by pucch-ResourceCommon through an index to a row of Table 9.2.1-1".

TS 38.213 9.2.3 says:
> "The PUCCH resource determination is based on a PUCCH resource indicator field in a last DCI
format ... that the UE detects",

with PRI values mapping to:
> "resourceList for PUCCH resources from a set of PUCCH resources provided by PUCCH-ResourceSet".

pucch-ResourceCommon vs PUCCH-ResourceSet are 2 different mappings and the presence of the latter shall be evaluated at DCI detection, not at ACK TX time.

OAI UE is already storing other PUCCH parameters (n_CCE, N_CCE, pucch_resource_indicator, k1 slot) into NR_UE_DL_HARQ_STATUS_t at DCI reception in set_harq_status(), so this fix is now storing also pucch_resource_common on the HARQ process at each DCI time, including retx (true when no dedicated PUCCH-ResourceSet exists per 9.2.3).

At the k1 slot, `get_downlink_ack()` checks `pucch_resource_common` across all HARQ processes due in that occasion. If any is set, `configure_initial_pucch()` is called, matching the resource the DU scheduled when it sent the DCI.

**Testing:** 

Failing test before this PR:
[ocudu-du.log](https://github.com/user-attachments/files/31224473/ocudu-du.log)
[rfsim5g-oai-cu.log](https://github.com/user-attachments/files/31224475/rfsim5g-oai-cu.log)
[rfsim5g-oai-nr-ue.log](https://github.com/user-attachments/files/31224476/rfsim5g-oai-nr-ue.log)

```mermaid
sequenceDiagram
    participant DU
    participant UE_MAC as UE MAC
    participant UE_RRC as UE RRC

    DU->>UE_MAC: DCI 1_0 (common PUCCH: PRB 0+50, symb 12-14)
    DU->>UE_MAC: PDSCH (RRCSetup + masterCellGroup)
    UE_MAC->>UE_RRC: PDSCH decoded
    UE_RRC->>UE_MAC: nr_rrc_mac_config_req_cg()
    Note over UE_MAC: dedicated PUCCH-Config installed
    UE_MAC->>UE_MAC: get_downlink_ack()
    Note over UE_MAC: !has_dedicated() = false<br/>dedicated PUCCH (symb 0-2)
    UE_MAC->>DU: HARQ-ACK on symb 0-2
    Note over DU: listening on symb 12-14 ->  sinr=-inf
    DU->>UE_MAC: HARQ NACK
    Note over UE_MAC: retransmit RRCSetup
```

Test with ODU with the commit in this PR (was tested with PR 272):
[ocudu-du.log](https://github.com/user-attachments/files/31224567/ocudu-du.log)
[rfsim5g-oai-cu.log](https://github.com/user-attachments/files/31224570/rfsim5g-oai-cu.log)
[rfsim5g-oai-nr-ue.log](https://github.com/user-attachments/files/31224571/rfsim5g-oai-nr-ue.log)

```mermaid
sequenceDiagram
    participant DU
    participant UE_MAC as UE MAC
    participant UE_RRC as UE RRC

    DU->>UE_MAC: DCI 1_0 (common PUCCH: PRB 0+50, symb 12-14)
    Note over UE_MAC: set_harq_status()<br/>pucch_resource_common = true
    DU->>UE_MAC: PDSCH (RRCSetup + masterCellGroup)
    UE_MAC->>UE_RRC: PDSCH decoded
    UE_RRC->>UE_MAC: nr_rrc_mac_config_req_cg()
    Note over UE_MAC: dedicated PUCCH-Config installed
    UE_MAC->>UE_MAC: get_downlink_ack()
    Note over UE_MAC: pucch_resource_common = true<br/>common PUCCH (symb 12-14)
    UE_MAC->>DU: HARQ-ACK on symb 12-14
    Note over DU: listening on symb 12-14 -> ack=1, sinr=30.8 dB
    DU->>UE_MAC: HARQ ACK
    UE_MAC->>DU: RRCSetupComplete
```

Assisted-by: Claude:Sonnet-5