### PR TITLE
Codebook-based digital beamforming in O-RU.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1806,7 +1806,7 @@ if (OAI_RU_FRONTHAUL)
     ${OPENAIR_DIR}/executables/nr-oru.c
   )
   target_link_libraries(nr-oru PRIVATE
-    UTIL NR_PHY_RU PHY_NR shlib_loader dl oru_fh MAC_NR_COMMON
+    UTIL NR_PHY_RU PHY_NR shlib_loader dl oru_fh oru_beamforming MAC_NR_COMMON
     radio_common softmodem_common nfapi_pnf_lib symbol_reorder)
   target_link_libraries(nr-oru PRIVATE pthread m CONFIG_LIB rt ${T_LIB} utils
     barrier actor nfapi_user_lib)

--- a/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru-bfp.conf
+++ b/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru-bfp.conf
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+Active_gNBs = ( "gNB-OAI");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    =  0xe00;
+    gNB_name  =  "gNB-OAI";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  1;
+    plmn_list = ({ mcc = 208; mnc = 99; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345678L;
+
+    ////////// Physical parameters:
+
+    pdsch_AntennaPorts_XP = 1;
+    pdsch_AntennaPorts_N1 = 1;
+    pusch_AntennaPorts    = 1;
+
+    servingCellConfigCommon = (
+    {
+ #spCellConfigCommon
+
+      physCellId                                                    = 0;
+#  downlinkConfigCommon
+    #frequencyInfoDL
+      # center frequency = 4049.76 MHz
+      # selected SSB frequency = 4049.76 MHz
+      absoluteFrequencySSB                                          = 669984;
+      dl_frequencyBand                                              = 77;
+      # frequency point A = 4030.68 MHz
+      dl_absoluteFrequencyPointA                                    = 668712;
+      #scs-SpecificCarrierList
+        dl_offstToCarrier                                           = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing                                        = 1;
+        dl_carrierBandwidth                                         = 106;
+     #initialDownlinkBWP
+      #genericParameters
+       initialDLBWPlocationAndBandwidth                             = 28875; #38.101-1 Table 5.3.2-1
+       #
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing                               = 1;
+      #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero                          = 11;
+        initialDLBWPsearchSpaceZero                                 = 0;
+
+  #uplinkConfigCommon
+     #frequencyInfoUL
+      ul_frequencyBand                                              = 77;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 106;
+      pMax                                                          = 23;
+     #initialUplinkBWP
+      #genericParameters
+        initialULBWPlocationAndBandwidth                            = 28875;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+        #rach-ConfigGeneric
+          prach_ConfigurationIndex                                  = 152;
+#prach_msg1_FDM
+#0 = one, 1=two, 2=four, 3=eight
+          prach_msg1_FDM                                            = 0;
+          prach_msg1_FrequencyStart                                 = 0;
+          zeroCorrelationZoneConfig                                 = 0;
+          preambleReceivedTargetPower                               = -100;
+#preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+          preambleTransMax                                          = 7;
+#powerRampingStep
+# 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep                                            = 2;
+#ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+#1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+#one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 15;
+#ra_ContentionResolutionTimer
+#(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer                                = 7;
+        rsrp_ThresholdSSB                                           = 19;
+#prach-RootSequenceIndex_PR
+#1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR                                  = 2;
+        prach_RootSequenceIndex                                     = 1;
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        #
+        msg1_SubcarrierSpacing                                      = 1,
+# restrictedSetConfig
+# 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig                                         = 0,
+
+# this is the offset between the last PRACH preamble power and the Msg3 PUSCH, 2 times the field value in dB
+        msg3_DeltaPreamble                                          = 2;
+        p0_NominalWithGrant                                         = -100;
+
+# pucch-ConfigCommon setup :
+# pucchGroupHopping
+# 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping                                           = 0;
+        hoppingId                                                   = 0;
+        p0_nominal                                                  = -96;
+
+      ssb_PositionsInBurst_Bitmap                                   = 0x1;
+
+# ssb_periodicityServingCell
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+# dmrs_TypeA_position
+# 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+  #tdd-UL-DL-ConfigurationCommon
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 5;
+      nrofDownlinkSlots                                             = 3;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 1;
+      nrofUplinkSymbols                                             = 4;
+
+  ssPBCH_BlockPower                                                 = 0;
+  }
+
+  );
+
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+    ////////// AMF parameters:
+    amf_ip_address = ({ ipv4 = "192.168.101.132"; });
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.101.140";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "192.168.101.140";
+        GNB_PORT_FOR_NGU                         = 2152; # Spec 2152
+    };
+  }
+);
+
+MACRLCs = (
+{
+  num_cc                      = 1;
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 200;
+  pucch_TargetSNRx10          = 200;
+  pusch_FailureThres          = 100;
+}
+);
+
+L1s = (
+{
+  num_cc = 1;
+  tr_n_preference = "local_mac";
+  prach_dtx_threshold = 200;
+  pucch0_dtx_threshold = 80;
+  pusch_dtx_threshold = -100;
+ # thread_pool_size = 8;
+  tx_amp_backoff_dB = 36;
+  L1_rx_thread_core = 10;
+  L1_tx_thread_core = 11;
+  phase_compensation = 0; # needs to match O-RU configuration
+}
+);
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 1;
+  nb_rx          = 1;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  ru_thread_core = 12;
+  sl_ahead       = 10;
+  tr_preference  = "raw_if4p5"; # important: activate FHI7.2
+  do_precoding   = 0; # needs to match O-RU configuration
+}
+);
+
+security = {
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms = ( "nea0" );
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms = ( "nia2", "nia0" );
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};
+
+fhi_72 = {
+  dpdk_devices = ("0000:41:11.0"); # one VF can be used as well
+  dpdk_iova_mode = "VA";
+  system_core = 7;
+  io_core = 8;
+  worker_cores = (9);
+  ru_addr = ("00:11:22:33:aa:67");
+  mtu = 9600;
+  fh_config = ({
+    T1a_cp_dl = (285, 470);
+    T1a_cp_ul = (285, 429);
+    T1a_up = (300, 450);
+    Ta4 = (0, 440);
+    ru_config = {
+      comp_hdr_type = "dynamic"; # must be "dynamic" when iq_width < 16: O-RU sends per-section compression headers
+      iq_width = 9;
+      iq_width_prach = 9;
+    };
+  });
+};

--- a/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.2x2-oaioru-bf.conf
+++ b/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.2x2-oaioru-bf.conf
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+Active_gNBs = ( "gNB-OAI");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    =  0xe00;
+    gNB_name  =  "gNB-OAI";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  1;
+    plmn_list = ({ mcc = 208; mnc = 99; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345678L;
+
+    ////////// Physical parameters:
+
+    pdsch_AntennaPorts_XP = 1;
+    pdsch_AntennaPorts_N1 = 1;
+    pusch_AntennaPorts    = 1;
+
+    servingCellConfigCommon = (
+    {
+ #spCellConfigCommon
+
+      physCellId                                                    = 0;
+#  downlinkConfigCommon
+    #frequencyInfoDL
+      # center frequency = 4049.76 MHz
+      # selected SSB frequency = 4049.76 MHz
+      absoluteFrequencySSB                                          = 669984;
+      dl_frequencyBand                                              = 77;
+      # frequency point A = 4030.68 MHz
+      dl_absoluteFrequencyPointA                                    = 668712;
+      #scs-SpecificCarrierList
+        dl_offstToCarrier                                           = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing                                        = 1;
+        dl_carrierBandwidth                                         = 106;
+     #initialDownlinkBWP
+      #genericParameters
+       initialDLBWPlocationAndBandwidth                             = 28875; #38.101-1 Table 5.3.2-1
+       #
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing                               = 1;
+      #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero                          = 11;
+        initialDLBWPsearchSpaceZero                                 = 0;
+
+  #uplinkConfigCommon
+     #frequencyInfoUL
+      ul_frequencyBand                                              = 77;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 106;
+      pMax                                                          = 23;
+     #initialUplinkBWP
+      #genericParameters
+        initialULBWPlocationAndBandwidth                            = 28875;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+        #rach-ConfigGeneric
+          prach_ConfigurationIndex                                  = 152;
+#prach_msg1_FDM
+#0 = one, 1=two, 2=four, 3=eight
+          prach_msg1_FDM                                            = 0;
+          prach_msg1_FrequencyStart                                 = 0;
+          zeroCorrelationZoneConfig                                 = 0;
+          preambleReceivedTargetPower                               = -100;
+#preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+          preambleTransMax                                          = 7;
+#powerRampingStep
+# 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep                                            = 2;
+#ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+#1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+#one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 15;
+#ra_ContentionResolutionTimer
+#(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer                                = 7;
+        rsrp_ThresholdSSB                                           = 19;
+#prach-RootSequenceIndex_PR
+#1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR                                  = 2;
+        prach_RootSequenceIndex                                     = 1;
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        #
+        msg1_SubcarrierSpacing                                      = 1,
+# restrictedSetConfig
+# 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig                                         = 0,
+
+# this is the offset between the last PRACH preamble power and the Msg3 PUSCH, 2 times the field value in dB
+        msg3_DeltaPreamble                                          = 2;
+        p0_NominalWithGrant                                         = -100;
+
+# pucch-ConfigCommon setup :
+# pucchGroupHopping
+# 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping                                           = 0;
+        hoppingId                                                   = 0;
+        p0_nominal                                                  = -96;
+
+      ssb_PositionsInBurst_Bitmap                                   = 0x1;
+
+# ssb_periodicityServingCell
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+# dmrs_TypeA_position
+# 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+  #tdd-UL-DL-ConfigurationCommon
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 5;
+      nrofDownlinkSlots                                             = 3;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 1;
+      nrofUplinkSymbols                                             = 4;
+
+  ssPBCH_BlockPower                                                 = 0;
+  }
+
+  );
+
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+    ////////// AMF parameters:
+    amf_ip_address = ({ ipv4 = "192.168.101.132"; });
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.101.140";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "192.168.101.140";
+        GNB_PORT_FOR_NGU                         = 2152; # Spec 2152
+    };
+
+  }
+);
+
+MACRLCs = (
+{
+  num_cc                      = 1;
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 200;
+  pucch_TargetSNRx10          = 200;
+  pusch_FailureThres          = 100;
+  # Preconfigured analog beamforming
+  set_analog_beamforming      = "lophy";
+  beam_duration               = 1;
+  beams_per_period            = 1;
+  beam_weights                = [0];
+}
+);
+
+L1s = (
+{
+  num_cc = 1;
+  tr_n_preference = "local_mac";
+  prach_dtx_threshold = 200;
+  pucch0_dtx_threshold = 80;
+  pusch_dtx_threshold = -100;
+ # thread_pool_size = 8;
+  tx_amp_backoff_dB = 36;
+  L1_rx_thread_core = 10;
+  L1_tx_thread_core = 11;
+  phase_compensation = 0; # needs to match O-RU configuration
+}
+);
+
+RUs = (
+{
+  local_rf       = "no";
+  # Cat-B: the O-RU is 2x2 but the FH carries 1 stream each way (codebook
+  # combining in the RU). The DU's low-PHY sees 1 U-plane stream per direction,
+  # so nb_tx/nb_rx are the stream counts, not the physical antenna counts.
+  nb_tx          = 1;
+  nb_rx          = 1;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  ru_thread_core = 12;
+  sl_ahead       = 10;
+  tr_preference  = "raw_if4p5"; # important: activate FHI7.2
+  do_precoding   = 0; # needs to match O-RU configuration
+}
+);
+
+security = {
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms = ( "nea0" );
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms = ( "nia2", "nia0" );
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};
+
+fhi_72 = {
+  dpdk_devices = ("0000:41:11.0"); # one VF can be used as well
+  dpdk_iova_mode = "VA";
+  system_core = 7;
+  io_core = 8;
+  worker_cores = (9);
+  ru_addr = ("00:11:22:33:aa:67");
+  mtu = 9600;
+  fh_config = ({
+    T1a_cp_dl = (285, 470);
+    T1a_cp_ul = (285, 429);
+    T1a_up = (300, 450);
+    Ta4 = (0, 440);
+    ru_config = {
+      iq_width = 16;
+      iq_width_prach = 16;
+    };
+  });
+};

--- a/ci-scripts/conf_files/ru.band77.mu1.106prb.1x1-bfp.conf
+++ b/ci-scripts/conf_files/ru.band77.mu1.106prb.1x1-bfp.conf
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+ORUs = (
+{
+  tx_bw = [106];
+  rx_bw = [106];
+  carrier_tx = [4049760];
+  carrier_rx = [4049760];
+  prach_config_index = 152;
+  prach_msg1_start = 0;
+  tdd_period = 5;
+  num_dl_slots = 3;
+  num_dl_symbols = 6;
+  num_ul_slots = 1;
+  num_ul_symbols = 4;
+  numerology = 1;
+  fronthaul = {
+    dpdk_devices = ("0000:01:01.0"); # one VF can be used as well
+    rx_core = 2;
+    du_mac_addr = ("00:11:22:33:aa:66");
+    mtu = 9216;
+    T2a_up = (250, 5000);
+    T2a_cp = (250, 5000);
+    prach_eaxc_offset = 1;
+    extra_eal_args = ("--file-prefix", "ru");
+    comp_type = "bfp"; # options: "none", "bfp", "blkscale", "ulaw"; must match iq_width on the O-DU side
+  }
+});
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 1;
+  nb_rx          = 1;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  sl_ahead       = 10;
+  tr_preference  = "raw_if4p5"; # important: activate FHI7.2
+  do_precoding   = 0; # needs to match O-RU configuration
+  # PRACH configuration
+  num_tp_cores = 4;
+  tp_cores = [-1,-1,-1,-1];
+});
+
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};

--- a/ci-scripts/conf_files/ru.band77.mu1.106prb.2x2-bf.conf
+++ b/ci-scripts/conf_files/ru.band77.mu1.106prb.2x2-bf.conf
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+ORUs = (
+{
+  tx_bw = [106];
+  rx_bw = [106];
+  carrier_tx = [4049760];
+  carrier_rx = [4049760];
+  prach_config_index = 152;
+  prach_msg1_start = 0;
+  tdd_period = 5;
+  num_dl_slots = 3;
+  num_dl_symbols = 6;
+  num_ul_slots = 1;
+  num_ul_symbols = 4;
+  numerology = 1;
+  fronthaul = {
+    dpdk_devices = ("0000:01:01.0"); # one VF can be used as well
+    rx_core = 2;
+    du_mac_addr = ("00:11:22:33:aa:66");
+    mtu = 9216;
+    T2a_up = (250, 5000);
+    T2a_cp = (250, 5000);
+    prach_eaxc_offset = 1;
+    extra_eal_args = ("--file-prefix", "ru");
+  }
+  # Digital codebook beamforming (Cat-B): O-RU applies the codebook to DL
+  # transmit and UL Rx combining (the C-plane section beamId selects the beam).
+  # 2 RX antennas combined into 1 fh stream: out = w0*X0 + w1*X1 per beam.
+  nb_fh_streams = 1;
+  codebook_nb_beams = 2;
+  # Q15 weights, layout: beam x tx_antenna x fh_stream x (Re, Im)
+  codebook_weights = [32767,0, 32767,0,
+                       32767,0, 0,32767];
+});
+
+RUs = (
+{
+  local_rf       = "no";
+  # Physical antennas: 2 TX / 2 RX. The FH to the DU carries nb_fh_streams=1
+  # stream each way (the O-DU side is configured 1x1).
+  nb_tx          = 2;
+  nb_rx          = 2;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  sl_ahead       = 10;
+  tr_preference  = "raw_if4p5"; # important: activate FHI7.2
+  do_precoding   = 0; # needs to match O-RU configuration
+  # PRACH configuration
+  num_tp_cores = 4;
+  tp_cores = [-1,-1,-1,-1];
+});
+
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};
+
+# Chanmod required for proper mixing of O-RU antennas
+channelmod = {
+  max_chan = 10;
+  modellist = "DefaultChannelList";
+  DefaultChannelList = (
+    {
+      model_name     = "server_tx_channel_model";
+      type           = "AWGN";
+      ploss_dB       = 0;
+      noise_power_dB = -100;
+      forgetfact     = 0;
+      offset         = 0;
+      ds_tdl         = 0;
+    }
+  );
+};

--- a/ci-scripts/xml_files/container_5g_oai_nr_oru_bf.xml
+++ b/ci-scripts/xml_files/container_5g_oai_nr_oru_bf.xml
@@ -1,0 +1,162 @@
+<!-- SPDX-License-Identifier: LicenseRef-CSSL-1.0 -->
+
+<testCaseList>
+  <htmlTabRef>oai-nr-oru-bf</htmlTabRef>
+  <htmlTabName>O-RU vrtsim 2x2 beamforming</htmlTabName>
+  <htmlTabIcon>wrench</htmlTabIcon>
+
+  <testCase>
+    <class>Pull_Local_Registry</class>
+    <desc>Pull Images from Local Registry</desc>
+    <node>stonechat</node>
+    <images>oai-gnb-fhi72</images>
+  </testCase>
+
+  <testCase>
+    <class>Pull_Local_Registry</class>
+    <desc>Pull Images from Local Registry</desc>
+    <node>matix</node>
+    <images>oai-nr-ue oai-nr-oru</images>
+  </testCase>
+
+  <testCase>
+    <class>Create_Workspace</class>
+    <desc>Create new Workspace</desc>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Create_Workspace</class>
+    <desc>Create new Workspace</desc>
+    <node>stonechat</node>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G CoreNetwork</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bf</yaml_path>
+    <services>mysql oai-amf oai-smf oai-upf oai-ext-dn</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI O-RU</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bf</yaml_path>
+    <services>oai-nr-oru</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G gNB 7.2</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bf</yaml_path>
+    <services>oai-gnb</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G NR-UE</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bf/</yaml_path>
+    <services>oai-nr-ue</services>
+  </testCase>
+
+  <testCase>
+    <class>Attach_UE</class>
+    <desc>Attach OAI UE (Wait for IP)</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Ping</class>
+    <desc>Ping ext-dn from NR-UE</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <ping_args>-c 20 -i 0.25</ping_args>
+    <ping_packetloss_threshold>5</ping_packetloss_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Ping</class>
+    <desc>Ping NR-UE from ext-dn</desc>
+    <id>rfsim5g_ext_dn</id>
+    <node>stonechat</node>
+    <svr_id>rfsim5g_ue</svr_id>
+    <svr_node>matix</svr_node>
+    <ping_args>-c 20 -i 0.25</ping_args>
+    <ping_packetloss_threshold>5</ping_packetloss_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>Iperf (DL/TCP)(20 sec)</desc>
+    <iperf_args>-t 20 -R</iperf_args>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <iperf_tcp_rate_target>90</iperf_tcp_rate_target>
+  </testCase>
+
+    <testCase>
+    <class>Iperf</class>
+    <desc>Iperf (UL/TCP)(20 sec)</desc>
+    <iperf_args>-t 20</iperf_args>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <iperf_tcp_rate_target>25</iperf_tcp_rate_target>
+  </testCase>
+
+  <testCase>
+    <class>Detach_UE</class>
+    <desc>Detach OAI UE</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Undeploy_Object</class>
+    <always_exec>true</always_exec>
+    <desc>Undeploy all OAI 5G stack</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bf/</yaml_path>
+    <analysis>
+      <services>oai-gnb=EndsWithBye</services>
+    </analysis>
+  </testCase>
+
+  <testCase>
+    <class>Undeploy_Object</class>
+    <always_exec>true</always_exec>
+    <desc>Undeploy all OAI 5G stack</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bf</yaml_path>
+    <analysis>
+      <services>oai-nr-ue oai-nr-oru</services>
+    </analysis>
+  </testCase>
+
+  <testCase>
+    <class>Clean_Test_Server_Images</class>
+    <always_exec>true</always_exec>
+    <desc>Clean Test Images on Test Server</desc>
+    <node>stonechat</node>
+    <images>oai-gnb-fhi72</images>
+  </testCase>
+
+  <testCase>
+    <class>Clean_Test_Server_Images</class>
+    <always_exec>true</always_exec>
+    <desc>Clean Test Images on Test Server</desc>
+    <node>matix</node>
+    <images>oai-nr-ue oai-nr-oru</images>
+  </testCase>
+
+</testCaseList>

--- a/ci-scripts/xml_files/container_5g_oai_nr_oru_bfp.xml
+++ b/ci-scripts/xml_files/container_5g_oai_nr_oru_bfp.xml
@@ -1,0 +1,162 @@
+<!-- SPDX-License-Identifier: LicenseRef-CSSL-1.0 -->
+
+<testCaseList>
+  <htmlTabRef>oai-nr-oru-bfp</htmlTabRef>
+  <htmlTabName>O-RU vrtsim 1x1 BFP compression</htmlTabName>
+  <htmlTabIcon>wrench</htmlTabIcon>
+
+  <testCase>
+    <class>Pull_Local_Registry</class>
+    <desc>Pull Images from Local Registry</desc>
+    <node>stonechat</node>
+    <images>oai-gnb-fhi72</images>
+  </testCase>
+
+  <testCase>
+    <class>Pull_Local_Registry</class>
+    <desc>Pull Images from Local Registry</desc>
+    <node>matix</node>
+    <images>oai-nr-ue oai-nr-oru</images>
+  </testCase>
+
+  <testCase>
+    <class>Create_Workspace</class>
+    <desc>Create new Workspace</desc>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Create_Workspace</class>
+    <desc>Create new Workspace</desc>
+    <node>stonechat</node>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G CoreNetwork</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp</yaml_path>
+    <services>mysql oai-amf oai-smf oai-upf oai-ext-dn</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI O-RU</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp</yaml_path>
+    <services>oai-nr-oru</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G gNB 7.2</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp</yaml_path>
+    <services>oai-gnb</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G NR-UE</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp/</yaml_path>
+    <services>oai-nr-ue</services>
+  </testCase>
+
+  <testCase>
+    <class>Attach_UE</class>
+    <desc>Attach OAI UE (Wait for IP)</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Ping</class>
+    <desc>Ping ext-dn from NR-UE</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <ping_args>-c 20 -i 0.25</ping_args>
+    <ping_packetloss_threshold>5</ping_packetloss_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Ping</class>
+    <desc>Ping NR-UE from ext-dn</desc>
+    <id>rfsim5g_ext_dn</id>
+    <node>stonechat</node>
+    <svr_id>rfsim5g_ue</svr_id>
+    <svr_node>matix</svr_node>
+    <ping_args>-c 20 -i 0.25</ping_args>
+    <ping_packetloss_threshold>5</ping_packetloss_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>Iperf (DL/TCP)(20 sec)</desc>
+    <iperf_args>-t 20 -R</iperf_args>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <iperf_tcp_rate_target>90</iperf_tcp_rate_target>
+  </testCase>
+
+    <testCase>
+    <class>Iperf</class>
+    <desc>Iperf (UL/TCP)(20 sec)</desc>
+    <iperf_args>-t 20</iperf_args>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <iperf_tcp_rate_target>25</iperf_tcp_rate_target>
+  </testCase>
+
+  <testCase>
+    <class>Detach_UE</class>
+    <desc>Detach OAI UE</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Undeploy_Object</class>
+    <always_exec>true</always_exec>
+    <desc>Undeploy all OAI 5G stack</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp/</yaml_path>
+    <analysis>
+      <services>oai-gnb=EndsWithBye</services>
+    </analysis>
+  </testCase>
+
+  <testCase>
+    <class>Undeploy_Object</class>
+    <always_exec>true</always_exec>
+    <desc>Undeploy all OAI 5G stack</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp</yaml_path>
+    <analysis>
+      <services>oai-nr-ue oai-nr-oru</services>
+    </analysis>
+  </testCase>
+
+  <testCase>
+    <class>Clean_Test_Server_Images</class>
+    <always_exec>true</always_exec>
+    <desc>Clean Test Images on Test Server</desc>
+    <node>stonechat</node>
+    <images>oai-gnb-fhi72</images>
+  </testCase>
+
+  <testCase>
+    <class>Clean_Test_Server_Images</class>
+    <always_exec>true</always_exec>
+    <desc>Clean Test Images on Test Server</desc>
+    <node>matix</node>
+    <images>oai-nr-ue oai-nr-oru</images>
+  </testCase>
+
+</testCaseList>

--- a/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue/docker-compose.yml
+++ b/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         devices:
             - /dev/vfio:/dev/vfio/
         volumes:
-            - ../../conf_files/ru.band77.mu1.106prb.1x1.conf:/opt/nr-oru/etc/nr-oru.conf
+            - ../../conf_files/${RU_CONF:-ru.band77.mu1.106prb.1x1.conf}:/opt/nr-oru/etc/nr-oru.conf
             - /dev/hugepages:/dev/hugepages
             - tmp_data:/tmp/
         cpuset: "2,3,4,5,6"

--- a/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bf/.env
+++ b/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bf/.env
@@ -1,0 +1,1 @@
+RU_CONF="ru.band77.mu1.106prb.2x2-bf.conf"

--- a/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bf/docker-compose.yml
+++ b/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bf/docker-compose.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+
+# Variant of 5g_vrtsim_fhi72_oaioru_1x1_ru_ue that deploys the O-RU with
+# digital codebook beamforming: the conf file to mount is picked by RU_CONF in
+# .env, so no docker file is duplicated. The UE setup scripts and service
+# definitions are the base compose's.
+include:
+    - ../5g_vrtsim_fhi72_oaioru_1x1_ru_ue/docker-compose.yml
+
+services:
+    oai-nr-oru:
+        environment:
+            USE_ADDITIONAL_OPTIONS: --device.name vrtsim --vrtsim.role server --vrtsim.chanmod 1

--- a/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp/.env
+++ b/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp/.env
@@ -1,0 +1,1 @@
+RU_CONF="ru.band77.mu1.106prb.1x1-bfp.conf"

--- a/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp/docker-compose.yml
+++ b/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp/docker-compose.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+
+# Variant of 5g_vrtsim_fhi72_oaioru_1x1_ru_ue that deploys the O-RU with BFP
+# compression: the conf file to mount is picked by RU_CONF in .env, so no
+# docker file is duplicated. The UE setup scripts and service definitions are
+# the base compose's.
+include:
+    - ../5g_vrtsim_fhi72_oaioru_1x1_ru_ue/docker-compose.yml

--- a/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb/docker-compose.yml
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb/docker-compose.yml
@@ -29,7 +29,7 @@ services:
         devices:
             - /dev/vfio:/dev/vfio/
         volumes:
-            - ../../conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru.conf:/opt/oai-gnb/etc/gnb.conf
+            - ../../conf_files/${GNB_CONF:-gnb.sa.band77.106prb.fhi72.1x1-oaioru.conf}:/opt/oai-gnb/etc/gnb.conf
             - /dev/hugepages:/dev/hugepages
         cpuset: "7,8,9,10,11,12,13,14,15,16"
         networks:

--- a/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bf/.env
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bf/.env
@@ -1,0 +1,1 @@
+GNB_CONF="gnb.sa.band77.106prb.fhi72.2x2-oaioru-bf.conf"

--- a/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bf/docker-compose.yml
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bf/docker-compose.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+
+# Variant of sa_fhi_7.2_oaioru_1x1_gnb that deploys the gNB with digital
+# codebook beamforming: the conf file to mount is picked by GNB_CONF in .env,
+# so no docker file is duplicated. The core network, setup scripts and service
+# definitions are the base compose's.
+include:
+    - ../sa_fhi_7.2_oaioru_1x1_gnb/docker-compose.yml

--- a/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp/.env
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp/.env
@@ -1,0 +1,1 @@
+GNB_CONF="gnb.sa.band77.106prb.fhi72.1x1-oaioru-bfp.conf"

--- a/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp/docker-compose.yml
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp/docker-compose.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+
+# Variant of sa_fhi_7.2_oaioru_1x1_gnb that deploys the gNB with BFP compression:
+# the conf file to mount is picked by GNB_CONF in .env, so no docker file is
+# duplicated. The core network, setup scripts and service definitions are the
+# base compose's.
+include:
+    - ../sa_fhi_7.2_oaioru_1x1_gnb/docker-compose.yml

--- a/common/utils/ds/CMakeLists.txt
+++ b/common/utils/ds/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(ds OBJECT
             hashtable.c
             obj_hashtable.c
             spsc_q.c
+            work_q.c
 )
 
 target_include_directories(ds PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/common/utils/ds/tests/CMakeLists.txt
+++ b/common/utils/ds/tests/CMakeLists.txt
@@ -16,3 +16,8 @@ add_dependencies(tests test_spsc_q)
 add_test(NAME test_spsc_q COMMAND test_spsc_q)
 add_executable(test_spsc_q_perf test_spsc_q_perf.cpp)
 target_link_libraries(test_spsc_q_perf PRIVATE ds benchmark::benchmark)
+
+add_executable(test_work_q test_work_q.cpp)
+target_link_libraries(test_work_q ds GTest::gtest)
+add_dependencies(tests test_work_q)
+add_test(NAME test_work_q COMMAND test_work_q)

--- a/common/utils/ds/tests/test_work_q.cpp
+++ b/common/utils/ds/tests/test_work_q.cpp
@@ -1,0 +1,289 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+extern "C" {
+#include "work_q.h"
+}
+
+struct Item {
+  uint64_t id;
+  work_q_t *queue;
+};
+
+static size_t idx_of(work_q_t *q, void *slot)
+{
+  return (size_t)((uint8_t *)slot - q->slots) / q->stride;
+}
+
+TEST(work_q, full_ring)
+{
+  constexpr size_t CNT = 64;
+  work_q_t q;
+  ASSERT_TRUE(work_q_alloc(&q, CNT, sizeof(Item)));
+
+  std::vector<void *> held;
+  for (size_t i = 0; i < CNT; ++i) {
+    Item it{i, &q};
+    void *slot = work_q_push(&q, &it);
+    ASSERT_NE(slot, nullptr);
+    ASSERT_EQ(idx_of(&q, slot), i);
+    held.push_back(slot);
+  }
+
+  Item overflow{CNT, &q};
+  EXPECT_EQ(work_q_push(&q, &overflow), nullptr); // all CNT slots held
+  work_q_done(&q, held[0]);
+  void *slot = nullptr;
+  for (int i = 0; i < (int)CNT; ++i) {
+    slot = work_q_push(&q, &overflow);
+    if (slot != nullptr)
+      break;
+  }
+  ASSERT_NE(slot, nullptr);
+  EXPECT_EQ(slot, held[0]);
+  EXPECT_EQ(work_q_push(&q, &overflow), nullptr); // busy again
+
+  for (size_t i = 0; i < CNT; ++i)
+    work_q_done(&q, held[i]);
+
+  std::vector<void *> reused;
+  for (size_t i = 0; i < CNT; ++i) {
+    Item it{1000 + i, &q};
+    void *slot = work_q_push(&q, &it);
+    ASSERT_NE(slot, nullptr);
+    ASSERT_EQ(((Item *)slot)->id, it.id);
+    reused.push_back(slot);
+  }
+  EXPECT_EQ(work_q_push(&q, &overflow), nullptr); // full again: all CNT slots busy
+
+  for (void *s : reused)
+    work_q_done(&q, s);
+  work_q_free(&q);
+}
+
+// Repeated fill/drain cycles in varying orders must recycle all slots without ever aliasing a
+// still-live item, and the item content must come back untouched.
+TEST(work_q, wrap_around)
+{
+  constexpr size_t CNT = 8;
+  work_q_t q;
+  ASSERT_TRUE(work_q_alloc(&q, CNT, sizeof(Item)));
+
+  for (int round = 0; round < 100; ++round) {
+    for (size_t i = 0; i < CNT; ++i) {
+      Item it{(uint64_t)round * 1000 + i, &q};
+      void *slot = work_q_push(&q, &it);
+      ASSERT_NE(slot, nullptr);
+      ASSERT_EQ(((Item *)slot)->id, it.id);
+    }
+    // release in reverse order
+    for (size_t i = 0; i < CNT; ++i) {
+      // the slots currently held are 0..CNT-1 in order; the producer wraps back to slot 0 only
+      // after the whole ring is released, so the round's items stay intact until their done
+      work_q_done(&q, q.slots + (CNT - 1 - i) * q.stride);
+    }
+  }
+  work_q_free(&q);
+}
+
+TEST(work_q, slow_consumer_not_overwritten)
+{
+  constexpr size_t CNT = 8;
+  constexpr int NUM_PUSHES = 200000;
+  constexpr int NUM_CONSUMERS = 4;
+
+  work_q_t q;
+  ASSERT_TRUE(work_q_alloc(&q, CNT, sizeof(Item)));
+
+  // MPMC-safe handoff of slot pointers to the consumers (a spsc_q would be an SPSC violation
+  // here: multiple consumers on one ring).
+  std::mutex mtx;
+  std::condition_variable cv;
+  std::deque<void *> handoff;
+  bool producer_done = false;
+
+  std::atomic<bool> in_use[CNT];
+  for (auto &f : in_use)
+    f = false;
+  std::atomic<bool> producer_error{false};
+  std::atomic<bool> consumer_content_error{false};
+  std::atomic<bool> consumer_handout_error{false};
+  std::atomic<uint64_t> pushed{0};
+
+  auto handoff_push = [&](void *slot) {
+    std::unique_lock<std::mutex> lk(mtx);
+    handoff.push_back(slot);
+    cv.notify_one();
+  };
+  // Returns a slot pointer, or NULL when the producer is done and the handoff is drained.
+  auto handoff_pop = [&]() -> void * {
+    std::unique_lock<std::mutex> lk(mtx);
+    cv.wait(lk, [&] { return !handoff.empty() || producer_done; });
+    if (handoff.empty())
+      return NULL;
+    void *slot = handoff.front();
+    handoff.pop_front();
+    return slot;
+  };
+
+  std::thread producer([&]() {
+    for (uint64_t id = 0; id < NUM_PUSHES; ++id) {
+      Item it{id, &q};
+      void *slot = work_q_push(&q, &it);
+      if (slot == nullptr)
+        continue; // ring full - allowed; consumers drain it
+      if (in_use[idx_of(&q, slot)].exchange(true))
+        producer_error = true; // handed out twice before done: the race
+      handoff_push(slot);
+    }
+    pushed.store(NUM_PUSHES);
+    {
+      std::unique_lock<std::mutex> lk(mtx);
+      producer_done = true;
+    }
+    cv.notify_all();
+  });
+
+  auto consumer = [&]() {
+    for (;;) {
+      void *slot = handoff_pop();
+      if (slot == NULL)
+        break;
+      Item *it = (Item *)slot;
+      if (it->id >= (uint64_t)NUM_PUSHES || it->queue != &q)
+        consumer_content_error = true; // torn or stale content
+      if (!in_use[idx_of(&q, slot)].load())
+        consumer_handout_error = true; // handed out while previous owner still working
+      // Mirror the queue's ownership exactly: clear the test flag BEFORE releasing the slot, so
+      // the producer's exchange() sees false the moment the queue lets it reuse the slot.
+      in_use[idx_of(&q, slot)].store(false);
+      work_q_done(&q, slot);
+    }
+  };
+  std::vector<std::thread> consumers;
+  for (int i = 0; i < NUM_CONSUMERS; ++i)
+    consumers.emplace_back(consumer);
+
+  producer.join();
+  for (auto &t : consumers)
+    t.join();
+
+  EXPECT_FALSE(producer_error);
+  EXPECT_FALSE(consumer_content_error);
+  EXPECT_FALSE(consumer_handout_error);
+  EXPECT_EQ(pushed.load(), (uint64_t)NUM_PUSHES);
+  EXPECT_TRUE(handoff.empty()); // everything drained
+
+  work_q_free(&q);
+}
+
+// Multi-producer push: each push reserves its slot with a fetch_add, so two producers pushing
+// concurrently must never alias
+TEST(work_q, two_producers_not_overwritten)
+{
+  constexpr size_t CNT = 8;
+  constexpr int NUM_PUSHES = 100000; // per producer
+  constexpr int NUM_CONSUMERS = 4;
+
+  work_q_t q;
+  ASSERT_TRUE(work_q_alloc(&q, CNT, sizeof(Item)));
+
+  std::mutex mtx;
+  std::condition_variable cv;
+  std::deque<void *> handoff;
+  int producers_done = 0;
+
+  std::atomic<bool> in_use[CNT];
+  for (auto &f : in_use)
+    f = false;
+  std::atomic<bool> producer_error{false};
+  std::atomic<bool> consumer_content_error{false};
+  std::atomic<bool> consumer_handout_error{false};
+  std::atomic<uint64_t> pushed{0};
+
+  auto handoff_push = [&](void *slot) {
+    std::unique_lock<std::mutex> lk(mtx);
+    handoff.push_back(slot);
+    cv.notify_one();
+  };
+  // Returns a slot pointer, or NULL when both producers are done and the handoff is drained.
+  auto handoff_pop = [&]() -> void * {
+    std::unique_lock<std::mutex> lk(mtx);
+    cv.wait(lk, [&] { return !handoff.empty() || producers_done == 2; });
+    if (handoff.empty())
+      return NULL;
+    void *slot = handoff.front();
+    handoff.pop_front();
+    return slot;
+  };
+
+  auto producer = [&](uint64_t base) {
+    for (uint64_t id = base; id < (uint64_t)NUM_PUSHES + base; ++id) {
+      Item it{id, &q};
+      void *slot = work_q_push(&q, &it);
+      if (slot == nullptr)
+        continue; // ring full (or another producer took the last free slot) - allowed
+      if (in_use[idx_of(&q, slot)].exchange(true))
+        producer_error = true; // handed out twice before done: the race
+      handoff_push(slot);
+    }
+    pushed.fetch_add(NUM_PUSHES);
+    {
+      std::unique_lock<std::mutex> lk(mtx);
+      ++producers_done;
+    }
+    cv.notify_all();
+  };
+
+  auto consumer = [&]() {
+    for (;;) {
+      void *slot = handoff_pop();
+      if (slot == NULL)
+        break;
+      Item *it = (Item *)slot;
+      if (it->id >= (uint64_t)(2 * NUM_PUSHES) || it->queue != &q)
+        consumer_content_error = true; // torn or stale content
+      if (!in_use[idx_of(&q, slot)].load())
+        consumer_handout_error = true; // handed out while previous owner still working
+      // Mirror the queue's ownership exactly: clear the test flag BEFORE releasing the slot, so
+      // a producer's exchange() sees false the moment the queue lets it reuse the slot.
+      in_use[idx_of(&q, slot)].store(false);
+      work_q_done(&q, slot);
+    }
+  };
+
+  std::thread producer_a(producer, 0);
+  std::thread producer_b(producer, (uint64_t)NUM_PUSHES);
+  std::vector<std::thread> consumers;
+  for (int i = 0; i < NUM_CONSUMERS; ++i)
+    consumers.emplace_back(consumer);
+
+  producer_a.join();
+  producer_b.join();
+  for (auto &t : consumers)
+    t.join();
+
+  EXPECT_FALSE(producer_error);
+  EXPECT_FALSE(consumer_content_error);
+  EXPECT_FALSE(consumer_handout_error);
+  EXPECT_EQ(pushed.load(), (uint64_t)(2 * NUM_PUSHES));
+  EXPECT_TRUE(handoff.empty()); // everything drained
+
+  work_q_free(&q);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/common/utils/ds/work_q.c
+++ b/common/utils/ds/work_q.c
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "work_q.h"
+
+bool work_q_alloc(work_q_t *q, size_t cnt, size_t elsiz)
+{
+  assert(cnt > 0 && (cnt & (cnt - 1)) == 0); // power of two, masked on use
+  assert(elsiz > 0);
+  const size_t stride = (elsiz + 31) & ~(size_t)31;
+  void *slots = NULL;
+  if (posix_memalign(&slots, 64, cnt * stride) != 0) {
+    return false;
+  }
+  memset(slots, 0, cnt * stride);
+  q->slots = slots;
+  q->busy = calloc(cnt, sizeof(*q->busy));
+  if (q->busy == NULL) {
+    free(q->slots);
+    q->slots = NULL;
+    return false;
+  }
+  q->elsiz = elsiz;
+  q->stride = stride;
+  q->mask = cnt - 1;
+  atomic_init(&q->prod_head, 0);
+  return true;
+}
+
+void work_q_free(work_q_t *q)
+{
+  free(q->slots);
+  free(q->busy);
+  memset(q, 0, sizeof(*q));
+}
+
+void *work_q_push(work_q_t *q, const void *src)
+{
+  const size_t idx = atomic_fetch_add_explicit(&q->prod_head, 1, memory_order_relaxed) & q->mask;
+  if (atomic_exchange_explicit(&q->busy[idx], 1, memory_order_acq_rel)) {
+    return NULL;
+  }
+
+  uint8_t *slot = &q->slots[idx * q->stride];
+  memcpy(slot, src, q->elsiz);
+  return slot;
+}
+
+void work_q_done(work_q_t *q, void *slot)
+{
+  uint8_t *s = (uint8_t *)slot;
+  assert(s >= q->slots && s < q->slots + (q->mask + 1) * q->stride);
+  assert(((size_t)(s - q->slots) % q->stride) == 0);
+  const size_t idx = (size_t)(s - q->slots) / q->stride;
+  atomic_store_explicit(&q->busy[idx], 0, memory_order_release);
+}

--- a/common/utils/ds/work_q.h
+++ b/common/utils/ds/work_q.h
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#ifndef WORK_Q_H_
+#define WORK_Q_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#if defined(__cplusplus)
+#include <atomic>
+// use atomic types to help interworking with C++
+using std::atomic_size_t;
+using std::atomic_uchar;
+#else
+#include <stdatomic.h>
+#endif
+
+// Multi-producer, multi-consumer slot-handoff work queue. A producer copies an item into the
+// next ring slot and hands that slot pointer to exactly one consumer (e.g. a thread-pool worker);
+// the consumer owns the slot until it calls work_q_done(). Slot reuse is gated on ownership, not
+// on a global in-flight count: push() refuses to wrap into a slot whose consumer has not finished,
+// so a slow consumer can never have its item overwritten by a later push - the flaw of count-based
+// admission, which only knows how many consumers are busy, not which slot is still owned.
+//
+// Producers may be any number of threads: each push reserves its slot with a fetch_add, so
+// concurrent pushes always get distinct slots. (When the queue is nearly full, a push can fail -
+// NULL - while another producer reserves a free slot: the drop is counted by the caller.)
+// Consumers may be any number of threads. cnt must be a power of two (used as a mask); the
+// usable depth is exactly cnt. The slot pitch is rounded up to 32 bytes and the slot array is
+// 32-byte aligned, so any slot is a valid aligned scratch for SIMD payloads (e.g. FFT windows).
+typedef struct work_q {
+  uint8_t *slots;
+  size_t elsiz;            // element size: how many bytes push copies from src
+  size_t stride;           // slot pitch: elsiz rounded up to 32 bytes
+  size_t mask;             // cnt - 1
+  atomic_size_t prod_head; // producer write index (monotonic, masked on use; advanced by fetch_add)
+  atomic_uchar *busy;      // per-slot ownership flag: 1 = handed out, 0 = free
+} work_q_t;
+
+bool work_q_alloc(work_q_t *q, size_t cnt, size_t elsiz);
+void work_q_free(work_q_t *q);
+
+// Copy src into the next free ring slot. Returns a pointer to the slot, to be handed to a single
+// consumer and kept valid until work_q_done(), or NULL if the queue is full (the target slot's
+// previous consumer has not called work_q_done() yet).
+void *work_q_push(work_q_t *q, const void *src);
+
+// Consumer-side: release a slot previously returned by work_q_push(). Must be called exactly once
+// per slot, after the consumer has finished reading it. The release store makes everything the
+// consumer read from the slot visible to the producer's acquire load before it reuses the slot.
+void work_q_done(work_q_t *q, void *slot);
+
+#endif /* WORK_Q_H_ */

--- a/executables/nr-oru.c
+++ b/executables/nr-oru.c
@@ -9,6 +9,7 @@
 #include "PHY/NR_TRANSPORT/nr_transport_proto.h"
 #include "oru_packet_processor.h"
 #include "common/utils/threadPool/thread-pool.h"
+#include "common/utils/ds/work_q.h"
 #include <stdatomic.h>
 #include <time.h>
 #include <unistd.h>
@@ -52,7 +53,9 @@
 #define HLP_ORU_NUM_UL_SYMBOLS "set the number of UL symbols in the mixed slot"
 #define HLP_NB_FH_STREAMS "number of fronthaul streams from DU (0=passthrough, enables codebook beamforming when > 0)"
 #define HLP_CODEBOOK_NB_BEAMS "number of beams in the O-RU codebook"
-#define HLP_CODEBOOK_WEIGHTS "Q15 codebook weights: nb_beams * nb_tx * nb_fh_streams interleaved Re/Im pairs"
+#define HLP_CODEBOOK_WEIGHTS \
+  "Q15 codebook weights: nb_beams * nb_tx * nb_fh_streams interleaved Re/Im pairs; per beam, the tx" \
+  " antenna row is also the UL Rx combine weight for that RX antenna"
 #define HLP_ORU_THREEQUARTER_FS "set the 3/4 sampling frequency"
 
 // clang-format off
@@ -148,6 +151,171 @@
   {CONFIG_STRING_CLOCK_TIMEBASE,             HLP_CLOCK_TIMEBASE,    0,                      .strptr=NULL,     .defstrval="utc",            TYPE_STRING,       0, CLOCK_TIMEBASE_CHECK}  \
 }
 // clang-format on
+
+#define UL_SYMBOL_MISS_LOG_RATELIMIT 10000
+#define UL_CAL_ERR_LOG_RATELIMIT 10000
+#define RATELIMIT(n, block)                                                               \
+  do {                                                                                    \
+    static _Atomic unsigned long counter = 0;                                             \
+    unsigned long current = atomic_fetch_add_explicit(&counter, 1, memory_order_relaxed); \
+    if (current % (n) == 0) {                                                             \
+      block                                                                               \
+    }                                                                                     \
+  } while (0)
+
+static void dispatch_ul_work(work_q_t *q, ORU_t *oru, int frame, int slot, int symbol, const ul_job_t *job);
+static void dispatch_ul_fft(work_q_t *fft_q,
+                            work_q_t *beam_q,
+                            ORU_t *oru,
+                            int frame,
+                            int slot,
+                            int symbol,
+                            const ul_job_t *jobs,
+                            int nb_jobs);
+
+// ---------------------------------------------------------------------------
+// UL job calendar: ring of UL_CAL_SLOTS slots x 14 symbols, UL_CAL_JOBS_PER_SYMBOL jobs per symbol
+// entry. Replaces the flat pending_ul[64] array: job arrival parks at its due symbol's entry in
+// O(1) instead of a linear scan, and the per-symbol tick drains exactly the jobs due now.
+//
+#define UL_CAL_SLOTS 4 // Number of slots ahead in the UL calendar ring
+#define UL_CAL_JOBS_PER_SYMBOL 10
+
+typedef struct {
+  ul_job_t job;
+  int symbols_sent; // symbols already dispatched (multi-symbol C-plane jobs)
+  bool active;
+} ul_cal_entry_t;
+
+typedef struct {
+  ul_cal_entry_t entries[UL_CAL_SLOTS * NR_SYMBOLS_PER_SLOT][UL_CAL_JOBS_PER_SYMBOL];
+} ul_calendar_t;
+
+static uint64_t ul_cal_abs_symbol(int frame, int slot, int symbol, int slots_per_frame)
+{
+  return ((uint64_t)frame * slots_per_frame + slot) * NR_SYMBOLS_PER_SLOT + symbol;
+}
+
+// Shortest-path difference between two absolute symbols (corrects for the 1024-frame wrap).
+static int64_t ul_cal_symbol_diff(uint64_t a, uint64_t b, int slots_per_frame)
+{
+  const int64_t total = (int64_t)1024 * slots_per_frame * NR_SYMBOLS_PER_SLOT;
+  int64_t diff = (int64_t)a - (int64_t)b;
+  if (diff < -total / 2) {
+    diff += total;
+  } else if (diff > total / 2) {
+    diff -= total;
+  }
+  return diff;
+}
+
+// Park a job on its due symbol's entry (used both for fresh arrivals and for multi-symbol
+// continuations). Returns false, counting a drop, if that symbol's entry is full.
+static bool ul_calendar_park(ul_calendar_t *cal, ORU_t *oru, const ul_job_t *job, int symbols_sent, uint64_t abs_symbol)
+{
+  const int idx = abs_symbol % (UL_CAL_SLOTS * NR_SYMBOLS_PER_SLOT);
+  for (int i = 0; i < UL_CAL_JOBS_PER_SYMBOL; i++) {
+    if (!cal->entries[idx][i].active) {
+      cal->entries[idx][i] = (ul_cal_entry_t){.job = *job, .symbols_sent = symbols_sent, .active = true};
+      return true;
+    }
+  }
+  __atomic_fetch_add(&oru->ul_cal_overflow_dropped, 1, __ATOMIC_RELAXED);
+  RATELIMIT(UL_CAL_ERR_LOG_RATELIMIT, {
+    LOG_W(PHY, "[ORU south] UL calendar entry full (%d jobs) at symbol %lu, dropping job ant=%d\n",
+          UL_CAL_JOBS_PER_SYMBOL, (unsigned long)abs_symbol, job->antenna_id);
+  });
+  return false;
+}
+
+// Dispatch the next `count` symbols of a job. Codebook mode routes through one FFT job per symbol
+// (it dispatches the beam items itself, so the per-antenna FFTs are computed once); passthrough
+// keeps one work item per symbol.
+static void ul_calendar_dispatch(work_q_t *beam_q, work_q_t *fft_q, ORU_t *oru, const ul_job_t *job, int symbols_sent, int count)
+{
+  const int sym = job->symbol + symbols_sent;
+  const bool beamforming = oru->codebook.nb_fh_streams > 0;
+  for (int k = 0; k < count; k++) {
+    if (beamforming) {
+      dispatch_ul_fft(fft_q, beam_q, oru, job->frame, job->slot_in_frame, sym + k, job, 1);
+    } else {
+      dispatch_ul_work(beam_q, oru, job->frame, job->slot_in_frame, sym + k, job);
+    }
+  }
+}
+
+// Route a freshly-polled UL job: dispatch right away if it is already due, park the rest at its
+// due symbol. Jobs more than a slot late are dropped (their radio data is long gone).
+static void ul_calendar_add(ul_calendar_t *cal, work_q_t *beam_q, work_q_t *fft_q, ORU_t *oru, uint64_t reader_abs, const ul_job_t *job)
+{
+  const int slots_per_frame = oru->ru->nr_frame_parms->slots_per_frame;
+  const uint64_t job_abs = ul_cal_abs_symbol(job->frame, job->slot_in_frame, job->symbol, slots_per_frame);
+  const int64_t diff = ul_cal_symbol_diff(job_abs, reader_abs, slots_per_frame);
+
+  if (diff <= -NR_SYMBOLS_PER_SLOT) {
+    __atomic_fetch_add(&oru->ul_symbols_missed, 1, __ATOMIC_RELAXED);
+    RATELIMIT(UL_SYMBOL_MISS_LOG_RATELIMIT, {
+      LOG_W(PHY, "[ORU south] missed UL symbol %d.%d.%d, dropping job ant=%d\n",
+            job->frame, job->slot_in_frame, job->symbol, job->antenna_id);
+    });
+    return;
+  }
+  if (diff >= UL_CAL_SLOTS * NR_SYMBOLS_PER_SLOT) {
+    __atomic_fetch_add(&oru->ul_cal_horizon_dropped, 1, __ATOMIC_RELAXED);
+    RATELIMIT(UL_CAL_ERR_LOG_RATELIMIT, {
+      LOG_W(PHY, "[ORU south] UL job %d.%d.%d declared %ld symbols ahead (calendar horizon %d), dropping\n",
+            job->frame, job->slot_in_frame, job->symbol, (long)diff, UL_CAL_SLOTS * NR_SYMBOLS_PER_SLOT);
+    });
+    return;
+  }
+
+  // Dispatch every symbol already due (the last one's radio data is in the buffer), park the rest.
+  int due = diff < 0 ? (int)(-diff) + 1 : 0;
+  if (due > job->num_symbols) {
+    due = job->num_symbols;
+  }
+  if (due > 0) {
+    ul_calendar_dispatch(beam_q, fft_q, oru, job, 0, due);
+  }
+  if (due < job->num_symbols) {
+    ul_calendar_park(cal, oru, job, due, job_abs + due);
+  }
+}
+
+// Per-symbol tick: dispatch one symbol of every job parked on the current symbol's entry, re-park
+// multi-symbol continuations on the next symbol's entry. Codebook mode batches the symbol's whole
+// job set into ONE FFT job - the per-antenna FFTs are computed once and every beam job of the
+// symbol shares them. Passthrough dispatches one work item per job as before.
+static void ul_calendar_tick(ul_calendar_t *cal, work_q_t *beam_q, work_q_t *fft_q, ORU_t *oru, uint64_t reader_abs)
+{
+  const int idx = reader_abs % (UL_CAL_SLOTS * NR_SYMBOLS_PER_SLOT);
+  ul_job_t batch[UL_CAL_JOBS_PER_SYMBOL];
+  int nb_batch = 0;
+  for (int i = 0; i < UL_CAL_JOBS_PER_SYMBOL; i++) {
+    ul_cal_entry_t *entry = &cal->entries[idx][i];
+    if (!entry->active) {
+      continue;
+    }
+    if (oru->codebook.nb_fh_streams > 0) {
+      batch[nb_batch++] = entry->job;
+    } else {
+      ul_calendar_dispatch(beam_q, fft_q, oru, &entry->job, entry->symbols_sent, 1);
+    }
+    if (entry->symbols_sent + 1 < entry->job.num_symbols) {
+      ul_calendar_park(cal, oru, &entry->job, entry->symbols_sent + 1, reader_abs + 1);
+    }
+    entry->active = false;
+  }
+  if (nb_batch > 0) {
+    // All jobs on this entry are due at the entry's own symbol - decode it for the FFT job.
+    const int sym_per_slot = NR_SYMBOLS_PER_SLOT;
+    const int slots_per_frame = oru->ru->nr_frame_parms->slots_per_frame;
+    const uint64_t per_frame = (uint64_t)slots_per_frame * sym_per_slot;
+    dispatch_ul_fft(fft_q, beam_q, oru, reader_abs / per_frame, (reader_abs % per_frame) / sym_per_slot,
+                    reader_abs % sym_per_slot, batch, nb_batch);
+  }
+}
+
 
 extern void set_scs_parameters(NR_DL_FRAME_PARMS *fp, int mu, int N_RB_DL, int ssb_case);
 int tx_rf_symbols(RU_t *ru, int frame, int slot, uint64_t timestamp, int start_symbol, int num_symbols);
@@ -275,6 +443,11 @@ int get_oru_options(ORU_t *oru)
     AssertFatal(oru->codebook.nb_fh_streams <= oru->ru->nb_tx,
                 "nb_fh_streams %d must not exceed nb_tx %d\n",
                 oru->codebook.nb_fh_streams,
+                oru->ru->nb_tx);
+    // The codebook's antenna axis serves both DL (nb_tx) and UL Rx combining (nb_rx antennas).
+    AssertFatal(oru->ru->nb_rx <= oru->ru->nb_tx,
+                "codebook beamforming needs nb_rx %d <= nb_tx %d (one weight row per RX antenna)\n",
+                oru->ru->nb_rx,
                 oru->ru->nb_tx);
     paramdef_t *wgt = gpd(param, nump, CONFIG_STRING_CODEBOOK_WEIGHTS);
     int expected = oru->codebook.nb_beams * oru->ru->nb_tx * oru->codebook.nb_fh_streams * 2;
@@ -740,25 +913,7 @@ void receive_prach(ORU_t *oru, int frame, int slot, int symbol, int prach_symbol
   oru_fh_rx_send_prach(oru->fronthaul, (uint32_t **)rxdataF_ptr, ru->nb_rx, frame, slot, symbol);
 }
 
-#define MAX_PENDING_UL_JOBS 64
-
-#define UL_SYMBOL_MISS_LOG_RATELIMIT 10000
-#define RATELIMIT(n, block)                                                               \
-  do {                                                                                    \
-    static _Atomic unsigned long counter = 0;                                             \
-    unsigned long current = atomic_fetch_add_explicit(&counter, 1, memory_order_relaxed); \
-    if (current % (n) == 0) {                                                             \
-      block                                                                               \
-    }                                                                                     \
-  } while (0)
-
-typedef struct {
-  ul_job_t job;
-  bool active;
-  int symbols_sent;
-} ul_pending_t;
-
-static void receive_pusch(ORU_t *oru, int frame, int slot, int symbol, ul_job_t *job)
+static void receive_pusch(ORU_t *oru, int frame, int slot, int symbol, ul_job_t *job, const c16_t *const *ant_fft)
 {
   struct timespec start, end;
   clock_gettime(CLOCK_MONOTONIC, &start);
@@ -766,15 +921,29 @@ static void receive_pusch(ORU_t *oru, int frame, int slot, int symbol, ul_job_t 
   RU_t *ru = oru->ru;
   NR_DL_FRAME_PARMS *fp = ru->nr_frame_parms;
   int aarx = job->antenna_id;
+  const oru_codebook_t *cb = &oru->codebook;
+  const bool beamforming = cb->nb_fh_streams > 0;
 
-  if (aarx < 0 || aarx >= fp->nb_antennas_rx) {
+  if (beamforming) {
+    // Codebook mode: the section's eaxc is the beam output stream, not a physical antenna.
+    if (aarx < 0 || aarx >= cb->nb_fh_streams) {
+      LOG_W(PHY, "[ORU south] receive_pusch: UL beam stream %d exceeds nb_fh_streams %d, dropping\n", aarx, cb->nb_fh_streams);
+      return;
+    }
+  } else if (aarx < 0 || aarx >= fp->nb_antennas_rx) {
     LOG_W(PHY, "[ORU south] receive_pusch: invalid antenna_id %d\n", aarx);
     return;
   }
 
   // CP removal + FFT → full ofdm_symbol_size frequency-domain output
   c16_t rxdataF_fft[fp->ofdm_symbol_size] __attribute__((aligned(32)));
-  nr_symbol_fep_ul(fp, (c16_t *)ru->common.rxdata[aarx], rxdataF_fft, symbol, slot, ru->N_TA_offset);
+  if (beamforming) {
+    // UL Rx beamforming: combinte per-antenna FFTs via codebook
+    combine_ul_beam_fd(ant_fft, ru->nb_rx, fp->ofdm_symbol_size, cb, job->beam_id, aarx, rxdataF_fft);
+  } else {
+    // No beamforming: perform FFT on the received antenna's time-domain signal
+    nr_symbol_fep_ul(fp, (c16_t *)ru->common.rxdata[aarx], rxdataF_fft, symbol, slot, ru->N_TA_offset);
+  }
 
   // Phase decompensation (conjugate rotation for UL)
   apply_nr_rotation_symbol_RX(fp->symbols_per_slot,
@@ -814,9 +983,8 @@ static void receive_pusch(ORU_t *oru, int frame, int slot, int symbol, ul_job_t 
   }
 }
 
-#define UL_WORK_QUEUE_DEPTH 128
-
-typedef struct ul_work_queue_s ul_work_queue_t;
+#define UL_WORK_QUEUE_DEPTH 128 // beam items: bound on in-flight UL jobs (backpressure)
+#define UL_FFT_QUEUE_DEPTH 32   // FFT items: one per symbol (codebook mode); a few symbols of margin
 
 typedef struct {
   ORU_t *oru;
@@ -824,45 +992,165 @@ typedef struct {
   int slot;
   int symbol;
   ul_job_t job;
-  ul_work_queue_t *queue;
-} __attribute__((aligned(64))) ul_work_item_t;
+  work_q_t *queue;
+  const c16_t *ant_fft[ORU_CODEBOOK_MAX_NB_TX]; // codebook: this symbol's per-antenna FFT windows
+  void *fft_slot; // codebook: the FFT item whose refs this job releases on completion (NULL in passthrough)
+} ul_work_item_t;
 
-struct ul_work_queue_s {
-  __attribute__((aligned(64))) ul_work_item_t ring[UL_WORK_QUEUE_DEPTH];
-  __attribute__((aligned(64))) uint32_t prod_head;
-  __attribute__((aligned(64))) _Atomic(uint32_t) pending_tasks;
-};
+// One FFT job per symbol (codebook mode): computes every RX antenna's FFT once, then dispatches
+// the symbol's UL jobs as beam items. The per-antenna windows live in this item's own queue slot
+// (payload after the fixed fields, 32-byte aligned - work_q slots are 32-byte aligned). Beam jobs
+// reference them via item pointers, and the slot is released by its last reader (refs), not by
+// the FFT job itself - so an FFT job arriving late for an overdue symbol computes into its own
+// slot and can never clobber a live one.
+typedef struct {
+  ORU_t *oru;
+  int frame;
+  int slot;
+  int symbol;
+  work_q_t *queue;      // the FFT queue this item lives in (for work_q_done)
+  work_q_t *beam_queue; // where the beam jobs go
+  int nb_jobs;
+  _Atomic(int) refs; // beam jobs outstanding on this slot; the last one returns it
+  ul_job_t jobs[UL_CAL_JOBS_PER_SYMBOL];
+  c16_t ant_fft[] __attribute__((aligned(32))); // nb_rx * ofdm_symbol_size samples
+} ul_fft_item_t;
+
+// Total size of an FFT item including its per-antenna FFT payload (the queue's element size).
+static size_t ul_fft_item_size(size_t payload_bytes)
+{
+  return sizeof(ul_fft_item_t) + payload_bytes;
+}
 
 static void ul_worker_pool_task(void *args)
 {
   ul_work_item_t *item = args;
-  receive_pusch(item->oru, item->frame, item->slot, item->symbol, &item->job);
-  __atomic_fetch_sub(&item->queue->pending_tasks, 1, __ATOMIC_RELEASE);
+  receive_pusch(item->oru, item->frame, item->slot, item->symbol, &item->job, item->ant_fft);
+  work_q_done(item->queue, item);
+  if (item->fft_slot != NULL) {
+    // Release the symbol's FFT slot: its payload stays alive until the last beam job that
+    // references it has finished. Read the queue before the decrement - the item is alive while
+    // refs >= 1, and the last reader frees it right after.
+    ul_fft_item_t *fft = item->fft_slot;
+    work_q_t *q = fft->queue;
+    if (atomic_fetch_sub(&fft->refs, 1) == 1) {
+      work_q_done(q, fft);
+    }
+  }
 }
 
-static void dispatch_ul_work(ul_work_queue_t *q, ORU_t *oru, int frame, int slot, int symbol, const ul_job_t *job)
+// The FFT worker: one FFT per RX antenna for the symbol, then hand each of the symbol's UL jobs
+// to the beam path. The payload lives in this item's own queue slot until the last beam job
+// releases it (refs), so the slot is safe to reference from every pushed beam item.
+static void ul_fft_pool_task(void *args)
 {
-  if (__atomic_load_n(&q->pending_tasks, __ATOMIC_ACQUIRE) >= UL_WORK_QUEUE_DEPTH) {
-    __atomic_fetch_add(&oru->ul_dropped_jobs, 1, __ATOMIC_RELAXED);
-    return;
+  ul_fft_item_t *item = args;
+  ORU_t *oru = item->oru;
+  RU_t *ru = oru->ru;
+  NR_DL_FRAME_PARMS *fp = ru->nr_frame_parms;
+  const int nb_rx = ru->nb_rx;
+  const int n = fp->ofdm_symbol_size;
+
+  // Window offset, N_TA and frame-boundary wrap all inside nr_symbol_fep_ul().
+  for (int a = 0; a < nb_rx; a++) {
+    nr_symbol_fep_ul(fp, (c16_t *)ru->common.rxdata[a], &item->ant_fft[a * n], item->symbol, item->slot,
+                     ru->N_TA_offset);
   }
 
-  uint32_t idx = q->prod_head & (UL_WORK_QUEUE_DEPTH - 1);
-  q->ring[idx] = (ul_work_item_t){
+  item->refs = item->nb_jobs; // plain store: readers only exist after the pushes below
+  const c16_t *ant_fft[ORU_CODEBOOK_MAX_NB_TX];
+  for (int a = 0; a < nb_rx; a++) {
+    ant_fft[a] = &item->ant_fft[a * n];
+  }
+
+  work_q_t *q = item->beam_queue;
+  for (int i = 0; i < item->nb_jobs; i++) {
+    ul_work_item_t beam = {
+        .oru = oru,
+        .frame = item->frame,
+        .slot = item->slot,
+        .symbol = item->symbol,
+        .job = item->jobs[i],
+        .queue = q,
+        .fft_slot = item,
+    };
+    memcpy(beam.ant_fft, ant_fft, nb_rx * sizeof(const c16_t *));
+    void *slot = work_q_push(q, &beam);
+    if (slot == NULL) {
+      __atomic_fetch_add(&oru->ul_dropped_jobs, 1, __ATOMIC_RELAXED);
+      // This push never reached a worker: release the slot ourselves.
+      if (atomic_fetch_sub(&item->refs, 1) == 1) {
+        work_q_done(item->queue, item);
+      }
+      continue;
+    }
+    pushTpool(oru->ru->threadPool, (task_t){.args = slot, .func = ul_worker_pool_task});
+  }
+  // NB: the FFT item's own slot is released by its last beam job (or the drop path above), not here.
+}
+
+// Push one FFT job for a symbol: the FFT worker computes all RX antennas' FFTs once and then
+// dispatches the symbol's UL jobs as beam items (one FFT per antenna per symbol, shared by all
+// beams). Passthrough mode never goes through here.
+static void dispatch_ul_fft(work_q_t *fft_q,
+                            work_q_t *beam_q,
+                            ORU_t *oru,
+                            int frame,
+                            int slot,
+                            int symbol,
+                            const ul_job_t *jobs,
+                            int nb_jobs)
+{
+  const size_t payload = (size_t)oru->ru->nb_rx * oru->ru->nr_frame_parms->ofdm_symbol_size * sizeof(c16_t);
+  const size_t item_size = ul_fft_item_size(payload);
+  uint8_t src[item_size]; // VLA: work_q_push copies a full element into its own slot
+  memset(src, 0, item_size);
+  ul_fft_item_t *item = (ul_fft_item_t *)src;
+  item->oru = oru;
+  item->frame = frame;
+  item->slot = slot;
+  item->symbol = symbol;
+  item->queue = fft_q;
+  item->beam_queue = beam_q;
+  item->nb_jobs = nb_jobs;
+  memcpy(item->jobs, jobs, nb_jobs * sizeof(ul_job_t));
+
+  void *slot_ptr = work_q_push(fft_q, src);
+  if (slot_ptr == NULL) {
+    // FFT queue is a few symbols behind: dropping the whole symbol is equivalent to dropping
+    // its jobs individually at this point.
+    __atomic_fetch_add(&oru->ul_dropped_jobs, nb_jobs, __ATOMIC_RELAXED);
+    RATELIMIT(UL_CAL_ERR_LOG_RATELIMIT, {
+      LOG_W(PHY, "[ORU south] UL FFT queue full at symbol %d.%d.%d, dropping %d jobs\n",
+            frame, slot, symbol, nb_jobs);
+    });
+    return;
+  }
+  pushTpool(oru->ru->threadPool, (task_t){.args = slot_ptr, .func = ul_fft_pool_task});
+}
+
+static void dispatch_ul_work(work_q_t *q, ORU_t *oru, int frame, int slot, int symbol, const ul_job_t *job)
+{
+  ul_work_item_t item = {
     .oru = oru,
     .frame = frame,
     .slot = slot,
     .symbol = symbol,
     .job = *job,
-    .queue = q
+    .queue = q,
   };
 
-  __atomic_fetch_add(&q->pending_tasks, 1, __ATOMIC_RELEASE);
-  q->prod_head++;
+  void *slot_ptr = work_q_push(q, &item);
+  if (slot_ptr == NULL) {
+    // Slot still owned by a previous job's worker: admission is per-slot, so this drop is
+    // precise - no overwrite of live work is ever possible.
+    __atomic_fetch_add(&oru->ul_dropped_jobs, 1, __ATOMIC_RELAXED);
+    return;
+  }
 
   task_t task = {
-    .args = &q->ring[idx],
-    .func = ul_worker_pool_task
+    .args = slot_ptr,
+    .func = ul_worker_pool_task,
   };
   pushTpool(oru->ru->threadPool, task);
 }
@@ -1020,12 +1308,18 @@ void *oru_south_read_thread(void *arg)
   slot = start_slot;
   frame = start_frame;
 
-  ul_work_queue_t work_queue = {
-    .prod_head = 0,
-    .pending_tasks = 0,
-  };
+  work_q_t beam_queue;
+  AssertFatal(work_q_alloc(&beam_queue, UL_WORK_QUEUE_DEPTH, sizeof(ul_work_item_t)),
+              "[ORU south] failed to allocate UL work queue\n");
 
-  ul_pending_t pending_ul[MAX_PENDING_UL_JOBS] = {0};
+  // Codebook mode: one FFT job per symbol computes every RX antenna's FFT once and dispatches
+  // the symbol's beam jobs; the FFT payload lives in the job's own queue slot (refcounted).
+  work_q_t fft_queue;
+  const size_t fft_payload = (size_t)ru->nb_rx * fp->ofdm_symbol_size * sizeof(c16_t);
+  AssertFatal(work_q_alloc(&fft_queue, UL_FFT_QUEUE_DEPTH, ul_fft_item_size(fft_payload)),
+              "[ORU south] failed to allocate UL FFT queue\n");
+
+  ul_calendar_t ul_cal = {0};
 
   while (!oai_exit) {
     int rx_slot_type = nr_slot_select(&ru->config, frame, slot);
@@ -1049,71 +1343,16 @@ void *oru_south_read_thread(void *arg)
             1,
             num_samples_read);
 
-      // Drain the UL job ring
+      // Drain the UL job ring into the calendar (jobs already due dispatch immediately)
+      const uint64_t reader_abs = ((uint64_t)frame * fp->slots_per_frame + slot) * NR_SYMBOLS_PER_SLOT + symbol;
       ul_job_t new_job;
       while (oru_fh_poll_ul_job(oru->fronthaul, &new_job) == 0) {
-        bool added = false;
-        for (int i = 0; i < MAX_PENDING_UL_JOBS; i++) {
-          if (!pending_ul[i].active) {
-            pending_ul[i] = (ul_pending_t){.job = new_job, .active = true, .symbols_sent = 0};
-            added = true;
-            break;
-          }
-        }
-        if (!added)
-          LOG_W(PHY, "[ORU south] UL pending queue full, dropping job frame=%d slot=%d sym=%d\n",
-                new_job.frame, new_job.slot_in_frame, new_job.symbol);
+        ul_calendar_add(&ul_cal, &beam_queue, &fft_queue, oru, reader_abs, &new_job);
       }
 
       if (rx_slot_type == NR_UPLINK_SLOT || rx_slot_type == NR_MIXED_SLOT) {
-
-        // Process pending jobs whose next symbol matches the current one
-        for (int i = 0; i < MAX_PENDING_UL_JOBS; i++) {
-          if (!pending_ul[i].active)
-            continue;
-          ul_job_t *j = &pending_ul[i].job;
-
-          int slots_per_frame = fp->slots_per_frame;
-          uint64_t total_symbols = (uint64_t)1024 * slots_per_frame * NR_SYMBOLS_PER_SLOT;
-          uint64_t reader_abs_symbol = ((uint64_t)frame * slots_per_frame + slot) * NR_SYMBOLS_PER_SLOT + symbol;
-
-          int expected_symbol = j->symbol + pending_ul[i].symbols_sent;
-          uint64_t job_abs_symbol =
-              ((uint64_t)j->frame * slots_per_frame + j->slot_in_frame) * NR_SYMBOLS_PER_SLOT + expected_symbol;
-
-          // Calculate the number of symbols in the past or future, correct for wrap-around the frame boundary
-          int64_t diff = (int64_t)(job_abs_symbol - reader_abs_symbol);
-          if (diff < -(int64_t)total_symbols / 2) {
-            diff += (int64_t)total_symbols;
-          } else if (diff > (int64_t)total_symbols / 2) {
-            diff -= (int64_t)total_symbols;
-          }
-
-          if (diff > 0) {
-            // Not due yet: revisit next iteration
-            continue;
-          }
-          if (diff <= -NR_SYMBOLS_PER_SLOT) {
-            __atomic_fetch_add(&oru->ul_symbols_missed, 1, __ATOMIC_RELAXED);
-            RATELIMIT(UL_SYMBOL_MISS_LOG_RATELIMIT, {
-              LOG_W(PHY, "[ORU south] missed UL symbol %d.%d.%d (now %d.%d.%d), dropping job ant=%d\n",
-                    j->frame, j->slot_in_frame, expected_symbol, frame, slot, symbol, j->antenna_id);
-            });
-            pending_ul[i].active = false;
-            continue;
-          }
-
-          while (diff <= 0) {
-            dispatch_ul_work(&work_queue, oru, j->frame, j->slot_in_frame, expected_symbol, j);
-            pending_ul[i].symbols_sent++;
-            if (pending_ul[i].symbols_sent == j->num_symbols) {
-              pending_ul[i].active = false;
-              break;
-            }
-            expected_symbol++;
-            diff++;
-          }
-        }
+        // Dispatch the jobs parked on this symbol's calendar entry
+        ul_calendar_tick(&ul_cal, &beam_queue, &fft_queue, oru, reader_abs);
       }
       int prach_symbol = get_prach_symbol(oru, frame, slot, symbol, ru->numerology);
       if (prach_symbol != -1)
@@ -1148,8 +1387,11 @@ void oru_self_diagnosis(ORU_t *oru)
   uint64_t ul_time_max = __atomic_exchange_n(&oru->ul_ant_time_max_us, 0, __ATOMIC_RELAXED);
   uint64_t ul_dropped = __atomic_exchange_n(&oru->ul_dropped_jobs, 0, __ATOMIC_RELAXED);
   uint64_t ul_symbols_missed = __atomic_exchange_n(&oru->ul_symbols_missed, 0, __ATOMIC_RELAXED);
+  uint64_t ul_cal_overflow = __atomic_exchange_n(&oru->ul_cal_overflow_dropped, 0, __ATOMIC_RELAXED);
+  uint64_t ul_cal_horizon = __atomic_exchange_n(&oru->ul_cal_horizon_dropped, 0, __ATOMIC_RELAXED);
 
-  if (dl_count == 0 && ul_count == 0 && ul_dropped == 0 && ul_symbols_missed == 0) {
+  if (dl_count == 0 && ul_count == 0 && ul_dropped == 0 && ul_symbols_missed == 0 && ul_cal_overflow == 0
+      && ul_cal_horizon == 0) {
     return;
   }
 
@@ -1205,7 +1447,7 @@ void oru_self_diagnosis(ORU_t *oru)
 
   LOG_I(PHY, "----------------------------------------------------------------------------\n");
 
-  if (ul_count > 0 || ul_dropped > 0 || ul_symbols_missed > 0) {
+  if (ul_count > 0 || ul_dropped > 0 || ul_symbols_missed > 0 || ul_cal_overflow > 0 || ul_cal_horizon > 0) {
     double ul_ant_avg_us = ul_count > 0 ? (double)ul_time_total / (ul_count * 16.0) : 0.0;
     double ul_ant_max_us = ul_count > 0 ? (double)ul_time_max / 16.0 : 0.0;
 
@@ -1245,6 +1487,16 @@ void oru_self_diagnosis(ORU_t *oru)
     }
     if (ul_symbols_missed > 0) {
       LOG_E(PHY, "  [DIAGNOSIS] UL CRITICAL: Dropped %lu jobs that arrived %d or more symbols too late!\n", ul_symbols_missed, NR_SYMBOLS_PER_SLOT);
+      pass = false;
+    }
+    if (ul_cal_overflow > 0) {
+      LOG_E(PHY, "  [DIAGNOSIS] UL CRITICAL: Dropped %lu jobs because a calendar symbol entry was full (>%d concurrent jobs on one symbol)!\n",
+            ul_cal_overflow, UL_CAL_JOBS_PER_SYMBOL);
+      pass = false;
+    }
+    if (ul_cal_horizon > 0) {
+      LOG_E(PHY, "  [DIAGNOSIS] UL CRITICAL: Dropped %lu jobs declared more than %d symbols ahead (beyond calendar horizon) - DU declaring UL C-plane too early?\n",
+            ul_cal_horizon, UL_CAL_SLOTS * NR_SYMBOLS_PER_SLOT);
       pass = false;
     }
   } else {

--- a/executables/nr-oru.c
+++ b/executables/nr-oru.c
@@ -517,10 +517,8 @@ static void dl_symbol_process(ORU_t *oru, int frame, int slot, int symbol, c16_t
 
   __attribute__((aligned(64))) c16_t txdataF_shifted[fp->ofdm_symbol_size];
   memset(txdataF_shifted, 0, sizeof(txdataF_shifted));
-  c16_t *rotation = fp->symbol_rotation[0] + (slot % fp->slots_per_subframe) * fp->symbols_per_slot + symbol;
   for (int aatx = 0; aatx < ru->nb_tx; aatx++) {
-    // Phase compensation
-    rotate_cpx_vector(txDataF[aatx], *rotation, txDataF[aatx], fp->N_RB_DL * NR_NB_SC_PER_RB, 15);
+    // txDataF is already phase-rotated by combine_dl_streams() - don't rotate again.
     // FFT Shift
     const int num_samp_half = fp->N_RB_DL * NR_NB_SC_PER_RB / 2;
     const int first_carrier_offset = fp->ofdm_symbol_size - num_samp_half;
@@ -547,6 +545,23 @@ static void dl_symbol_process(ORU_t *oru, int frame, int slot, int symbol, c16_t
   }
 
   dl_symbol_completed(oru, abs_symbol);
+}
+
+// Computes this symbol's phase rotation and hands off to combine_dl_streams() (oru_beamforming.c).
+static void assemble_dl_symbol(ORU_t *oru,
+                               int slot,
+                               int symbol,
+                               c16_t **txDataF,
+                               int n_rb_dl,
+                               const dl_iq_stream_t *streams,
+                               int num_streams)
+{
+  RU_t *ru = (RU_t *)oru->ru;
+  NR_DL_FRAME_PARMS *fp = ru->nr_frame_parms;
+  const int n_sc = n_rb_dl * NR_NB_SC_PER_RB;
+  c16_t rotation = *(fp->symbol_rotation[0] + (slot % fp->slots_per_subframe) * fp->symbols_per_slot + symbol);
+
+  combine_dl_streams(txDataF, ru->nb_tx, n_sc, streams, num_streams, &oru->codebook, rotation);
 }
 
 static pthread_mutex_t south_read_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -598,6 +613,10 @@ void *oru_north_read_worker(void *arg)
   for (int aatx = 0; aatx < ru->nb_tx; aatx++) {
     txDataF_ptr[aatx] = txDataF[aatx];
   }
+  // Scratch for read_dl_iq_streams(): reused every iteration, sized once for the worst case
+  // (MAX_DL_IQ_STREAMS_PER_SYMBOL streams, each up to a full-band PRB run).
+  dl_iq_stream_t dl_streams[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  __attribute__((aligned(64))) uint32_t dl_iq_arena[MAX_DL_IQ_STREAMS_PER_SYMBOL * fp->N_RB_DL * NR_NB_SC_PER_RB];
   uint32_t start_frame, start_slot;
   uint64_t start_hyper_frame;
   int64_t start_timestamp;
@@ -645,8 +664,15 @@ anchor_ready:
   while (!oai_exit) {
     int frame = -1, slot = -1, symbol = -1;
     uint64_t hyper_frame;
-    int ret = oru_fh_tx_read_symbol(oru->fronthaul, (uint32_t **)txDataF_ptr, ru->nb_tx, &hyper_frame, &frame, &slot, &symbol);
-    if (ret != 0) {
+    int num_streams = oru_fh_tx_read_symbol(oru->fronthaul,
+                                            dl_streams,
+                                            dl_iq_arena,
+                                            MAX_DL_IQ_STREAMS_PER_SYMBOL,
+                                            &hyper_frame,
+                                            &frame,
+                                            &slot,
+                                            &symbol);
+    if (num_streams < 0) {
       LOG_E(PHY, "[RU_thread] read data error: frame %d, slot %d, symbol %d\n", frame, slot, symbol);
       continue;
     }
@@ -659,6 +685,7 @@ anchor_ready:
     if (timestamp < 0) {
       continue;
     }
+    assemble_dl_symbol(oru, slot, symbol, txDataF_ptr, fp->N_RB_DL, dl_streams, num_streams);
     uint64_t abs_symbol = num_frames * (fp->slots_per_frame * fp->symbols_per_slot) + slot * fp->symbols_per_slot + symbol;
     dl_symbol_process(oru, frame, slot, symbol, txDataF_ptr, timestamp, abs_symbol);
     if (frame % 256 == 0 && slot == 0 && symbol == 0) {

--- a/executables/nr-oru.c
+++ b/executables/nr-oru.c
@@ -32,6 +32,9 @@
 #define CONFIG_STRING_ORU_NUM_UL_SLOTS "num_ul_slots"
 #define CONFIG_STRING_ORU_NUM_DL_SYMBOLS "num_dl_symbols"
 #define CONFIG_STRING_ORU_NUM_UL_SYMBOLS "num_ul_symbols"
+#define CONFIG_STRING_NB_FH_STREAMS "nb_fh_streams"
+#define CONFIG_STRING_CODEBOOK_NB_BEAMS "codebook_nb_beams"
+#define CONFIG_STRING_CODEBOOK_WEIGHTS "codebook_weights"
 #define CONFIG_STRING_ORU_TX_CORE "tx_core"
 
 #define HLP_ORU_TX_BW "set the TX bandwidth list per component carrier"
@@ -47,6 +50,9 @@
 #define HLP_ORU_NUM_UL_SLOTS "set the number of UL Slots in TDD"
 #define HLP_ORU_NUM_DL_SYMBOLS "set the number of DL symbols in the mixed slot"
 #define HLP_ORU_NUM_UL_SYMBOLS "set the number of UL symbols in the mixed slot"
+#define HLP_NB_FH_STREAMS "number of fronthaul streams from DU (0=passthrough, enables codebook beamforming when > 0)"
+#define HLP_CODEBOOK_NB_BEAMS "number of beams in the O-RU codebook"
+#define HLP_CODEBOOK_WEIGHTS "Q15 codebook weights: nb_beams * nb_tx * nb_fh_streams interleaved Re/Im pairs"
 #define HLP_ORU_THREEQUARTER_FS "set the 3/4 sampling frequency"
 
 // clang-format off
@@ -65,6 +71,9 @@
   {CONFIG_STRING_ORU_NUM_UL_SLOTS,              HLP_ORU_NUM_UL_SLOTS,               0,    .uptr=NULL,       .defintval=1,                 TYPE_UINT,         0}, \
   {CONFIG_STRING_ORU_NUM_DL_SYMBOLS,            HLP_ORU_NUM_DL_SYMBOLS,             0,    .uptr=NULL,       .defintval=7,                 TYPE_UINT,         0}, \
   {CONFIG_STRING_ORU_NUM_UL_SYMBOLS,            HLP_ORU_NUM_UL_SYMBOLS,             0,    .uptr=NULL,       .defintval=3,                 TYPE_UINT,         0}, \
+  {CONFIG_STRING_NB_FH_STREAMS,                 HLP_NB_FH_STREAMS,                  0,    .iptr=NULL,       .defintval=0,                 TYPE_INT,          0}, \
+  {CONFIG_STRING_CODEBOOK_NB_BEAMS,             HLP_CODEBOOK_NB_BEAMS,              0,    .iptr=NULL,       .defintval=0,                 TYPE_INT,          0}, \
+  {CONFIG_STRING_CODEBOOK_WEIGHTS,              HLP_CODEBOOK_WEIGHTS,               0,    .iptr=NULL,       .defintarrayval=NULL,          TYPE_INTARRAY,     0}, \
   {CONFIG_STRING_ORU_TX_CORE,                   "The CPU core to be used to deploy south write thread for O-RU.", 0, .iptr=NULL, .defintval=-1, TYPE_INT, 0}, \
 }
 
@@ -250,6 +259,49 @@ int get_oru_options(ORU_t *oru)
   oru->num_UL_slots = *gpd(param, nump, CONFIG_STRING_ORU_NUM_UL_SLOTS)->iptr;
   oru->num_DL_symbols = *gpd(param, nump, CONFIG_STRING_ORU_NUM_DL_SYMBOLS)->iptr;
   oru->num_UL_symbols = *gpd(param, nump, CONFIG_STRING_ORU_NUM_UL_SYMBOLS)->iptr;
+  oru->codebook.nb_fh_streams = *gpd(param, nump, CONFIG_STRING_NB_FH_STREAMS)->iptr;
+  oru->codebook.nb_beams = *gpd(param, nump, CONFIG_STRING_CODEBOOK_NB_BEAMS)->iptr;
+  AssertFatal(oru->codebook.nb_fh_streams >= 0, "nb_fh_streams %d must be non-negative\n", oru->codebook.nb_fh_streams);
+  if (oru->codebook.nb_fh_streams > 0) {
+    AssertFatal(oru->codebook.nb_fh_streams <= ORU_CODEBOOK_MAX_STREAMS,
+                "nb_fh_streams %d exceeds maximum %d\n",
+                oru->codebook.nb_fh_streams,
+                ORU_CODEBOOK_MAX_STREAMS);
+    AssertFatal(oru->codebook.nb_beams > 0 && oru->codebook.nb_beams <= ORU_CODEBOOK_MAX_BEAMS,
+                "codebook_nb_beams %d invalid (range 1..%d)\n",
+                oru->codebook.nb_beams,
+                ORU_CODEBOOK_MAX_BEAMS);
+    AssertFatal(oru->ru->nb_tx <= ORU_CODEBOOK_MAX_NB_TX, "nb_tx %d exceeds maximum %d\n", oru->ru->nb_tx, ORU_CODEBOOK_MAX_NB_TX);
+    AssertFatal(oru->codebook.nb_fh_streams <= oru->ru->nb_tx,
+                "nb_fh_streams %d must not exceed nb_tx %d\n",
+                oru->codebook.nb_fh_streams,
+                oru->ru->nb_tx);
+    paramdef_t *wgt = gpd(param, nump, CONFIG_STRING_CODEBOOK_WEIGHTS);
+    int expected = oru->codebook.nb_beams * oru->ru->nb_tx * oru->codebook.nb_fh_streams * 2;
+    AssertFatal(wgt->numelt == expected,
+                "codebook_weights: expected %d elements (nb_beams=%d * nb_tx=%d * nb_fh_streams=%d * 2)\n",
+                expected,
+                oru->codebook.nb_beams,
+                oru->ru->nb_tx,
+                oru->codebook.nb_fh_streams);
+    int idx = 0;
+    for (int b = 0; b < oru->codebook.nb_beams; b++)
+      for (int t = 0; t < oru->ru->nb_tx; t++)
+        for (int s = 0; s < oru->codebook.nb_fh_streams; s++) {
+          AssertFatal(wgt->iptr[idx] >= INT16_MIN && wgt->iptr[idx] <= INT16_MAX,
+                      "codebook_weights[%d] value %d out of Q15 range\n", idx, wgt->iptr[idx]);
+          oru->codebook.w[b][t][s].r = (int16_t)wgt->iptr[idx++];
+          AssertFatal(wgt->iptr[idx] >= INT16_MIN && wgt->iptr[idx] <= INT16_MAX,
+                      "codebook_weights[%d] value %d out of Q15 range\n", idx, wgt->iptr[idx]);
+          oru->codebook.w[b][t][s].i = (int16_t)wgt->iptr[idx++];
+        }
+    LOG_I(NR_PHY,
+          "Codebook beamforming enabled: nb_fh_streams=%d nb_beams=%d nb_tx=%d\n",
+          oru->codebook.nb_fh_streams,
+          oru->codebook.nb_beams,
+          oru->ru->nb_tx);
+  }
+
   oru->tx_write.core = *gpd(param, nump, CONFIG_STRING_ORU_TX_CORE)->iptr;
 
   paramdef_t fh_param[] = CMDLINE_PARAMS_DESC_ORU_FH;

--- a/executables/nr-oru.h
+++ b/executables/nr-oru.h
@@ -11,6 +11,16 @@
 #include "openair2/LAYER2/NR_MAC_COMMON/nr_prach_config.h"
 #include "openair1/PHY/defs_gNB.h"
 
+#define ORU_CODEBOOK_MAX_BEAMS 64
+#define ORU_CODEBOOK_MAX_NB_TX 8
+#define ORU_CODEBOOK_MAX_STREAMS 4
+
+typedef struct {
+  int nb_fh_streams;
+  int nb_beams;
+  c16_t w[ORU_CODEBOOK_MAX_BEAMS][ORU_CODEBOOK_MAX_NB_TX][ORU_CODEBOOK_MAX_STREAMS];
+} oru_codebook_t;
+
 #define MAX_DL_READ_THREADS 8
 #define MAX_ORU_UL_WORKERS 8
 
@@ -73,6 +83,7 @@ typedef struct {
   time_stats_t rx_prach;
   time_stats_t rx;
   prach_item_t prach_item;
+  oru_codebook_t codebook;
   bool threequarter_fs;
 
   // Real-time Self-diagnosis metrics

--- a/executables/nr-oru.h
+++ b/executables/nr-oru.h
@@ -10,16 +10,7 @@
 #include "common/utils/symbol_reorder/symbol_reorder.h"
 #include "openair2/LAYER2/NR_MAC_COMMON/nr_prach_config.h"
 #include "openair1/PHY/defs_gNB.h"
-
-#define ORU_CODEBOOK_MAX_BEAMS 64
-#define ORU_CODEBOOK_MAX_NB_TX 8
-#define ORU_CODEBOOK_MAX_STREAMS 4
-
-typedef struct {
-  int nb_fh_streams;
-  int nb_beams;
-  c16_t w[ORU_CODEBOOK_MAX_BEAMS][ORU_CODEBOOK_MAX_NB_TX][ORU_CODEBOOK_MAX_STREAMS];
-} oru_codebook_t;
+#include "oru_beamforming.h"
 
 #define MAX_DL_READ_THREADS 8
 #define MAX_ORU_UL_WORKERS 8

--- a/executables/nr-oru.h
+++ b/executables/nr-oru.h
@@ -85,6 +85,8 @@ typedef struct {
   uint64_t ul_ant_time_max_us; // in SQ4
   _Atomic(uint64_t) ul_dropped_jobs;
   _Atomic(uint64_t) ul_symbols_missed;
+  _Atomic(uint64_t) ul_cal_overflow_dropped; // calendar symbol entry full (UL_CAL_JOBS_PER_SYMBOL)
+  _Atomic(uint64_t) ul_cal_horizon_dropped;  // job declared > UL_CAL_SLOTS slots ahead (beyond calendar ring)
 } ORU_t;
 
 int get_oru_options(ORU_t *oru);

--- a/fronthaul/oru/CMakeLists.txt
+++ b/fronthaul/oru/CMakeLists.txt
@@ -16,6 +16,10 @@ add_library(oru_packet_processor oru_packet_processor.c)
 target_include_directories(oru_packet_processor PUBLIC ./)
 target_link_libraries(oru_packet_processor PUBLIC ${dpdk_LIBRARIES} PRIVATE xran_pkt UTIL fh_compression)
 
+add_library(oru_beamforming oru_beamforming.c)
+target_include_directories(oru_beamforming PUBLIC ./)
+target_link_libraries(oru_beamforming PUBLIC oru_packet_processor PRIVATE UTIL)
+
 add_library(oru_fh oru_fh.c)
 target_include_directories(oru_fh PUBLIC ./)
 target_link_libraries(oru_fh PUBLIC fh_core oru_io xran_pkt oru_packet_processor ${dpdk_LIBRARIES})

--- a/fronthaul/oru/oru_beamforming.c
+++ b/fronthaul/oru/oru_beamforming.c
@@ -80,3 +80,33 @@ void combine_dl_streams(c16_t **txDataF,
     combine_codebook(txDataF, nb_tx, n_sc, streams, num_streams, cb, rotation);
   }
 }
+
+void combine_ul_beam_fd(const c16_t *const fft_data[],
+                        int nb_rx,
+                        int n,
+                        const oru_codebook_t *cb,
+                        int beam_id,
+                        int stream_id,
+                        c16_t *out)
+{
+  if (stream_id >= cb->nb_fh_streams) {
+    LOG_W(PHY, "UL stream %d exceeds nb_fh_streams %d, dropping\n", stream_id, cb->nb_fh_streams);
+    memset(out, 0, n * sizeof(c16_t));
+    return;
+  }
+  int bidx = beam_id;
+  if (bidx >= cb->nb_beams) {
+    LOG_W(PHY, "beam_id %u out of range (nb_beams=%d), falling back to beam 0\n", beam_id, cb->nb_beams);
+    bidx = 0;
+  }
+  memset(out, 0, n * sizeof(c16_t));
+  if (nb_rx > ORU_CODEBOOK_MAX_NB_TX) {
+    LOG_W(PHY, "nb_rx %d exceeds codebook antenna dimension %d, combining first %d antennas\n",
+          nb_rx, ORU_CODEBOOK_MAX_NB_TX, ORU_CODEBOOK_MAX_NB_TX);
+  }
+  const int nb_ant = nb_rx < ORU_CODEBOOK_MAX_NB_TX ? nb_rx : ORU_CODEBOOK_MAX_NB_TX;
+  for (int a = 0; a < nb_ant; a++) {
+    // Same per-bin saturating multiply-accumulate as the DL codebook path.
+    rotate_add_cpx_vector(fft_data[a], cb->w[bidx][a][stream_id], out, n, 15);
+  }
+}

--- a/fronthaul/oru/oru_beamforming.c
+++ b/fronthaul/oru/oru_beamforming.c
@@ -43,10 +43,6 @@ static void combine_codebook(c16_t **txDataF,
     memset(txDataF[aatx], 0, n_sc * sizeof(c16_t));
   }
 
-  // Reused scratch for the rotated+weighted term of the stream/txru pair currently being folded
-  // in - sized to the whole symbol so it can hold any single stream's PRB run, never nb_tx times.
-  c16_t term[n_sc];
-
   for (int i = 0; i < num_streams; i++) {
     const dl_iq_stream_t *stream = &streams[i];
     if (stream->ant_id >= cb->nb_fh_streams) {
@@ -62,10 +58,10 @@ static void combine_codebook(c16_t **txDataF,
     const int n_re = stream->num_prb * NR_NB_SC_PER_RB;
     const int re_off = stream->start_prb * NR_NB_SC_PER_RB;
     for (int txru = 0; txru < nb_tx; txru++) {
-      // Fold rotation into the weight once, instead of a separate rotate pass afterward.
+      // Fold rotation into the weight once, instead of a separate rotate pass afterward. Fused
+      // multiply+saturating-accumulate straight into txDataF - no scratch buffer, one pass.
       c16_t w_rot = c16mulShift(cb->w[bidx][txru][stream->ant_id], rotation, 15);
-      rotate_cpx_vector(src, w_rot, term, n_re, 15);
-      add_cpx_vector(term, &txDataF[txru][re_off], n_re);
+      rotate_add_cpx_vector(src, w_rot, &txDataF[txru][re_off], n_re, 15);
     }
   }
 }

--- a/fronthaul/oru/oru_beamforming.c
+++ b/fronthaul/oru/oru_beamforming.c
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include "oru_beamforming.h"
+#include "openair1/PHY/TOOLS/tools_defs.h"
+#include "common/utils/nr/nr_common.h"
+#include "log.h"
+#include <string.h>
+
+static void combine_passthrough(c16_t **txDataF,
+                                int nb_tx,
+                                int n_sc,
+                                const dl_iq_stream_t *streams,
+                                int num_streams,
+                                c16_t rotation)
+{
+  for (int aatx = 0; aatx < nb_tx; aatx++) {
+    memset(txDataF[aatx], 0, n_sc * sizeof(c16_t));
+  }
+
+  // Direct overwrite, assume no overalpping streams on the same tx antenna.
+  for (int i = 0; i < num_streams; i++) {
+    const dl_iq_stream_t *stream = &streams[i];
+    if (stream->ant_id >= (unsigned)nb_tx) {
+      continue;
+    }
+    c16_t *dst = &txDataF[stream->ant_id][stream->start_prb * NR_NB_SC_PER_RB];
+    const c16_t *src = (const c16_t *)stream->iq;
+    rotate_cpx_vector(src, rotation, dst, stream->num_prb * NR_NB_SC_PER_RB, 15);
+  }
+}
+
+static void combine_codebook(c16_t **txDataF,
+                             int nb_tx,
+                             int n_sc,
+                             const dl_iq_stream_t *streams,
+                             int num_streams,
+                             const oru_codebook_t *cb,
+                             c16_t rotation)
+{
+  for (int aatx = 0; aatx < nb_tx; aatx++) {
+    memset(txDataF[aatx], 0, n_sc * sizeof(c16_t));
+  }
+
+  // Reused scratch for the rotated+weighted term of the stream/txru pair currently being folded
+  // in - sized to the whole symbol so it can hold any single stream's PRB run, never nb_tx times.
+  c16_t term[n_sc];
+
+  for (int i = 0; i < num_streams; i++) {
+    const dl_iq_stream_t *stream = &streams[i];
+    if (stream->ant_id >= cb->nb_fh_streams) {
+      LOG_W(PHY, "DL stream ant_id %d exceeds nb_fh_streams %d, dropping\n", stream->ant_id, cb->nb_fh_streams);
+      continue;
+    }
+    int bidx = stream->beam_id;
+    if (bidx >= cb->nb_beams) {
+      LOG_W(PHY, "beam_id %u out of range (nb_beams=%d), falling back to beam 0\n", stream->beam_id, cb->nb_beams);
+      bidx = 0;
+    }
+    const c16_t *src = (const c16_t *)stream->iq;
+    const int n_re = stream->num_prb * NR_NB_SC_PER_RB;
+    const int re_off = stream->start_prb * NR_NB_SC_PER_RB;
+    for (int txru = 0; txru < nb_tx; txru++) {
+      // Fold rotation into the weight once, instead of a separate rotate pass afterward.
+      c16_t w_rot = c16mulShift(cb->w[bidx][txru][stream->ant_id], rotation, 15);
+      rotate_cpx_vector(src, w_rot, term, n_re, 15);
+      add_cpx_vector(term, &txDataF[txru][re_off], n_re);
+    }
+  }
+}
+
+void combine_dl_streams(c16_t **txDataF,
+                        int nb_tx,
+                        int n_sc,
+                        const dl_iq_stream_t *streams,
+                        int num_streams,
+                        const oru_codebook_t *cb,
+                        c16_t rotation)
+{
+  if (cb->nb_fh_streams <= 0) {
+    combine_passthrough(txDataF, nb_tx, n_sc, streams, num_streams, rotation);
+  } else {
+    combine_codebook(txDataF, nb_tx, n_sc, streams, num_streams, cb, rotation);
+  }
+}

--- a/fronthaul/oru/oru_beamforming.h
+++ b/fronthaul/oru/oru_beamforming.h
@@ -42,6 +42,16 @@ void combine_dl_streams(c16_t **txDataF,
                         const oru_codebook_t *cb,
                         c16_t rotation);
 
+// UL Rx beamforming: combine per-antenna FFT output into one beam stream, out[k] =
+// sum_a w[beam][a][stream] * fft_data[a][k]
+void combine_ul_beam_fd(const c16_t *const rxdataF[],
+                        int nb_rx,
+                        int n,
+                        const oru_codebook_t *cb,
+                        int beam_id,
+                        int stream_id,
+                        c16_t *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/fronthaul/oru/oru_beamforming.h
+++ b/fronthaul/oru/oru_beamforming.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#pragma once
+
+#include "oru_packet_processor.h"
+#include "common/platform_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ORU_CODEBOOK_MAX_BEAMS 64
+#define ORU_CODEBOOK_MAX_NB_TX 8
+#define ORU_CODEBOOK_MAX_STREAMS 4
+
+typedef struct {
+  int nb_fh_streams;
+  int nb_beams;
+  c16_t w[ORU_CODEBOOK_MAX_BEAMS][ORU_CODEBOOK_MAX_NB_TX][ORU_CODEBOOK_MAX_STREAMS];
+} oru_codebook_t;
+
+// Turns read_dl_iq_streams()'s raw PRB runs into physical-antenna IQ. Pure function (no
+// RU_t/ORU_t) so the math is directly unit-testable - see test_oru_beamforming.c. Digital
+// beamforming only: no beam_id/GPIO output, since a beam here is a weight, not an antenna state.
+//
+// Passthrough (cb->nb_fh_streams <= 0): ant_id is the physical antenna; streams are placed
+// directly, one stream per PRB range (no accumulation needed there). Codebook (cb->nb_fh_streams >
+// 0): ant_id is a logical fronthaul stream index, weighted per PRB run by cb->w[beam][txru][ant_id]
+// and summed onto each physical antenna - weighting per run (not per symbol).
+//
+// rotation (per-symbol phase compensation, Q1.15) is folded into the weight/each sample here -
+// callers must not rotate txDataF again afterward.
+//
+// txDataF: nb_tx buffers of at least n_sc samples, zeroed by this function.
+void combine_dl_streams(c16_t **txDataF,
+                        int nb_tx,
+                        int n_sc,
+                        const dl_iq_stream_t *streams,
+                        int num_streams,
+                        const oru_codebook_t *cb,
+                        c16_t rotation);
+
+#ifdef __cplusplus
+}
+#endif

--- a/fronthaul/oru/oru_fh.c
+++ b/fronthaul/oru/oru_fh.c
@@ -231,13 +231,19 @@ void oru_fh_cleanup(void *handle)
   free(fh);
 }
 
-int oru_fh_tx_read_symbol(void *handle, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol)
+int oru_fh_tx_read_symbol(void *handle,
+                          dl_iq_stream_t *streams,
+                          uint32_t *iq_arena,
+                          int max_streams,
+                          uint64_t *hyper_frame,
+                          int *frame,
+                          int *slot,
+                          int *symbol)
 {
   if (!handle)
     return -1;
   oru_fh_t *fh = (oru_fh_t *)handle;
-  read_dl_iq(fh->packet_processor, txdataF, nb_tx, hyper_frame, frame, slot, symbol);
-  return 0;
+  return read_dl_iq_streams(fh->packet_processor, streams, iq_arena, max_streams, hyper_frame, frame, slot, symbol);
 }
 
 int oru_fh_get_ready_jobs(void *handle)

--- a/fronthaul/oru/oru_fh.h
+++ b/fronthaul/oru/oru_fh.h
@@ -73,18 +73,32 @@ void oru_fh_cleanup(void *handle);
 int oru_fh_get_ready_jobs(void *handle);
 
 /**
- * @brief Read downlink symbol data (IQ samples) from the Fronthaul interface.
+ * @brief Read downlink symbol data from the Fronthaul interface as raw, unassembled IQ streams.
+ *
+ * Each returned stream is one continuous, decompressed PRB run - see dl_iq_stream_t in
+ * oru_packet_processor.h for the full contract. Placing/summing them into the final per-antenna
+ * buffer is the caller's job, not this function's.
  *
  * @param handle Pointer to the fronthaul handle.
- * @param txdataF Array of pointers to buffers to store the received frequency-domain IQ samples (per TX antenna).
- * @param nb_tx Number of TX antennas.
+ * @param streams Caller-owned array, at least max_streams entries.
+ * @param iq_arena Caller-owned scratch, at least MAX_DL_IQ_STREAMS_PER_SYMBOL * num_prb * NR_NB_SC_PER_RB
+ *                 uint32_t (num_prb as configured for this fronthaul instance).
+ * @param max_streams Capacity of `streams` (pass MAX_DL_IQ_STREAMS_PER_SYMBOL).
  * @param hyper_frame Absolute GPS hyper-frame number
  * @param frame Pointer to store the frame number of the read symbol.
  * @param slot Pointer to store the slot number of the read symbol.
  * @param symbol Pointer to store the symbol number.
- * @return 0 on success or -1 on failure
+ * @return Number of streams filled in (0..max_streams; 0 is a normal "nothing scheduled" outcome,
+ *         not an error), or -1 on failure (invalid handle).
  */
-int oru_fh_tx_read_symbol(void *handle, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol);
+int oru_fh_tx_read_symbol(void *handle,
+                          dl_iq_stream_t *streams,
+                          uint32_t *iq_arena,
+                          int max_streams,
+                          uint64_t *hyper_frame,
+                          int *frame,
+                          int *slot,
+                          int *symbol);
 
 /**
  * @brief Get the UTC anchor point mapping between 5G time and system time.

--- a/fronthaul/oru/oru_packet_processor.c
+++ b/fronthaul/oru/oru_packet_processor.c
@@ -40,28 +40,42 @@
 #define MAX_TDD_PATTERN_LENGTH_MS 10
 #define MAX_SLOTS_PER_MS 4
 #define SYMBOL_BITMASK_SIZE ((NR_SYMBOLS_PER_SLOT * MAX_TDD_PATTERN_LENGTH_MS * MAX_SLOTS_PER_MS + 7) / 8)
-#define MAX_RX_FRAGMENTS 4
+#define MAX_SECTIONS_PER_DL_STREAM 4 // C-Plane sections (e.g. split PRB ranges) that can share one (eaxc, beam) stream in a DL symbol
+#define MAX_DL_STREAMS_PER_SYMBOL 16 // cap on distinct (eaxc, beam) pairs declared for one DL symbol
 #define MAX_MBUFS_PER_SYMBOL 64
 #define MAX_SLOTS_PER_FRAME 160
 #define XRAN_IQ_BITS_UNCOMPRESSED 16 /* xRAN table 7.7.1.1-1: udIqWidth=0 means 16-bit samples */
 
+// One (eaxc, beam_id) pair's bookkeeping for a DL symbol: completion tracking and declared
+// section_ids, no IQ. Payload fragments live in dl_symbol_job_t.fragments[] instead.
 typedef struct {
-  struct {
-    bool cplane_received;
-    int section_id;
-    struct {
-      int start_prbc;
-      int num_prbc;
-      void *iq_data;
-      void *mbuf;
-    } rx_fragments[MAX_RX_FRAGMENTS];
-    int num_rx_fragments;
-  } per_antenna[MAX_ANTENNAS];
-  int expected_iq;
-  int received_iq;
-  uint64_t absolute_symbol;
+  uint8_t eaxc_id;
+  uint16_t beam_id;
+  uint16_t section_ids[MAX_SECTIONS_PER_DL_STREAM]; // every C-Plane section_id declared into this stream
+  int num_section_ids;
+  int expected_iq; // PRBs declared via C-Plane for this stream, summed across its section_ids
+  int received_iq; // PRBs actually received via U-Plane for this stream
+} dl_stream_slot_t;
+
+// One joined C-Plane+U-Plane PRB run. comp_method/iq_width come from the U-Plane packet itself,
+// not the C-Plane declaration - sections in the same symbol aren't guaranteed the same compression.
+typedef struct {
+  uint8_t eaxc_id;
+  uint16_t beam_id;
+  int start_prbc;
+  int num_prbc;
   fh_comp_method_t comp_method;
   uint8_t iq_width;
+  void *iq_data; // points into mbuf; valid until this fragment is unpacked and mbuf is freed
+  void *mbuf;
+} dl_fragment_t;
+
+typedef struct {
+  dl_stream_slot_t streams[MAX_DL_STREAMS_PER_SYMBOL];
+  int num_streams;
+  dl_fragment_t fragments[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  int num_fragments;
+  uint64_t absolute_symbol;
 } dl_symbol_job_t;
 
 typedef struct {
@@ -99,6 +113,7 @@ typedef struct {
   prach_job_t prach_jobs[MAX_SLOTS_PER_FRAME][MAX_ANTENNAS];
   uint64_t current_absolute_symbol;
   uint64_t window_tail_symbol;
+  uint64_t cplane_closed_tail_symbol;
   struct rte_ring *dl_free_jobs;
   struct rte_ring *dl_ready_jobs;
   struct rte_ring *ul_free_jobs;
@@ -134,6 +149,54 @@ static inline void set_bit(uint8_t *bits, uint64_t bit)
 static inline int test_bit(uint8_t *bits, uint64_t bit)
 {
   return bits[bit / 8] & (1 << (bit % 8));
+}
+
+// U-Plane packets carry (eaxc, section_id) - find which beam-stream declared that section_id.
+static dl_stream_slot_t *find_dl_stream_by_section(dl_symbol_job_t *job, uint8_t eaxc_id, uint16_t section_id)
+{
+  for (int s = 0; s < job->num_streams; s++) {
+    dl_stream_slot_t *stream = &job->streams[s];
+    if (stream->eaxc_id != eaxc_id) {
+      continue;
+    }
+    for (int i = 0; i < stream->num_section_ids; i++) {
+      if (stream->section_ids[i] == section_id) {
+        return stream;
+      }
+    }
+  }
+  return NULL;
+}
+
+// Only C-Plane creates stream slots; a U-Plane packet with no match counts as
+// uplane_missing_cplane rather than fabricating a zero-expected_iq slot.
+static dl_stream_slot_t *find_or_add_dl_stream(dl_symbol_job_t *job, uint8_t eaxc_id, uint16_t beam_id)
+{
+  for (int s = 0; s < job->num_streams; s++) {
+    if (job->streams[s].eaxc_id == eaxc_id && job->streams[s].beam_id == beam_id) {
+      return &job->streams[s];
+    }
+  }
+  if (job->num_streams >= MAX_DL_STREAMS_PER_SYMBOL) {
+    return NULL;
+  }
+  dl_stream_slot_t *slot = &job->streams[job->num_streams++];
+  memset(slot, 0, sizeof(*slot));
+  slot->eaxc_id = eaxc_id;
+  slot->beam_id = beam_id;
+  return slot;
+}
+
+// Appends one joined PRB run; mbuf ownership passes to the job, freed later by read_dl_iq_streams().
+static dl_fragment_t *add_dl_fragment(dl_symbol_job_t *job, uint8_t eaxc_id, uint16_t beam_id)
+{
+  if (job->num_fragments >= MAX_DL_IQ_STREAMS_PER_SYMBOL) {
+    return NULL;
+  }
+  dl_fragment_t *frag = &job->fragments[job->num_fragments++];
+  frag->eaxc_id = eaxc_id;
+  frag->beam_id = beam_id;
+  return frag;
 }
 
 void txrx_window_histogram_count(txrx_histogram_t *hist, int32_t diff)
@@ -240,26 +303,42 @@ void cleanup_packet_processor(void *context)
   }
 }
 
-// Releases a single symbol job the instant it individually completes, independent of any other
-// symbol's state (sliding window: no head-of-line blocking on neighboring, still-incomplete jobs).
-void release_completed_symbol_job(oru_packet_processor_context_t *ctx, uint64_t absolute_symbol)
+static bool dl_job_fully_delivered(const dl_symbol_job_t *job)
 {
-  uint32_t job_index = absolute_symbol % NUM_CONCURRENT_DL_SYMBOL_WINDOWS;
-  dl_symbol_job_t *job = ctx->dl_symbol_rx_window[job_index];
-  if (!job || job->absolute_symbol != absolute_symbol) {
-    return;
+  for (int s = 0; s < job->num_streams; s++) {
+    if (job->streams[s].received_iq != job->streams[s].expected_iq) {
+      return false;
+    }
   }
-  ctx->dl_symbol_rx_window[job_index] = NULL;
-  ctx->was_dl_symbol_completed[job_index] = true;
-  int ret = rte_ring_enqueue(ctx->dl_ready_jobs, (void *)job);
-  if (ret != 0) {
-    ctx->stats.application_too_slow++;
+  return true;
+}
+
+// Releases a job early once its C-Plane window has closed and everything declared has already
+// arrived, instead of waiting for push_symbol_job()'s mandatory backstop.
+static void release_cplane_complete_jobs(oru_packet_processor_context_t *ctx, uint64_t absolute_symbol)
+{
+  while (ctx->cplane_closed_tail_symbol <= absolute_symbol) {
+    if (!test_bit(ctx->dl_symbol_bitmask, ctx->cplane_closed_tail_symbol % ctx->symbol_bitmask_length)) {
+      ctx->cplane_closed_tail_symbol++;
+      continue;
+    }
+    uint32_t job_index = ctx->cplane_closed_tail_symbol % NUM_CONCURRENT_DL_SYMBOL_WINDOWS;
+    dl_symbol_job_t *job = ctx->dl_symbol_rx_window[job_index];
+    if (job && job->absolute_symbol == ctx->cplane_closed_tail_symbol && dl_job_fully_delivered(job)) {
+      ctx->dl_symbol_rx_window[job_index] = NULL;
+      ctx->was_dl_symbol_completed[job_index] = true;
+      int ret = rte_ring_enqueue(ctx->dl_ready_jobs, (void *)job);
+      if (ret != 0) {
+        ctx->stats.application_too_slow++;
+      }
+    }
+    ctx->cplane_closed_tail_symbol++;
   }
 }
 
-// Happens during timer expiry: slides the trailing edge of the window forward, forcibly evicting
-// any slot that fell behind (reclaiming it for the job pool) so every DL symbol eventually reaches
-// dl_ready_jobs even if it was never released early via release_completed_symbol_job().
+// Mandatory backstop, run on timer expiry: force-flushes every DL symbol job by its T2a deadline,
+// complete or not. Symbols already released early by release_cplane_complete_jobs() are skipped
+// via was_dl_symbol_completed.
 void push_symbol_job(oru_packet_processor_context_t *ctx, uint64_t absolute_symbol)
 {
   while (ctx->window_tail_symbol <= absolute_symbol) {
@@ -280,7 +359,7 @@ void push_symbol_job(oru_packet_processor_context_t *ctx, uint64_t absolute_symb
         ctx->stats.application_too_slow++;
       }
     } else if (ctx->was_dl_symbol_completed[job_index]) {
-      // Already released early for this exact symbol - nothing to do.
+      // Already released early for this exact symbol by release_cplane_complete_jobs() - nothing to do.
       ctx->was_dl_symbol_completed[job_index] = false;
     } else {
       // Never got a single C-plane packet for this symbol - push an empty placeholder so the
@@ -307,9 +386,17 @@ void handle_absolute_symbol_tick(void *context, uint64_t absolute_symbol)
   if (ctx->current_absolute_symbol == 0) {
     ctx->current_absolute_symbol = absolute_symbol - 1;
     ctx->window_tail_symbol = absolute_symbol - 1;
+    ctx->cplane_closed_tail_symbol = absolute_symbol - 1;
   }
   ctx->current_absolute_symbol = absolute_symbol;
-  uint64_t window_expiry_symbol = ctx->current_absolute_symbol + ctx->T2a_min_up_dl_sym_diff;
+  // Guard against underflow: T2a_min_*_sym_diff can legitimately be 0.
+  if (ctx->T2a_min_cp_sym_diff > 0) {
+    uint64_t cplane_closed_symbol = ctx->current_absolute_symbol + ctx->T2a_min_cp_sym_diff - 1;
+    release_cplane_complete_jobs(ctx, cplane_closed_symbol);
+  }
+  uint32_t min_t2a_min_sym_diff =
+      ctx->T2a_min_cp_sym_diff < ctx->T2a_min_up_dl_sym_diff ? ctx->T2a_min_cp_sym_diff : ctx->T2a_min_up_dl_sym_diff;
+  uint64_t window_expiry_symbol = ctx->current_absolute_symbol + (min_t2a_min_sym_diff > 0 ? min_t2a_min_sym_diff - 1 : 0);
   push_symbol_job(ctx, window_expiry_symbol);
 }
 
@@ -372,7 +459,41 @@ void handle_uplane_packet(void *context, void *pkt)
     rte_pktmbuf_free(pkt);
     return;
   }
-  AssertFatal(Ant_ID <= MAX_ANTENNAS, "Antenna id (%d) exceeds supported value %d\n", Ant_ID, MAX_ANTENNAS);
+  if (Ant_ID >= MAX_ANTENNAS) {
+    // Wire-controlled field - drop rather than let a malformed/out-of-range packet crash the process.
+    ctx->stats.invalid_eaxc_id++;
+    rte_pktmbuf_free(pkt);
+    return;
+  }
+  uint16_t effective_num_prbu = num_prbu == 0 ? ctx->num_prb : num_prbu;
+  uint8_t effective_iq_width = iqWidth == 0 ? XRAN_IQ_BITS_UNCOMPRESSED : iqWidth;
+  // start_prbu/num_prbu are wire-controlled. combine_dl_streams() writes num_prb PRBs at start_prb
+  // into a txDataF buffer sized for ctx->num_prb PRBs - reject anything that wouldn't fit.
+  if (start_prbu > ctx->num_prb || effective_num_prbu > (uint16_t)(ctx->num_prb - start_prbu)) {
+    LOG_W(HW,
+          "U-plane packet: start_prbu %u + num_prbu %u exceeds configured num_prb %d, dropping\n",
+          start_prbu,
+          effective_num_prbu,
+          ctx->num_prb);
+    ctx->stats.uplane_err_prb_range++;
+    rte_pktmbuf_free(pkt);
+    return;
+  }
+  // ret is the packet length still remaining after xran_extract_iq_samples() stripped the headers -
+  // verify it actually holds the IQ payload the header claims, before iq_data_start is handed off
+  // to the deferred unpack_iq() in read_dl_iq_streams().
+  size_t expected_bytes = has_comp_hdr ? (size_t)effective_num_prbu * FH_COMP_PRB_BYTES(effective_iq_width)
+                                       : (size_t)effective_num_prbu * NR_NB_SC_PER_RB * 2 * sizeof(uint16_t);
+  if ((size_t)ret < expected_bytes) {
+    LOG_W(HW,
+          "U-plane packet: payload too short (%d bytes, need %zu for %u PRBs), dropping\n",
+          ret,
+          expected_bytes,
+          effective_num_prbu);
+    ctx->stats.uplane_err_short_payload++;
+    rte_pktmbuf_free(pkt);
+    return;
+  }
   LOG_D(HW,
         "ORAN: U-plane packet received. CC_ID %d, Ant_ID %d, frame_id %d, subframe_id %d, slot_id %d, symb_id %d, filter_id %d, "
         "num_prbu %d, start_prbu %d, sym_inc %d, rb %d, sect_id %d, compMeth %d, iqWidth %d\n",
@@ -436,22 +557,31 @@ void handle_uplane_packet(void *context, void *pkt)
     return;
   }
 
-  if (job->per_antenna[Ant_ID].num_rx_fragments < MAX_RX_FRAGMENTS) {
-    int frag_idx = job->per_antenna[Ant_ID].num_rx_fragments++;
-    job->per_antenna[Ant_ID].rx_fragments[frag_idx].iq_data = iq_data_start;
-    job->per_antenna[Ant_ID].rx_fragments[frag_idx].mbuf = pkt;
-    job->per_antenna[Ant_ID].rx_fragments[frag_idx].start_prbc = start_prbu;
-    job->per_antenna[Ant_ID].rx_fragments[frag_idx].num_prbc = num_prbu == 0 ? ctx->num_prb : num_prbu;
-  } else {
+  dl_stream_slot_t *stream = find_dl_stream_by_section(job, Ant_ID, sect_id);
+  if (!stream) {
+    // C-Plane never declared this (eaxc, section) - drop rather than guess.
+    ctx->stats.uplane_missing_cplane++;
+    rte_pktmbuf_free(pkt);
+    return;
+  }
+
+  dl_fragment_t *frag = add_dl_fragment(job, Ant_ID, stream->beam_id);
+  if (!frag) {
+    ctx->stats.dl_iq_streams_pool_exhausted++;
     LOG_W(HW, "ORU: Dropping extra segment for Ant %d, sym %lu\n", Ant_ID, target_absolute_symbol);
     rte_pktmbuf_free(pkt);
+    return;
   }
-  job->received_iq += num_prbu == 0 ? ctx->num_prb : num_prbu;
-  job->comp_method = (fh_comp_method_t)compMeth;
-  job->iq_width = iqWidth == 0 ? XRAN_IQ_BITS_UNCOMPRESSED : iqWidth;
-  if (job->expected_iq == job->received_iq) {
-    release_completed_symbol_job(ctx, target_absolute_symbol);
-  }
+  frag->start_prbc = start_prbu;
+  frag->num_prbc = effective_num_prbu;
+  frag->iq_data = iq_data_start;
+  frag->mbuf = pkt;
+  frag->comp_method = (fh_comp_method_t)compMeth;
+  frag->iq_width = effective_iq_width;
+  // Only counted once actually stored - crediting a dropped fragment would let
+  // dl_job_fully_delivered() falsely report this symbol complete.
+  stream->received_iq += frag->num_prbc;
+  // Release happens in release_cplane_complete_jobs() or push_symbol_job(), not here.
   return;
 }
 
@@ -461,6 +591,11 @@ static void handle_dl_cplane_packet(oru_packet_processor_context_t *ctx,
                                     struct xran_cp_radioapp_section1 *section,
                                     int ant_id)
 {
+  if (ant_id < 0 || ant_id >= MAX_ANTENNAS) {
+    // Wire-controlled field - drop rather than let a malformed/out-of-range packet crash the process.
+    ctx->stats.invalid_eaxc_id++;
+    return;
+  }
   int numerology = ctx->numerology;
   int slot_in_frame = hdr->cmnhdr.field.slotId + hdr->cmnhdr.field.subframeId * (1 << numerology);
   uint32_t start_symbol = hdr->cmnhdr.field.startSymbolId;
@@ -492,28 +627,30 @@ static void handle_dl_cplane_packet(oru_packet_processor_context_t *ctx,
     return;
   }
   for (int i = 0; i < num_symbols; i++) {
+    // Multi-symbol section: symbol i of the section sits at target_absolute_symbol + i, so its own
+    // offset from "now" is diff + i (later symbols are further out, not closer) - check each one
+    // individually against both bounds, not just the section's first symbol.
+    int32_t sym_diff = diff + i;
+    if (sym_diff > (int32_t)ctx->T2a_max_cp_sym_diff) {
+      ctx->stats.cplane_err_early++;
+      return;
+    }
+    if (sym_diff < (int32_t)ctx->T2a_min_cp_sym_diff) {
+      ctx->stats.cplane_err_late++;
+      return;
+    }
     uint32_t job_index = (target_absolute_symbol + i) % NUM_CONCURRENT_DL_SYMBOL_WINDOWS;
     dl_symbol_job_t *job = ctx->dl_symbol_rx_window[job_index];
     if (!job) {
-      // First cplane packet of in this reception slot
+      // First C-Plane packet for this symbol.
       int ret = rte_ring_dequeue(ctx->dl_free_jobs, (void **)&job);
       if (ret != 0) {
         ctx->stats.application_too_slow++;
         return;
       }
       job->absolute_symbol = target_absolute_symbol + i;
-      job->expected_iq = 0;
-      job->received_iq = 0;
-      job->comp_method = FH_COMP_NONE;
-      job->iq_width = 16;
-      for (int j = 0; j < MAX_ANTENNAS; j++) {
-        job->per_antenna[j].cplane_received = false;
-        job->per_antenna[j].num_rx_fragments = 0;
-        for (int k = 0; k < MAX_RX_FRAGMENTS; k++) {
-          job->per_antenna[j].rx_fragments[k].iq_data = NULL;
-          job->per_antenna[j].rx_fragments[k].mbuf = NULL;
-        }
-      }
+      job->num_streams = 0;
+      job->num_fragments = 0;
       ctx->dl_symbol_rx_window[job_index] = job;
       ctx->was_dl_symbol_completed[job_index] = false;
     } else {
@@ -521,16 +658,27 @@ static void handle_dl_cplane_packet(oru_packet_processor_context_t *ctx,
         ctx->stats.cplane_err_late++;
         return;
       }
-      if (job->per_antenna[ant_id].cplane_received) {
-        ctx->stats.cplane_err_dup++;
-        ctx->stats.cplane_err_dup_dl++;
-        return;
-      }
     }
-    job->per_antenna[ant_id].section_id = section->hdr.u1.common.sectionId;
-    job->expected_iq += section->hdr.u1.common.numPrbc == 0 ? ctx->num_prb : section->hdr.u1.common.numPrbc;
-    job->comp_method = (fh_comp_method_t)hdr->udComp.udCompMeth;
-    job->iq_width = hdr->udComp.udIqWidth == 0 ? XRAN_IQ_BITS_UNCOMPRESSED : hdr->udComp.udIqWidth;
+    uint16_t section_id = section->hdr.u1.common.sectionId;
+    if (find_dl_stream_by_section(job, (uint8_t)ant_id, section_id)) {
+      // Duplicate C-Plane packet for this section_id.
+      ctx->stats.cplane_err_dup++;
+      ctx->stats.cplane_err_dup_dl++;
+      return;
+    }
+    dl_stream_slot_t *stream = find_or_add_dl_stream(job, (uint8_t)ant_id, section->hdr.u.s1.beamId);
+    if (!stream) {
+      ctx->stats.dl_stream_pool_exhausted++;
+      return;
+    }
+    if (stream->num_section_ids >= MAX_SECTIONS_PER_DL_STREAM) {
+      ctx->stats.dl_stream_sections_exhausted++;
+      return;
+    }
+    stream->section_ids[stream->num_section_ids++] = section_id;
+    stream->expected_iq += section->hdr.u1.common.numPrbc == 0 ? ctx->num_prb : section->hdr.u1.common.numPrbc;
+    // comp_method/iq_width come from each U-Plane packet's own header, not the C-Plane
+    // declaration - see dl_fragment_t.
   }
 }
 
@@ -819,6 +967,14 @@ void print_packet_processor_stats(void *context)
     LOG_I(HW, "  U-Plane Duplicate Packet Errors: %lu\n", ctx->stats.uplane_err_dup);
   if (ctx->stats.uplane_missing_cplane > 0)
     LOG_I(HW, "  U-Plane Missing C-Plane Errors: %lu\n", ctx->stats.uplane_missing_cplane);
+  if (ctx->stats.dl_stream_pool_exhausted > 0)
+    LOG_I(HW, "  DL Stream Pool Exhausted Errors: %lu\n", ctx->stats.dl_stream_pool_exhausted);
+  if (ctx->stats.dl_stream_sections_exhausted > 0)
+    LOG_I(HW, "  DL Stream Sections Exhausted Errors: %lu\n", ctx->stats.dl_stream_sections_exhausted);
+  if (ctx->stats.dl_iq_streams_pool_exhausted > 0)
+    LOG_I(HW, "  DL IQ Streams Pool Exhausted Errors: %lu\n", ctx->stats.dl_iq_streams_pool_exhausted);
+  if (ctx->stats.invalid_eaxc_id > 0)
+    LOG_I(HW, "  Invalid Eaxc/Antenna ID Errors: %lu\n", ctx->stats.invalid_eaxc_id);
   if (ctx->stats.dl_tdd_mismatch + ctx->thread_safe_stats.dl_tdd_mismatch > 0)
     LOG_I(HW, "  DL TDD Mismatch Errors: %lu\n", ctx->stats.dl_tdd_mismatch + ctx->thread_safe_stats.dl_tdd_mismatch);
   if (ctx->stats.ul_tdd_mismatch + ctx->thread_safe_stats.ul_tdd_mismatch > 0)
@@ -892,11 +1048,18 @@ static void unpack_iq(c16_t *txdataF, const uint8_t *iqdata, int start_prb, int 
   }
 }
 
-void read_dl_iq(void *context, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol)
+int read_dl_iq_streams(void *context,
+                       dl_iq_stream_t *streams,
+                       uint32_t *iq_arena,
+                       int max_streams,
+                       uint64_t *hyper_frame,
+                       int *frame,
+                       int *slot,
+                       int *symbol)
 {
   oru_packet_processor_context_t *ctx = (oru_packet_processor_context_t *)context;
   if (ctx == NULL)
-    return;
+    return -1;
   dl_symbol_job_t *job;
   int ret = -1;
   while (ret != 0) {
@@ -912,27 +1075,38 @@ void read_dl_iq(void *context, uint32_t **txdataF, int nb_tx, uint64_t *hyper_fr
   *slot = (absolute_gps_symbol % num_symbols_per_frame) / NR_SYMBOLS_PER_SLOT;
   *symbol = absolute_gps_symbol % NR_SYMBOLS_PER_SLOT;
 
-  for (int aatx = 0; aatx < nb_tx; aatx++) {
-    memset(txdataF[aatx], 0, ctx->num_prb * NR_NB_SC_PER_RB * sizeof(uint32_t));
-    if (job->per_antenna[aatx].num_rx_fragments == 0) {
+  // Each fragment becomes one output stream, compact (start_prb/num_prb are metadata, not an
+  // offset into a full-band buffer).
+  int out_count = 0;
+  for (int f = 0; f < job->num_fragments; f++) {
+    dl_fragment_t *frag = &job->fragments[f];
+    if (out_count >= max_streams) {
+      // Caller-sized array too small for what this symbol actually carried - drop the rest rather
+      // than overflow. Sizing streams/iq_arena for MAX_DL_IQ_STREAMS_PER_SYMBOL avoids this.
+      LOG_W(HW, "ORU: read_dl_iq_streams() output too small (max_streams=%d) - dropping remaining fragments\n", max_streams);
+      if (frag->mbuf) {
+        rte_pktmbuf_free(frag->mbuf);
+      }
       continue;
     }
-    for (int k = 0; k < job->per_antenna[aatx].num_rx_fragments; k++) {
-      unpack_iq((c16_t *)txdataF[aatx],
-                job->per_antenna[aatx].rx_fragments[k].iq_data,
-                job->per_antenna[aatx].rx_fragments[k].start_prbc,
-                job->per_antenna[aatx].rx_fragments[k].num_prbc,
-                job->comp_method,
-                job->iq_width);
-      if (job->per_antenna[aatx].rx_fragments[k].mbuf) {
-        rte_pktmbuf_free(job->per_antenna[aatx].rx_fragments[k].mbuf);
-      }
+    dl_iq_stream_t *out = &streams[out_count];
+    out->ant_id = frag->eaxc_id;
+    out->beam_id = frag->beam_id;
+    out->start_prb = frag->start_prbc;
+    out->num_prb = frag->num_prbc;
+    out->iq = iq_arena + (size_t)out_count * ctx->num_prb * NR_NB_SC_PER_RB;
+    unpack_iq((c16_t *)out->iq, frag->iq_data, 0, frag->num_prbc, frag->comp_method, frag->iq_width);
+    if (frag->mbuf) {
+      rte_pktmbuf_free(frag->mbuf);
     }
+    out_count++;
   }
+
   ret = rte_ring_enqueue(ctx->dl_free_jobs, (void *)job);
   AssertFatal(ret == 0,
               "Failed to enqueue to ring dl_free_jobs. dl_free_jobs num_elements %d\n",
               rte_ring_count(ctx->dl_free_jobs));
+  return out_count;
 }
 
 int get_ready_job_count(void *context)

--- a/fronthaul/oru/oru_packet_processor.c
+++ b/fronthaul/oru/oru_packet_processor.c
@@ -735,6 +735,7 @@ static void handle_ul_cplane_packet(oru_packet_processor_context_t *ctx,
     ul_job->symbol = absolute_gps_symbol % 14;
     ul_job->num_symbols = num_symbols;
     ul_job->antenna_id = ant_id;
+    ul_job->beam_id = section->hdr.u.s1.beamId;
     ul_job->num_prb = section->hdr.u1.common.numPrbc == 0 ? ctx->num_prb : section->hdr.u1.common.numPrbc;
     ul_job->start_prb = section->hdr.u1.common.startPrbc;
     int ret = rte_ring_enqueue(ctx->ul_ready_jobs, (void *)ul_job);

--- a/fronthaul/oru/oru_packet_processor.h
+++ b/fronthaul/oru/oru_packet_processor.h
@@ -45,7 +45,8 @@ typedef struct {
   int slot_in_frame;
   int symbol;
   int num_symbols;
-  int antenna_id;
+  int antenna_id; // eaxc: physical RX antenna (passthrough) or beam output stream (codebook)
+  uint16_t beam_id; // beam this section was declared under (UL Rx beamforming)
   int start_prb;
   int num_prb;
 } ul_job_t;

--- a/fronthaul/oru/oru_packet_processor.h
+++ b/fronthaul/oru/oru_packet_processor.h
@@ -97,6 +97,10 @@ typedef struct {
   uint64_t ul_uplane_ota_delay_count;
 } oru_packet_processor_stats_t;
 
+// Forward-declared rather than pulling in <rte_mbuf.h>: only used here as an opaque pointer type,
+// and this header must stay includable by TUs (e.g. oru_beamforming.c) that don't otherwise need DPDK.
+struct rte_mbuf;
+
 typedef void *(*alloc_func_t)(void *io_controller);
 typedef void (*send_func_t)(void *io_controller, struct rte_mbuf **mbufs, uint32_t num_mbufs);
 

--- a/fronthaul/oru/oru_packet_processor.h
+++ b/fronthaul/oru/oru_packet_processor.h
@@ -13,12 +13,24 @@ extern "C" {
 #endif
 
 #define HIST_SIZE 64
+#define MAX_DL_IQ_STREAMS_PER_SYMBOL 32 // cap on distinct beam/PRB-run fragments returned for one DL symbol
 
 typedef struct {
   uint64_t hist[HIST_SIZE];
   int64_t sum;
   uint64_t count;
 } txrx_histogram_t;
+
+// One continuous PRB run, decompressed. read_dl_iq_streams() returns these ungrouped - more than
+// one stream can share an ant_id (multiple beams on one eaxc) or a beam_id (one beam split across
+// sections). Placing/summing into the final per-antenna buffer is the caller's job.
+typedef struct {
+  uint8_t ant_id; // RU port / eaxc this fragment targets
+  uint16_t beam_id; // beam this PRB run was declared under
+  int start_prb;
+  int num_prb;
+  uint32_t *iq; // num_prb * NR_NB_SC_PER_RB samples (same packed format as txdataF elsewhere)
+} dl_iq_stream_t;
 
 typedef struct {
   int section_id;
@@ -58,7 +70,13 @@ typedef struct {
   uint64_t uplane_err_late;
   uint64_t uplane_err_early;
   uint64_t uplane_err_dup;
+  uint64_t uplane_err_prb_range; // start_prbu/num_prbu from the wire fell outside [0, ctx->num_prb)
+  uint64_t uplane_err_short_payload; // packet payload shorter than num_prbu/iqWidth/compMeth implied
   uint64_t uplane_missing_cplane;
+  uint64_t dl_stream_pool_exhausted; // distinct (eaxc, beam) pairs for one DL symbol exceeded MAX_DL_STREAMS_PER_SYMBOL
+  uint64_t dl_stream_sections_exhausted; // sections sharing one (eaxc, beam) stream exceeded MAX_SECTIONS_PER_DL_STREAM
+  uint64_t dl_iq_streams_pool_exhausted; // PRB-run fragments for one DL symbol exceeded MAX_DL_IQ_STREAMS_PER_SYMBOL
+  uint64_t invalid_eaxc_id; // eaxc/antenna id from a C-Plane or U-Plane packet was out of MAX_ANTENNAS range
   uint64_t application_too_slow;
   uint64_t dl_tdd_mismatch;
   uint64_t ul_tdd_mismatch;
@@ -108,7 +126,17 @@ void handle_uplane_packet(void *context, void *pkt);
 void handle_cplane_packet(void *context, void *pkt);
 void print_packet_processor_stats(void *context);
 void get_packet_processor_stats(void *context, oru_packet_processor_stats_t *out_stats);
-void read_dl_iq(void *context, uint32_t **txdataF, int nb_tx, uint64_t *hyper_frame, int *frame, int *slot, int *symbol);
+// Dequeues the next ready DL symbol job into `streams`/`iq_arena` (caller-owned; iq_arena needs
+// MAX_DL_IQ_STREAMS_PER_SYMBOL * num_prb * NR_NB_SC_PER_RB uint32_t). Returns stream count
+// (0..max_streams; 0 is normal, not an error), or -1 if `context` is NULL.
+int read_dl_iq_streams(void *context,
+                       dl_iq_stream_t *streams,
+                       uint32_t *iq_arena,
+                       int max_streams,
+                       uint64_t *hyper_frame,
+                       int *frame,
+                       int *slot,
+                       int *symbol);
 int get_ready_job_count(void *context);
 int poll_ul_job(void *context, ul_job_t *job);
 void get_dl_symbol_bitmask(void *context, const uint8_t **bitmask, uint16_t *bit_length);

--- a/fronthaul/oru/tests/CMakeLists.txt
+++ b/fronthaul/oru/tests/CMakeLists.txt
@@ -37,11 +37,14 @@ target_link_libraries(test_oru_pcap PRIVATE oru_packet_processor log_headers ${d
 target_include_directories(test_oru_pcap PRIVATE ${dpdk_INCLUDE_DIRS} ${PCAP_INCLUDE_DIRS})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/run_oru_pcap_test.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-add_test(NAME test_oru_pcap_1 COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_oru_pcap_test.sh https://github.com/bpodrygajlo/openairinterface5g/releases/download/fhi72-pcaps/capture-oai-odu-4x4-273prb-truncated.pcap.xz $<TARGET_FILE:test_oru_pcap> 1090 3 1 6 4 5 9600 4 -- ${DPDK_TEST_ARGS} "--file-prefix=test_oru_pcap_1")
+add_test(NAME test_oru_pcap_1 COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_oru_pcap_test.sh https://github.com/bpodrygajlo/openairinterface5g/releases/download/fhi72-pcaps/capture-oai-odu-4x4-273prb-truncated.pcap.xz $<TARGET_FILE:test_oru_pcap> 1 1090 3 1 6 4 5 9600 4 -- ${DPDK_TEST_ARGS} "--file-prefix=test_oru_pcap_1")
 set_property(TEST test_oru_pcap_1 PROPERTY LABELS fronthaul)
 
-add_test(NAME test_oru_pcap_frag COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_oru_pcap_test.sh https://github.com/bpodrygajlo/openairinterface5g/releases/download/fhi72-pcaps/capture-oai-odu-4x4-273prb-truncated.pcap.xz $<TARGET_FILE:test_oru_pcap> 1090 3 1 6 4 5 1500 4 -- ${DPDK_TEST_ARGS} "--file-prefix=test_oru_pcap_frag")
+add_test(NAME test_oru_pcap_frag COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_oru_pcap_test.sh https://github.com/bpodrygajlo/openairinterface5g/releases/download/fhi72-pcaps/capture-oai-odu-4x4-273prb-truncated.pcap.xz $<TARGET_FILE:test_oru_pcap> 1 1090 3 1 6 4 5 1500 4 -- ${DPDK_TEST_ARGS} "--file-prefix=test_oru_pcap_frag")
 set_property(TEST test_oru_pcap_frag PROPERTY LABELS fronthaul)
+
+add_test(NAME test_oru_pcap_beamids COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_oru_pcap_test.sh https://github.com/bpodrygajlo/openairinterface5g/releases/download/fhi72-pcaps-gnb-sa-band257-132prb-2x2/fronthaul.pcap.xz $<TARGET_FILE:test_oru_pcap> 3 1146820 3 1 10 2 5 9216 0 -- ${DPDK_TEST_ARGS} "--file-prefix=test_oru_pcap_beamids")
+set_property(TEST test_oru_pcap_beamids PROPERTY LABELS fronthaul)
 
 add_dependencies(tests test_oru_pcap)
 

--- a/fronthaul/oru/tests/CMakeLists.txt
+++ b/fronthaul/oru/tests/CMakeLists.txt
@@ -22,6 +22,12 @@ add_dependencies(tests test_fh_compression)
 add_test(NAME test_fh_compression COMMAND test_fh_compression)
 set_property(TEST test_fh_compression PROPERTY LABELS fronthaul)
 
+add_executable(test_oru_beamforming test_oru_beamforming.cpp)
+target_link_libraries(test_oru_beamforming PRIVATE oru_beamforming log_headers GTest::gtest)
+add_dependencies(tests test_oru_beamforming)
+add_test(NAME test_oru_beamforming COMMAND test_oru_beamforming)
+set_property(TEST test_oru_beamforming PROPERTY LABELS fronthaul)
+
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PCAP REQUIRED libpcap)
 

--- a/fronthaul/oru/tests/test_oru_beamforming.cpp
+++ b/fronthaul/oru/tests/test_oru_beamforming.cpp
@@ -1,0 +1,253 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include <stdint.h>
+#include <string.h>
+#include "oru_beamforming.h"
+#include "openair1/PHY/TOOLS/tools_defs.h"
+#include "common/utils/nr/nr_common.h"
+#include "log.h"
+#include "common/config/config_userapi.h"
+
+// OAI Linkage Satisfiers
+void exit_function(const char *file, const char *function, const int line, const char *s, const int assertflag)
+{
+  fprintf(stderr, "Error at %s:%s:%d - %s\n", file, function, line, s ? s : "None");
+  exit(1);
+}
+configmodule_interface_t *uniqCfg = NULL;
+}
+
+#define N_RB 2
+#define N_SC (N_RB * NR_NB_SC_PER_RB)
+
+static void fill_iq(uint32_t *buf, int n_re, int16_t base)
+{
+  c16_t *iq = (c16_t *)buf;
+  for (int i = 0; i < n_re; i++) {
+    iq[i].r = (int16_t)(base + i);
+    iq[i].i = (int16_t)(base - i);
+  }
+}
+
+static void assert_zero(const c16_t *buf, int n_re)
+{
+  for (int i = 0; i < n_re; i++) {
+    EXPECT_EQ(buf[i].r, 0);
+    EXPECT_EQ(buf[i].i, 0);
+  }
+}
+
+// No codebook: placement only, but every RE still passes through the rotation multiply exactly
+// once - single stream at PRB 0, PRB 1 must stay zero, other antenna must stay zero.
+TEST(oru_beamforming, passthrough_single_stream)
+{
+  oru_codebook_t cb = {.nb_fh_streams = 0};
+  c16_t rotation = {.r = 23170, .i = 23170}; // ~45 degrees, non-trivial
+
+  uint32_t iq_buf[NR_NB_SC_PER_RB];
+  fill_iq(iq_buf, NR_NB_SC_PER_RB, 100);
+
+  dl_iq_stream_t streams[1] = {{.ant_id = 0, .beam_id = 7, .start_prb = 0, .num_prb = 1, .iq = iq_buf}};
+
+  uint32_t ant0_buf[N_SC], ant1_buf[N_SC];
+  c16_t *txDataF[2] = {(c16_t *)ant0_buf, (c16_t *)ant1_buf};
+
+  combine_dl_streams(txDataF, 2, N_SC, streams, 1, &cb, rotation);
+
+  c16_t *ant0 = (c16_t *)ant0_buf;
+  const c16_t *src = (const c16_t *)iq_buf;
+  for (int i = 0; i < NR_NB_SC_PER_RB; i++) {
+    c16_t expected = c16mulShift(src[i], rotation, 15);
+    EXPECT_EQ(ant0[i].r, expected.r);
+    EXPECT_EQ(ant0[i].i, expected.i);
+  }
+  assert_zero(ant0 + NR_NB_SC_PER_RB, NR_NB_SC_PER_RB);
+  assert_zero((c16_t *)ant1_buf, N_SC);
+}
+
+// Two streams on the same antenna, disjoint PRBs: both get placed at their own offset.
+TEST(oru_beamforming, passthrough_multi_stream_placement)
+{
+  oru_codebook_t cb = {.nb_fh_streams = 0};
+  c16_t rotation = {.r = 32767, .i = 0}; // ~identity, exercises the multiply without complicating expected values
+
+  uint32_t iq_a[NR_NB_SC_PER_RB], iq_b[NR_NB_SC_PER_RB];
+  fill_iq(iq_a, NR_NB_SC_PER_RB, 10);
+  fill_iq(iq_b, NR_NB_SC_PER_RB, -40);
+
+  dl_iq_stream_t streams[2] = {
+      {.ant_id = 0, .beam_id = 1, .start_prb = 0, .num_prb = 1, .iq = iq_a},
+      {.ant_id = 0, .beam_id = 2, .start_prb = 1, .num_prb = 1, .iq = iq_b},
+  };
+
+  uint32_t ant0_buf[N_SC];
+  c16_t *txDataF[1] = {(c16_t *)ant0_buf};
+
+  combine_dl_streams(txDataF, 1, N_SC, streams, 2, &cb, rotation);
+
+  c16_t *ant0 = (c16_t *)ant0_buf;
+  for (int i = 0; i < NR_NB_SC_PER_RB; i++) {
+    c16_t exp_a = c16mulShift(((c16_t *)iq_a)[i], rotation, 15);
+    c16_t exp_b = c16mulShift(((c16_t *)iq_b)[i], rotation, 15);
+    EXPECT_EQ(ant0[i].r, exp_a.r);
+    EXPECT_EQ(ant0[i].i, exp_a.i);
+    EXPECT_EQ(ant0[NR_NB_SC_PER_RB + i].r, exp_b.r);
+    EXPECT_EQ(ant0[NR_NB_SC_PER_RB + i].i, exp_b.i);
+  }
+}
+
+// Codebook mode: one logical stream weight-combined onto two antennas with different weight
+// vectors, with rotation folded into each weight.
+TEST(oru_beamforming, codebook_single_stream_two_antennas)
+{
+  oru_codebook_t cb = {0};
+  cb.nb_fh_streams = 1;
+  cb.nb_beams = 1;
+  cb.w[0][0][0] = (c16_t){.r = 20000, .i = 5000};
+  cb.w[0][1][0] = (c16_t){.r = -8000, .i = 15000};
+  c16_t rotation = {.r = 23170, .i = -23170};
+
+  uint32_t iq_buf[NR_NB_SC_PER_RB];
+  fill_iq(iq_buf, NR_NB_SC_PER_RB, 200);
+  dl_iq_stream_t streams[1] = {{.ant_id = 0, .beam_id = 0, .start_prb = 0, .num_prb = 1, .iq = iq_buf}};
+
+  uint32_t ant0_buf[N_SC], ant1_buf[N_SC];
+  c16_t *txDataF[2] = {(c16_t *)ant0_buf, (c16_t *)ant1_buf};
+
+  combine_dl_streams(txDataF, 2, N_SC, streams, 1, &cb, rotation);
+
+  const c16_t *src = (const c16_t *)iq_buf;
+  c16_t *ant0 = (c16_t *)ant0_buf;
+  c16_t *ant1 = (c16_t *)ant1_buf;
+  c16_t w0_rot = c16mulShift(cb.w[0][0][0], rotation, 15);
+  c16_t w1_rot = c16mulShift(cb.w[0][1][0], rotation, 15);
+  for (int i = 0; i < NR_NB_SC_PER_RB; i++) {
+    c16_t exp0 = c16mulShift(src[i], w0_rot, 15);
+    c16_t exp1 = c16mulShift(src[i], w1_rot, 15);
+    EXPECT_EQ(ant0[i].r, exp0.r);
+    EXPECT_EQ(ant0[i].i, exp0.i);
+    EXPECT_EQ(ant1[i].r, exp1.r);
+    EXPECT_EQ(ant1[i].i, exp1.i);
+  }
+  assert_zero(ant0 + NR_NB_SC_PER_RB, NR_NB_SC_PER_RB);
+  assert_zero(ant1 + NR_NB_SC_PER_RB, NR_NB_SC_PER_RB);
+}
+
+// Sub-band beam switching: one stream, two PRB ranges, two beams - each range keeps its own weight.
+TEST(oru_beamforming, codebook_sub_band_beam_switch)
+{
+  oru_codebook_t cb = {0};
+  cb.nb_fh_streams = 1;
+  cb.nb_beams = 2;
+  cb.w[0][0][0] = (c16_t){.r = 30000, .i = 0};
+  cb.w[1][0][0] = (c16_t){.r = 0, .i = 30000};
+  c16_t rotation = {.r = 32767, .i = 0};
+
+  uint32_t iq_a[NR_NB_SC_PER_RB], iq_b[NR_NB_SC_PER_RB];
+  fill_iq(iq_a, NR_NB_SC_PER_RB, 50);
+  fill_iq(iq_b, NR_NB_SC_PER_RB, 50); // same source pattern - only the weight/beam differs
+
+  dl_iq_stream_t streams[2] = {
+      {.ant_id = 0, .beam_id = 0, .start_prb = 0, .num_prb = 1, .iq = iq_a},
+      {.ant_id = 0, .beam_id = 1, .start_prb = 1, .num_prb = 1, .iq = iq_b},
+  };
+
+  uint32_t ant0_buf[N_SC];
+  c16_t *txDataF[1] = {(c16_t *)ant0_buf};
+  combine_dl_streams(txDataF, 1, N_SC, streams, 2, &cb, rotation);
+
+  c16_t *ant0 = (c16_t *)ant0_buf;
+  c16_t w0_rot = c16mulShift(cb.w[0][0][0], rotation, 15);
+  c16_t w1_rot = c16mulShift(cb.w[1][0][0], rotation, 15);
+  for (int i = 0; i < NR_NB_SC_PER_RB; i++) {
+    c16_t exp_lo = c16mulShift(((c16_t *)iq_a)[i], w0_rot, 15);
+    c16_t exp_hi = c16mulShift(((c16_t *)iq_b)[i], w1_rot, 15);
+    EXPECT_EQ(ant0[i].r, exp_lo.r);
+    EXPECT_EQ(ant0[i].i, exp_lo.i);
+    EXPECT_EQ(ant0[NR_NB_SC_PER_RB + i].r, exp_hi.r);
+    EXPECT_EQ(ant0[NR_NB_SC_PER_RB + i].i, exp_hi.i);
+  }
+  // The two beams' weights are different (real-only vs imaginary-only), so unless sub-band
+  // switching actually worked, the low/high PRB halves would be identical - assert they differ.
+  EXPECT_NE(memcmp(ant0, ant0 + NR_NB_SC_PER_RB, NR_NB_SC_PER_RB * sizeof(c16_t)), 0);
+}
+
+// Two logical streams contributing to the SAME PRB range of the same physical antenna: their
+// weighted contributions must accumulate (spatial combination), not overwrite each other.
+TEST(oru_beamforming, codebook_stream_accumulation)
+{
+  oru_codebook_t cb = {0};
+  cb.nb_fh_streams = 2;
+  cb.nb_beams = 1;
+  cb.w[0][0][0] = (c16_t){.r = 15000, .i = 0};
+  cb.w[0][0][1] = (c16_t){.r = 10000, .i = 0};
+  c16_t rotation = {.r = 32767, .i = 0};
+
+  uint32_t iq_a[NR_NB_SC_PER_RB], iq_b[NR_NB_SC_PER_RB];
+  fill_iq(iq_a, NR_NB_SC_PER_RB, 300);
+  fill_iq(iq_b, NR_NB_SC_PER_RB, -100);
+
+  dl_iq_stream_t streams[2] = {
+      {.ant_id = 0, .beam_id = 0, .start_prb = 0, .num_prb = 1, .iq = iq_a},
+      {.ant_id = 1, .beam_id = 0, .start_prb = 0, .num_prb = 1, .iq = iq_b},
+  };
+
+  uint32_t ant0_buf[N_SC];
+  c16_t *txDataF[1] = {(c16_t *)ant0_buf};
+  combine_dl_streams(txDataF, 1, N_SC, streams, 2, &cb, rotation);
+
+  c16_t *ant0 = (c16_t *)ant0_buf;
+  c16_t wa_rot = c16mulShift(cb.w[0][0][0], rotation, 15);
+  c16_t wb_rot = c16mulShift(cb.w[0][0][1], rotation, 15);
+  for (int i = 0; i < NR_NB_SC_PER_RB; i++) {
+    c16_t term_a = c16mulShift(((c16_t *)iq_a)[i], wa_rot, 15);
+    c16_t term_b = c16mulShift(((c16_t *)iq_b)[i], wb_rot, 15);
+    EXPECT_EQ(ant0[i].r, (int16_t)(term_a.r + term_b.r));
+    EXPECT_EQ(ant0[i].i, (int16_t)(term_a.i + term_b.i));
+  }
+}
+
+// Out-of-range ant_id (>= nb_fh_streams) is dropped entirely; out-of-range beam_id falls back to
+// beam 0 rather than indexing out of bounds.
+TEST(oru_beamforming, codebook_out_of_range_fallbacks)
+{
+  oru_codebook_t cb = {0};
+  cb.nb_fh_streams = 1;
+  cb.nb_beams = 1;
+  cb.w[0][0][0] = (c16_t){.r = 32767, .i = 0};
+  c16_t rotation = {.r = 32767, .i = 0};
+
+  uint32_t iq_dropped[NR_NB_SC_PER_RB], iq_fallback[NR_NB_SC_PER_RB];
+  fill_iq(iq_dropped, NR_NB_SC_PER_RB, 500);
+  fill_iq(iq_fallback, NR_NB_SC_PER_RB, 500);
+
+  dl_iq_stream_t streams[2] = {
+      {.ant_id = 5, .beam_id = 0, .start_prb = 0, .num_prb = 1, .iq = iq_dropped}, // ant_id out of range
+      {.ant_id = 0, .beam_id = 99, .start_prb = 0, .num_prb = 1, .iq = iq_fallback}, // beam_id out of range -> beam 0
+  };
+
+  uint32_t ant0_buf[N_SC];
+  c16_t *txDataF[1] = {(c16_t *)ant0_buf};
+  combine_dl_streams(txDataF, 1, N_SC, streams, 2, &cb, rotation);
+
+  c16_t *ant0 = (c16_t *)ant0_buf;
+  c16_t w_rot = c16mulShift(cb.w[0][0][0], rotation, 15);
+  for (int i = 0; i < NR_NB_SC_PER_RB; i++) {
+    // Only the second stream (falling back to beam 0) should have contributed.
+    c16_t expected = c16mulShift(((c16_t *)iq_fallback)[i], w_rot, 15);
+    EXPECT_EQ(ant0[i].r, expected.r);
+    EXPECT_EQ(ant0[i].i, expected.i);
+  }
+}
+
+int main(int argc, char **argv)
+{
+  logInit();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/fronthaul/oru/tests/test_oru_beamforming.cpp
+++ b/fronthaul/oru/tests/test_oru_beamforming.cpp
@@ -245,6 +245,89 @@ TEST(oru_beamforming, codebook_out_of_range_fallbacks)
   }
 }
 
+// UL Rx beamforming: per-antenna FFT output combined into one beam stream in the frequency
+// domain, out[k] = w[0]*X0[k] + w[1]*X1[k], the same saturating multiply-accumulate as the DL
+// codebook path. The inputs are FFT windows (what nr_symbol_fep_ul() produces per antenna).
+TEST(oru_beamforming, ul_combine_two_antennas)
+{
+  oru_codebook_t cb = {0};
+  cb.nb_fh_streams = 1;
+  cb.nb_beams = 1;
+  cb.w[0][0][0] = (c16_t){.r = 20000, .i = 5000};
+  cb.w[0][1][0] = (c16_t){.r = -8000, .i = 15000};
+
+  uint32_t buf0[N_SC], buf1[N_SC];
+  fill_iq(buf0, N_SC, 100);
+  fill_iq(buf1, N_SC, -50);
+  const c16_t *fft[2] = {(c16_t *)buf0, (c16_t *)buf1};
+  c16_t out[N_SC];
+  combine_ul_beam_fd(fft, 2, N_SC, &cb, 0, 0, out);
+
+  for (int i = 0; i < N_SC; i++) {
+    c16_t term0 = c16mulShift(((c16_t *)buf0)[i], cb.w[0][0][0], 15);
+    c16_t term1 = c16mulShift(((c16_t *)buf1)[i], cb.w[0][1][0], 15);
+    EXPECT_EQ(out[i].r, (int16_t)(term0.r + term1.r));
+    EXPECT_EQ(out[i].i, (int16_t)(term0.i + term1.i));
+  }
+}
+
+// Two beams from the same antennas: each gets its own weight vector, so the outputs differ
+// even though the FFT input is identical (sub-band beam switching in UL is the same machinery
+// at the job level - one beam per C-plane section).
+TEST(oru_beamforming, ul_combine_two_beams)
+{
+  oru_codebook_t cb = {0};
+  cb.nb_fh_streams = 1;
+  cb.nb_beams = 2;
+  cb.w[0][0][0] = (c16_t){.r = 32767, .i = 0};
+  cb.w[1][0][0] = (c16_t){.r = 20000, .i = 10000};
+
+  uint32_t buf[N_SC];
+  fill_iq(buf, N_SC, 300);
+  const c16_t *fft[1] = {(c16_t *)buf};
+
+  c16_t out0[N_SC], out1[N_SC];
+  combine_ul_beam_fd(fft, 1, N_SC, &cb, 0, 0, out0);
+  combine_ul_beam_fd(fft, 1, N_SC, &cb, 1, 0, out1);
+
+  for (int i = 0; i < N_SC; i++) {
+    c16_t exp0 = c16mulShift(((c16_t *)buf)[i], cb.w[0][0][0], 15);
+    c16_t exp1 = c16mulShift(((c16_t *)buf)[i], cb.w[1][0][0], 15);
+    EXPECT_EQ(out0[i].r, exp0.r);
+    EXPECT_EQ(out0[i].i, exp0.i);
+    EXPECT_EQ(out1[i].r, exp1.r);
+    EXPECT_EQ(out1[i].i, exp1.i);
+  }
+  EXPECT_NE(memcmp(out0, out1, N_SC * sizeof(c16_t)), 0);
+}
+
+// Stream index (the section's eaxc in codebook mode) out of range is dropped to silence; beam_id
+// out of range falls back to beam 0, mirroring the DL behavior.
+TEST(oru_beamforming, ul_combine_fallbacks)
+{
+  oru_codebook_t cb = {0};
+  cb.nb_fh_streams = 1;
+  cb.nb_beams = 2;
+  cb.w[0][0][0] = (c16_t){.r = 32767, .i = 0};
+  cb.w[1][0][0] = (c16_t){.r = 20000, .i = 10000};
+
+  uint32_t buf[N_SC];
+  fill_iq(buf, N_SC, 300);
+  const c16_t *fft[1] = {(c16_t *)buf};
+
+  c16_t out_zero[N_SC];
+  combine_ul_beam_fd(fft, 1, N_SC, &cb, 0, 5, out_zero); // stream out of range
+  assert_zero(out_zero, N_SC);
+
+  c16_t out_beam[N_SC];
+  combine_ul_beam_fd(fft, 1, N_SC, &cb, 99, 0, out_beam); // beam out of range
+  for (int i = 0; i < N_SC; i++) {
+    c16_t expected = c16mulShift(((c16_t *)buf)[i], cb.w[0][0][0], 15);
+    EXPECT_EQ(out_beam[i].r, expected.r);
+    EXPECT_EQ(out_beam[i].i, expected.i);
+  }
+}
+
 int main(int argc, char **argv)
 {
   logInit();

--- a/fronthaul/oru/tests/test_oru_fh.c
+++ b/fronthaul/oru/tests/test_oru_fh.c
@@ -100,8 +100,8 @@ int main(int argc, char **argv)
   assert(s < (10 << cfg.numerology));
 
   printf("Running live loop for 2 seconds...\n");
-  uint32_t *txData[1];
-  txData[0] = malloc(273 * 12 * sizeof(uint32_t));
+  dl_iq_stream_t dl_streams[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  uint32_t *iq_arena = malloc(MAX_DL_IQ_STREAMS_PER_SYMBOL * 273 * 12 * sizeof(uint32_t));
   for (int i = 0; i < 2000; i++) {
 
     uint64_t start_cycles = rte_get_timer_cycles();
@@ -110,11 +110,11 @@ int main(int argc, char **argv)
       int f, s, sym;
       uint64_t hf;
       while (oru_fh_get_ready_jobs(handle) > 0) {
-        oru_fh_tx_read_symbol(handle, txData, 1, &hf, &f, &s, &sym);
+        oru_fh_tx_read_symbol(handle, dl_streams, iq_arena, MAX_DL_IQ_STREAMS_PER_SYMBOL, &hf, &f, &s, &sym);
       }
     }
   }
-  free(txData[0]);
+  free(iq_arena);
 
   printf("Stopping ORU_FH...\n");
   oru_fh_stop(handle);

--- a/fronthaul/oru/tests/test_oru_packet_processor.c
+++ b/fronthaul/oru/tests/test_oru_packet_processor.c
@@ -75,6 +75,40 @@ void test_send_mbuf(void *io_controller, struct rte_mbuf **mbufs, uint32_t num_m
   }
 }
 
+// Places/sums read_dl_iq_streams()'s raw output into txdataF, and picks a representative
+// beam_id per antenna (largest PRB coverage) for tests that check it.
+static void test_assemble_streams(uint32_t **txdataF,
+                                  int nb_tx,
+                                  int num_prb,
+                                  const dl_iq_stream_t *streams,
+                                  int num_streams,
+                                  uint16_t *beam_ids)
+{
+  for (int a = 0; a < nb_tx; a++) {
+    memset(txdataF[a], 0, num_prb * 12 * sizeof(uint32_t));
+  }
+  int best_num_prb[nb_tx];
+  memset(best_num_prb, 0, sizeof(best_num_prb));
+  if (beam_ids) {
+    memset(beam_ids, 0, nb_tx * sizeof(*beam_ids));
+  }
+  for (int i = 0; i < num_streams; i++) {
+    const dl_iq_stream_t *s = &streams[i];
+    if (s->ant_id >= (unsigned)nb_tx) {
+      continue;
+    }
+    int16_t *dst = (int16_t *)&txdataF[s->ant_id][s->start_prb * 12];
+    const int16_t *src = (const int16_t *)s->iq;
+    for (int j = 0; j < s->num_prb * 12 * 2; j++) {
+      dst[j] += src[j];
+    }
+    if (beam_ids && s->num_prb > best_num_prb[s->ant_id]) {
+      best_num_prb[s->ant_id] = s->num_prb;
+      beam_ids[s->ant_id] = s->beam_id;
+    }
+  }
+}
+
 void test_init_cleanup()
 {
   printf("Testing init and cleanup...\n");
@@ -234,6 +268,7 @@ void test_cplane_uplane_match()
       (struct xran_cp_radioapp_section1 *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_cp_radioapp_section1));
   memset(sec, 0, sizeof(*sec));
   sec->hdr.u.s1.numSymbol = 1;
+  sec->hdr.u.s1.beamId = 37;
   sec->hdr.u1.common.numPrbc = 1;
   *((uint64_t *)sec) = rte_be_to_cpu_64(*((uint64_t *)sec));
 
@@ -296,11 +331,16 @@ void test_cplane_uplane_match()
 
   int frame, slot, symbol;
   uint64_t hyper_frame;
+  uint16_t beam_ids[1] = {0};
+  dl_iq_stream_t dl_streams[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  uint32_t dl_iq_arena[MAX_DL_IQ_STREAMS_PER_SYMBOL * 273 * 12];
   do {
-    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol);
-  } while (!(frame == (target_sym / num_symbols_per_frame) % 1024 && symbol == target_sym % 14));
+    int n = read_dl_iq_streams(ctx, dl_streams, dl_iq_arena, MAX_DL_IQ_STREAMS_PER_SYMBOL, &hyper_frame, &frame, &slot, &symbol);
+    test_assemble_streams(txdataF, 1, 273, dl_streams, n, beam_ids);
+  } while (!(frame == (target_sym / num_symbols_per_frame) % 1024 && slot == slot_in_frame && symbol == target_sym % 14));
 
   assert(symbol == target_sym % 14);
+  assert(beam_ids[0] == 37);
   uint16_t *out_iq = (uint16_t *)output_iq;
   assert(out_iq[0] == 0x00FF);
   assert(out_iq[1] == 0x11EE);
@@ -309,6 +349,319 @@ void test_cplane_uplane_match()
 
   cleanup_packet_processor(ctx);
   printf("C-Plane / U-Plane match passed!\n");
+}
+
+// start_prbu/num_prbu are wire-controlled. combine_dl_streams() later writes num_prb PRBs at
+// start_prb into a txDataF buffer sized for ctx->num_prb PRBs - a packet claiming a range beyond
+// ctx->num_prb must be rejected up front, not handed through to that write.
+void test_uplane_prb_range_rejected()
+{
+  printf("Testing U-Plane PRB range rejection...\n");
+  int mu = 1;
+  void *ctx = init_packet_processor(mu, 273, 200, 400, 100, 300, 2, 2, 0, 0, 5, test_alloc_mbuf, test_send_mbuf, NULL, 1500, 0, FH_COMP_NONE, 0);
+  assert(ctx != NULL);
+
+  uint64_t current_sym = 1000;
+  handle_absolute_symbol_tick(ctx, current_sym);
+
+  struct rte_mbuf *u_mbuf = rte_pktmbuf_alloc(mp);
+  struct xran_ecpri_hdr *u_ecpri = (struct xran_ecpri_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct xran_ecpri_hdr));
+  u_ecpri->ecpri_xtc_id = xran_compose_cid(&g_eaxcid_config, 0, 0, 0, 0); // Ant 0
+
+  struct radio_app_common_hdr *u_app =
+      (struct radio_app_common_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct radio_app_common_hdr));
+  u_app->frame_id = 0;
+  u_app->sf_slot_sym.symb_id = 0;
+  u_app->sf_slot_sym.value = rte_cpu_to_be_16(u_app->sf_slot_sym.value);
+
+  struct data_section_hdr *u_data = (struct data_section_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct data_section_hdr));
+  u_data->fields.num_prbu = 10; // 270 + 10 = 280 > ctx->num_prb (273)
+  u_data->fields.start_prbu = 270;
+  u_data->fields.sect_id = 0;
+  u_data->fields.all_bits = rte_cpu_to_be_32(u_data->fields.all_bits);
+
+  uint16_t *iq = (uint16_t *)rte_pktmbuf_append(u_mbuf, 10 * 12 * 4);
+  assert(iq != NULL);
+  memset(iq, 0, 10 * 12 * 4);
+
+  handle_uplane_packet(ctx, u_mbuf);
+
+  oru_packet_processor_stats_t stats;
+  get_packet_processor_stats(ctx, &stats);
+  assert(stats.uplane_err_prb_range == 1);
+  assert(stats.uplane_missing_cplane == 0); // rejected before the C-Plane stream lookup even ran
+  assert(stats.uplane_err_short_payload == 0);
+
+  cleanup_packet_processor(ctx);
+  printf("U-Plane PRB range rejection passed!\n");
+}
+
+// xran_extract_iq_samples() returns the packet length still remaining after stripping headers -
+// a truncated packet (fewer bytes than num_prbu/iqWidth/compMeth implies) must be rejected before
+// its iq_data pointer is handed off to the deferred unpack_iq() in read_dl_iq_streams().
+void test_uplane_short_payload_rejected()
+{
+  printf("Testing U-Plane short payload rejection...\n");
+  int mu = 1;
+  void *ctx = init_packet_processor(mu, 273, 200, 400, 100, 300, 2, 2, 0, 0, 5, test_alloc_mbuf, test_send_mbuf, NULL, 1500, 0, FH_COMP_NONE, 0);
+  assert(ctx != NULL);
+
+  uint64_t current_sym = 1000;
+  handle_absolute_symbol_tick(ctx, current_sym);
+
+  struct rte_mbuf *u_mbuf = rte_pktmbuf_alloc(mp);
+  struct xran_ecpri_hdr *u_ecpri = (struct xran_ecpri_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct xran_ecpri_hdr));
+  u_ecpri->ecpri_xtc_id = xran_compose_cid(&g_eaxcid_config, 0, 0, 0, 0); // Ant 0
+
+  struct radio_app_common_hdr *u_app =
+      (struct radio_app_common_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct radio_app_common_hdr));
+  u_app->frame_id = 0;
+  u_app->sf_slot_sym.symb_id = 0;
+  u_app->sf_slot_sym.value = rte_cpu_to_be_16(u_app->sf_slot_sym.value);
+
+  struct data_section_hdr *u_data = (struct data_section_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct data_section_hdr));
+  u_data->fields.num_prbu = 1; // uncompressed 1 PRB needs 12 * 2 * sizeof(uint16_t) = 48 bytes
+  u_data->fields.start_prbu = 0;
+  u_data->fields.sect_id = 0;
+  u_data->fields.all_bits = rte_cpu_to_be_32(u_data->fields.all_bits);
+
+  // Only 8 of the required 48 bytes present - truncated packet.
+  uint16_t *iq = (uint16_t *)rte_pktmbuf_append(u_mbuf, 8);
+  assert(iq != NULL);
+  memset(iq, 0, 8);
+
+  handle_uplane_packet(ctx, u_mbuf);
+
+  oru_packet_processor_stats_t stats;
+  get_packet_processor_stats(ctx, &stats);
+  assert(stats.uplane_err_short_payload == 1);
+  assert(stats.uplane_err_prb_range == 0);
+  assert(stats.uplane_missing_cplane == 0);
+
+  cleanup_packet_processor(ctx);
+  printf("U-Plane short payload rejection passed!\n");
+}
+
+// Two C-Plane sections for one beam (disjoint PRB ranges) must merge into one stream. A repeated
+// section_id is rejected as a duplicate. A third section with a *different* beam on the same eaxc
+// (sub-band precoding) is accepted as a genuinely separate stream, not merged or rejected.
+void test_dl_multi_section_same_beam()
+{
+  printf("Testing DL multi-section same-beam merge...\n");
+  int mu = 1; // 30kHz
+  int slots_per_subframe = 1 << mu;
+  void *ctx = init_packet_processor(mu,
+                                    273,
+                                    200,
+                                    400,
+                                    100,
+                                    300,
+                                    2,
+                                    2,
+                                    0,
+                                    0,
+                                    5,
+                                    test_alloc_mbuf,
+                                    test_send_mbuf,
+                                    NULL,
+                                    1500,
+                                    0,
+                                    FH_COMP_NONE,
+                                    0);
+  assert(ctx != NULL);
+
+  uint64_t current_sym = 1000;
+  handle_absolute_symbol_tick(ctx, current_sym);
+
+  uint64_t target_sym = current_sym + 7;
+  int num_symbols_per_frame = 10 * slots_per_subframe * 14;
+  int frameId = (target_sym / num_symbols_per_frame) % 256;
+  int slot_in_frame = (target_sym % num_symbols_per_frame) / 14;
+  int subframeId = slot_in_frame / slots_per_subframe;
+  int slotId = slot_in_frame % slots_per_subframe;
+  int startSymbolId = target_sym % 14;
+  const uint16_t beam_id = 42;
+
+  // Two C-Plane sections for the same eaxc/beam, disjoint PRB ranges, distinct sectionId.
+  int section_ids[2] = {0, 1};
+  int start_prbc[2] = {0, 10};
+  int num_prbc[2] = {10, 10};
+  for (int i = 0; i < 2; i++) {
+    struct rte_mbuf *c_mbuf = rte_pktmbuf_alloc(mp);
+    struct xran_ecpri_hdr *ecpri = (struct xran_ecpri_hdr *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_ecpri_hdr));
+    ecpri->ecpri_xtc_id = xran_compose_cid(&g_eaxcid_config, 0, 0, 0, 0);
+
+    struct xran_cp_radioapp_section1_header *apphdr =
+        (struct xran_cp_radioapp_section1_header *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_cp_radioapp_section1_header));
+    memset(apphdr, 0, sizeof(*apphdr));
+    apphdr->cmnhdr.field.dataDirection = XRAN_DIR_DL;
+    apphdr->cmnhdr.field.payloadVer = XRAN_PAYLOAD_VER;
+    apphdr->cmnhdr.field.frameId = frameId;
+    apphdr->cmnhdr.field.subframeId = subframeId;
+    apphdr->cmnhdr.field.slotId = slotId;
+    apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+    apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
+    apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
+
+    struct xran_cp_radioapp_section1 *sec =
+        (struct xran_cp_radioapp_section1 *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_cp_radioapp_section1));
+    memset(sec, 0, sizeof(*sec));
+    sec->hdr.u.s1.numSymbol = 1;
+    sec->hdr.u.s1.beamId = beam_id;
+    sec->hdr.u1.common.sectionId = section_ids[i];
+    sec->hdr.u1.common.startPrbc = start_prbc[i];
+    sec->hdr.u1.common.numPrbc = num_prbc[i];
+    *((uint64_t *)sec) = rte_be_to_cpu_64(*((uint64_t *)sec));
+    handle_cplane_packet(ctx, c_mbuf);
+  }
+
+  // Re-declaring sectionId 0 must be rejected as a duplicate, not merged as a third section.
+  {
+    struct rte_mbuf *c_mbuf = rte_pktmbuf_alloc(mp);
+    struct xran_ecpri_hdr *ecpri = (struct xran_ecpri_hdr *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_ecpri_hdr));
+    ecpri->ecpri_xtc_id = xran_compose_cid(&g_eaxcid_config, 0, 0, 0, 0);
+
+    struct xran_cp_radioapp_section1_header *apphdr =
+        (struct xran_cp_radioapp_section1_header *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_cp_radioapp_section1_header));
+    memset(apphdr, 0, sizeof(*apphdr));
+    apphdr->cmnhdr.field.dataDirection = XRAN_DIR_DL;
+    apphdr->cmnhdr.field.payloadVer = XRAN_PAYLOAD_VER;
+    apphdr->cmnhdr.field.frameId = frameId;
+    apphdr->cmnhdr.field.subframeId = subframeId;
+    apphdr->cmnhdr.field.slotId = slotId;
+    apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+    apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
+    apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
+
+    struct xran_cp_radioapp_section1 *sec =
+        (struct xran_cp_radioapp_section1 *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_cp_radioapp_section1));
+    memset(sec, 0, sizeof(*sec));
+    sec->hdr.u.s1.numSymbol = 1;
+    sec->hdr.u.s1.beamId = beam_id;
+    sec->hdr.u1.common.sectionId = 0;
+    sec->hdr.u1.common.startPrbc = 0;
+    sec->hdr.u1.common.numPrbc = 10;
+    *((uint64_t *)sec) = rte_be_to_cpu_64(*((uint64_t *)sec));
+    handle_cplane_packet(ctx, c_mbuf);
+  }
+
+  const uint16_t beam_id2 = beam_id + 1;
+  // A third section for the same eaxc, new sectionId, a *different* beamId, and a disjoint PRB
+  // range - accepted as a genuinely separate stream (sub-band precoding), not rejected.
+  {
+    struct rte_mbuf *c_mbuf = rte_pktmbuf_alloc(mp);
+    struct xran_ecpri_hdr *ecpri = (struct xran_ecpri_hdr *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_ecpri_hdr));
+    ecpri->ecpri_xtc_id = xran_compose_cid(&g_eaxcid_config, 0, 0, 0, 0);
+
+    struct xran_cp_radioapp_section1_header *apphdr =
+        (struct xran_cp_radioapp_section1_header *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_cp_radioapp_section1_header));
+    memset(apphdr, 0, sizeof(*apphdr));
+    apphdr->cmnhdr.field.dataDirection = XRAN_DIR_DL;
+    apphdr->cmnhdr.field.payloadVer = XRAN_PAYLOAD_VER;
+    apphdr->cmnhdr.field.frameId = frameId;
+    apphdr->cmnhdr.field.subframeId = subframeId;
+    apphdr->cmnhdr.field.slotId = slotId;
+    apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+    apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
+    apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
+
+    struct xran_cp_radioapp_section1 *sec =
+        (struct xran_cp_radioapp_section1 *)rte_pktmbuf_append(c_mbuf, sizeof(struct xran_cp_radioapp_section1));
+    memset(sec, 0, sizeof(*sec));
+    sec->hdr.u.s1.numSymbol = 1;
+    sec->hdr.u.s1.beamId = beam_id2;
+    sec->hdr.u1.common.sectionId = 2; // new sectionId, not a duplicate
+    sec->hdr.u1.common.startPrbc = 20;
+    sec->hdr.u1.common.numPrbc = 10;
+    *((uint64_t *)sec) = rte_be_to_cpu_64(*((uint64_t *)sec));
+    handle_cplane_packet(ctx, c_mbuf);
+  }
+
+  oru_packet_processor_stats_t stats;
+  get_packet_processor_stats(ctx, &stats);
+  assert(stats.cplane_err_dup == 1);
+  assert(stats.cplane_err_dup_dl == 1);
+  assert(stats.dl_stream_pool_exhausted == 0);
+  assert(stats.dl_stream_sections_exhausted == 0);
+
+  current_sym += 3;
+  handle_absolute_symbol_tick(ctx, current_sym);
+
+  // Three U-Plane packets: two for beam_id's merged sections, one for beam_id2's separate section.
+  int all_section_ids[3] = {section_ids[0], section_ids[1], 2};
+  int all_start_prbc[3] = {start_prbc[0], start_prbc[1], 20};
+  int all_num_prbc[3] = {num_prbc[0], num_prbc[1], 10};
+  uint16_t patterns[3] = {0x1111, 0x2222, 0x3333};
+  for (int i = 0; i < 3; i++) {
+    struct rte_mbuf *u_mbuf = rte_pktmbuf_alloc(mp);
+    struct xran_ecpri_hdr *u_ecpri = (struct xran_ecpri_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct xran_ecpri_hdr));
+    u_ecpri->ecpri_xtc_id = xran_compose_cid(&g_eaxcid_config, 0, 0, 0, 0);
+
+    struct radio_app_common_hdr *u_app =
+        (struct radio_app_common_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct radio_app_common_hdr));
+    u_app->frame_id = frameId;
+    u_app->sf_slot_sym.subframe_id = subframeId;
+    u_app->sf_slot_sym.slot_id = slotId;
+    u_app->sf_slot_sym.symb_id = startSymbolId;
+    u_app->sf_slot_sym.value = rte_cpu_to_be_16(u_app->sf_slot_sym.value);
+
+    struct data_section_hdr *u_data = (struct data_section_hdr *)rte_pktmbuf_append(u_mbuf, sizeof(struct data_section_hdr));
+    u_data->fields.num_prbu = all_num_prbc[i];
+    u_data->fields.start_prbu = all_start_prbc[i];
+    u_data->fields.sect_id = all_section_ids[i];
+    u_data->fields.all_bits = rte_cpu_to_be_32(u_data->fields.all_bits);
+
+    uint16_t *iq = (uint16_t *)rte_pktmbuf_append(u_mbuf, all_num_prbc[i] * 12 * 4);
+    assert(iq != NULL);
+    for (int j = 0; j < all_num_prbc[i] * 12 * 2; j++) {
+      iq[j] = rte_cpu_to_be_16(patterns[i]);
+    }
+
+    handle_uplane_packet(ctx, u_mbuf);
+  }
+
+  get_packet_processor_stats(ctx, &stats);
+  assert(stats.uplane_err_early == 0);
+  assert(stats.uplane_err_late == 0);
+  assert(stats.uplane_missing_cplane == 0);
+
+  current_sym += 10;
+  handle_absolute_symbol_tick(ctx, current_sym);
+
+  uint32_t *txdataF[4] = {0};
+  uint32_t output_iq[273 * 12] = {0};
+  txdataF[0] = output_iq;
+
+  int frame, slot, symbol;
+  uint64_t hyper_frame;
+  uint16_t beam_ids[1] = {0};
+  dl_iq_stream_t dl_streams[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  uint32_t dl_iq_arena[MAX_DL_IQ_STREAMS_PER_SYMBOL * 273 * 12];
+  do {
+    int n = read_dl_iq_streams(ctx, dl_streams, dl_iq_arena, MAX_DL_IQ_STREAMS_PER_SYMBOL, &hyper_frame, &frame, &slot, &symbol);
+    test_assemble_streams(txdataF, 1, 273, dl_streams, n, beam_ids);
+  } while (!(frame == frameId && slot == slot_in_frame && symbol == startSymbolId));
+
+  // beam_id covers 20 PRBs total (2 merged sections) vs. beam_id2's 10 - the representative beam
+  // for a single-beam-per-antenna consumer must be the larger one.
+  assert(beam_ids[0] == beam_id);
+  uint16_t *out_iq = (uint16_t *)output_iq;
+  for (int prb = 0; prb < 30; prb++) {
+    uint16_t expected = prb < 10 ? patterns[0] : prb < 20 ? patterns[1] : patterns[2];
+    for (int sc = 0; sc < 12; sc++) {
+      int idx = prb * 12 + sc;
+      assert(out_iq[2 * idx] == expected);
+      assert(out_iq[2 * idx + 1] == expected);
+    }
+  }
+
+  get_packet_processor_stats(ctx, &stats);
+  assert(stats.dl_stream_pool_exhausted == 0);
+  assert(stats.dl_stream_sections_exhausted == 0);
+  assert(stats.dl_iq_streams_pool_exhausted == 0);
+
+  cleanup_packet_processor(ctx);
+  printf("DL multi-section same-beam merge passed!\n");
 }
 
 void test_frame_wrap_around()
@@ -422,9 +775,12 @@ void test_frame_wrap_around()
 
   int frame, slot, symbol;
   uint64_t hyper_frame;
+  dl_iq_stream_t dl_streams[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  uint32_t dl_iq_arena[MAX_DL_IQ_STREAMS_PER_SYMBOL * 273 * 12];
   do {
-    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol);
-  } while (!(frame == (target_sym / num_symbols_per_frame) % 1024 && symbol == target_sym % 14));
+    int n = read_dl_iq_streams(ctx, dl_streams, dl_iq_arena, MAX_DL_IQ_STREAMS_PER_SYMBOL, &hyper_frame, &frame, &slot, &symbol);
+    test_assemble_streams(txdataF, 1, 273, dl_streams, n, NULL);
+  } while (!(frame == (target_sym / num_symbols_per_frame) % 1024 && slot == slot_in_frame && symbol == target_sym % 14));
 
   assert(frame == (target_sym / num_symbols_per_frame) % 1024);
   assert(symbol == target_sym % 14);
@@ -437,10 +793,13 @@ void test_cplane_14_symbols()
 {
   printf("Testing 1 C-plane message for 14 symbols...\n");
   int mu = 1; // 30kHz
+  // T2a_cp_max is widened to 900uS: a single section spanning 14 symbols needs its LAST symbol to
+  // still be within T2a_min_cp of "now" too (each symbol has its own individual C-Plane deadline,
+  // not just the section's first symbol), so the window has to be at least ~14 symbols wide.
   void *ctx = init_packet_processor(mu,
                                     273,
                                     200,
-                                    400,
+                                    900,
                                     100,
                                     300,
                                     5,
@@ -460,7 +819,10 @@ void test_cplane_14_symbols()
   uint64_t current_sym = 1000;
   handle_absolute_symbol_tick(ctx, current_sym);
 
-  uint64_t target_sym = current_sym + 7; // Good for C-plane (between 5 and 11)
+  // T2a_min_cp_sym_diff=5, T2a_max_cp_sym_diff=25. Symbol i of the section sits at diff+i, so with
+  // diff=10 the first symbol (i=0) is at 10 (>=5) and the last (i=13) is at 23 (<=25) - both stay
+  // comfortably inside the window.
+  uint64_t target_sym = current_sym + 10;
 
   // 1. C-plane packet with numSymbol = 14
   struct rte_mbuf *c_mbuf = rte_pktmbuf_alloc(mp);
@@ -499,8 +861,10 @@ void test_cplane_14_symbols()
   assert(stats.dl_tdd_mismatch == 0);
   assert(stats.ul_tdd_mismatch == 0);
 
-  // 2. Advance time so we can send U-plane for ALL 14 symbols
-  current_sym += 3;
+  // 2. Advance time so we can send U-plane for ALL 14 symbols. target_sym - current_sym must land
+  // within U-Plane's own [T2a_min_up_dl_sym_diff, T2a_max_up_dl_sym_diff] = [2, 8] window and stay
+  // there as both advance together below.
+  current_sym += 6;
   handle_absolute_symbol_tick(ctx, current_sym);
 
   for (int i = 0; i < 14; i++) {
@@ -550,13 +914,17 @@ void test_cplane_14_symbols()
   uint32_t output_iq[273 * 12] = {0};
   txdataF[0] = output_iq;
 
+  dl_iq_stream_t dl_streams[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  uint32_t dl_iq_arena[MAX_DL_IQ_STREAMS_PER_SYMBOL * 273 * 12];
   for (int i = 0; i < 14; i++) {
     int frame, slot, symbol;
     uint64_t hyper_frame;
     uint64_t sym_i = target_sym + i;
+    int sym_i_slot_in_frame = (sym_i % num_symbols_per_frame) / 14;
     do {
-      read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol);
-    } while (!(frame == (sym_i / num_symbols_per_frame) % 1024 && symbol == sym_i % 14));
+      int n = read_dl_iq_streams(ctx, dl_streams, dl_iq_arena, MAX_DL_IQ_STREAMS_PER_SYMBOL, &hyper_frame, &frame, &slot, &symbol);
+      test_assemble_streams(txdataF, 1, 273, dl_streams, n, NULL);
+    } while (!(frame == (sym_i / num_symbols_per_frame) % 1024 && slot == sym_i_slot_in_frame && symbol == sym_i % 14));
 
     assert(frame == (sym_i / num_symbols_per_frame) % 1024);
     assert(symbol == sym_i % 14);
@@ -681,8 +1049,11 @@ void test_other_bw_4ant_prb_offset()
 
   int frame, slot, symbol;
   uint64_t hyper_frame;
+  dl_iq_stream_t dl_streams[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  uint32_t dl_iq_arena[MAX_DL_IQ_STREAMS_PER_SYMBOL * 106 * 12];
   do {
-    read_dl_iq(ctx, txdataF, 4, &hyper_frame, &frame, &slot, &symbol);
+    int n = read_dl_iq_streams(ctx, dl_streams, dl_iq_arena, MAX_DL_IQ_STREAMS_PER_SYMBOL, &hyper_frame, &frame, &slot, &symbol);
+    test_assemble_streams(txdataF, 4, 106, dl_streams, n, NULL);
   } while (!(frame == frameId && symbol == startSymbolId));
 
   // Verify memory contents for each antenna
@@ -1437,9 +1808,12 @@ void test_hyper_frame_calculation()
 
   int frame, slot, symbol;
   uint64_t hyper_frame = 0xFFFFFFFF;
+  dl_iq_stream_t dl_streams[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  uint32_t dl_iq_arena[MAX_DL_IQ_STREAMS_PER_SYMBOL * 273 * 12];
   do {
-    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol);
-  } while (!(frame == (target_sym / num_symbols_per_frame) % 1024 && symbol == target_sym % 14));
+    int n = read_dl_iq_streams(ctx, dl_streams, dl_iq_arena, MAX_DL_IQ_STREAMS_PER_SYMBOL, &hyper_frame, &frame, &slot, &symbol);
+    test_assemble_streams(txdataF, 1, 273, dl_streams, n, NULL);
+  } while (!(frame == (target_sym / num_symbols_per_frame) % 1024 && slot == slot_in_frame && symbol == target_sym % 14));
 
   assert(hyper_frame == 3);
   assert(frame == 5);
@@ -1547,9 +1921,13 @@ void test_dl_bfp_decompression(void)
 
   int frame, slot, symbol;
   uint64_t hyper_frame;
+  uint16_t beam_ids[1];
+  dl_iq_stream_t dl_streams[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  uint32_t dl_iq_arena[MAX_DL_IQ_STREAMS_PER_SYMBOL * 273 * 12];
   do {
-    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol);
-  } while (!(frame == (int)((target_sym / num_symbols_per_frame) % 1024) && symbol == (int)(target_sym % 14)));
+    int n = read_dl_iq_streams(ctx, dl_streams, dl_iq_arena, MAX_DL_IQ_STREAMS_PER_SYMBOL, &hyper_frame, &frame, &slot, &symbol);
+    test_assemble_streams(txdataF, 1, 273, dl_streams, n, beam_ids);
+  } while (!(frame == (int)((target_sym / num_symbols_per_frame) % 1024) && slot == slot_in_frame && symbol == (int)(target_sym % 14)));
 
   // I=100, Q=-200 with exponent=0: exact round-trip through BFP
   int16_t *recovered = (int16_t *)output_iq;
@@ -1742,9 +2120,13 @@ void test_large_delay_profile()
 
   int frame, slot, symbol;
   uint64_t hyper_frame = 0;
+  uint16_t beam_ids[1];
+  dl_iq_stream_t dl_streams[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  uint32_t dl_iq_arena[MAX_DL_IQ_STREAMS_PER_SYMBOL * 273 * 12];
   do {
-    read_dl_iq(ctx, txdataF, 1, &hyper_frame, &frame, &slot, &symbol);
-  } while (!(frame == (target_sym / num_symbols_per_frame) % 1024 && symbol == target_sym % 14));
+    int n = read_dl_iq_streams(ctx, dl_streams, dl_iq_arena, MAX_DL_IQ_STREAMS_PER_SYMBOL, &hyper_frame, &frame, &slot, &symbol);
+    test_assemble_streams(txdataF, 1, 273, dl_streams, n, beam_ids);
+  } while (!(frame == (target_sym / num_symbols_per_frame) % 1024 && slot == slot_in_frame && symbol == target_sym % 14));
 
   uint16_t *out_iq = (uint16_t *)output_iq;
   assert(out_iq[0] == 0x1111);
@@ -1763,6 +2145,13 @@ int main(int argc, char **argv)
   test_cplane_timing_errors();
   usleep(10000);
   test_cplane_uplane_match();
+
+  test_uplane_prb_range_rejected();
+  usleep(10000);
+  test_uplane_short_payload_rejected();
+  usleep(10000);
+
+  test_dl_multi_section_same_beam();
   usleep(10000);
   test_frame_wrap_around();
   usleep(10000);

--- a/fronthaul/oru/tests/test_oru_packet_processor.c
+++ b/fronthaul/oru/tests/test_oru_packet_processor.c
@@ -188,6 +188,7 @@ void test_cplane_timing_errors()
   apphdr->cmnhdr.field.subframeId = slot_in_frame / (1 << 1);
   apphdr->cmnhdr.field.slotId = slot_in_frame % (1 << 1);
   apphdr->cmnhdr.field.startSymbolId = target_sym % 14;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -261,6 +262,7 @@ void test_cplane_uplane_match()
   apphdr->cmnhdr.field.subframeId = slot_in_frame / slots_per_subframe;
   apphdr->cmnhdr.field.slotId = slot_in_frame % slots_per_subframe;
   apphdr->cmnhdr.field.startSymbolId = target_sym % 14;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -500,6 +502,7 @@ void test_dl_multi_section_same_beam()
     apphdr->cmnhdr.field.subframeId = subframeId;
     apphdr->cmnhdr.field.slotId = slotId;
     apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+    apphdr->cmnhdr.numOfSections = 1;
     apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
     apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -530,6 +533,7 @@ void test_dl_multi_section_same_beam()
     apphdr->cmnhdr.field.subframeId = subframeId;
     apphdr->cmnhdr.field.slotId = slotId;
     apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+    apphdr->cmnhdr.numOfSections = 1;
     apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
     apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -562,6 +566,7 @@ void test_dl_multi_section_same_beam()
     apphdr->cmnhdr.field.subframeId = subframeId;
     apphdr->cmnhdr.field.slotId = slotId;
     apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+    apphdr->cmnhdr.numOfSections = 1;
     apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
     apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -714,6 +719,7 @@ void test_frame_wrap_around()
   apphdr->cmnhdr.field.subframeId = slot_in_frame / slots_per_subframe;
   apphdr->cmnhdr.field.slotId = slot_in_frame % slots_per_subframe;
   apphdr->cmnhdr.field.startSymbolId = target_sym % 14;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -841,6 +847,7 @@ void test_cplane_14_symbols()
   apphdr->cmnhdr.field.subframeId = slot_in_frame / 2;
   apphdr->cmnhdr.field.slotId = slot_in_frame % 2;
   apphdr->cmnhdr.field.startSymbolId = target_sym % 14;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -989,6 +996,7 @@ void test_other_bw_4ant_prb_offset()
     apphdr->cmnhdr.field.subframeId = subframeId;
     apphdr->cmnhdr.field.slotId = slotId;
     apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+    apphdr->cmnhdr.numOfSections = 1;
     apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
     apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -1299,6 +1307,7 @@ void test_uplink_basic()
   apphdr->cmnhdr.field.subframeId = subframeId;
   apphdr->cmnhdr.field.slotId = slotId;
   apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -1391,6 +1400,7 @@ void test_uplink_fragmentation()
   apphdr->cmnhdr.field.subframeId = subframeId;
   apphdr->cmnhdr.field.slotId = slotId;
   apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -1484,6 +1494,7 @@ void test_uplink_large_mtu()
   apphdr->cmnhdr.field.subframeId = subframeId;
   apphdr->cmnhdr.field.slotId = slotId;
   apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -1576,6 +1587,7 @@ void test_uplink_prb_offset()
   apphdr->cmnhdr.field.subframeId = subframeId;
   apphdr->cmnhdr.field.slotId = slotId;
   apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -1757,6 +1769,7 @@ void test_hyper_frame_calculation()
   apphdr->cmnhdr.field.subframeId = slot_in_frame / slots_per_subframe;
   apphdr->cmnhdr.field.slotId = slot_in_frame % slots_per_subframe;
   apphdr->cmnhdr.field.startSymbolId = target_sym % 14;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 
@@ -1867,6 +1880,7 @@ void test_dl_bfp_decompression(void)
   apphdr->cmnhdr.field.subframeId = slot_in_frame / slots_per_subframe;
   apphdr->cmnhdr.field.slotId = slot_in_frame % slots_per_subframe;
   apphdr->cmnhdr.field.startSymbolId = target_sym % 14;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
   struct xran_cp_radioapp_section1 *sec =
@@ -1985,6 +1999,7 @@ void test_ul_bfp_compression(void)
   apphdr->cmnhdr.field.subframeId = subframeId;
   apphdr->cmnhdr.field.slotId = slotId;
   apphdr->cmnhdr.field.startSymbolId = startSymbolId;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->udComp.udCompMeth = FH_COMP_BFP;
   apphdr->udComp.udIqWidth = XRAN_CONVERT_IQWIDTH(iq_bits);
@@ -2062,6 +2077,7 @@ void test_large_delay_profile()
   apphdr->cmnhdr.field.subframeId = slot_in_frame / slots_per_subframe;
   apphdr->cmnhdr.field.slotId = slot_in_frame % slots_per_subframe;
   apphdr->cmnhdr.field.startSymbolId = target_sym % 14;
+  apphdr->cmnhdr.numOfSections = 1;
   apphdr->cmnhdr.sectionType = XRAN_CP_SECTIONTYPE_1;
   apphdr->cmnhdr.field.all_bits = rte_cpu_to_be_32(apphdr->cmnhdr.field.all_bits);
 

--- a/fronthaul/oru/tests/test_oru_pcap.c
+++ b/fronthaul/oru/tests/test_oru_pcap.c
@@ -46,9 +46,9 @@ void test_send_mbuf(void *io_controller, struct rte_mbuf **mbufs, uint32_t num_m
 
 int main(int argc, char *argv[])
 {
-  if (argc < 11) {
+  if (argc < 12) {
     printf(
-        "Usage: %s <pcap_file> <initial_symbol> <num_dl_slots> <num_ul_slots> <num_dl_symbols> <num_ul_symbols> "
+        "Usage: %s <pcap_file> <numerology> <initial_symbol> <num_dl_slots> <num_ul_slots> <num_dl_symbols> <num_ul_symbols> "
         "<tdd_pattern_length_slots> <mtu> <prach_eaxc_offset> -- <eal args>\n",
         argv[0]);
     return 1;
@@ -77,22 +77,24 @@ int main(int argc, char *argv[])
   mp = rte_pktmbuf_pool_create("test_pool", 4096, 0, 0, 10240, rte_socket_id());
   assert(mp != NULL);
 
-  uint64_t initial_symbol = atoll(argv[2]);
-  int num_dl_slots = atoi(argv[3]);
-  int num_ul_slots = atoi(argv[4]);
-  int num_dl_symbols = atoi(argv[5]);
-  int num_ul_symbols = atoi(argv[6]);
-  int tdd_pattern_length_slots = atoi(argv[7]);
-  size_t mtu = atoi(argv[8]);
-  int prach_eaxc_offset = atoi(argv[9]);
+  int numerology = atoi(argv[2]);
+  uint64_t initial_symbol = atoll(argv[3]);
+  int num_dl_slots = atoi(argv[4]);
+  int num_ul_slots = atoi(argv[5]);
+  int num_dl_symbols = atoi(argv[6]);
+  int num_ul_symbols = atoi(argv[7]);
+  int tdd_pattern_length_slots = atoi(argv[8]);
+  size_t mtu = atoi(argv[9]);
+  int prach_eaxc_offset = atoi(argv[10]);
 
-  if (eal_args_start < 10) {
+  if (eal_args_start < 11) {
     printf("Error: Missing '--' separator for EAL arguments\n");
     return 1;
   }
 
   printf("Starting test with parameters:\n");
   printf("  pcap: %s\n", argv[1]);
+  printf("  numerology: %d\n", numerology);
   printf("  initial_symbol: %lu\n", initial_symbol);
   printf("  TDD: DL %d slots + %d sym, UL %d slots + %d sym, Pattern Length %d slots\n",
          num_dl_slots,
@@ -103,7 +105,7 @@ int main(int argc, char *argv[])
   printf("  MTU: %zu\n", mtu);
   printf("  PRACH eAxC Offset: %d\n", prach_eaxc_offset);
 
-  void *ctx = init_packet_processor(1,
+  void *ctx = init_packet_processor(numerology,
                                     273,
                                     0,
                                     1500,
@@ -185,7 +187,7 @@ int main(int argc, char *argv[])
         uint8_t slot = (fields >> 6) & 0x3F;
         uint8_t start_sym = (fields) & 0x3F;
 
-        uint64_t target_sym = (uint64_t)frame * 280 + (subframe * 2 + slot) * 14 + start_sym;
+        uint64_t target_sym = (uint64_t)frame * (140 * (1 << numerology)) + (subframe * (1 << numerology) + slot) * 14 + start_sym;
         handle_absolute_symbol_tick(ctx, initial_symbol);
         last_tick_sym = initial_symbol;
         first_ts = ts;
@@ -194,7 +196,8 @@ int main(int argc, char *argv[])
       }
 
       if (synced) {
-        uint64_t elapsed_syms = (uint64_t)((ts - first_ts) / 0.0000357142857);
+        double sym_duration = 1.0 / (14000.0 * (1 << numerology));
+        uint64_t elapsed_syms = (uint64_t)((ts - first_ts) / sym_duration);
         uint64_t current_sym = initial_symbol + elapsed_syms;
 
         if (current_sym > last_tick_sym) {
@@ -210,8 +213,8 @@ int main(int argc, char *argv[])
                 write_ul_iq(ctx, txdataF[0], job.symbol + i, &job);
               }
             }
-            int frame = (s / 280) % 1024;
-            int slot = (s / 14) % 20;
+            int frame = (s / (140 * (1 << numerology))) % 1024;
+            int slot = (s / 14) % (10 * (1 << numerology));
             int sym = s % 14;
             write_prach_iq(ctx, txdataF, MAX_ANTENNAS, frame, slot, sym);
 

--- a/fronthaul/oru/tests/test_oru_pcap.c
+++ b/fronthaul/oru/tests/test_oru_pcap.c
@@ -144,6 +144,10 @@ int main(int argc, char *argv[])
   for (int i = 0; i < MAX_ANTENNAS; i++)
     txdataF[i] = malloc(273 * 12 * sizeof(uint32_t));
 
+  static dl_iq_stream_t dl_streams[MAX_DL_IQ_STREAMS_PER_SYMBOL];
+  static uint32_t *dl_iq_arena = NULL;
+  dl_iq_arena = malloc(MAX_DL_IQ_STREAMS_PER_SYMBOL * 273 * 12 * sizeof(uint32_t));
+
   while (pcap_next_ex(pcap, &pkthdr, &packet) >= 0) {
     pkt_count++;
     double ts = pkthdr->ts.tv_sec + pkthdr->ts.tv_usec / 1000000.0;
@@ -215,7 +219,7 @@ int main(int argc, char *argv[])
             int f, sl, sy;
             uint64_t hf;
             while (get_ready_job_count(ctx) > 0) {
-              read_dl_iq(ctx, txdataF, MAX_ANTENNAS, &hf, &f, &sl, &sy);
+              read_dl_iq_streams(ctx, dl_streams, dl_iq_arena, MAX_DL_IQ_STREAMS_PER_SYMBOL, &hf, &f, &sl, &sy);
             }
           }
           last_tick_sym = current_sym;
@@ -243,7 +247,7 @@ int main(int argc, char *argv[])
     int f, sl, sy;
     uint64_t hf;
     while (get_ready_job_count(ctx) > 0) {
-      read_dl_iq(ctx, txdataF, MAX_ANTENNAS, &hf, &f, &sl, &sy);
+      read_dl_iq_streams(ctx, dl_streams, dl_iq_arena, MAX_DL_IQ_STREAMS_PER_SYMBOL, &hf, &f, &sl, &sy);
     }
   }
 
@@ -278,6 +282,7 @@ int main(int argc, char *argv[])
     rte_mempool_free(mp);
   for (int i = 0; i < MAX_ANTENNAS; i++)
     free(txdataF[i]);
+  free(dl_iq_arena);
 
   return 0;
 }

--- a/fronthaul/xran_pkt/tests/CMakeLists.txt
+++ b/fronthaul/xran_pkt/tests/CMakeLists.txt
@@ -15,3 +15,4 @@ target_link_libraries(xran_pcap_dump PRIVATE xran_pkt ${dpdk_LIBRARIES} ${PCAP_L
 target_compile_options(xran_pcap_dump PRIVATE ${dpdk_CFLAGS} -march=native)
 target_include_directories(xran_pcap_dump PRIVATE ../ ${PCAP_INCLUDE_DIRS})
 
+

--- a/fronthaul/xran_pkt/tests/xran_pcap_dump.c
+++ b/fronthaul/xran_pkt/tests/xran_pcap_dump.c
@@ -176,11 +176,12 @@ void packet_handler(u_char *user, const struct pcap_pkthdr *pkthdr, const u_char
               if (section) {
                 section->hdr.u1.second_4byte = rte_be_to_cpu_32(section->hdr.u1.second_4byte);
                 section->hdr.u.first_4byte = rte_be_to_cpu_32(section->hdr.u.first_4byte);
-                printf("  [Sec 1] SectionID: %d  StartPRB: %d  NumPRB: %d  NumSym: %d\n",
+                printf("  [Sec 1] SectionID: %d  StartPRB: %d  NumPRB: %d  NumSym: %d  BeamID: %d\n",
                        section->hdr.u1.common.sectionId,
                        section->hdr.u1.common.startPrbc,
                        section->hdr.u1.common.numPrbc,
-                       section->hdr.u.s1.numSymbol);
+                       section->hdr.u.s1.numSymbol,
+                       section->hdr.u.s1.beamId);
               }
               break;
             }

--- a/fronthaul/xran_pkt/tests/xran_pcap_dump.c
+++ b/fronthaul/xran_pkt/tests/xran_pcap_dump.c
@@ -171,17 +171,28 @@ void packet_handler(u_char *user, const struct pcap_pkthdr *pkthdr, const u_char
             case XRAN_CP_SECTIONTYPE_1: {
               struct xran_cp_radioapp_section1_header *hdr = (struct xran_cp_radioapp_section1_header *)apphdr;
               printf("  [Sec 1] udCompMeth: %d  udIqWidth: %d\n", hdr->udComp.udCompMeth, hdr->udComp.udIqWidth);
-              struct xran_cp_radioapp_section1 *section =
-                  (struct xran_cp_radioapp_section1 *)rte_pktmbuf_adj(mbuf, sizeof(struct xran_cp_radioapp_section1_header));
-              if (section) {
-                section->hdr.u1.second_4byte = rte_be_to_cpu_32(section->hdr.u1.second_4byte);
-                section->hdr.u.first_4byte = rte_be_to_cpu_32(section->hdr.u.first_4byte);
-                printf("  [Sec 1] SectionID: %d  StartPRB: %d  NumPRB: %d  NumSym: %d  BeamID: %d\n",
-                       section->hdr.u1.common.sectionId,
-                       section->hdr.u1.common.startPrbc,
-                       section->hdr.u1.common.numPrbc,
-                       section->hdr.u.s1.numSymbol,
-                       section->hdr.u.s1.beamId);
+              uint8_t *sec_ptr = (uint8_t *)rte_pktmbuf_adj(mbuf, sizeof(struct xran_cp_radioapp_section1_header));
+              if (sec_ptr) {
+                for (int i = 0; i < apphdr->numOfSections; i++) {
+                  struct xran_cp_radioapp_section1 sec_copy;
+                  memcpy(&sec_copy, sec_ptr, sizeof(sec_copy));
+                  *((uint64_t *)&sec_copy) = rte_be_to_cpu_64(*((uint64_t *)&sec_copy));
+                  printf("  [Sec 1] SectionID: %d  StartPRB: %d  NumPRB: %d  NumSym: %d  BeamID: %d\n",
+                         sec_copy.hdr.u1.common.sectionId,
+                         sec_copy.hdr.u1.common.startPrbc,
+                         sec_copy.hdr.u1.common.numPrbc,
+                         sec_copy.hdr.u.s1.numSymbol,
+                         sec_copy.hdr.u.s1.beamId);
+
+                  sec_ptr += sizeof(struct xran_cp_radioapp_section1);
+                  int ef = sec_copy.hdr.u.s1.ef;
+                  while (ef) {
+                    uint8_t extLen = sec_ptr[0];
+                    uint8_t ext_ef = (sec_ptr[1] >> 7) & 1;
+                    sec_ptr += extLen * 4;
+                    ef = ext_ef;
+                  }
+                }
               }
               break;
             }

--- a/openair1/PHY/TOOLS/tests/CMakeLists.txt
+++ b/openair1/PHY/TOOLS/tests/CMakeLists.txt
@@ -12,6 +12,12 @@ add_dependencies(tests benchmark_rotate_vector)
 add_test(NAME benchmark_rotate_vector
   COMMAND ./benchmark_rotate_vector)
 
+add_executable(test_rotate_add_cpx_vector test_rotate_add_cpx_vector.cpp)
+target_link_libraries(test_rotate_add_cpx_vector PRIVATE GTest::gtest benchmark::benchmark UTIL PHY_NR)
+add_dependencies(tests test_rotate_add_cpx_vector)
+add_test(NAME test_rotate_add_cpx_vector
+  COMMAND ./test_rotate_add_cpx_vector)
+
 add_executable(benchmark_dot_product benchmark_dot_product.cpp)
 target_link_libraries(benchmark_dot_product PRIVATE benchmark::benchmark UTIL PHY_NR)
 add_dependencies(tests benchmark_dot_product)

--- a/openair1/PHY/TOOLS/tests/test_rotate_add_cpx_vector.cpp
+++ b/openair1/PHY/TOOLS/tests/test_rotate_add_cpx_vector.cpp
@@ -1,0 +1,229 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ */
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+extern "C" {
+#include "openair1/PHY/TOOLS/tools_defs.h"
+struct configmodule_interface_s;
+struct configmodule_interface_s *uniqCfg = NULL;
+void exit_function(const char *file, const char *function, const int line, const char *s, const int assert)
+{
+  if (assert) {
+    abort();
+  } else {
+    exit(EXIT_SUCCESS);
+  }
+}
+}
+// tools_defs.h drags in common/utils/T/T.h, whose T(...) tracing macro shadows gtest's pervasive
+// "T" template parameter name - undo it before pulling gtest in (same fix as
+// common/utils/simple_executable.h).
+#ifdef T
+#undef T
+#endif
+#include <gtest/gtest.h>
+#include "benchmark/benchmark.h"
+#include "openair1/PHY/TOOLS/phy_test_tools.hpp"
+
+// Reference model matching production semantics exactly: the shifted product is saturated to
+// Q1.15 (like the SIMD tiers' packs_epi32), then the accumulate saturates on top of that.
+static c16_t rotate_add_ref_term(c16_t x, c16_t alpha, int shift)
+{
+  return c16mulShiftSat(x, alpha, shift);
+}
+
+static int16_t sat16_ref(int32_t v)
+{
+  if (v > INT16_MAX)
+    return INT16_MAX;
+  if (v < INT16_MIN)
+    return INT16_MIN;
+  return (int16_t)v;
+}
+
+static void rotate_add_cpx_vector_ref(const c16_t *x, c16_t alpha, c16_t *y, uint32_t N, int shift)
+{
+  for (uint32_t k = 0; k < N; k++) {
+    c16_t term = rotate_add_ref_term(x[k], alpha, shift);
+    y[k].r = sat16_ref((int32_t)y[k].r + term.r);
+    y[k].i = sat16_ref((int32_t)y[k].i + term.i);
+  }
+}
+
+static AlignedVector512<c16_t> small_c16(size_t num, int16_t base)
+{
+  AlignedVector512<c16_t> vec;
+  vec.resize(num);
+  for (size_t i = 0; i < num; i++) {
+    vec[i] = {(int16_t)(base + (int)i), (int16_t)(base - (int)i)};
+  }
+  return vec;
+}
+
+class RotateAddCpxVector : public ::testing::TestWithParam<int> {};
+
+TEST_P(RotateAddCpxVector, MatchesReferenceAcrossTierAndTail)
+{
+  const int N = GetParam();
+  auto x = small_c16(N, 50);
+  c16_t alpha = {23170, -12000};
+  const int shift = 15;
+
+  AlignedVector512<c16_t> y(N), y_ref(N);
+  for (int i = 0; i < N; i++) {
+    y[i] = y_ref[i] = {(int16_t)(10 - i), (int16_t)(i - 10)};
+  }
+
+  rotate_add_cpx_vector(x.data(), alpha, y.data(), N, shift);
+  rotate_add_cpx_vector_ref(x.data(), alpha, y_ref.data(), N, shift);
+
+  for (int i = 0; i < N; i++) {
+    EXPECT_EQ(y[i].r, y_ref[i].r) << "real mismatch at " << i << " (N=" << N << ")";
+    EXPECT_EQ(y[i].i, y_ref[i].i) << "imag mismatch at " << i << " (N=" << N << ")";
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(Sizes, RotateAddCpxVector, ::testing::Values(1, 2, 3, 4, 5, 7, 8, 13, 100, 131));
+
+TEST(RotateAddCpxVector, SaturatesInsteadOfWrapping)
+{
+  const int N = 8;
+  AlignedVector512<c16_t> x(N);
+  std::fill(x.begin(), x.end(), c16_t{32767, 32767});
+  c16_t alpha = {32767, 0}; // near-identity: term ~= x
+
+  AlignedVector512<c16_t> y(N);
+  std::fill(y.begin(), y.end(), c16_t{32767, 32767}); // already saturated - adding more must not wrap
+
+  rotate_add_cpx_vector(x.data(), alpha, y.data(), N, 0 /* no shift: force a large term */);
+
+  for (int i = 0; i < N; i++) {
+    EXPECT_EQ(y[i].r, INT16_MAX) << "index " << i;
+    EXPECT_EQ(y[i].i, INT16_MAX) << "index " << i;
+  }
+}
+
+// Equivalence with rotate_cpx_vector(): accumulating onto zero must be bit-identical to overwrite.
+TEST(RotateAddCpxVector, EquivalentToRotateWhenStartingFromZero)
+{
+  const int N = 37; // spans the SIMD tier and the scalar tail
+  auto x = generate_random_c16(N);
+  c16_t alpha = {20000, -9000};
+  const int shift = 15;
+
+  AlignedVector512<c16_t> y_fused(N, c16_t{0, 0});
+  AlignedVector512<c16_t> y_overwrite(N);
+
+  rotate_add_cpx_vector(x.data(), alpha, y_fused.data(), N, shift);
+  rotate_cpx_vector(x.data(), alpha, y_overwrite.data(), N, shift);
+
+  for (int i = 0; i < N; i++) {
+    EXPECT_EQ(y_fused[i].r, y_overwrite[i].r) << "index " << i;
+    EXPECT_EQ(y_fused[i].i, y_overwrite[i].i) << "index " << i;
+  }
+}
+
+
+TEST(RotateAddCpxVector, EquivalentToRotateThenAdd)
+{
+  const int N = 41;
+  auto x = generate_random_c16(N);
+  c16_t alpha = {-15000, 27000};
+  const int shift = 15;
+
+  AlignedVector512<c16_t> y_fused = generate_random_c16(N);
+  AlignedVector512<c16_t> y_twopass = y_fused;
+
+  rotate_add_cpx_vector(x.data(), alpha, y_fused.data(), N, shift);
+
+  AlignedVector512<c16_t> term(N);
+  rotate_cpx_vector(x.data(), alpha, term.data(), N, shift);
+  add_cpx_vector(term.data(), y_twopass.data(), N);
+
+  for (int i = 0; i < N; i++) {
+    EXPECT_EQ(y_fused[i].r, y_twopass[i].r) << "index " << i;
+    EXPECT_EQ(y_fused[i].i, y_twopass[i].i) << "index " << i;
+  }
+}
+
+TEST(RotateAddCpxVector, AccumulatesAcrossMultipleCalls)
+{
+  const int N = 12;
+  auto x1 = small_c16(N, 20);
+  auto x2 = small_c16(N, -30);
+  c16_t alpha1 = {23170, 5000};
+  c16_t alpha2 = {-9000, 18000};
+  const int shift = 15;
+
+  AlignedVector512<c16_t> y(N, c16_t{0, 0});
+  rotate_add_cpx_vector(x1.data(), alpha1, y.data(), N, shift);
+  rotate_add_cpx_vector(x2.data(), alpha2, y.data(), N, shift);
+
+  AlignedVector512<c16_t> y_ref(N, c16_t{0, 0});
+  rotate_add_cpx_vector_ref(x1.data(), alpha1, y_ref.data(), N, shift);
+  rotate_add_cpx_vector_ref(x2.data(), alpha2, y_ref.data(), N, shift);
+
+  for (int i = 0; i < N; i++) {
+    EXPECT_EQ(y[i].r, y_ref[i].r) << "index " << i;
+    EXPECT_EQ(y[i].i, y_ref[i].i) << "index " << i;
+  }
+}
+
+// --- Benchmarks: not run by default, see main() below (pass --run_benchmarks) ---
+
+static void BM_rotate_add_cpx_vector_fused(benchmark::State &state)
+{
+  int vector_size = state.range(0);
+  auto x = generate_random_c16(vector_size);
+  auto alpha = generate_random_c16(1);
+  AlignedVector512<c16_t> y(vector_size, c16_t{0, 0});
+  for (auto _ : state) {
+    rotate_add_cpx_vector(x.data(), alpha.data()[0], y.data(), vector_size, 15);
+  }
+}
+BENCHMARK(BM_rotate_add_cpx_vector_fused)->RangeMultiplier(4)->Range(12, 3276);
+
+static void BM_rotate_then_add_cpx_vector(benchmark::State &state)
+{
+  int vector_size = state.range(0);
+  auto x = generate_random_c16(vector_size);
+  auto alpha = generate_random_c16(1);
+  AlignedVector512<c16_t> term(vector_size);
+  AlignedVector512<c16_t> y(vector_size, c16_t{0, 0});
+  for (auto _ : state) {
+    rotate_cpx_vector(x.data(), alpha.data()[0], term.data(), vector_size, 15);
+    add_cpx_vector(term.data(), y.data(), vector_size);
+  }
+}
+BENCHMARK(BM_rotate_then_add_cpx_vector)->RangeMultiplier(4)->Range(12, 3276);
+
+int main(int argc, char **argv)
+{
+  bool benchmark_mode = false;
+  std::vector<char *> filtered;
+  filtered.push_back(argv[0]);
+  for (int i = 1; i < argc; i++) {
+    std::string arg = argv[i];
+    if (arg == "--mode=benchmark") {
+      benchmark_mode = true;
+    } else if (arg == "--mode=test") {
+      benchmark_mode = false;
+    } else {
+      filtered.push_back(argv[i]);
+    }
+  }
+  int argc2 = (int)filtered.size();
+  char **argv2 = filtered.data();
+
+  if (benchmark_mode) {
+    benchmark::Initialize(&argc2, argv2);
+    benchmark::RunSpecifiedBenchmarks();
+    return 0;
+  }
+
+  testing::InitGoogleTest(&argc2, argv2);
+  return RUN_ALL_TESTS();
+}

--- a/openair1/PHY/TOOLS/tools_defs.h
+++ b/openair1/PHY/TOOLS/tools_defs.h
@@ -518,6 +518,29 @@ static inline void multadd_cpx_vector(const c16_t *x1, const c16_t *x2, c16_t *y
   }
 }
 
+/*!
+  Element-wise saturating accumulation of one complex vector into another: y = sat16(y + x).
+  @param x - input, added into y   in the format  |Re0 Im0 Re1 Im1|,......,|Re(N-2)  Im(N-2) Re(N-1) Im(N-1)|
+  @param y - accumulator, updated in place, same format
+  @param N - the number of complex numbers (any N; the remainder past the last full 128-bit
+             register is handled by a scalar tail, unlike multadd_cpx_vector() above)
+*/
+static inline void add_cpx_vector(const c16_t *x, c16_t *y, const uint32_t N)
+{
+  const simd_q15_t *x_128 = (const simd_q15_t *)x;
+  simd_q15_t *y_128 = (simd_q15_t *)y;
+  const uint32_t n_simd = N / 4; // 4 complex (8 int16 lanes) per 128-bit register
+  for (uint32_t i = 0; i < n_simd; i++) {
+    y_128[i] = adds_int16(y_128[i], x_128[i]);
+  }
+  for (uint32_t i = n_simd * 4; i < N; i++) {
+    int32_t r = (int32_t)y[i].r + x[i].r;
+    int32_t im = (int32_t)y[i].i + x[i].i;
+    y[i].r = r > INT16_MAX ? INT16_MAX : r < INT16_MIN ? INT16_MIN : (int16_t)r;
+    y[i].i = im > INT16_MAX ? INT16_MAX : im < INT16_MIN ? INT16_MIN : (int16_t)im;
+  }
+}
+
 static const int16_t ones_epi16[16] __attribute__((aligned(32))) = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 static inline simde__m256i protected_abs256(const simde__m256i in)
 {

--- a/openair1/PHY/TOOLS/tools_defs.h
+++ b/openair1/PHY/TOOLS/tools_defs.h
@@ -37,6 +37,7 @@
 #include <simde/x86/avx512/srai.h>
 #include <simde/x86/avx512/packs.h>
 #include <simde/x86/avx512/shuffle.h>
+#include <simde/x86/avx512/adds.h>
 #endif
 
 #define simd_q15_t simde__m128i
@@ -918,6 +919,16 @@ static inline idft_size_idx_t get_idft(int size)
   return IDFT_SIZE_IDXTABLESIZE; // never reached and will trigger assertion in idft function
 }
 
+// Saturates a shifted 32-bit re/im product to Q1.15, matching what the SIMD tiers' packs_epi32
+// does - the scalar tail must agree with them instead of narrowing via c16mulShift(), which wraps.
+static inline c16_t c16mulShiftSat(const c16_t a, const c16_t b, const int shift)
+{
+  int32_t r = ((int32_t)a.r * b.r - (int32_t)a.i * b.i) >> shift;
+  int32_t im = ((int32_t)a.r * b.i + (int32_t)a.i * b.r) >> shift;
+  return (c16_t){.r = (int16_t)(r > INT16_MAX ? INT16_MAX : r < INT16_MIN ? INT16_MIN : r),
+                 .i = (int16_t)(im > INT16_MAX ? INT16_MAX : im < INT16_MIN ? INT16_MIN : im)};
+}
+
 /*!\fn int32_t rotate_cpx_vector(c16_t *x,c16_t alpha,c16_t *y,uint32_t N,uint16_t output_shift)
 This function performs componentwise multiplication of a vector with a complex scalar.
 @param x Vector input (Q1.15)  in the format  |Re0  Im0|,......,|Re(N-1) Im(N-1)|
@@ -1095,7 +1106,119 @@ static inline void rotate_cpx_vector(const c16_t *const x, const c16_t alpha, c1
 
   // scalar tail: catches any remainder the SIMD tiers above (each width-gated on N) left behind
   for (; i < N; i++)
-    y[i] = c16mulShift(x[i], alpha, output_shift);
+    y[i] = c16mulShiftSat(x[i], alpha, output_shift);
+}
+
+/*
+Fused variant of rotate_cpx_vector() above that saturating-accumulates into y instead of
+overwriting it: y = sat16(y + alpha*x).
+
+@param x Vector input (Q1.15) in the format |Re0 Im0|,......,|Re(N-1) Im(N-1)|
+@param alpha Scalar input (Q1.15) in the format |Re0 Im0|
+@param y Accumulator, updated in place: y = sat16(y + alpha*x)
+@param N Length of x (any N; a scalar tail handles the remainder past the last full-width register)
+@param output_shift Number of bits to shift the product down to Q1.15
+*/
+static inline void rotate_add_cpx_vector(const c16_t *const x, const c16_t alpha, c16_t *y, uint32_t N, int output_shift)
+{
+  uint32_t i = 0;
+
+#if defined(__x86_64__) || defined(__i386__)
+#if defined(__AVX512F__) && defined(__AVX512BW__)
+  {
+    const c16_t for_re = {alpha.r, (int16_t)-alpha.i};
+    const simde__m512i alpha_for_real = simde_mm512_set1_epi32(*(uint32_t *)&for_re);
+    const c16_t for_im = {alpha.i, alpha.r};
+    const simde__m512i alpha_for_im = simde_mm512_set1_epi32(*(uint32_t *)&for_im);
+    const simde__m512i perm_mask = simde_mm512_set_epi8(15, 14, 7, 6, 13, 12, 5, 4, 11, 10, 3, 2, 9, 8, 1, 0,
+                                                         15, 14, 7, 6, 13, 12, 5, 4, 11, 10, 3, 2, 9, 8, 1, 0,
+                                                         15, 14, 7, 6, 13, 12, 5, 4, 11, 10, 3, 2, 9, 8, 1, 0,
+                                                         15, 14, 7, 6, 13, 12, 5, 4, 11, 10, 3, 2, 9, 8, 1, 0);
+    for (; i < (N & ~15u); i += 16) {
+      const simde__m512i x512 = simde_mm512_loadu_si512((const simde__m512i *)(x + i));
+      const simde__m512i xre = simde_mm512_srai_epi32(simde_mm512_madd_epi16(x512, alpha_for_real), output_shift);
+      const simde__m512i xim = simde_mm512_srai_epi32(simde_mm512_madd_epi16(x512, alpha_for_im), output_shift);
+      const simde__m512i term = simde_mm512_shuffle_epi8(simde_mm512_packs_epi32(xre, xim), perm_mask);
+      const simde__m512i y512 = simde_mm512_loadu_si512((const simde__m512i *)(y + i));
+      simde_mm512_storeu_si512((simde__m512i *)(y + i), simde_mm512_adds_epi16(y512, term));
+    }
+  }
+#endif
+#ifdef __AVX2__
+  {
+    const c16_t for_re = {alpha.r, (int16_t)-alpha.i};
+    const simde__m256i alpha_for_real = simde_mm256_set1_epi32(*(uint32_t *)&for_re);
+    const c16_t for_im = {alpha.i, alpha.r};
+    const simde__m256i alpha_for_im = simde_mm256_set1_epi32(*(uint32_t *)&for_im);
+    const simde__m256i perm_mask = simde_mm256_set_epi8(31,
+                                                        30,
+                                                        23,
+                                                        22,
+                                                        29,
+                                                        28,
+                                                        21,
+                                                        20,
+                                                        27,
+                                                        26,
+                                                        19,
+                                                        18,
+                                                        25,
+                                                        24,
+                                                        17,
+                                                        16,
+                                                        15,
+                                                        14,
+                                                        7,
+                                                        6,
+                                                        13,
+                                                        12,
+                                                        5,
+                                                        4,
+                                                        11,
+                                                        10,
+                                                        3,
+                                                        2,
+                                                        9,
+                                                        8,
+                                                        1,
+                                                        0);
+    for (; i < (N & ~7u); i += 8) {
+      const simde__m256i x256 = simde_mm256_lddqu_si256((const simde__m256i *)(x + i));
+      const simde__m256i xre = simde_mm256_srai_epi32(simde_mm256_madd_epi16(x256, alpha_for_real), output_shift);
+      const simde__m256i xim = simde_mm256_srai_epi32(simde_mm256_madd_epi16(x256, alpha_for_im), output_shift);
+      const simde__m256i term = simde_mm256_shuffle_epi8(simde_mm256_packs_epi32(xre, xim), perm_mask);
+      const simde__m256i y256 = simde_mm256_lddqu_si256((const simde__m256i *)(y + i));
+      simde_mm256_storeu_si256((simde__m256i *)(y + i), simde_mm256_adds_epi16(y256, term));
+    }
+  }
+#endif
+#endif // defined(__x86_64__) || defined(__i386__)
+
+  // portable 128-bit tier: SSE2 on x86 (remainder handler for the AVX512/AVX2 tiers above),
+  // transparently portable elsewhere (including aarch64) via SIMDe.
+  {
+    const int32_t *xd = (const int32_t *)x;
+    const simde__m128i shift = simde_mm_cvtsi32_si128(output_shift);
+    const simde__m128i alpha_128 =
+        simde_mm_setr_epi16(alpha.r, (int16_t)-alpha.i, alpha.i, alpha.r, alpha.r, (int16_t)-alpha.i, alpha.i, alpha.r);
+
+    for (; i < (N & ~3u); i += 4) {
+      simde__m128i *y_128 = (simde__m128i *)(y + i);
+      simde__m128i term = simde_mm_packs_epi32( // pack in 16bit integers with saturation [re im re im re im re im]
+          simde_mm_sra_epi32(simde_mm_madd_epi16(simde_mm_setr_epi32(xd[i], xd[i], xd[i + 1], xd[i + 1]), alpha_128), shift),
+          simde_mm_sra_epi32(simde_mm_madd_epi16(simde_mm_setr_epi32(xd[i + 2], xd[i + 2], xd[i + 3], xd[i + 3]), alpha_128), shift));
+      *y_128 = simde_mm_adds_epi16(*y_128, term); // saturating accumulate into y
+    }
+  }
+
+  // scalar tail: catches any remainder the SIMD tiers above (each width-gated on N) left behind
+  for (; i < N; i++) {
+    c16_t term = c16mulShiftSat(x[i], alpha, output_shift);
+    int32_t r = (int32_t)y[i].r + term.r;
+    int32_t im = (int32_t)y[i].i + term.i;
+    y[i].r = r > INT16_MAX ? INT16_MAX : r < INT16_MIN ? INT16_MIN : (int16_t)r;
+    y[i].i = im > INT16_MAX ? INT16_MAX : im < INT16_MIN ? INT16_MIN : (int16_t)im;
+  }
 }
 
 /*!\fn int32_t sub_cpx_vector16(c16_t *x,c16_t *y, c16_t z, uint32_t N)

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.band77.mu1.106rb.2x2_catb.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.band77.mu1.106rb.2x2_catb.conf
@@ -1,0 +1,185 @@
+Active_gNBs = ( "gNB-OAI");
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    gNB_ID    =  0xe00;
+    gNB_name  =  "gNB-OAI";
+    tracking_area_code  =  40960;
+    plmn_list = ({ mcc = 208; mnc = 95; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+    nr_cellid = 12345678L;
+    min_rxtxtime = 4;
+    pdsch_AntennaPorts_XP = 2;
+    pdsch_AntennaPorts_N1 = 1;
+    maxMIMO_layers        = 2;
+    pusch_AntennaPorts    = 2;
+    do_CSIRS              = 0;
+    do_SRS                = "none";
+    sib1_tda              = 15;
+
+    servingCellConfigCommon = (
+    {
+      physCellId                                                    = 0;
+      absoluteFrequencySSB                                          = 669984;
+      dl_frequencyBand                                              = 77;
+      dl_absoluteFrequencyPointA                                    = 668712;
+      dl_offstToCarrier                                             = 0;
+      dl_subcarrierSpacing                                          = 1;
+      dl_carrierBandwidth                                           = 106;
+      initialDLBWPlocationAndBandwidth                              = 28875;
+      initialDLBWPsubcarrierSpacing                                 = 1;
+      initialDLBWPcontrolResourceSetZero                            = 11;
+      initialDLBWPsearchSpaceZero                                   = 0;
+      ul_frequencyBand                                              = 77;
+      ul_offstToCarrier                                             = 0;
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 106;
+      pMax                                                          = 23;
+      initialULBWPlocationAndBandwidth                              = 28875;
+      initialULBWPsubcarrierSpacing                                 = 1;
+      prach_ConfigurationIndex                                      = 157;
+      prach_msg1_FDM                                                = 0;
+      prach_msg1_FrequencyStart                                     = 0;
+      zeroCorrelationZoneConfig                                     = 0;
+      preambleReceivedTargetPower                                   = -100;
+      preambleTransMax                                              = 7;
+      powerRampingStep                                              = 2;
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                  = 4;
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB                     = 15;
+      ra_ContentionResolutionTimer                                  = 7;
+      rsrp_ThresholdSSB                                             = 19;
+      prach_RootSequenceIndex_PR                                    = 2;
+      prach_RootSequenceIndex                                       = 1;
+      msg1_SubcarrierSpacing                                        = 1,
+      restrictedSetConfig                                           = 0,
+      msg3_DeltaPreamble                                            = 2;
+      p0_NominalWithGrant                                           = -100;
+      pucchGroupHopping                                             = 0;
+      hoppingId                                                     = 0;
+      p0_nominal                                                    = -96;
+      ssb_PositionsInBurst_Bitmap                                   = 0x1;
+      ssb_periodicityServingCell                                    = 2;
+      dmrs_TypeA_Position                                           = 0;
+      subcarrierSpacing                                             = 1;
+      referenceSubcarrierSpacing                                    = 1;
+      dl_UL_TransmissionPeriodicity                                 = 5;
+      nrofDownlinkSlots                                             = 3;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 1;
+      nrofUplinkSymbols                                             = 4;
+      ssPBCH_BlockPower                                             = 0;
+    }
+    );
+
+    SCTP :
+    {
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+    amf_ip_address = ({ ipv4 = "192.168.70.136"; });
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.70.129";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "192.168.70.129";
+        GNB_PORT_FOR_S1U                         = 2152;
+    };
+  }
+);
+
+MACRLCs = (
+{
+  num_cc                      = 1;
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 200;
+  pucch_TargetSNRx10          = 200;
+  ul_bler_target_upper        = .35;
+  ul_bler_target_lower        = .15;
+  pusch_FailureThres          = 100;
+
+  # Preconfigured analog beamforming: maps DL beam index to O-RU codebook beam ID
+  set_analog_beamforming      = "lophy";
+  beam_duration               = 1;
+  beams_per_period            = 1;
+  beam_weights                = [0];
+}
+);
+
+L1s = (
+{
+  num_cc = 1;
+  tr_n_preference = "local_mac";
+  prach_dtx_threshold = 110;
+  pucch0_dtx_threshold = 80;
+  pusch_dtx_threshold = -100;
+  tx_amp_backoff_dB = 36;
+  L1_rx_thread_core = 11;
+  L1_tx_thread_core = 12;
+  phase_compensation = 0;
+}
+);
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 2;
+  nb_rx          = 2;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  ru_thread_core = 10;
+  sl_ahead       = 5;
+  tr_preference  = "raw_if4p5";
+  do_precoding   = 0;
+}
+);
+
+security = {
+  ciphering_algorithms = ( "nea0" );
+  integrity_algorithms = ( "nia2", "nia0" );
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};
+
+fhi_72 = {
+  dpdk_devices = ("0000:01:11.2", "0000:01:11.3");
+  system_core = 7;
+  io_core = 8;
+  worker_cores = (9);
+  ru_addr = ("00:11:22:44:64:66", "00:11:22:44:64:67");
+  mtu = 9600;
+  fh_config = ({
+    T1a_cp_dl = (285, 470);
+    T1a_cp_ul = (285, 470);
+    T1a_up = (300, 450);
+    Ta4 = (400, 440);
+    Ta3_up = (200, 350);
+    T2a_up = (300, 450);
+    ru_config = {
+      # Must be "dynamic" when iq_width < 16: O-RU sends per-section compression headers
+      comp_hdr_type = "dynamic";
+      iq_width = 16;
+      iq_width_prach = 16;
+    };
+  });
+};

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.band77.mu1.106rb.2x2_catb.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.band77.mu1.106rb.2x2_catb.conf
@@ -26,9 +26,9 @@ ORUs = (
     T2a_cp = (285, 3200);
     prach_eaxc_offset = 1;
     extra_eal_args = ("--file-prefix", "ru");
-    # IQ compression: 0=none  1=BFP  2=BLKSCALE  3=ULAW
+    # IQ compression: "none", "bfp", "blkscale", "ulaw"
     # Must match iq_width setting on the O-DU side (fhi_72.fh_config.ru_config.iq_width)
-    comp_type = 0;
+    comp_type = "none";
   }
   nb_fh_streams = 2;
   codebook_nb_beams = 2;

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.band77.mu1.106rb.2x2_catb.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/ru.band77.mu1.106rb.2x2_catb.conf
@@ -1,0 +1,71 @@
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+ORUs = (
+{
+  tx_bw = [106];
+  rx_bw = [106];
+  carrier_tx = [4049760];
+  carrier_rx = [4049760];
+  prach_config_index = 157;
+  prach_msg1_start = 0;
+  tdd_period = 5;
+  num_dl_slots = 3;
+  num_dl_symbols = 6;
+  num_ul_slots = 1;
+  num_ul_symbols = 4;
+  numerology = 1;
+  fronthaul = {
+    # Mellanox Virtual Functions on Spark configured via spark-setup-ifs.sh
+    dpdk_devices = ("0000:01:11.0", "0000:01:11.1");
+    rx_core = 20;
+    # Matches O-DU MAC addresses in setup_du_ifs_for_spark.sh
+    du_mac_addr = ("00:11:22:44:54:00", "00:11:22:44:54:01");
+    mtu = 9216;
+    T2a_up = (300, 3200);
+    T2a_cp = (285, 3200);
+    prach_eaxc_offset = 1;
+    extra_eal_args = ("--file-prefix", "ru");
+    # IQ compression: 0=none  1=BFP  2=BLKSCALE  3=ULAW
+    # Must match iq_width setting on the O-DU side (fhi_72.fh_config.ru_config.iq_width)
+    comp_type = 0;
+  }
+  nb_fh_streams = 2;
+  codebook_nb_beams = 2;
+  # Q15 weights, layout: beam x tx_antenna x fh_stream x (Re, Im)
+  codebook_weights = [32767,0, 0,0, 0,0, 32767,0,
+                       32767,0, 0,0, 0,0, 0,32767];
+});
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 2; # 2x2 MIMO setup
+  nb_rx          = 2;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  sl_ahead       = 5;
+  tr_preference  = "raw_if4p5"; # Activate FHI7.2
+  do_precoding   = 0;
+  # PRACH configuration
+  num_tp_cores = 4;
+  tp_cores = [16,17,18,19];
+});
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};


### PR DESCRIPTION
This PR replaces #349

The purpose of this change is to introduce support for beam-id field in the O-RU packet processor and introduce fused phase compensation and beamforming step before FFT/CP insertion in downlink.