### PR TITLE
SIMULATION: harmonize per-tap R_sqrt matrices

### DIFF
--- a/openair1/SIMULATION/TOOLS/random_channel.c
+++ b/openair1/SIMULATION/TOOLS/random_channel.c
@@ -58,6 +58,67 @@ static channel_desc_t **defined_channels;
 static char *modellist_name;
 static int noise_power_dBFS = INVALID_DBFS_VALUE;
 
+static void allocate_tap_correlation_matrices(channel_desc_t *desc, const struct complexd *matrix)
+{
+  const int n_links = desc->nb_tx * desc->nb_rx;
+  const size_t matrix_entries = n_links * n_links;
+
+  desc->R_sqrt = calloc(desc->nb_taps, sizeof(*desc->R_sqrt));
+  for (int tap = 0; tap < desc->nb_taps; ++tap) {
+    desc->R_sqrt[tap] = calloc(matrix_entries, sizeof(**desc->R_sqrt));
+    if (matrix != NULL) {
+      memcpy(desc->R_sqrt[tap], matrix, matrix_entries * sizeof(**desc->R_sqrt));
+    } else {
+      for (int link = 0; link < n_links; ++link)
+        desc->R_sqrt[tap][link * n_links + link].r = 1.0;
+    }
+  }
+}
+
+/* SCM correlation data contains one matrix per cluster of three subpaths. Expand
+ * it here so all consumers can address correlation matrices directly by tap. */
+static void allocate_clustered_tap_correlation_matrices(channel_desc_t *desc, const struct complexd *cluster_matrices)
+{
+  const int n_links = desc->nb_tx * desc->nb_rx;
+  const size_t matrix_entries = n_links * n_links;
+  int cluster = 0;
+  int subpath = 0;
+
+  desc->R_sqrt = calloc(desc->nb_taps, sizeof(*desc->R_sqrt));
+  for (int tap = 0; tap < desc->nb_taps; ++tap) {
+    desc->R_sqrt[tap] = calloc(matrix_entries, sizeof(**desc->R_sqrt));
+    if (cluster_matrices != NULL) {
+      memcpy(desc->R_sqrt[tap],
+             cluster_matrices + cluster * matrix_entries,
+             matrix_entries * sizeof(**desc->R_sqrt));
+    } else {
+      for (int link = 0; link < n_links; ++link)
+        desc->R_sqrt[tap][link * n_links + link].r = 1.0;
+    }
+
+    if (++subpath == 3) {
+      subpath = 0;
+      ++cluster;
+    }
+  }
+}
+
+static void apply_correlation_matrix(const channel_desc_t *desc,
+                                     int tap,
+                                     const struct complexd *anew,
+                                     struct complexd *acorr)
+{
+  const int n_links = desc->nb_tx * desc->nb_rx;
+  memset(acorr, 0, n_links * sizeof(*acorr));
+  for (int row = 0; row < n_links; ++row) {
+    const struct complexd *r_row = &desc->R_sqrt[tap][row * n_links];
+    for (int col = 0; col < n_links; ++col) {
+      const cd_t tmp = cdMul(anew[row], r_row[col]);
+      csum(acorr[col], tmp, acorr[col]);
+    }
+  }
+}
+
 void fill_channel_desc(channel_desc_t *chan_desc,
                        uint8_t nb_tx,
                        uint8_t nb_rx,
@@ -131,28 +192,7 @@ void fill_channel_desc(channel_desc_t *chan_desc,
 
   LOG_D(OCM,"[CHANNEL] Doing R_sqrt ...\n");
 
-  if (R_sqrt == NULL) {
-    chan_desc->R_sqrt         = (struct complexd **) calloc(nb_taps,sizeof(struct complexd *));
-    chan_desc->free_flags=chan_desc->free_flags|CHANMODEL_FREE_RSQRT_NTAPS ;
-
-    for (i = 0; i<nb_taps; i++) {
-      chan_desc->R_sqrt[i]    = (struct complexd *) calloc(nb_tx*nb_rx*nb_tx*nb_rx,sizeof(struct complexd));
-
-      for (j = 0; j<nb_tx*nb_rx*nb_tx*nb_rx; j+=(nb_tx*nb_rx+1)) {
-        chan_desc->R_sqrt[i][j].r = 1.0;
-        chan_desc->R_sqrt[i][j].i = 0.0;
-      }
-    }
-  } else {
-    chan_desc->R_sqrt = (struct complexd **) calloc(nb_taps,sizeof(struct complexd *));
-
-    for (i = 0; i<nb_taps; i++) {
-      //chan_desc->R_sqrt[i]    = (struct complexd*) calloc(nb_tx*nb_rx*nb_tx*nb_rx,sizeof(struct complexd));
-      //chan_desc->R_sqrt = (struct complexd*)&R_sqrt[i][0];
-      /* all chan_desc share the same R_sqrt, coming from caller */
-      chan_desc->R_sqrt[i] = R_sqrt;
-    }
-  }
+  allocate_tap_correlation_matrices(chan_desc, R_sqrt);
 
   for (i = 0; i<nb_taps; i++) {
     for (j = 0; j<nb_tx*nb_rx*nb_tx*nb_rx; j+=(nb_tx*nb_rx+1)) {
@@ -426,15 +466,12 @@ void tdlModel(int  tdl_paths, double *tdl_delays, double *tdl_amps_dB, double DS
     }
   }
 
-  chan_desc->R_sqrt = calloc(matrix_size, sizeof(*chan_desc->R_sqrt));
-  for (int row = 0; row < matrix_size; row++) {
-    chan_desc->R_sqrt[row] = calloc(matrix_size, sizeof(**chan_desc->R_sqrt));
-    if (correlation_matrix[row] == NULL) {
-      // TS 38.104 - Table G.2.3.1.2-4: MIMO correlation matrices for low correlation
-      chan_desc->R_sqrt[row][row].r = 1.0;
-    } else {
-      for (int col = 0; col < matrix_size; col++) {
-        chan_desc->R_sqrt[row][col].r = correlation_matrix[row][col];
+  allocate_tap_correlation_matrices(chan_desc, NULL);
+  if (correlation_matrix[0] != NULL) {
+    for (int tap = 0; tap < chan_desc->nb_taps; ++tap) {
+      for (int row = 0; row < matrix_size; ++row) {
+        for (int col = 0; col < matrix_size; ++col)
+          chan_desc->R_sqrt[tap][row * matrix_size + col].r = correlation_matrix[row][col];
       }
     }
   }
@@ -502,16 +539,8 @@ double get_normalization_ch_factor(channel_desc_t *desc)
         } // for (int aatx = 0; aatx < desc->nb_tx; aatx++)
       } // for (int aarx = 0; aarx < desc->nb_rx; aarx++)
 
-      // Apply correlation matrix
-      bzero(acorr, desc->nb_tx * desc->nb_rx * sizeof(struct complexd));
-      for (int aatx = 0; aatx < desc->nb_tx; aatx++) {
-        for (int aarx = 0; aarx < desc->nb_rx; aarx++) {
-          for (int inside = 0; inside < desc->nb_tx * desc->nb_rx; inside++) {
-            const cd_t tmp = cdMul(anew[aarx + aatx * desc->nb_rx], desc->R_sqrt[aarx + aatx * desc->nb_rx][inside]);
-            csum(acorr[inside], tmp, acorr[inside]);
-          }
-        } // for (int aarx = 0; aarx < desc->nb_rx; aarx++)
-      } // for (int aatx = 0; aatx < desc->nb_tx; aatx++)
+      // Apply the tap-specific correlation matrix.
+      apply_correlation_matrix(desc, l, anew, acorr);
       memcpy(a[l], acorr, desc->nb_tx * desc->nb_rx * sizeof(*acorr));
     } // for (int l = 0; l < (int)desc->nb_taps; l++)
 
@@ -567,11 +596,12 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
     }
   }
 
-  uint16_t i,j;
+  uint16_t i;
   double sum_amps;
   double aoa, ricean_factor, Td;
   int channel_length,nb_taps;
   struct complexd *R_sqrt_ptr2;
+  const struct complexd *correlation_matrices;
   chan_desc->modelid                    = channel_model;
   chan_desc->nb_tx                      = nb_tx;
   chan_desc->nb_rx                      = nb_rx;
@@ -637,32 +667,16 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       for (i = 0; i<chan_desc->nb_taps; i++)
         chan_desc->a[i]         = calloc(nb_tx*nb_rx, sizeof(struct complexd));
 
-      chan_desc->R_sqrt  = calloc(6, sizeof(struct complexd **));
-
-      if (nb_tx==2 && nb_rx==2) {
-        for (i = 0; i<6; i++)
-          chan_desc->R_sqrt[i] = (struct complexd *) &R22_sqrt[i][0];
-      } else if (nb_tx==2 && nb_rx==1) {
-        for (i = 0; i<6; i++)
-          chan_desc->R_sqrt[i] = (struct complexd *) &R21_sqrt[i][0];
-      } else if (nb_tx==1 && nb_rx==2) {
-        for (i = 0; i<6; i++)
-          chan_desc->R_sqrt[i] = (struct complexd *) &R12_sqrt[i][0];
-      } else {
-        chan_desc->free_flags=chan_desc->free_flags|CHANMODEL_FREE_RSQRT_6 ;
-
-        for (i = 0; i<6; i++) {
-          chan_desc->R_sqrt[i]    = calloc(nb_tx*nb_rx*nb_tx*nb_rx, sizeof(struct complexd));
-
-          for (j = 0; j<nb_tx*nb_rx*nb_tx*nb_rx; j+=(nb_tx*nb_rx+1)) {
-            chan_desc->R_sqrt[i][j].r = 1.0;
-            chan_desc->R_sqrt[i][j].i = 0.0;
-          }
-
-          LOG_W(OCM,"correlation matrix not implemented for nb_tx==%d and nb_rx==%d, using identity\n", nb_tx, nb_rx);
-        }
-      }
-
+      correlation_matrices = NULL;
+      if (nb_tx == 2 && nb_rx == 2)
+        correlation_matrices = (const struct complexd *)&R22_sqrt[0][0];
+      else if (nb_tx == 2 && nb_rx == 1)
+        correlation_matrices = (const struct complexd *)&R21_sqrt[0][0];
+      else if (nb_tx == 1 && nb_rx == 2)
+        correlation_matrices = (const struct complexd *)&R12_sqrt[0][0];
+      else
+        LOG_W(OCM, "correlation matrix not implemented for nb_tx==%d and nb_rx==%d, using identity\n", nb_tx, nb_rx);
+      allocate_clustered_tap_correlation_matrices(chan_desc, correlation_matrices);
       break;
 
     case SCM_D:
@@ -699,32 +713,16 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       for (i = 0; i<chan_desc->nb_taps; i++)
         chan_desc->a[i]         = (struct complexd *) malloc(nb_tx*nb_rx * sizeof(struct complexd));
 
-      chan_desc->R_sqrt  = (struct complexd **) malloc(6*sizeof(struct complexd **));
-
-      if (nb_tx==2 && nb_rx==2) {
-        for (i = 0; i<6; i++)
-          chan_desc->R_sqrt[i] = (struct complexd *) &R22_sqrt[i][0];
-      } else if (nb_tx==2 && nb_rx==1) {
-        for (i = 0; i<6; i++)
-          chan_desc->R_sqrt[i] = (struct complexd *) &R21_sqrt[i][0];
-      } else if (nb_tx==1 && nb_rx==2) {
-        for (i = 0; i<6; i++)
-          chan_desc->R_sqrt[i] = (struct complexd *) &R12_sqrt[i][0];
-      } else {
-        chan_desc->free_flags=chan_desc->free_flags|CHANMODEL_FREE_RSQRT_6 ;
-
-        for (i = 0; i<6; i++) {
-          chan_desc->R_sqrt[i]    = (struct complexd *) malloc(nb_tx*nb_rx*nb_tx*nb_rx * sizeof(struct complexd));
-
-          for (j = 0; j<nb_tx*nb_rx*nb_tx*nb_rx; j+=(nb_tx*nb_rx+1)) {
-            chan_desc->R_sqrt[i][j].r = 1.0;
-            chan_desc->R_sqrt[i][j].i = 0.0;
-          }
-
-          LOG_W(OCM,"correlation matrix not implemented for nb_tx==%d and nb_rx==%d, using identity\n", nb_tx, nb_rx);
-        }
-      }
-
+      correlation_matrices = NULL;
+      if (nb_tx == 2 && nb_rx == 2)
+        correlation_matrices = (const struct complexd *)&R22_sqrt[0][0];
+      else if (nb_tx == 2 && nb_rx == 1)
+        correlation_matrices = (const struct complexd *)&R21_sqrt[0][0];
+      else if (nb_tx == 1 && nb_rx == 2)
+        correlation_matrices = (const struct complexd *)&R12_sqrt[0][0];
+      else
+        LOG_W(OCM, "correlation matrix not implemented for nb_tx==%d and nb_rx==%d, using identity\n", nb_tx, nb_rx);
+      allocate_clustered_tap_correlation_matrices(chan_desc, correlation_matrices);
       break;
       /*  tapped delay line (TDL)  channel model from TR 38.901 Section 7.7.2 */
 #define tdl_m(MoDel)\
@@ -796,27 +794,12 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       for (i = 0; i<chan_desc->nb_taps; i++)
         chan_desc->a[i]         = (struct complexd *) malloc(nb_tx*nb_rx * sizeof(struct complexd));
 
-      if (nb_tx==2 && nb_rx==2) {
-        chan_desc->R_sqrt  = (struct complexd **) malloc(6*sizeof(struct complexd **));
-
-        for (i = 0; i<6; i++)
-          chan_desc->R_sqrt[i] = (struct complexd *) &R22_sqrt[i][0];
-      } else {
-        chan_desc->R_sqrt         = (struct complexd **) malloc(6*sizeof(struct complexd **));
-        chan_desc->free_flags=chan_desc->free_flags|CHANMODEL_FREE_RSQRT_6 ;
-
-        for (i = 0; i<6; i++) {
-          chan_desc->R_sqrt[i]    = (struct complexd *) malloc(nb_tx*nb_rx*nb_tx*nb_rx * sizeof(struct complexd));
-
-          for (j = 0; j<nb_tx*nb_rx*nb_tx*nb_rx; j+=(nb_tx*nb_rx+1)) {
-            chan_desc->R_sqrt[i][j].r = 1.0;
-            chan_desc->R_sqrt[i][j].i = 0.0;
-          }
-
-          LOG_W(OCM,"correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
-        }
-      }
-
+      correlation_matrices = NULL;
+      if (nb_tx == 2 && nb_rx == 2)
+        correlation_matrices = (const struct complexd *)&R22_sqrt[0][0];
+      else
+        LOG_W(OCM, "correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
+      allocate_clustered_tap_correlation_matrices(chan_desc, correlation_matrices);
       break;
 
     case EPA_low:
@@ -852,26 +835,12 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       for (i = 0; i<chan_desc->nb_taps; i++)
         chan_desc->a[i]         = (struct complexd *) malloc(nb_tx*nb_rx * sizeof(struct complexd));
 
-      if (nb_tx==2 && nb_rx==2) {
-        chan_desc->R_sqrt  = (struct complexd **) malloc(chan_desc->nb_taps*sizeof(struct complexd **));
-
-        for (i = 0; i<chan_desc->nb_taps; i++)
-          chan_desc->R_sqrt[i] = R_sqrt_22_EPA_low;
-      } else {
-        printf("Correlation matrices are implemented for 2 x 2 only");
+      if (nb_tx == 2 && nb_rx == 2)
+        allocate_tap_correlation_matrices(chan_desc, R_sqrt_22_EPA_low);
+      else {
+        LOG_W(OCM, "correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
+        allocate_tap_correlation_matrices(chan_desc, NULL);
       }
-
-      /*else {
-        chan_desc->R_sqrt         = (struct complexd**) malloc(6*sizeof(struct complexd**));
-        for (i = 0; i<6; i++) {
-          chan_desc->R_sqrt[i]    = (struct complexd*) malloc(nb_tx*nb_rx*nb_tx*nb_rx * sizeof(struct complexd));
-          for (j = 0; j<nb_tx*nb_rx*nb_tx*nb_rx; j+=(nb_tx*nb_rx+1)) {
-            chan_desc->R_sqrt[i][j].x = 1.0;
-            chan_desc->R_sqrt[i][j].y = 0.0;
-          }
-          LOG_W(OCM,"correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
-        }
-      }*/
       break;
 
     case EPA_high:
@@ -907,26 +876,12 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       for (i = 0; i<chan_desc->nb_taps; i++)
         chan_desc->a[i]         = (struct complexd *) malloc(nb_tx*nb_rx * sizeof(struct complexd));
 
-      if (nb_tx==2 && nb_rx==2) {
-        chan_desc->R_sqrt  = (struct complexd **) malloc(chan_desc->nb_taps*sizeof(struct complexd **));
-
-        for (i = 0; i<chan_desc->nb_taps; i++)
-          chan_desc->R_sqrt[i] = R_sqrt_22_EPA_high;
-      } else {
-        printf("Correlation matrices are implemented for 2 x 2 only");
+      if (nb_tx == 2 && nb_rx == 2)
+        allocate_tap_correlation_matrices(chan_desc, R_sqrt_22_EPA_high);
+      else {
+        LOG_W(OCM, "correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
+        allocate_tap_correlation_matrices(chan_desc, NULL);
       }
-
-      /*else {
-        chan_desc->R_sqrt         = (struct complexd**) malloc(6*sizeof(struct complexd**));
-        for (i = 0; i<6; i++) {
-          chan_desc->R_sqrt[i]    = (struct complexd*) malloc(nb_tx*nb_rx*nb_tx*nb_rx * sizeof(struct complexd));
-          for (j = 0; j<nb_tx*nb_rx*nb_tx*nb_rx; j+=(nb_tx*nb_rx+1)) {
-            chan_desc->R_sqrt[i][j].x = 1.0;
-            chan_desc->R_sqrt[i][j].y = 0.0;
-          }
-          LOG_W(OCM,"correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
-        }
-      }*/
       break;
 
     case EPA_medium:
@@ -962,26 +917,12 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       for (i = 0; i<chan_desc->nb_taps; i++)
         chan_desc->a[i]         = (struct complexd *) malloc(nb_tx*nb_rx * sizeof(struct complexd));
 
-      if (nb_tx==2 && nb_rx==2) {
-        chan_desc->R_sqrt  = (struct complexd **) malloc(chan_desc->nb_taps*sizeof(struct complexd **));
-
-        for (i = 0; i<chan_desc->nb_taps; i++)
-          chan_desc->R_sqrt[i] = R_sqrt_22_EPA_medium;
-      } else {
-        printf("Correlation matrices are implemented for 2 x 2 only");
+      if (nb_tx == 2 && nb_rx == 2)
+        allocate_tap_correlation_matrices(chan_desc, R_sqrt_22_EPA_medium);
+      else {
+        LOG_W(OCM, "correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
+        allocate_tap_correlation_matrices(chan_desc, NULL);
       }
-
-      /*else {
-        chan_desc->R_sqrt         = (struct complexd**) malloc(6*sizeof(struct complexd**));
-        for (i = 0; i<6; i++) {
-          chan_desc->R_sqrt[i]    = (struct complexd*) malloc(nb_tx*nb_rx*nb_tx*nb_rx * sizeof(struct complexd));
-          for (j = 0; j<nb_tx*nb_rx*nb_tx*nb_rx; j+=(nb_tx*nb_rx+1)) {
-            chan_desc->R_sqrt[i][j].x = 1.0;
-            chan_desc->R_sqrt[i][j].y = 0.0;
-          }
-          LOG_W(OCM,"correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
-        }
-      }*/
       break;
 
     case EVA:
@@ -1017,27 +958,12 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       for (i = 0; i<chan_desc->nb_taps; i++)
         chan_desc->a[i]         = (struct complexd *) malloc(nb_tx*nb_rx * sizeof(struct complexd));
 
-      if (nb_tx==2 && nb_rx==2) {
-        chan_desc->R_sqrt  = (struct complexd **) malloc(6*sizeof(struct complexd **));
-
-        for (i = 0; i<6; i++)
-          chan_desc->R_sqrt[i] = (struct complexd *) &R22_sqrt[i][0];
-      } else {
-        chan_desc->R_sqrt         = (struct complexd **) malloc(6*sizeof(struct complexd **));
-        chan_desc->free_flags=chan_desc->free_flags|CHANMODEL_FREE_RSQRT_6 ;
-
-        for (i = 0; i<6; i++) {
-          chan_desc->R_sqrt[i]    = (struct complexd *) malloc(nb_tx*nb_rx*nb_tx*nb_rx * sizeof(struct complexd));
-
-          for (j = 0; j<nb_tx*nb_rx*nb_tx*nb_rx; j+=(nb_tx*nb_rx+1)) {
-            chan_desc->R_sqrt[i][j].r = 1.0;
-            chan_desc->R_sqrt[i][j].i = 0.0;
-          }
-
-          LOG_W(OCM,"correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
-        }
-      }
-
+      correlation_matrices = NULL;
+      if (nb_tx == 2 && nb_rx == 2)
+        correlation_matrices = (const struct complexd *)&R22_sqrt[0][0];
+      else
+        LOG_W(OCM, "correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
+      allocate_clustered_tap_correlation_matrices(chan_desc, correlation_matrices);
       break;
 
     case ETU:
@@ -1073,27 +999,12 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       for (i = 0; i<chan_desc->nb_taps; i++)
         chan_desc->a[i]         = (struct complexd *) malloc(nb_tx*nb_rx * sizeof(struct complexd));
 
-      if (nb_tx==2 && nb_rx==2) {
-        chan_desc->R_sqrt  = (struct complexd **) malloc(6*sizeof(struct complexd **));
-
-        for (i = 0; i<6; i++)
-          chan_desc->R_sqrt[i] = (struct complexd *) &R22_sqrt[i][0];
-      } else {
-        chan_desc->R_sqrt         = (struct complexd **) malloc(6*sizeof(struct complexd **));
-        chan_desc->free_flags=chan_desc->free_flags|CHANMODEL_FREE_RSQRT_6 ;
-
-        for (i = 0; i<6; i++) {
-          chan_desc->R_sqrt[i]    = (struct complexd *) malloc(nb_tx*nb_rx*nb_tx*nb_rx * sizeof(struct complexd));
-
-          for (j = 0; j<nb_tx*nb_rx*nb_tx*nb_rx; j+=(nb_tx*nb_rx+1)) {
-            chan_desc->R_sqrt[i][j].r = 1.0;
-            chan_desc->R_sqrt[i][j].i = 0.0;
-          }
-
-          LOG_W(OCM,"correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
-        }
-      }
-
+      correlation_matrices = NULL;
+      if (nb_tx == 2 && nb_rx == 2)
+        correlation_matrices = (const struct complexd *)&R22_sqrt[0][0];
+      else
+        LOG_W(OCM, "correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
+      allocate_clustered_tap_correlation_matrices(chan_desc, correlation_matrices);
       break;
 
     case MBSFN:
@@ -1129,20 +1040,7 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       for (i = 0; i<chan_desc->nb_taps; i++)
         chan_desc->a[i]         = (struct complexd *) malloc(nb_tx*nb_rx * sizeof(struct complexd));
 
-      chan_desc->R_sqrt  = (struct complexd **) malloc(6*sizeof(struct complexd *));
-      chan_desc->free_flags=chan_desc->free_flags|CHANMODEL_FREE_RSQRT_6;
-
-      for (i = 0; i<6; i++) {
-        chan_desc->R_sqrt[i]    = (struct complexd *) malloc(nb_tx*nb_rx*nb_tx*nb_rx * sizeof(struct complexd));
-
-        for (j = 0; j<nb_tx*nb_rx*nb_tx*nb_rx; j+=(nb_tx*nb_rx+1)) {
-          chan_desc->R_sqrt[i][j].r = 1.0;
-          chan_desc->R_sqrt[i][j].i = 0.0;
-        }
-
-        LOG_W(OCM,"correlation matrix only implemented for nb_tx==2 and nb_rx==2, using identity\n");
-      }
-
+      allocate_tap_correlation_matrices(chan_desc, NULL);
       break;
 
     case Rayleigh8:
@@ -1258,7 +1156,7 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       aoa = .03;
       maxDoppler = 0;
 
-      if ((nb_tx==2) && (nb_rx==1)) {
+      if (((nb_tx==2) && (nb_rx==1)) || ((nb_tx==1) && (nb_rx==2))) {
         R_sqrt_ptr2 = R_sqrt_21_corr;
       } else if ((nb_tx==2) && (nb_rx==2)) {
         R_sqrt_ptr2 = R_sqrt_22_corr;
@@ -1292,7 +1190,7 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       aoa = .03;
       maxDoppler = 0;
 
-      if ((nb_tx==2) && (nb_rx==1)) { //check this
+     if (((nb_tx==2) && (nb_rx==1)) || ((nb_tx==1) && (nb_rx==2))) {
         R_sqrt_ptr2 = R_sqrt_21_anticorr;
       } else if ((nb_tx==2) && (nb_rx==2)) {
         R_sqrt_ptr2 = R_sqrt_22_anticorr;
@@ -1408,7 +1306,7 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       aoa = .03;
       maxDoppler = 0;
 
-      if ((nb_tx==2) && (nb_rx==1)) {
+      if (((nb_tx==2) && (nb_rx==1)) || ((nb_tx==1) && (nb_rx==2))) {
         R_sqrt_ptr2 = R_sqrt_21_corr;
       } else if ((nb_tx==2) && (nb_rx==2)) {
         R_sqrt_ptr2 = R_sqrt_22_corr;
@@ -1442,7 +1340,7 @@ channel_desc_t *new_channel_desc_scm(uint8_t nb_tx,
       aoa = .03;
       maxDoppler = 0;
 
-      if ((nb_tx==2) && (nb_rx==1)) {
+      if (((nb_tx==2) && (nb_rx==1)) || ((nb_tx==1) && (nb_rx==2))) {
         R_sqrt_ptr2 = R_sqrt_21_anticorr;
       } else if ((nb_tx==2) && (nb_rx==2)) {
         R_sqrt_ptr2 = R_sqrt_22_anticorr;
@@ -1710,13 +1608,8 @@ void free_channel_desc_scm(channel_desc_t *ch) {
   if(ch->free_flags&CHANMODEL_FREE_DELAY)
     free(ch->delays);
 
-  if(ch->free_flags&CHANMODEL_FREE_RSQRT_6)
-    for (int i = 0; i<6; i++)
-      free(ch->R_sqrt[i]);
-
-  if(ch->free_flags&CHANMODEL_FREE_RSQRT_NTAPS)
-    for (int i = 0; i<ch->nb_taps; i++)
-      free(ch->R_sqrt[i]);
+  for (int i = 0; i < ch->nb_taps; ++i)
+    free(ch->R_sqrt[i]);
 
   free(ch->R_sqrt);
   free(ch->Doppler_phase_cur);
@@ -1813,24 +1706,8 @@ int random_channel(channel_desc_t *desc, uint8_t abstraction_flag) {
      }
     }
     */
-    //apply correlation matrix
-    //compute acorr = R_sqrt[i] * anew
-    bzero(acorr, desc->nb_tx * desc->nb_rx * sizeof(struct complexd));
-    if (desc->modelid >= TDL_A && desc->modelid <= TDL_E) {
-      for (aatx = 0; aatx < desc->nb_tx; aatx++) {
-        for (aarx=0; aarx<desc->nb_rx; aarx++) {
-          for (int inside = 0; inside < desc->nb_tx * desc->nb_rx; inside++) {
-            const cd_t tmp = cdMul(anew[aarx + aatx * desc->nb_rx], desc->R_sqrt[aarx + aatx * desc->nb_rx][inside]);
-            csum(acorr[inside], tmp, acorr[inside]);
-          }
-        }
-      }
-    } else {
-      for (int inside = 0; inside < desc->nb_tx * desc->nb_rx; inside++) {
-        const cd_t tmp = cdMul(desc->R_sqrt[i / 3][0], anew[inside]);
-        csum(acorr[inside], tmp, acorr[inside]);
-      }
-    }
+    // Apply the tap-specific correlation matrix.
+    apply_correlation_matrix(desc, i, anew, acorr);
 
     if (desc->first_run==1) {
       memcpy(desc->a[i], acorr, desc->nb_tx * desc->nb_rx * sizeof(*acorr));

--- a/openair1/SIMULATION/TOOLS/sim.h
+++ b/openair1/SIMULATION/TOOLS/sim.h
@@ -31,8 +31,6 @@ typedef enum {
 #define MODULEID_STR_INIT {"","rfsimulator"}
 
 #define CHANMODEL_FREE_DELAY       1<<0
-#define CHANMODEL_FREE_RSQRT_6     1<<1
-#define CHANMODEL_FREE_RSQRT_NTAPS 1<<2
 #define CHANMODEL_FREE_AMPS        1<<3
 #define SHR3 (jz = jsr, jsr ^= (jsr << 13), jsr ^= (jsr >> 17), jsr ^= (jsr << 5), jz + jsr)
 


### PR DESCRIPTION
## Summary

Harmonize the representation and application of spatial correlation matrices in `random_channel.c`.

`R_sqrt` now consistently uses dimensions `[tap][row * n_links + col]` for every channel model, where `n_links = nb_tx * nb_rx`.

## Changes
- Allocate one flattened spatial correlation matrix per channel tap.
- Copy shared legacy correlation matrices into every applicable tap.
- Expand clustered SCM/EPA/EVA/ETU correlation data during initialization.
- Initialize unsupported correlation configurations with per-tap identity matrices.
- Use a single model-independent matrix multiplication path.
- Remove the legacy i / 3 correlation lookup.
- Apply the same correlation helper during TDL normalization.
- Unify R_sqrt ownership and cleanup.
- Remove obsolete R_sqrt ownership flags.