### PR TITLE
Build LDPC for tests

### DIFF
--- a/openair1/PHY/CODING/CMakeLists.txt
+++ b/openair1/PHY/CODING/CMakeLists.txt
@@ -32,6 +32,9 @@ add_dependencies(nr_ulsim ldpc ldpc_orig)
 add_dependencies(nr_ulschsim ldpc ldpc_orig)
 add_dependencies(nr_dlsim ldpc ldpc_orig)
 add_dependencies(nr_dlschsim ldpc ldpc_orig)
+if (ENABLE_TESTS)
+  add_dependencies(tests ldpc ldpc_orig)
+endif()
 
 add_library(crc_byte OBJECT crc_byte.c)
 


### PR DESCRIPTION
In current develop dlbench would fail if compiled as described in unit test documentation (ninja tests) with the following assertion
```
Assertion (ret_loader == 0) failed!
error loading LDPC library
```
This PR fixes it by linking ldpc into the tests target, such that tests that require ldpc (e.g., nr_dlbench) will find the library present.