### PR TITLE
LDPC decoder: fix parity check when number of CNs is multiple of 32

### DIFF
--- a/openair1/PHY/CODING/nrLDPC_decoder/nrLDPC_cnProc.h
+++ b/openair1/PHY/CODING/nrLDPC_decoder/nrLDPC_cnProc.h
@@ -1227,6 +1227,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG1(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -1295,6 +1297,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG1(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -1364,6 +1368,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG1(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -1432,6 +1438,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG1(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -1500,6 +1508,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG1(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -1568,6 +1578,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG1(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -1636,6 +1648,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG1(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -1704,6 +1718,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG1(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -1772,6 +1788,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG1(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -1868,6 +1886,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG2(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -1936,6 +1956,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG2(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -2004,6 +2026,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG2(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -2072,6 +2096,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG2(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -2140,6 +2166,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG2(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -2208,6 +2236,8 @@ static inline uint32_t nrLDPC_cnProcPc_BG2(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
         // Only use valid CNs
         if (Mrem)
           pcResSum |= (pcRes&(0xFFFFFFFF>>(32-Mrem)));
+        else
+          pcResSum |= pcRes;
 
         // If PC failed we can stop here
         if (pcResSum > 0)
@@ -2220,6 +2250,5 @@ static inline uint32_t nrLDPC_cnProcPc_BG2(t_nrLDPC_lut* p_lut, int8_t* cnProcBu
 }
 
 #endif
-
 
 


### PR DESCRIPTION
### Problem

In the LDPC decoder’s parity check functions (`nrLDPC_cnProcPc_BG1` and `nrLDPC_cnProcPc_BG2`), each degree group’s CNs are processed in chunks of 32 using SIMD instructions. The code separately handles the last chunk (index `M32-1`) outside the main loop to optionally apply a mask when the chunk is not full.

The original logic was:

```c
if (Mrem)
    pcResSum |= (pcRes & (0xFFFFFFFF >> (32 - Mrem)));
```

If `Mrem` (the number of valid CNs in the last chunk) was non‑zero, the result was masked and merged. If `Mrem == 0`, the last chunk is actually a complete block of 32 valid CNs, but **no action was taken** – When `Mrem == 0` and `pcRes` is non-zero (indicating a parity failure), the original code skipped the merge, causing the failure to be silently ignored.

As a consequence, when the total number of CNs in a group is a multiple of 32, the parity check for that entire last block was never considered. This could lead to parity failures going undetected and the decoder incorrectly reporting a successful decode.

### Fix

Add an `else` branch that directly ORs `pcRes` into `pcResSum` when `Mrem == 0`:

```c
if (Mrem)
    pcResSum |= (pcRes & (0xFFFFFFFF >> (32 - Mrem)));
else
    pcResSum |= pcRes;
```

This ensures that the complete last block is included in the accumulated parity result, exactly as intended.

### Impact

- Corrects parity check logic for all LDPC decoding operations.
- Eliminates a class of false‑positive successful decodes that could occur for certain combinations of lifting size `Z` and number of CNs in a degree group.
- No performance regression – the added branch is outside the main SIMD loop and executed only once per degree group.

### Testing

- Verified with synthetic test cases that trigger `numCn * Z` being a multiple of 32.
- Confirmed that parity failures are now correctly detected.
- Existing LDPC test suite passes with no regressions.

---

Please review and merge. Thank you!