### PR TITLE
Add frequency-domain network slicing (SCHE_NS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1227,6 +1227,7 @@ set (MAC_NR_SRC
   ${NR_GNB_MAC_DIR}/gNB_scheduler_bch.c
   ${NR_GNB_MAC_DIR}/gNB_scheduler_dlsch.c
   ${NR_GNB_MAC_DIR}/gNB_scheduler_dlsch_default_policies.c
+  ${NR_GNB_MAC_DIR}/slice_prb_allocator/slice_prb_allocator.c
   ${NR_GNB_MAC_DIR}/gNB_scheduler_ulsch.c
   ${NR_GNB_MAC_DIR}/gNB_scheduler_ulsch_default_policies.c
   ${NR_GNB_MAC_DIR}/gNB_scheduler_primitives.c

--- a/ci-scripts/yaml_files/5g_sa_nws/gnb.sa.band78.133prb.rfsim5slices.nsboth.yaml
+++ b/ci-scripts/yaml_files/5g_sa_nws/gnb.sa.band78.133prb.rfsim5slices.nsboth.yaml
@@ -1,0 +1,284 @@
+Active_gNBs:
+ - gnb-rfsim
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity: none
+gNBs:
+    ##### Identification parameters:
+  - gNB_ID: 0xe00
+    gNB_name: gnb-rfsim
+    disable_harq: 0
+    TIMERS:
+      sr_ProhibitTimer: 0
+      sr_TransMax: 64
+      sr_ProhibitTimer_v1700: 0
+      t300: 400
+      t301: 400
+      t310: 2000
+      n310: 20
+      t311: 3000
+      n311: 1
+      t319: 400
+    tracking_area_code: 81
+    # UE-specific search space (UESS) PDCCH candidates per aggregation level.
+    # Order: [L1, L2, L4, L8, L16]. Max for ~44-CCE CORESET (133 PRB, duration 2):
+    # L8 capped at 5 (8*8>44), L16 capped at 2 (8*16>44).
+    uess_agg_levels: [8, 8, 8, 5, 2]
+    # CORESET duration in OFDM symbols (1, 2 or 3). Use 2 for all slice experiments.
+    coreset_duration: 2
+    plmn_list:
+      - mcc: 001
+        mnc: 01
+        mnc_length: 2
+        snssaiList:
+          - sst: 1
+            sd: 0xffffff
+          - sst: 1
+            sd: 0x01
+          - sst: 1
+            sd: 0x02
+          - sst: 1
+            sd: 0x03
+          - sst: 1
+            sd: 0x04
+          - sst: 1
+            sd: 0x05
+    nr_cellid: 12345678
+    ##### Physical parameters:
+    min_rxtxtime: 6
+    servingCellConfigCommon:
+      #spCellConfigCommon
+      - physCellId: 0
+      #  downlinkConfigCommon
+      #frequencyInfoDL
+        # this is 3301.68 MHz + 22*12*30e-3 MHz = 3309.6
+        absoluteFrequencySSB: 620640
+        # this is 3301.68 MHz
+        dl_absoluteFrequencyPointA: 620112
+        #scs-SpecificCarrierList
+        dl_offstToCarrier: 0
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing: 1
+        dl_carrierBandwidth: 133
+        #initialDownlinkBWP
+        #genericParameters
+        # this is RBstart=0,L=133 (275*(L-1))+RBstart
+        initialDLBWPlocationAndBandwidth: 36300
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing: 1
+        #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero: 10
+        initialDLBWPsearchSpaceZero: 0
+        #uplinkConfigCommon
+        #frequencyInfoUL
+        ul_frequencyBand: 78
+        #scs-SpecificCarrierList
+        ul_offstToCarrier: 0
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        ul_subcarrierSpacing: 1
+        ul_carrierBandwidth: 133
+        pMax: 20
+        #initialUplinkBWP
+        #genericParameters
+        initialULBWPlocationAndBandwidth: 36300
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing: 1
+        #rach-ConfigCommon
+        #rach-ConfigGeneric
+        prach_ConfigurationIndex: 98
+        #prach_msg1_FDM
+        #0 = one, 1=two, 2=four, 3=eight
+        prach_msg1_FDM: 0
+        prach_msg1_FrequencyStart: 0
+        zeroCorrelationZoneConfig: 12
+        preambleReceivedTargetPower: -104
+        #preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+        preambleTransMax: 6
+        #powerRampingStep
+        # 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep: 1
+        #ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+        #1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR: 4
+        #one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB: 15
+        #ra_ContentionResolutionTimer
+        #(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer: 7
+        rsrp_ThresholdSSB: 19
+        #prach-RootSequenceIndex_PR
+        #1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR: 2
+        prach_RootSequenceIndex: 1
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        msg1_SubcarrierSpacing: 1
+        # restrictedSetConfig
+        # 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig: 0
+        msg3_DeltaPreamble: 1
+        p0_NominalWithGrant: -90
+
+        # pucch-ConfigCommon setup :
+        # pucchGroupHopping
+        # 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping: 0
+        hoppingId: 40
+        p0_nominal: -90
+        ssb_PositionsInBurst_Bitmap: 1
+        # ssb_periodicityServingCell
+        # 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+        ssb_periodicityServingCell: 2
+        
+        # dmrs_TypeA_position
+        # 0 = pos2, 1 = pos3
+        dmrs_TypeA_Position: 0
+        
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        subcarrierSpacing: 1
+        
+        #tdd-UL-DL-ConfigurationCommon
+        # subcarrierSpacing
+        # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        referenceSubcarrierSpacing: 1
+        
+        # pattern1
+        # dl_UL_TransmissionPeriodicity
+        # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+        dl_UL_TransmissionPeriodicity: 6
+        nrofDownlinkSlots: 7
+        nrofDownlinkSymbols: 6
+        nrofUplinkSlots: 2
+        nrofUplinkSymbols: 6
+        ssPBCH_BlockPower: -25
+    SCTP:
+      SCTP_INSTREAMS: 2
+      SCTP_OUTSTREAMS: 2
+
+    ##### AMF parameters:
+    amf_ip_address:
+      - ipv4: 10.53.1.2
+
+    NETWORK_INTERFACES:
+      GNB_IPV4_ADDRESS_FOR_NG_AMF: 10.53.1.140
+      GNB_IPV4_ADDRESS_FOR_NGU: 10.53.1.140
+      GNB_PORT_FOR_S1U: 2152 # Spec 2152
+
+
+MACRLCs:
+  - num_cc: 1
+    tr_s_preference: local_L1
+    tr_n_preference: local_RRC
+    pusch_TargetSNRx10: 150
+    pucch_TargetSNRx10: 150
+    stats_max_ue: 17
+    # Scheduler type: 0=SCHE_PF (Proportional Fair), 1=SCHE_NS (Network Slicing)
+    dl_scheduler_type: 1
+    ul_scheduler_type: 1
+    pusch_FailureThres: 1000
+    pucch_FailureThres: 1000
+    dl_harq_round_max: 8
+    ul_harq_round_max: 8
+
+# Network Slices configuration (for SCHE_NS scheduler)
+# PRB ratios are in percentage (0-100). Shared row: dedicated_prb_ratio, min_prb_ratio, max_prb_ratio.
+# Optional DL/UL overrides (omit or -1 to inherit shared row): dl_dedicated_prb_ratio, dl_min_prb_ratio,
+# dl_max_prb_ratio, ul_dedicated_prb_ratio, ul_min_prb_ratio, ul_max_prb_ratio. Sum(dedicated) <= 100 per DL and per UL.
+Slices:
+  - slice_id: 0
+    sst: 1
+    sd: 0xffffff
+    dedicated_prb_ratio: 0.0
+    min_prb_ratio: 00.0
+    max_prb_ratio: 100.0
+    # Unused
+  - slice_id: 1
+    sst: 1
+    sd: 0x000001
+    dedicated_prb_ratio: 0.0
+    min_prb_ratio: 00.0
+    max_prb_ratio: 100.0
+    # Total 100Mbps --> 28Mbps
+  - slice_id: 2
+    sst: 1
+    sd: 0x000002
+    dedicated_prb_ratio: 0.0
+    min_prb_ratio: 00.0
+    max_prb_ratio: 100.0
+    # Total 100Mbps --> 28Mbps
+  - slice_id: 3
+    sst: 1
+    sd: 0x000003
+    dedicated_prb_ratio: 0.0
+    min_prb_ratio: 00.0
+    max_prb_ratio: 50.0
+    # Total 100Mbps --> 14Mbps
+  - slice_id: 4
+    sst: 1
+    sd: 0x000004
+    dedicated_prb_ratio: 0.0
+    min_prb_ratio: 00.0
+    max_prb_ratio: 50.0
+    # Total 100Mbps --> 14Mbps
+  - slice_id: 5
+    sst: 1
+    sd: 0x000005
+    dedicated_prb_ratio: 0.0
+    min_prb_ratio: 00.0
+    max_prb_ratio: 50.0
+    # Total 100Mbps --> 14Mbps
+L1s:
+  - num_cc: 1
+    tr_n_preference:  local_mac
+    prach_dtx_threshold: 200
+    # pucch0_dtx_threshold = 150;
+
+RUs:
+  - local_rf: yes
+    nb_tx: 1
+    nb_rx: 1
+    att_tx: 0
+    att_rx: 0
+    bands: [78]
+    max_pdschReferenceSignalPower: -27
+    max_rxgain: 75
+    eNB_instances: [0]
+    sf_extension: 0
+    sdr_addrs: serial=XXXXXXX
+
+rfsimulator:
+  - serveraddr: server
+
+security:
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms: [nea0]
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms: [nia2, nia0]
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering: yes
+  drb_integrity: no
+
+log_config:
+  global_log_level: info
+  hw_log_level: info
+  phy_log_level: info
+  mac_log_level: info
+  rlc_log_level: info
+  pdcp_log_level: info
+  rrc_log_level: info
+  ngap_log_level: debug
+  f1ap_log_level: debug
+
+e2_agent:
+  near_ric_ip_addr: 192.168.201.142
+  sm_dir: /usr/local/lib/flexric/

--- a/common/utils/telnetsrv/telnetsrv_proccmd.c
+++ b/common/utils/telnetsrv/telnetsrv_proccmd.c
@@ -33,6 +33,10 @@
 #include "common/config/config_userapi.h"
 #include "openair1/PHY/phy_extern.h"
 #include "telnetsrv_proccmd.h"
+#include "openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h"
+#include "openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_types.h"
+#include "openair2/LAYER2/NR_MAC_gNB/mac_proto.h"
+#include "openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/slice_prb_allocator.h"
 
 void decode_procstat(char *record, int debug, telnet_printfunc_t prnt, webdatadef_t *tdata)
 {
@@ -439,6 +443,127 @@ int proccmd_show(char *buf, int debug, telnet_printfunc_t prnt)
        }
        for(int i=0; i<RC.nb_macrlc_inst; i++) {
            prnt("    lte macrlc %i:  %02i CC(s)\n",i,((RC.nb_mac_CC == NULL)?0:RC.nb_mac_CC[i]));
+       }
+   }
+   if (strcasestr(buf, "sch") != NULL || strcasestr(buf, "slice") != NULL) {
+       if (RC.nb_nr_macrlc_inst > 0 && RC.nrmac != NULL && RC.nrmac[0] != NULL) {
+           gNB_MAC_INST *mac = RC.nrmac[0];
+           NR_SCHED_LOCK(&mac->sched_lock);
+
+           prnt("\n=== Network Slice Statistics ===\n");
+           prnt("DL scheduler: %s (%d)\n",
+                mac->scheduler_type_dl == SCHE_NS ? "SCHE_NS" : "SCHE_PF",
+                mac->scheduler_type_dl);
+           prnt("UL scheduler: %s (%d)\n",
+                mac->scheduler_type_ul == SCHE_NS ? "SCHE_NS" : "SCHE_PF",
+                mac->scheduler_type_ul);
+
+           if ((mac->scheduler_type_dl == SCHE_NS || mac->scheduler_type_ul == SCHE_NS)
+               && (mac->slice_scheduler_dl != NULL || mac->slice_scheduler_ul != NULL)) {
+               for (int dir = 0; dir < 2; dir++) {
+                   slice_scheduler_t *sch = (dir == 0) ? mac->slice_scheduler_dl : mac->slice_scheduler_ul;
+                   const char *dir_label = (dir == 0) ? "DL" : "UL";
+                   if (sch == NULL) {
+                       prnt("\n[%s] slice scheduler not initialized\n", dir_label);
+                       continue;
+                   }
+                   int num_slices = slice_sch_get_num_slices(sch);
+                   prnt("\n--- %s (%d slices) ---\n", dir_label, num_slices);
+                   if (num_slices <= 0) {
+                       prnt("No slices configured\n");
+                       continue;
+                   }
+                   int num_stats = 0;
+                   const slice_statistics_t *all_stats = slice_sch_get_all_statistics(sch, &num_stats);
+                   if (all_stats == NULL) {
+                       continue;
+                   }
+                   prnt("\nSlice configuration (%s):\n", dir_label);
+                   prnt("  %-4s %-18s %-12s %-12s %-12s\n",
+                        "Idx", "SST/SD", "Dedicated", "Min Ratio", "Max Ratio");
+                   prnt("  %s\n", "----------------------------------------------------------------------------");
+                   for (int s = 0; s < num_stats; ++s) {
+                       uint8_t sst = all_stats[s].slice_id.sst;
+                       uint32_t sd = all_stats[s].slice_id.sd;
+                       float dedicated, min_r, max_r;
+                       if (slice_sch_get_slice_config(sch, sst, sd, NULL, NULL, &dedicated, &min_r, &max_r) == 0) {
+                           char sst_sd_str[32];
+                           if (sd > 0)
+                               snprintf(sst_sd_str, sizeof(sst_sd_str), "%3d/%06x", sst, sd);
+                           else
+                               snprintf(sst_sd_str, sizeof(sst_sd_str), "%3d/0x000000", sst);
+                           prnt("  %-4d %-18s %-12.3f %-12.3f %-12.3f\n", s, sst_sd_str, dedicated, min_r, max_r);
+                       }
+                   }
+                   int num_active_slices = 0;
+                   int total_allocated_prbs = 0;
+                   if (slice_sch_get_stats(sch, &num_active_slices, &total_allocated_prbs) == 0) {
+                       prnt("\nAllocation statistics (%s):\n", dir_label);
+                       prnt("  Active slices: %d\n", num_active_slices);
+                       prnt("  Total allocated PRBs: %d\n", total_allocated_prbs);
+                       int num_ranges = 0;
+                       const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+                       if (ranges != NULL && num_ranges > 0) {
+                           prnt("\nCurrent PRB allocations (%s):\n", dir_label);
+                           prnt("  %-18s %-12s %-12s %-12s\n", "SST/SD", "Start PRB", "End PRB", "Num PRBs");
+                           prnt("  %s\n", "------------------------------------------------------------");
+                           for (int r = 0; r < num_ranges; ++r) {
+                               if (ranges[r].num_prbs > 0) {
+                                   char sst_sd_str[32];
+                                   if (ranges[r].slice_id.sd > 0)
+                                       snprintf(sst_sd_str, sizeof(sst_sd_str), "%3d/%06x",
+                                                ranges[r].slice_id.sst, ranges[r].slice_id.sd);
+                                   else
+                                       snprintf(sst_sd_str, sizeof(sst_sd_str), "%3d/0x000000",
+                                                ranges[r].slice_id.sst);
+                                   prnt("  %-18s %-12d %-12d %-12d\n",
+                                        sst_sd_str, ranges[r].start_prb, ranges[r].end_prb, ranges[r].num_prbs);
+                               }
+                           }
+                       }
+                       prnt("\nPer-slice statistics (%s):\n", dir_label);
+                       prnt("  %-18s %-12s %-12s %-12s %-12s\n",
+                            "SST/SD", "Latest PRBs", "Avg PRBs", "Samples", "Allocated");
+                       prnt("  %s\n", "----------------------------------------------------------------------------");
+                       for (int s = 0; s < num_stats; ++s) {
+                           uint8_t sst = all_stats[s].slice_id.sst;
+                           uint32_t sd = all_stats[s].slice_id.sd;
+                           char sst_sd_str[32];
+                           if (sd > 0)
+                               snprintf(sst_sd_str, sizeof(sst_sd_str), "%3d/%06x", sst, sd);
+                           else
+                               snprintf(sst_sd_str, sizeof(sst_sd_str), "%3d/0x000000", sst);
+                           prnt("  %-18s %-12d %-12.1f %-12d",
+                                sst_sd_str,
+                                all_stats[s].latest_num_prbs,
+                                all_stats[s].avg_num_prbs,
+                                all_stats[s].sample_count);
+                           bool has_allocation = (all_stats[s].latest_num_prbs > 0);
+                           prnt("  %s\n", has_allocation ? "Yes" : "No");
+                       }
+                   }
+               }
+           } else if (mac->scheduler_type_dl == SCHE_NS || mac->scheduler_type_ul == SCHE_NS) {
+               prnt("\nNetwork slicing enabled but slice schedulers (DL/UL) not initialized\n");
+           }
+
+           UE_iterator(mac->UE_info.connected_ue_list, UE) {
+               NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
+               nssai_t ue_slice = {0};
+               nr_mac_get_ue_effective_nssai(sched_ctrl, &ue_slice);
+               prnt("UE %04x effective slice SST 0x%02x SD 0x%06x\n",
+                    UE->rnti, ue_slice.sst, (unsigned)ue_slice.sd);
+               for (int i = 0; i < seq_arr_size(&sched_ctrl->lc_config); i++) {
+                   const nr_lc_config_t *c = seq_arr_at(&sched_ctrl->lc_config, i);
+                   prnt("  LCID %d SST 0x%02x SD 0x%06x\n",
+                        c->lcid, c->nssai.sst, (unsigned)c->nssai.sd);
+               }
+           }
+
+           NR_SCHED_UNLOCK(&mac->sched_lock);
+           prnt("\n=============================\n");
+       } else {
+           prnt("gNB MAC instance not available\n");
        }
    }
    return 0;

--- a/doc/MAC/scheduler-architecture.md
+++ b/doc/MAC/scheduler-architecture.md
@@ -105,6 +105,11 @@ The preprocessor itself is a pluggable function pointer (`pre_processor_ul`), so
 custom implementation can replace the entire outer strategy — including how many UL
 slots to target and what to do when the DCI budget is limited.
 
+When `scheduler_type_ul == SCHE_NS`, the same preprocessor calls `nr_ul_schedule_ns()`
+after collection; NS filters the candidate snapshot per slice and reuses the modular
+`nr_ul_schedule()` pipeline inside each slice PRB range. See
+[network_slice_3gpp_impl.md](../network_slice_3gpp_impl.md).
+
 ### Candidate struct
 
 Each candidate is an `nr_{dl,ul}_candidate_t` struct that flows through the pipeline,
@@ -300,6 +305,11 @@ allocation across LCIDs.
 
 Top-level orchestrators that run the full pipeline above. In phy-test mode, replaced by
 `nr_preprocessor_phytest` / `nr_ul_preprocessor_phytest` which bypass the staged pipeline.
+
+When `scheduler_type_dl` / `scheduler_type_ul` is `SCHE_NS`, each preprocessor branches
+to `nr_*_schedule_ns()` (slice PRB allocator + per-slice `nr_*_schedule()`). PF and NS
+share the same function pointers; see
+[network_slice_3gpp_impl.md](../network_slice_3gpp_impl.md).
 
 ---
 

--- a/doc/SW_archi.md
+++ b/doc/SW_archi.md
@@ -219,13 +219,8 @@ use-case/deployment type, e.g., one user for phytest in
   2)  Find first free start RB in vrb_map_UL, and as many free consecutive RBs
       as possible.
   3)  Either set up resource allocation directly (e.g., for a single UE,
-      phytest), or call into a function to perform actual resource allocation.
-      Currently, this is done using pf_ul() which implements a basic
-      proportional fair scheduler:
-      * for every UE, check for retransmission and allocate as necessary
-      * Calculate DMRS stuff (nr_set_pusch_semi_static())
-      * Calculate the PF coefficient and put eligible UEs into a list
-      * Allocate resources to the UE(s) with the highest coefficient
+      phytest), or call the modular scheduler (`nr_ul_schedule()` →
+      `nr_ul_proportional_fair`; NS uses `nr_ul_schedule_ns()` per slice).
   4)  Mark used resources in vrb_map_UL.
 * loop through all users: get a HARQ process as indicated through the
   preprocessor, update statistics, fill nFAPI structures directly for PUSCH,
@@ -248,12 +243,8 @@ nr_preprocessor_phytest()], multiple users [nr_dlsch_preprocessor()].
   1)  Check available resources in the vrb_map
   2)  Checks the quantity of waiting data in RLC
   3)  Either set up resource allocation directly (e.g., for a single UE,
-      phytest), or call into a function to perform actual resource allocation.
-      Currently, this is done using pf_dl() which implements a basic
-      proportional fair scheduler:
-      * for every UE, check for retransmission and allocate as necessary
-      * Calculate the PF coefficient and put eligible UEs into a list
-      * Allocate resources to the UE(s) with the highest coefficient
+      phytest), or call the modular scheduler (`nr_dl_schedule()` →
+      `nr_dl_proportional_fair`; NS uses `nr_dl_schedule_ns()` per slice).
   4)  Mark taken resources in the vrb_map
 * loop through all users: check if a new TA is necessary. Then, if a user has
   allocated resources, update statistics (round, sent bytes), update HARQ

--- a/doc/network_slice_3gpp_impl.md
+++ b/doc/network_slice_3gpp_impl.md
@@ -1,0 +1,470 @@
+# Network Slicing (3GPP-oriented MAC Implementation)
+
+This document describes the **frequency-domain network slicing** feature in the OAI
+gNB MAC scheduler: how it maps to 3GPP concepts, how it is configured, and where
+the code lives.
+
+For the general modular scheduler pipeline (collect → RI/PMI → beam → TDA → MCS →
+RB alloc), see [MAC/scheduler-architecture.md](MAC/scheduler-architecture.md).
+
+For end-to-end lab bring-up (Open5GS, rfsim, FlexRIC xApp), see the workspace
+[`nws/scripts/readme.md`](../../nws/scripts/readme.md).
+
+---
+
+## Scope
+
+| In scope | Out of scope (this feature) |
+|----------|-----------------------------|
+| Per-slice **PRB range** allocation on DL/UL | Per-slice CORESET / separate PDCCH search spaces |
+| S-NSSAI-based UE-to-slice mapping (SST + SD) | RAN slicing at L1 beam / cell level |
+| `dedicated` / `min` / `max` PRB ratio policy | CN slice selection (NSSF) — handled by core |
+| Per-direction scheduler (`dl_scheduler_type` / `ul_scheduler_type`) | |
+| Intra-slice UE scheduling via modular `nr_*_proportional_fair` | |
+| E2 Slice SM read/write of NS policy (RAN func) | |
+
+Isolation is **frequency-domain**: each slice gets a contiguous PRB window for the
+slot; UEs are scheduled inside that window with proportional-fair logic.
+
+---
+
+## 3GPP mapping
+
+### S-NSSAI
+
+Slices are identified by **SST** (8-bit Slice/Service Type) and **SD** (24-bit Slice
+Differentiator), matching 5G S-NSSAI:
+
+```c
+typedef struct {
+  uint32_t sst : 8;
+  uint32_t sd  : 24;
+} slice_nssai_t;
+```
+
+UEs are associated with a slice via:
+
+- DRB `nssai` on logical channel config (from RRC / NGAP), and
+- `nr_mac_get_ue_effective_nssai()` for scheduling decisions.
+
+The default slice `SST=1, SD=0xffffff` is reserved and must not be used as a
+data-slice target in E2 SET requests.
+
+### RAN resource model (PRB ratios)
+
+Each slice policy uses three ratios (0.0–1.0), with:
+
+`dedicated_prb_ratio ≤ min_prb_ratio ≤ max_prb_ratio`
+
+| Ratio | Meaning |
+|-------|---------|
+| **dedicated** | Non-shareable guarantee; always reserved (Pass 1) |
+| **min** | Minimum when the slice has traffic; prioritized shareable part = `min − dedicated` (Pass 2) |
+| **max** | Hard upper cap; shareable pool above min = `max − min` (Pass 3) |
+
+Algorithm details: [`slice_prb_allocator/README.md`](../openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/README.md).
+
+### CORESET / PDCCH
+
+CORESET and CCE resources are **cell-wide and shared** across slices. NWS lab configs
+tune `coreset_duration` and `uess_agg_levels` so multiple UEs (across slices) can
+obtain DL/UL DCIs in the same slot. This is a **deployment requirement** for
+multi-slice experiments, not per-slice CORESET partitioning.
+
+Typical slice experiment settings (106 PRB):
+
+```yaml
+uess_agg_levels: [8, 8, 8, 4, 2]   # sized for ~34-CCE CORESET
+coreset_duration: 2                 # 2 OFDM symbols; use for all slice experiments
+```
+
+`coreset_duration` is parsed in `gnb_config.c` → `fix_scc()` and stored in
+`nr_mac_config_t.coreset_duration`.
+
+---
+
+## Scheduler types
+
+```c
+typedef enum {
+  SCHE_PF = 0,  /* Proportional Fair (default) */
+  SCHE_NS = 1   /* Network Slicing (frequency-domain) */
+} scheduler_type_t;
+```
+
+DL and UL are configured **independently**:
+
+```yaml
+MACRLCs:
+  - dl_scheduler_type: 0   # 0 = SCHE_PF, 1 = SCHE_NS
+    ul_scheduler_type: 1
+```
+
+Common lab modes (see `nws/scripts/readme.md`):
+
+| Mode | DL | UL | Notes |
+|------|----|----|-------|
+| `NSUL` | PF | NS | Stable default in many NWS configs |
+| `NSDL` | NS | PF | DL NS needs shared `remainUEs` across slices |
+| `NSBOTH` | NS | NS | Both directions sliced |
+| `PF` | PF | PF | No RAN slicing; slices in YAML ignored for scheduler |
+
+---
+
+## Architecture
+
+NS scheduling is a **two-layer** design: a slice PRB allocator runs first (frequency
+isolation), then the standard modular UE scheduler runs **once per slice** inside the
+allocated window (intra-slice proportional fair).
+
+### Layer model
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Layer 0 — MAC entry (per DL slot / per reachable UL slot)              │
+│  nr_schedule_ue_spec()          nr_schedule_ulsch()                     │
+│       │                                │                                │
+│       ▼                                ▼                                │
+│  pre_processor_dl                pre_processor_ul                       │
+│  nr_dlsch_preprocessor           nr_ulsch_preprocessor                  │
+│  (PF vs NS via scheduler_type_*) (PF vs NS via scheduler_type_*)        │
+└───────────────────────────────┬─────────────────────────────────────────┘
+                                │
+        ┌───────────────────────┴───────────────────────┐
+        │ SCHE_PF                                         │ SCHE_NS
+        ▼                                                 ▼
+  nr_*_schedule()                              nr_*_schedule_ns()
+  (full BWP)                                   │
+                                               ├─ per beam ─────────────────┐
+                                               │                            │
+                                               ▼                            ▼
+                                    slice_prb_allocator          candidate filter (UL)
+                                    (required_prbs → ranges)     or UE list (DL)
+                                               │                            │
+                                               └──────────┬─────────────────┘
+                                                          ▼
+                                               nr_*_schedule(slice_prb, remainUEs)
+                                               DL: collect inside schedule
+                                               UL: filter pre-collected candidates
+                                               → … → nr_*_proportional_fair
+                                               (RB search limited to slice PRB range)
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+| Layer | Responsibility | Key functions / objects |
+|-------|----------------|-------------------------|
+| **Preprocessor** | Branch PF vs NS; UL also iterates K2 / target UL slots | `nr_dlsch_preprocessor`, `nr_ulsch_preprocessor` |
+| **Slice (PRB)** | Demand estimation, ratio policy, contiguous PRB ranges | `slice_scheduler_{dl,ul}`, `slice_sch_schedule()` |
+| **UE (intra-slice)** | Per-UE MCS, beam, TDA, CCE, RB placement inside window | `nr_dl_schedule()`, `nr_ul_schedule()` |
+| **RB policy** | PF retx → minimal grant → new data; slice-bounded search | `nr_*_proportional_fair`, `get_rb_alloc_slice()` |
+
+DL and UL maintain **separate** slice schedulers (`slice_scheduler_dl`,
+`slice_scheduler_ul`) so each direction can use different ratio policies and
+`dl_scheduler_type` / `ul_scheduler_type` independently.
+
+### Per-slot execution — downlink
+
+`nr_dlsch_preprocessor()` branches on `scheduler_type_dl`. When `SCHE_NS`,
+`nr_dl_schedule_ns()` runs **once per DL slot**:
+
+```
+for each beam_idx:
+  1. Build UEs_in_this_beam (UE->UE_beam_index == beam_idx)
+  2. slice_sch_update_total_prbs(slice_scheduler_dl, n_rb_sched[beam])
+  3. For each configured slice:
+       a. Sum required_prbs over UEs matching slice S-NSSAI:
+          - RLC bytes per LCID (incl. SRB STATUS-trigger edge cases)
+          - pending DL HARQ retx rbSize
+          - floor at min_sched_prbs (max(min_grant_prb, 5)) when demand > 0
+       b. slice_sch_update_require(sst, sd, required_prbs)
+  4. slice_sch_schedule()  →  slice_prb_range_t[] per slice
+  5. Rotate slice order: start = (frame * slots_per_frame + slot) % num_ranges
+  6. For each slice s in rotated order:
+       a. Build UEs_in_this_slice (effective nssai matches allocation[s])
+       b. nr_dl_schedule(mac, UEs_in_this_slice, …, &allocation[s], remainUEs)
+```
+
+Inside `nr_dl_schedule()` with a non-NULL `slice_prb`:
+
+1. `collect_dl_candidates()` — only UEs in the slice subset
+2. Pipeline stages 2–5 — same as `SCHE_PF` (RI/PMI, beam, TDA, MCS)
+3. `nr_dl_proportional_fair()` — `slice_rb_start` / `slice_rb_end` constrain RB search;
+   `n_rb_avail = slice_prb->num_prbs`; `max_num_ue = remainUEs[beam]`
+4. Dispatch scheduled candidates; decrement `remainUEs[beam]` by count scheduled
+5. Retx candidates that could not be placed in the slice PRB range → HARQ abort
+
+### Per-slot execution — uplink
+
+`nr_ulsch_preprocessor()` has an **outer** loop (reachable UL slots via K2, DCI
+budget). Each iteration:
+
+1. `collect_ul_candidates()` on the full connected UE list (shared by PF and NS)
+2. If `scheduler_type_ul == SCHE_NS` → `nr_ul_schedule_ns(candidates, n_cand, …)`
+   else → `nr_ul_schedule(candidates, n_cand, …, slice_prb = NULL)`
+
+Inside `nr_ul_schedule_ns()` (same beam / slice / rotate pattern as DL):
+
+```
+for each beam_idx:
+  … slice_sch_update_require / slice_sch_schedule …
+  for each slice s (rotated order):
+    filter_ul_candidates_for_slice(candidates, beam_idx, allocation[s])
+    nr_ul_schedule_candidates()  →  copy + nr_ul_schedule(slice_prb, remainUEs)
+```
+
+`nr_ul_schedule()` in slice mode mirrors DL: slice fields on `nr_ul_sched_params_t`,
+shared `remainUEs`, retx abort on failure. `remainUEs` is decremented in the
+dispatch loop when each UE is committed.
+
+### Shared vs isolated resources
+
+| Resource | Scope under NS | Notes |
+|----------|----------------|-------|
+| **PRB ranges** | Per slice (isolated windows) | Allocator output `[start_prb, end_prb)`; PF searches only inside window |
+| **VRB map** | Cell-wide (shared) | Allocations from slice A mark bits used for slice B in the same slot |
+| **CORESET / CCE** | Cell-wide (shared) | `remainUEs` caps total DCIs per slot (max 4); slices compete for budget |
+| **Beams** | Per UE | NS loops `beam_idx`; slice allocator runs per beam independently |
+
+Frequency isolation is **soft at scheduling time**: the allocator assigns windows;
+`get_rb_alloc_slice()` enforces that UE grants stay inside the slice. There is no
+separate VRB map per slice.
+
+### DCI budget (`remainUEs`)
+
+FAPI limits concurrent DCIs (`MAX_DCI_CORESET`, typically 4 per slot). NS uses one
+shared `remainUEs[num_beams]` array for **all slices** in a slot:
+
+- Initialized to `max_num_ue` (4) at the start of `nr_*_schedule_ns()`
+- Each successful `nr_*_schedule()` call consumes from `remainUEs[beam]`
+- **Slice order rotates** per slot (`start = (frame * slots + slot) % num_slices`) so
+  no slice permanently starves for DCIs when PRB ranges are fixed
+
+PRB ranges from `slice_sch_schedule()` do **not** rotate — only UE scheduling order does.
+
+### Slice allocation result
+
+```c
+typedef struct {
+  slice_nssai_t slice_id;  /* SST + SD */
+  int start_prb;           /* inclusive */
+  int end_prb;             /* exclusive */
+  int num_prbs;            /* end_prb - start_prb */
+} slice_prb_range_t;
+```
+
+Passed into `nr_dl_schedule()` / `nr_ul_schedule()` as `slice_prb`; copied into
+sched params as `slice_rb_start` / `slice_rb_end`.
+
+### Init-time preprocessor selection
+
+`nr_mac_init_scheduler()` in `main.c` always binds the same preprocessors (after gNB
+YAML is loaded). PF vs NS is selected **inside** the preprocessor via
+`scheduler_type_dl` / `scheduler_type_ul`:
+
+```c
+mac->pre_processor_dl = nr_dlsch_preprocessor;
+mac->pre_processor_ul = nr_ulsch_preprocessor;
+```
+
+`nr_dlsch_preprocessor()` / `nr_ulsch_preprocessor()` branch:
+
+```c
+if (mac->scheduler_type_dl == SCHE_NS)
+  nr_dl_schedule_ns(...);
+else
+  nr_dl_schedule(..., NULL, NULL);
+
+/* UL: collect_ul_candidates() first, then */
+if (nr_mac->scheduler_type_ul == SCHE_NS)
+  nr_ul_schedule_ns(..., candidates, n_cand, ...);
+else
+  nr_ul_schedule(..., candidates, n_cand, ..., NULL, NULL);
+```
+
+Called from `mac_top_init_gNB()` (defaults) and again from `gnb_config.c` after
+`set_slice_config()`.
+
+Stages 2–6 inside `nr_*_schedule()` still use the **same** function pointers as PF
+(`dl_rb_alloc` → `nr_dl_proportional_fair`, etc.). NS does not replace those; it
+only branches in the preprocessor, runs the slice allocator, and passes slice-window
+sched params.
+
+Function pointer types: `nr_pp_impl_dl` / `nr_pp_impl_ul` in `nr_mac_gNB.h`.
+
+### Slice-aware sched params
+
+When `nr_dl_schedule()` / `nr_ul_schedule()` run inside NS, `nr_*_sched_params_t` carries:
+
+| Field | Meaning |
+|-------|---------|
+| `slice_rb_start` | Absolute PRB start of slice PRB range (`-1` = full BWP) |
+| `slice_rb_end` | Absolute PRB end, exclusive (`-1` = full BWP) |
+| `n_rb_avail[]` | Set to `slice_prb->num_prbs` for PF fair-share within the slice |
+
+RB allocation uses `get_rb_alloc_slice()` to limit search to the intersection of the
+UE BWP and `[slice_rb_start, slice_rb_end)`.
+
+### PF vs NS — same UE scheduler
+
+Both modes use `nr_dl_proportional_fair` / `nr_ul_proportional_fair` for RB allocation.
+NS adds:
+
+- Slice PRB windows from `slice_prb_allocator`
+- Per-slice UE subsets filtered by `nr_mac_get_ue_effective_nssai()`
+- Slice-bounded RB search and slice-sized `n_rb_avail`
+- Cross-slice `remainUEs` accounting and retx HARQ abort when retx does not fit
+
+### Fallback
+
+If `slice_scheduler_*` is NULL or has zero slices, `nr_*_schedule_ns` falls back to
+full-band `nr_dl_schedule()` / `nr_ul_schedule_candidates()` with `slice_prb = NULL`
+(same modular PF path as `SCHE_PF`). UL reuses the candidates already collected in
+`nr_ulsch_preprocessor()`.
+
+### High-level call graph (reference)
+
+```
+nr_schedule_ue_spec / nr_schedule_ulsch
+        │
+        ▼
+  nr_dlsch_preprocessor / nr_ulsch_preprocessor
+        │
+        ├── scheduler_type_* == SCHE_PF
+        │      └── nr_dl_schedule() / nr_ul_schedule()
+        │            └── nr_*_proportional_fair
+        │
+        └── scheduler_type_* == SCHE_NS
+               └── nr_dl_schedule_ns() / nr_ul_schedule_ns()
+                     ├── slice_prb_allocator
+                     └── per slice: nr_*_schedule(slice_prb, remainUEs)
+                           └── nr_*_proportional_fair (slice PRB range)
+```
+
+UL note: `collect_ul_candidates()` runs once per K2 iteration in
+`nr_ulsch_preprocessor()` before the PF/NS branch; NS filters that snapshot per slice
+instead of re-collecting.
+
+---
+
+## Configuration
+
+### gNB YAML: `Slices` block
+
+Parsed in `gnb_config.c` → `set_slice_config()`. Only active when at least one
+direction uses `SCHE_NS`.
+
+```yaml
+Slices:
+  - slice_id: 1
+    sst: 1
+    sd: 0x000001
+    dedicated_prb_ratio: 0.0
+    min_prb_ratio: 0.0
+    max_prb_ratio: 100.0
+    # Optional per-direction overrides:
+    # dl_dedicated_prb_ratio, dl_min_prb_ratio, dl_max_prb_ratio
+    # ul_dedicated_prb_ratio, ul_min_prb_ratio, ul_max_prb_ratio
+```
+
+Constraints enforced at config time:
+
+- `dedicated ≤ min ≤ max` per slice
+- Sum of `dedicated` ratios ≤ 1.0 per direction (DL and UL separately)
+
+### PLMN / core alignment
+
+NWS configs list matching S-NSSAIs under `plmn_list.snssaiList` and map UEs to
+slices via Open5GS subscriber `sst` / `sd`. Core and RAN slice identifiers must
+match for correct UE-to-slice mapping.
+
+Example configs: `nws/configs/gnb/gnb.sa.band78.*.yaml`.
+
+---
+
+## E2 / O-RAN control
+
+Slice policy can be read and updated over E2:
+
+| Component | Path |
+|-----------|------|
+| RAN function | `openair2/E2AP/RAN_FUNCTION/CUSTOMIZED/ran_func_slice.c` |
+| Policy source | `slice_scheduler_dl` / `slice_scheduler_ul` when `SCHE_NS` active |
+| xApp (NWS) | `nws/scripts/xapp/` — REST on port 18080, Slice SM indications |
+
+E2 SET updates dedicated/min/max ratios at runtime; gNB logs `NS E2 SET applied`
+on success.
+
+---
+
+## Code map
+
+| Area | File |
+|------|------|
+| Scheduler types | `openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_types.h` |
+| Init / preprocessor bind | `openair2/LAYER2/NR_MAC_gNB/main.c` (`nr_mac_init_scheduler`) |
+| DL preprocessor | `gNB_scheduler_dlsch.c` — `nr_dlsch_preprocessor` (PF/NS branch) |
+| DL NS core | `gNB_scheduler_dlsch.c` — `nr_dl_schedule_ns`, `nr_dl_schedule` (slice mode) |
+| UL preprocessor | `gNB_scheduler_ulsch.c` — `nr_ulsch_preprocessor` (collect + PF/NS branch) |
+| UL NS core | `gNB_scheduler_ulsch.c` — `nr_ul_schedule_ns`, `filter_ul_candidates_for_slice`, `nr_ul_schedule_candidates` |
+| Slice-aware RB policy | `gNB_scheduler_*_default_policies.c` — `nr_*_proportional_fair` |
+| RB search in slice | `gNB_scheduler_primitives.c` — `get_rb_alloc_slice()`, `nr_slice_rb_bounds()` |
+| PRB allocator | `slice_prb_allocator/slice_prb_allocator.c` |
+| YAML slice config | `openair2/GNB_APP/gnb_config.c` — `set_slice_config` |
+| CORESET duration | `openair2/GNB_APP/gnb_config.c` — `fix_scc`, `coreset_duration` |
+| E2 slice SM | `openair2/E2AP/RAN_FUNCTION/CUSTOMIZED/ran_func_slice.c` |
+| Telnet stats | `common/utils/telnetsrv/telnetsrv_proccmd.c` (scheduler + slice dump) |
+
+---
+
+## Observability
+
+### gNB logs
+
+At startup:
+
+```
+MAC instance 0: dl_scheduler_type=0, ul_scheduler_type=1
+MAC scheduler preprocessors: DL=SCHE_PF UL=SCHE_NS
+```
+
+### Telnet
+
+Use the MAC stats command (see telnetsrv docs) to print scheduler type and per-slice
+PRB allocation when NS is enabled.
+
+### xApp / FlexRIC
+
+```bash
+curl -s http://127.0.0.1:18080/api/v1/slices | jq .
+```
+
+---
+
+## Code change summary (slice-aware modular PF)
+
+Intra-slice scheduling was moved from legacy monolithic schedulers to the
+same modular pipeline used by `SCHE_PF`. The slice layer (`nr_*_schedule_ns`) is
+unchanged; only the per-slice UE scheduler path uses `nr_*_schedule()` now.
+
+| Change | Purpose |
+|--------|---------|
+| `nr_dl_schedule(..., slice_prb, remainUEs)` | Optional NS args: slice PRB range + shared DCI budget |
+| `nr_ul_schedule(..., slice_prb, remainUEs)` | Same for UL; `remainUEs` decremented on dispatch |
+| `filter_ul_candidates_for_slice()` | Per-slice subset of pre-collected UL candidates |
+| `nr_ul_schedule_candidates()` | Copy candidates + call `nr_ul_schedule()` (per-slice NS) |
+| Unified preprocessors | `nr_*sch_preprocessor` branch on `scheduler_type_*` (no `_ns` variants) |
+| `nr_*_sched_params_t::slice_rb_start/end` | Absolute PRB window passed to RB policy |
+| `nr_slice_rb_bounds()` | Map absolute slice PRB range to BWP-relative bounds |
+| `get_rb_alloc_slice()` | Contiguous RB search limited to slice ∩ BWP |
+| `nr_*_get_rb_alloc()` in default policies | Wire slice PRB range into proportional fair |
+| `nr_mac_init_scheduler()` | Always bind `nr_dlsch_preprocessor` / `nr_ulsch_preprocessor` |
+| HARQ abort in `nr_*_schedule()` | Retx that cannot fit in slice PRB range is dropped |
+
+---
+
+## Related documentation
+
+- [MAC/scheduler-architecture.md](MAC/scheduler-architecture.md) — modular PF pipeline
+- [slice_prb_allocator/README.md](../openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/README.md) — allocation algorithm
+- [nws/scripts/readme.md](../../nws/scripts/readme.md) — lab bring-up and `--sch` modes
+- [nws/scripts/xapp/readme.md](../../nws/scripts/xapp/readme.md) — REST / E2 control

--- a/openair1/SIMULATION/NR_PHY/dlsim.c
+++ b/openair1/SIMULATION/NR_PHY/dlsim.c
@@ -805,7 +805,8 @@ int main(int argc, char **argv)
                                 .timer_config.n311 = 1,
                                 .timer_config.t319 = 400,
                                 .num_agg_level_candidates = {0, 0, 1, 1, 0},
-                                .spatial_stream_index = {0, 1, 2, 3}};
+                                .spatial_stream_index = {0, 1, 2, 3},
+                                .coreset_duration = 1};
   const nr_rlc_configuration_t rlc_config = {
     .srb = {
       .t_poll_retransmit = 45,

--- a/openair1/SIMULATION/NR_PHY/ulsim.c
+++ b/openair1/SIMULATION/NR_PHY/ulsim.c
@@ -787,7 +787,8 @@ int main(int argc, char *argv[])
                                 .timer_config.t311 = 3000,
                                 .timer_config.n311 = 1,
                                 .timer_config.t319 = 400,
-                                .spatial_stream_index = {0, 1, 2, 3, 4, 5, 6, 7}};
+                                .spatial_stream_index = {0, 1, 2, 3, 4, 5, 6, 7},
+                                .coreset_duration = 1};
   const nr_rlc_configuration_t rlc_config = {
     .srb = {
       .t_poll_retransmit = 45,

--- a/openair2/E2AP/RAN_FUNCTION/CMakeLists.txt
+++ b/openair2/E2AP/RAN_FUNCTION/CMakeLists.txt
@@ -80,6 +80,9 @@ add_library(e2_ran_func_du_cucp_cuup STATIC
             )
 
 target_link_libraries(e2_ran_func_du_cucp_cuup PUBLIC asn1_nr_rrc nr_rrc asn1_nr_rrc_hdrs e2_time_obj kpm_ric_info_common_obj kpm_ric_info_obj 3gpp_derived_ie_obj e2sm_rc_ir_obj sm_common_ie_obj ds sm_common_enc_asn_obj_rc 3gpp_derived_ie_enc_asn_obj_rc)
+target_include_directories(e2_ran_func_du_cucp_cuup PRIVATE
+  ${CMAKE_SOURCE_DIR}/openair2/LAYER2/NR_MAC_gNB
+  ${CMAKE_SOURCE_DIR}/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator)
 target_compile_definitions(e2_ran_func_du_cucp_cuup PUBLIC ${E2AP_VERSION}  ${KPM_VERSION} NGRAN_GNB_DU NGRAN_GNB_CUCP NGRAN_GNB_CUUP)
 
 # Current implementation:

--- a/openair2/E2AP/RAN_FUNCTION/CUSTOMIZED/oai_ns_slice_ie.h
+++ b/openair2/E2AP/RAN_FUNCTION/CUSTOMIZED/oai_ns_slice_ie.h
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-CSSL-1.0
+ *
+ * OAI-local NS slice IE definitions for ran_func_slice.c.
+ *
+ * Keeps openairinterface5g buildable when the flexric submodule stays on
+ * upstream ef6d722f2. Runtime wire format still requires libslice_sm.so built
+ * from flexric branch nws-3gpp-impl (see nws/build_scripts/build_oai_flexric_quick.sh).
+ *
+ * Layout mirrors flexric nws-3gpp-impl src/sm/slice_sm/ie/slice_data_ie.h.
+ */
+
+#ifndef OAI_NS_SLICE_IE_H
+#define OAI_NS_SLICE_IE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openair2/E2AP/flexric/src/sm/slice_sm/ie/slice_data_ie.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NS_SLICE_DEFAULT_SD 0xffffffu
+
+#ifndef SLICE_CTRL_SM_V0_NS_SET_POLICY
+/* Upstream flexric ends the enum here; NS_SET_POLICY uses the same value. */
+#define SLICE_CTRL_SM_V0_NS_SET_POLICY SLICE_CTRL_SM_V0_END
+#endif
+
+typedef enum {
+  NS_SLICE_DIR_DL = 0,
+  NS_SLICE_DIR_UL = 1,
+} ns_slice_dir_e;
+
+typedef struct {
+  uint8_t sst;
+  uint32_t sd;
+  ns_slice_dir_e direction;
+  float dedicated_pct;
+  float min_pct;
+  float max_pct;
+} ns_slice_policy_entry_t;
+
+typedef struct {
+  uint32_t len_entries;
+  ns_slice_policy_entry_t *entries;
+} ns_slice_policy_list_t;
+
+/* Extended layouts (must match custom FlexRIC slice_data_ie.h). */
+typedef struct {
+  slice_conf_t slice_conf;
+  ue_slice_conf_t ue_slice_conf;
+  ns_slice_policy_list_t ns_policy;
+  int64_t tstamp;
+} oai_slice_ind_msg_layout_t;
+
+typedef struct {
+  slice_conf_t add_mod_slice;
+  del_slice_conf_t del_slice;
+  ue_slice_conf_t ue_slice;
+  ns_slice_policy_list_t ns_set_policy;
+} oai_slice_ctrl_msg_u_layout_t;
+
+static inline oai_slice_ind_msg_layout_t *oai_slice_ind_msg(slice_ind_msg_t *msg)
+{
+  return (oai_slice_ind_msg_layout_t *)msg;
+}
+
+static inline const oai_slice_ind_msg_layout_t *oai_slice_ind_msg_const(const slice_ind_msg_t *msg)
+{
+  return (const oai_slice_ind_msg_layout_t *)msg;
+}
+
+static inline ns_slice_policy_list_t *oai_slice_ctrl_ns_policy(slice_ctrl_msg_t *msg)
+{
+  return &((oai_slice_ctrl_msg_u_layout_t *)&msg->u)->ns_set_policy;
+}
+
+static inline const ns_slice_policy_list_t *oai_slice_ctrl_ns_policy_const(const slice_ctrl_msg_t *msg)
+{
+  return &((const oai_slice_ctrl_msg_u_layout_t *)&msg->u)->ns_set_policy;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OAI_NS_SLICE_IE_H */

--- a/openair2/E2AP/RAN_FUNCTION/CUSTOMIZED/ran_func_slice.c
+++ b/openair2/E2AP/RAN_FUNCTION/CUSTOMIZED/ran_func_slice.c
@@ -4,50 +4,273 @@
 
 #include "ran_func_slice.h"
 #include "../../flexric/test/rnd/fill_rnd_data_slice.h"
+#include "oai_ns_slice_ie.h"
+#include "NR_MAC_gNB/nr_mac_gNB.h"
+#include "NR_MAC_gNB/gNB_scheduler_types.h"
+#include "common/utils/LOG/log.h"
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-bool read_slice_sm(void* data)
+static const int mod_id = 0;
+
+static bool is_default_slice(uint32_t sd)
+{
+  return sd == NS_SLICE_DEFAULT_SD;
+}
+
+static void append_ns_policy_from_scheduler(ns_slice_policy_list_t *list,
+                                            slice_scheduler_t *sched,
+                                            ns_slice_dir_e direction)
+{
+  if (sched == NULL)
+    return;
+
+  const int n = slice_sch_get_num_slices(sched);
+  if (n <= 0)
+    return;
+
+  for (int i = 0; i < n; ++i) {
+    const slice_nssai_t *nssai = slice_sch_get_slice_nssai(sched, i);
+    if (nssai == NULL)
+      continue;
+
+    float ded = 0.f;
+    float min = 0.f;
+    float max = 0.f;
+    if (slice_sch_get_slice_config(sched, nssai->sst, nssai->sd, NULL, NULL, &ded, &min, &max) != 0)
+      continue;
+
+    const uint32_t new_len = list->len_entries + 1;
+    ns_slice_policy_entry_t *grown =
+        realloc(list->entries, new_len * sizeof(ns_slice_policy_entry_t));
+    assert(grown != NULL && "Memory exhausted");
+    list->entries = grown;
+
+    ns_slice_policy_entry_t *e = &list->entries[list->len_entries];
+    e->sst = nssai->sst;
+    e->sd = nssai->sd;
+    e->direction = direction;
+    e->dedicated_pct = ded * 100.f;
+    e->min_pct = min * 100.f;
+    e->max_pct = max * 100.f;
+    list->len_entries = new_len;
+  }
+}
+
+static void read_ns_policy_from_mac(ns_slice_policy_list_t *out, gNB_MAC_INST *mac)
+{
+  assert(out != NULL);
+  assert(mac != NULL);
+
+  out->len_entries = 0;
+  out->entries = NULL;
+
+  NR_SCHED_LOCK(&mac->sched_lock);
+
+  if (mac->slice_scheduler_dl != NULL && mac->scheduler_type_dl == SCHE_NS)
+    append_ns_policy_from_scheduler(out, mac->slice_scheduler_dl, NS_SLICE_DIR_DL);
+
+  if (mac->slice_scheduler_ul != NULL && mac->scheduler_type_ul == SCHE_NS)
+    append_ns_policy_from_scheduler(out, mac->slice_scheduler_ul, NS_SLICE_DIR_UL);
+
+  NR_SCHED_UNLOCK(&mac->sched_lock);
+}
+
+static bool validate_ns_entry(const ns_slice_policy_entry_t *e, char *err, size_t err_len)
+{
+  const char *dir = e->direction == NS_SLICE_DIR_UL ? "ul" : e->direction == NS_SLICE_DIR_DL ? "dl" : "?";
+
+  if (e->direction != NS_SLICE_DIR_DL && e->direction != NS_SLICE_DIR_UL) {
+    snprintf(err, err_len, "SST=%u SD=0x%06x: invalid direction", e->sst, e->sd);
+    return false;
+  }
+  if (is_default_slice(e->sd)) {
+    snprintf(err, err_len, "SST=%u SD=0x%06x %s: cannot control default slice (sd=0xffffff)", e->sst, e->sd, dir);
+    return false;
+  }
+  if (e->dedicated_pct < 0.f || e->dedicated_pct > 100.f || e->min_pct < 0.f || e->min_pct > 100.f || e->max_pct < 0.f
+      || e->max_pct > 100.f) {
+    snprintf(err, err_len, "SST=%u SD=0x%06x %s: ratios must be in [0, 100]%%", e->sst, e->sd, dir);
+    return false;
+  }
+  if (e->dedicated_pct > e->min_pct) {
+    snprintf(err,
+             err_len,
+             "SST=%u SD=0x%06x %s: dedicated %.1f%% > min %.1f%% (need dedicated <= min <= max)",
+             e->sst,
+             e->sd,
+             dir,
+             e->dedicated_pct,
+             e->min_pct);
+    return false;
+  }
+  if (e->min_pct > e->max_pct) {
+    snprintf(err,
+             err_len,
+             "SST=%u SD=0x%06x %s: min %.1f%% > max %.1f%% (need dedicated <= min <= max)",
+             e->sst,
+             e->sd,
+             dir,
+             e->min_pct,
+             e->max_pct);
+    return false;
+  }
+  return true;
+}
+
+static double ratio_sum_scheduler(const slice_scheduler_t *sched, bool min_not_dedicated)
+{
+  double sum = 0.0;
+  const int n = slice_sch_get_num_slices(sched);
+  for (int i = 0; i < n; ++i) {
+    const slice_nssai_t *nssai = slice_sch_get_slice_nssai(sched, i);
+    if (nssai == NULL)
+      continue;
+    float ded = 0.f;
+    float min = 0.f;
+    if (slice_sch_get_slice_config(sched, nssai->sst, nssai->sd, NULL, NULL, &ded, &min, NULL) == 0)
+      sum += min_not_dedicated ? min : ded;
+  }
+  return sum;
+}
+
+static double dedicated_sum_scheduler(const slice_scheduler_t *sched)
+{
+  return ratio_sum_scheduler(sched, false);
+}
+
+static sm_ag_if_ans_t make_slice_ctrl_out(slice_ctrl_out_e rc, const char *diag)
+{
+  sm_ag_if_ans_t ans = {.type = CTRL_OUTCOME_SM_AG_IF_ANS_V0};
+  ans.ctrl_out.type = SLICE_AGENT_IF_CTRL_ANS_V0;
+  ans.ctrl_out.slice.ans = rc;
+  if (diag != NULL && diag[0] != '\0') {
+    ans.ctrl_out.slice.len_diag = strlen(diag);
+    ans.ctrl_out.slice.diagnostic = malloc(ans.ctrl_out.slice.len_diag + 1);
+    assert(ans.ctrl_out.slice.diagnostic != NULL && "Memory exhausted");
+    memcpy(ans.ctrl_out.slice.diagnostic, diag, ans.ctrl_out.slice.len_diag + 1);
+  }
+  return ans;
+}
+
+bool read_slice_sm(void *data)
 {
   assert(data != NULL);
-//  assert(data->type == SLICE_STATS_V0);
 
-  slice_ind_data_t* slice = (slice_ind_data_t*)data;
+  slice_ind_data_t *slice = (slice_ind_data_t *)data;
+  oai_slice_ind_msg_layout_t *ind_msg = oai_slice_ind_msg(&slice->msg);
   fill_slice_ind_data(slice);
+  ind_msg->tstamp = time_now_us();
+
+  gNB_MAC_INST *mac = RC.nrmac[mod_id];
+  read_ns_policy_from_mac(&ind_msg->ns_policy, mac);
 
   return true;
 }
 
-void read_slice_setup_sm(void* data)
+void read_slice_setup_sm(void *data)
 {
   assert(data != NULL);
-//  assert(data->type == SLICE_AGENT_IF_E2_SETUP_ANS_V0 );
-
-  assert(0 !=0 && "Not supported");
+  assert(0 != 0 && "Not supported");
 }
 
-sm_ag_if_ans_t write_ctrl_slice_sm(void const* data)
+sm_ag_if_ans_t write_ctrl_slice_sm(void const *data)
 {
   assert(data != NULL);
-//  assert(data->type == SLICE_CTRL_REQ_V0);
 
-  slice_ctrl_req_data_t const* slice_req_ctrl = (slice_ctrl_req_data_t const* )data; // &data->slice_req_ctrl;
-  slice_ctrl_msg_t const* msg = &slice_req_ctrl->msg;
+  const slice_ctrl_req_data_t *slice_req_ctrl = (const slice_ctrl_req_data_t *)data;
+  const slice_ctrl_msg_t *msg = &slice_req_ctrl->msg;
 
-  if(msg->type == SLICE_CTRL_SM_V0_ADD){
-    printf("[E2 Agent]: SLICE CONTROL ADD rx\n");
-  } else if (msg->type == SLICE_CTRL_SM_V0_DEL){
-    printf("[E2 Agent]: SLICE CONTROL DEL rx\n");
-  } else if (msg->type == SLICE_CTRL_SM_V0_UE_SLICE_ASSOC){
-    printf("[E2 Agent]: SLICE CONTROL ASSOC rx\n");
-  } else {
-    assert(0!=0 && "Unknown msg_type!");
+  if (msg->type == SLICE_CTRL_SM_V0_NS_SET_POLICY) {
+    gNB_MAC_INST *mac = RC.nrmac[mod_id];
+    const ns_slice_policy_list_t *pol = oai_slice_ctrl_ns_policy_const(msg);
+    char err[256] = {0};
+
+    for (uint32_t i = 0; i < pol->len_entries; ++i) {
+      if (!validate_ns_entry(&pol->entries[i], err, sizeof(err)))
+        return make_slice_ctrl_out(SLICE_CTRL_OUT_ERROR, err);
+    }
+
+    NR_SCHED_LOCK(&mac->sched_lock);
+
+    for (uint32_t i = 0; i < pol->len_entries; ++i) {
+      const ns_slice_policy_entry_t *e = &pol->entries[i];
+      slice_scheduler_t *sched = NULL;
+
+      if (e->direction == NS_SLICE_DIR_DL) {
+        if (mac->scheduler_type_dl != SCHE_NS || mac->slice_scheduler_dl == NULL) {
+          NR_SCHED_UNLOCK(&mac->sched_lock);
+          return make_slice_ctrl_out(SLICE_CTRL_OUT_ERROR, "DL NS scheduler not enabled");
+        }
+        sched = mac->slice_scheduler_dl;
+      } else {
+        if (mac->scheduler_type_ul != SCHE_NS || mac->slice_scheduler_ul == NULL) {
+          NR_SCHED_UNLOCK(&mac->sched_lock);
+          return make_slice_ctrl_out(SLICE_CTRL_OUT_ERROR, "UL NS scheduler not enabled");
+        }
+        sched = mac->slice_scheduler_ul;
+      }
+
+      const float ded = e->dedicated_pct / 100.f;
+      const float min = e->min_pct / 100.f;
+      const float max = e->max_pct / 100.f;
+      if (slice_sch_add_slice(sched, e->sst, e->sd, ded, min, max, 0) != 0) {
+        NR_SCHED_UNLOCK(&mac->sched_lock);
+        snprintf(err,
+                 sizeof(err),
+                 "SST=%u SD=0x%06x %s: slice_sch_add_slice failed",
+                 e->sst,
+                 e->sd,
+                 e->direction == NS_SLICE_DIR_UL ? "ul" : "dl");
+        return make_slice_ctrl_out(SLICE_CTRL_OUT_ERROR, err);
+      }
+      sched->result_valid = false;
+      LOG_I(NR_MAC,
+            "NS E2 SET applied: SST=%u SD=0x%06x %s dedicated=%.1f%% min=%.1f%% max=%.1f%%\n",
+            e->sst,
+            e->sd,
+            e->direction == NS_SLICE_DIR_UL ? "ul" : "dl",
+            e->dedicated_pct,
+            e->min_pct,
+            e->max_pct);
+    }
+
+    if (mac->slice_scheduler_dl != NULL && mac->scheduler_type_dl == SCHE_NS) {
+      if (dedicated_sum_scheduler(mac->slice_scheduler_dl) > 1.0 + 1e-6) {
+        NR_SCHED_UNLOCK(&mac->sched_lock);
+        return make_slice_ctrl_out(SLICE_CTRL_OUT_ERROR, "sum of DL dedicated ratios exceeds 100%");
+      }
+      if (ratio_sum_scheduler(mac->slice_scheduler_dl, true) > 1.0 + 1e-6) {
+        NR_SCHED_UNLOCK(&mac->sched_lock);
+        return make_slice_ctrl_out(SLICE_CTRL_OUT_ERROR, "sum of DL min ratios exceeds 100%");
+      }
+    }
+    if (mac->slice_scheduler_ul != NULL && mac->scheduler_type_ul == SCHE_NS) {
+      if (dedicated_sum_scheduler(mac->slice_scheduler_ul) > 1.0 + 1e-6) {
+        NR_SCHED_UNLOCK(&mac->sched_lock);
+        return make_slice_ctrl_out(SLICE_CTRL_OUT_ERROR, "sum of UL dedicated ratios exceeds 100%");
+      }
+      if (ratio_sum_scheduler(mac->slice_scheduler_ul, true) > 1.0 + 1e-6) {
+        NR_SCHED_UNLOCK(&mac->sched_lock);
+        return make_slice_ctrl_out(SLICE_CTRL_OUT_ERROR, "sum of UL min ratios exceeds 100%");
+      }
+    }
+
+    NR_SCHED_UNLOCK(&mac->sched_lock);
+    return make_slice_ctrl_out(SLICE_CTRL_OUT_OK, NULL);
   }
 
-  sm_ag_if_ans_t ans = {.type = CTRL_OUTCOME_SM_AG_IF_ANS_V0};
-  ans.ctrl_out.type = SLICE_AGENT_IF_CTRL_ANS_V0;
-  return ans;
+  if (msg->type == SLICE_CTRL_SM_V0_ADD) {
+    printf("[E2 Agent]: SLICE CONTROL ADD rx\n");
+  } else if (msg->type == SLICE_CTRL_SM_V0_DEL) {
+    printf("[E2 Agent]: SLICE CONTROL DEL rx\n");
+  } else if (msg->type == SLICE_CTRL_SM_V0_UE_SLICE_ASSOC) {
+    printf("[E2 Agent]: SLICE CONTROL ASSOC rx\n");
+  } else {
+    assert(0 != 0 && "Unknown msg_type!");
+  }
 
+  return make_slice_ctrl_out(SLICE_CTRL_OUT_OK, NULL);
 }
-
-

--- a/openair2/E2AP/RAN_FUNCTION/CUSTOMIZED/ran_func_slice.h
+++ b/openair2/E2AP/RAN_FUNCTION/CUSTOMIZED/ran_func_slice.h
@@ -6,6 +6,9 @@
 #define RAN_FUNC_SM_SLICE_READ_WRITE_AGENT_H
 
 #include "openair2/E2AP/flexric/src/agent/../sm/sm_io.h"
+#include "common/ran_context.h"
+#include "openair2/LAYER2/NR_MAC_gNB/mac_proto.h"
+#include "openair2/E2AP/flexric/src/util/time_now_us.h"
 
 bool read_slice_sm(void*);
 
@@ -14,4 +17,3 @@ void read_slice_setup_sm(void* data);
 sm_ag_if_ans_t write_ctrl_slice_sm(void const* data);
 
 #endif
-

--- a/openair2/GNB_APP/MACRLC_nr_paramdef.h
+++ b/openair2/GNB_APP/MACRLC_nr_paramdef.h
@@ -55,6 +55,8 @@
 #define MACRLC_PUCCH_RSSI_THRESHOLD          "pucch_RSSI_Threshold"
 #define MACRLC_STATS_MAX_UE                  "stats_max_ue"
 #define MACRLC_SPATIAL_STREAM_IDX            "spatial_stream_index"
+#define MACRLC_DL_SCHEDULER_TYPE             "dl_scheduler_type"
+#define MACRLC_UL_SCHEDULER_TYPE             "ul_scheduler_type"
 
 #define HLP_MACRLC_UL_PRBBLACK "SNR threshold to decide whether a PRB will be blacklisted or not"
 #define HLP_MACRLC_DL_BLER_UP "Upper threshold of BLER to decrease DL MCS"
@@ -127,6 +129,8 @@
   {MACRLC_STATS_MAX_UE,                HLP_MACRLC_STATS_MAX_UE,  0, .iptr=NULL,   .defintval=8,               TYPE_INT,     0}, \
   {MACRLC_SPATIAL_STREAM_IDX,          HLP_MACRLC_SPATIAL_STREAM_INDEX, \
                                                                                0, .uptr=NULL,   .defintarrayval=0,          TYPE_INTARRAY,0}, \
+  {MACRLC_DL_SCHEDULER_TYPE,           NULL,                     0, .uptr=NULL,   .defuintval=0,              TYPE_UINT,    0}, \
+  {MACRLC_UL_SCHEDULER_TYPE,           NULL,                     0, .uptr=NULL,   .defuintval=0,              TYPE_UINT,    0}, \
 }
 // clang-format off
 
@@ -174,6 +178,8 @@
   { .s2 =  { config_check_intrange, {-1280, 0}} }, /* PUCCH RSSI threshold range */ \
   { .s5 = { NULL } }, \
   { .s2 = { NULL } }, /* Spatial stream index */ \
+  { .s5 = { NULL } }, \
+  { .s5 = { NULL } }, \
 }
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------------*/

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -14,6 +14,9 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include "openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h"
+#include "openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_types.h"
+#include "openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/slice_prb_allocator.h"
 #include "BIT_STRING.h"
 #include "L1_nr_paramdef.h"
 #include "MACRLC_nr_paramdef.h"
@@ -25,6 +28,7 @@
 #include "asn_internal.h"
 #include "NR_MAC_gNB/nr_mac_gNB.h"
 #include "NR_MAC_gNB/mac_proto.h"
+#include "NR_MAC_gNB/gNB_scheduler_types.h"
 #include "common/5g_platform_types.h"
 #include "common/config/config_paramdesc.h"
 #include "common/config/config_userapi.h"
@@ -74,6 +78,247 @@ static int DEFRUTPCORES[] = {-1,-1,-1,-1};
     (element)->present = NR_SetupRelease_##type##_PR_setup;                  \
     (element)->choice.setup = CALLOC(1, sizeof(*((element)->choice.setup))); \
   } while (0)
+
+/*! \brief Parse network slice configuration from YAML and initialize slice structures in MAC instance.
+ *
+ * Creates slice_scheduler_dl / slice_scheduler_ul when at least one direction uses
+ * SCHE_NS. Each slot, nr_dl_schedule_ns() / nr_ul_schedule_ns() feed traffic demand
+ * into these objects and consume slice_prb_range_t output for intra-slice scheduling.
+ *  \param mac MAC instance to initialize slices for
+ *  \return Number of slices configured
+ */
+static int set_slice_config(gNB_MAC_INST *mac)
+{
+  GET_PARAMS_LIST(SliceParamList,
+                  SliceParams,
+                  GNBSLICEPARAMS_DESC,
+                  GNB_CONFIG_STRING_SLICES_LIST,
+                  NULL,
+                  SLICEPARAMS_CHECK);
+  int num_slices = SliceParamList.numelt;
+  
+  if (num_slices == 0) {
+    LOG_I(NR_MAC, "No slices configured, network slicing scheduler will not be active\n");
+    return 0;
+  }
+
+  const bool dl_ns_enabled = (mac->scheduler_type_dl == SCHE_NS);
+  const bool ul_ns_enabled = (mac->scheduler_type_ul == SCHE_NS);
+  if (!dl_ns_enabled && !ul_ns_enabled) {
+    LOG_I(NR_MAC,
+          "Slices are configured but both dl_scheduler_type and ul_scheduler_type are SCHE_PF; "
+          "network slicing is disabled for both directions\n");
+    return 0;
+  }
+  
+  AssertFatal(num_slices <= MAX_NUM_SLICES, "Number of slices %d exceeds maximum %d\n", num_slices, MAX_NUM_SLICES);
+  
+  // Temporary arrays for validation
+  int slice_ids[MAX_NUM_SLICES];
+  uint8_t slice_sst[MAX_NUM_SLICES];
+  uint32_t slice_sd[MAX_NUM_SLICES];
+  float slice_dedicated[MAX_NUM_SLICES];
+  float slice_min[MAX_NUM_SLICES];
+  float slice_max[MAX_NUM_SLICES];
+  float slice_dl_dedicated[MAX_NUM_SLICES];
+  float slice_dl_min[MAX_NUM_SLICES];
+  float slice_dl_max[MAX_NUM_SLICES];
+  float slice_ul_dedicated[MAX_NUM_SLICES];
+  float slice_ul_min[MAX_NUM_SLICES];
+  float slice_ul_max[MAX_NUM_SLICES];
+  double total_dedicated_ratio = 0.0;
+  double total_dl_dedicated_ratio = 0.0;
+  double total_ul_dedicated_ratio = 0.0;
+  
+  // First pass: Parse and validate individual slice parameters
+  for (int s = 0; s < num_slices; ++s) {
+    slice_ids[s] = *SliceParamList.paramarray[s][GNB_SLICE_ID_IDX].iptr;
+    slice_sst[s] = *SliceParamList.paramarray[s][GNB_SLICE_SST_IDX].uptr;
+    slice_sd[s] = *SliceParamList.paramarray[s][GNB_SLICE_SD_IDX].uptr;
+    
+    // Convert percentage to ratio (0.0-1.0)
+    double dedicated_pct = *SliceParamList.paramarray[s][GNB_SLICE_DEDICATED_PRB_RATIO_IDX].dblptr;
+    double min_pct = *SliceParamList.paramarray[s][GNB_SLICE_MIN_PRB_RATIO_IDX].dblptr;
+    double max_pct = *SliceParamList.paramarray[s][GNB_SLICE_MAX_PRB_RATIO_IDX].dblptr;
+    
+    slice_dedicated[s] = dedicated_pct / 100.0;
+    slice_min[s] = min_pct / 100.0;
+    slice_max[s] = max_pct / 100.0;
+    
+    // Validate individual slice parameters
+    AssertFatal(slice_ids[s] >= 0 && slice_ids[s] <= 1023,
+                "Slice %d: slice_id must be in [0, 1023], but is %d\n", s, slice_ids[s]);
+    AssertFatal(slice_sst[s] >= 0 && slice_sst[s] <= 255,
+                "Slice %d: SST must be in [0, 255], but is %d\n", s, slice_sst[s]);
+    AssertFatal(slice_sd[s] <= 0xffffff,
+                "Slice %d: SD cannot be bigger than 0xffffff, but is 0x%06x\n", s, slice_sd[s]);
+    
+    // Validate PRB ratios are in valid range
+    AssertFatal(dedicated_pct >= 0.0 && dedicated_pct <= 100.0,
+                "Slice %d: Dedicated PRB ratio must be in [0.0, 100.0]%%, but is %.1f%%\n", s, dedicated_pct);
+    AssertFatal(min_pct >= 0.0 && min_pct <= 100.0,
+                "Slice %d: Min PRB ratio must be in [0.0, 100.0]%%, but is %.1f%%\n", s, min_pct);
+    AssertFatal(max_pct >= 0.0 && max_pct <= 100.0,
+                "Slice %d: Max PRB ratio must be in [0.0, 100.0]%%, but is %.1f%%\n", s, max_pct);
+    
+    // Validate ratio relationships: dedicated <= min <= max
+    AssertFatal(slice_dedicated[s] <= slice_min[s],
+                "Slice %d: Dedicated PRB ratio (%.1f%%) must be <= Min PRB ratio (%.1f%%)\n",
+                s, dedicated_pct, min_pct);
+    AssertFatal(slice_min[s] <= slice_max[s],
+                "Slice %d: Min PRB ratio (%.1f%%) must be <= Max PRB ratio (%.1f%%)\n",
+                s, min_pct, max_pct);
+    
+    total_dedicated_ratio += slice_dedicated[s];
+    
+    double dl_ded_pct = *SliceParamList.paramarray[s][GNB_SLICE_DL_DEDICATED_PRB_RATIO_IDX].dblptr;
+    double dl_min_pct = *SliceParamList.paramarray[s][GNB_SLICE_DL_MIN_PRB_RATIO_IDX].dblptr;
+    double dl_max_pct = *SliceParamList.paramarray[s][GNB_SLICE_DL_MAX_PRB_RATIO_IDX].dblptr;
+    double ul_ded_pct = *SliceParamList.paramarray[s][GNB_SLICE_UL_DEDICATED_PRB_RATIO_IDX].dblptr;
+    double ul_min_pct = *SliceParamList.paramarray[s][GNB_SLICE_UL_MIN_PRB_RATIO_IDX].dblptr;
+    double ul_max_pct = *SliceParamList.paramarray[s][GNB_SLICE_UL_MAX_PRB_RATIO_IDX].dblptr;
+
+    if (dl_ded_pct < 0.0) {
+      slice_dl_dedicated[s] = slice_dedicated[s];
+      slice_dl_min[s] = slice_min[s];
+      slice_dl_max[s] = slice_max[s];
+    } else {
+      AssertFatal(dl_ded_pct >= 0.0 && dl_ded_pct <= 100.0,
+                  "Slice %d: dl_dedicated_prb_ratio must be in [0.0, 100.0]%% or -1, but is %.1f%%\n", s, dl_ded_pct);
+      slice_dl_dedicated[s] = (float)(dl_ded_pct / 100.0);
+      if (dl_min_pct < 0.0)
+        slice_dl_min[s] = slice_min[s];
+      else {
+        AssertFatal(dl_min_pct >= 0.0 && dl_min_pct <= 100.0,
+                    "Slice %d: dl_min_prb_ratio must be in [0.0, 100.0]%% or -1, but is %.1f%%\n", s, dl_min_pct);
+        slice_dl_min[s] = (float)(dl_min_pct / 100.0);
+      }
+      if (dl_max_pct < 0.0)
+        slice_dl_max[s] = slice_max[s];
+      else {
+        AssertFatal(dl_max_pct >= 0.0 && dl_max_pct <= 100.0,
+                    "Slice %d: dl_max_prb_ratio must be in [0.0, 100.0]%% or -1, but is %.1f%%\n", s, dl_max_pct);
+        slice_dl_max[s] = (float)(dl_max_pct / 100.0);
+      }
+      AssertFatal(slice_dl_dedicated[s] <= slice_dl_min[s],
+                  "Slice %d: DL dedicated must be <= DL min\n", s);
+      AssertFatal(slice_dl_min[s] <= slice_dl_max[s],
+                  "Slice %d: DL min must be <= DL max\n", s);
+    }
+
+    if (ul_ded_pct < 0.0) {
+      slice_ul_dedicated[s] = slice_dedicated[s];
+      slice_ul_min[s] = slice_min[s];
+      slice_ul_max[s] = slice_max[s];
+    } else {
+      AssertFatal(ul_ded_pct >= 0.0 && ul_ded_pct <= 100.0,
+                  "Slice %d: ul_dedicated_prb_ratio must be in [0.0, 100.0]%% or -1, but is %.1f%%\n", s, ul_ded_pct);
+      slice_ul_dedicated[s] = (float)(ul_ded_pct / 100.0);
+      if (ul_min_pct < 0.0)
+        slice_ul_min[s] = slice_min[s];
+      else {
+        AssertFatal(ul_min_pct >= 0.0 && ul_min_pct <= 100.0,
+                    "Slice %d: ul_min_prb_ratio must be in [0.0, 100.0]%% or -1, but is %.1f%%\n", s, ul_min_pct);
+        slice_ul_min[s] = (float)(ul_min_pct / 100.0);
+      }
+      if (ul_max_pct < 0.0)
+        slice_ul_max[s] = slice_max[s];
+      else {
+        AssertFatal(ul_max_pct >= 0.0 && ul_max_pct <= 100.0,
+                    "Slice %d: ul_max_prb_ratio must be in [0.0, 100.0]%% or -1, but is %.1f%%\n", s, ul_max_pct);
+        slice_ul_max[s] = (float)(ul_max_pct / 100.0);
+      }
+      AssertFatal(slice_ul_dedicated[s] <= slice_ul_min[s],
+                  "Slice %d: UL dedicated must be <= UL min\n", s);
+      AssertFatal(slice_ul_min[s] <= slice_ul_max[s],
+                  "Slice %d: UL min must be <= UL max\n", s);
+    }
+
+    total_dl_dedicated_ratio += slice_dl_dedicated[s];
+    total_ul_dedicated_ratio += slice_ul_dedicated[s];
+
+    LOG_I(NR_MAC,
+          "Configured slice %d: SST=%d, SD=0x%06x, shared Dedicated=%.1f%%, Min=%.1f%%, Max=%.1f%% | "
+          "DL: %.1f%%, %.1f%%, %.1f%% | UL: %.1f%%, %.1f%%, %.1f%%\n",
+          slice_ids[s],
+          slice_sst[s],
+          slice_sd[s],
+          dedicated_pct,
+          min_pct,
+          max_pct,
+          slice_dl_dedicated[s] * 100.0,
+          slice_dl_min[s] * 100.0,
+          slice_dl_max[s] * 100.0,
+          slice_ul_dedicated[s] * 100.0,
+          slice_ul_min[s] * 100.0,
+          slice_ul_max[s] * 100.0);
+  }
+  
+  // Second pass: Validate cross-slice constraints
+  // Check for duplicate slice IDs
+  for (int s1 = 0; s1 < num_slices; ++s1) {
+    for (int s2 = s1 + 1; s2 < num_slices; ++s2) {
+      AssertFatal(slice_ids[s1] != slice_ids[s2],
+                  "Duplicate slice_id %d found in slices %d and %d\n", slice_ids[s1], s1, s2);
+    }
+  }
+  
+  // Check for duplicate NSSAI (SST+SD combinations)
+  for (int s1 = 0; s1 < num_slices; ++s1) {
+    for (int s2 = s1 + 1; s2 < num_slices; ++s2) {
+      AssertFatal(!(slice_sst[s1] == slice_sst[s2] && slice_sd[s1] == slice_sd[s2]),
+                  "Duplicate NSSAI (SST=%d, SD=0x%06x) found in slices %d and %d\n",
+                  slice_sst[s1], slice_sd[s1], s1, s2);
+    }
+  }
+  
+  // Check that sum of dedicated ratios doesn't exceed 100% (shared legacy row, and per-direction)
+  AssertFatal(total_dedicated_ratio <= 1.0,
+              "Sum of dedicated PRB ratios (%.1f%%) exceeds 100%%\n", total_dedicated_ratio * 100.0);
+  AssertFatal(total_dl_dedicated_ratio <= 1.0,
+              "Sum of DL dedicated PRB ratios (%.1f%%) exceeds 100%%\n", total_dl_dedicated_ratio * 100.0);
+  AssertFatal(total_ul_dedicated_ratio <= 1.0,
+              "Sum of UL dedicated PRB ratios (%.1f%%) exceeds 100%%\n", total_ul_dedicated_ratio * 100.0);
+  
+  if (total_dedicated_ratio > 0.9) {
+    LOG_W(NR_MAC, "Warning: Sum of dedicated PRB ratios (%.1f%%) is very high, may limit flexibility\n",
+          total_dedicated_ratio * 100.0);
+  }
+  
+  const int default_total_prbs = 100; // Updated when scheduling runs
+  if (dl_ns_enabled && mac->slice_scheduler_dl == NULL) {
+    mac->slice_scheduler_dl = slice_sch_create(default_total_prbs);
+    AssertFatal(mac->slice_scheduler_dl != NULL, "Failed to create DL slice scheduler\n");
+  }
+  if (ul_ns_enabled && mac->slice_scheduler_ul == NULL) {
+    mac->slice_scheduler_ul = slice_sch_create(default_total_prbs);
+    AssertFatal(mac->slice_scheduler_ul != NULL, "Failed to create UL slice scheduler\n");
+  }
+  
+  for (int s = 0; s < num_slices; ++s) {
+    if (dl_ns_enabled) {
+      int ret_dl = slice_sch_add_slice(mac->slice_scheduler_dl, slice_sst[s], slice_sd[s],
+                                       slice_dl_dedicated[s], slice_dl_min[s], slice_dl_max[s], 0);
+      AssertFatal(ret_dl == 0, "Failed to add slice %d (SST=%d, SD=0x%06x) to DL scheduler\n",
+                  slice_ids[s], slice_sst[s], slice_sd[s]);
+    }
+    if (ul_ns_enabled) {
+      int ret_ul = slice_sch_add_slice(mac->slice_scheduler_ul, slice_sst[s], slice_sd[s],
+                                       slice_ul_dedicated[s], slice_ul_min[s], slice_ul_max[s], 0);
+      AssertFatal(ret_ul == 0, "Failed to add slice %d (SST=%d, SD=0x%06x) to UL scheduler\n",
+                  slice_ids[s], slice_sst[s], slice_sd[s]);
+    }
+  }
+  
+  LOG_I(NR_MAC,
+        "Configured %d network slices (DL scheduler: %s, UL scheduler: %s, DL total dedicated: %.1f%%, UL total dedicated: %.1f%%)\n",
+        num_slices,
+        dl_ns_enabled ? "SCHE_NS" : "SCHE_PF",
+        ul_ns_enabled ? "SCHE_NS" : "SCHE_PF",
+        total_dl_dedicated_ratio * 100.0,
+        total_ul_dedicated_ratio * 100.0);
+  return num_slices;
+}
 
 /**
  * Allocate memory and initialize ServingCellConfigCommon struct members
@@ -1626,6 +1871,14 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg, nr_cell_sched_t **out_cel
         config.num_agg_level_candidates[PDCCH_AGG_LEVEL8],
         config.num_agg_level_candidates[PDCCH_AGG_LEVEL16]);
 
+  // coreset_duration: optional gNB config (default 1). Controls CORESET#1 duration in
+  // symbols and the matching PDSCH TDA start; previously hard-coded from BWP size.
+  config.coreset_duration = *GNBParamList.paramarray[0][GNB_CORESET_DURATION_IDX].iptr;
+  AssertFatal(config.coreset_duration >= 1 && config.coreset_duration <= 3,
+              "coreset_duration must be 1, 2 or 3, got %d\n",
+              config.coreset_duration);
+  LOG_I(NR_MAC, "CORESET duration: %d symbol(s)\n", config.coreset_duration);
+
   NR_ServingCellConfigCommon_t *scc = get_scc_config(config.minRXTXTIME, config.do_SRS);
   // BWP
   get_bwp_config(&config, scc);
@@ -1665,6 +1918,40 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg, nr_cell_sched_t **out_cel
     for (j = 0; j < RC.nb_nr_macrlc_inst; j++) {
       gNB_MAC_INST *nrmac = RC.nrmac[j];
       params = MacRLC_ParamList.paramarray[j]; // RC.nb_nr_macrlc_inst == 1 as per assert, but keep consistent
+
+      // Scheduler is configured per direction.
+      RC.nrmac[j]->scheduler_type_dl = SCHE_PF;
+      RC.nrmac[j]->scheduler_type_ul = SCHE_PF;
+      const paramdef_t *p_dl_sche = gpd(params, np, MACRLC_DL_SCHEDULER_TYPE);
+      if (p_dl_sche && (p_dl_sche->paramflags & PARAMFLAG_PARAMSET)) {
+        uint32_t dl_scheduler_type = *p_dl_sche->uptr;
+        if (dl_scheduler_type <= SCHE_NS) {
+          RC.nrmac[j]->scheduler_type_dl = (scheduler_type_t)dl_scheduler_type;
+        } else {
+          LOG_W(NR_MAC,
+                "MAC instance %d: Invalid dl_scheduler_type %d in configuration, using default SCHE_PF\n",
+                j,
+                dl_scheduler_type);
+        }
+      }
+      const paramdef_t *p_ul_sche = gpd(params, np, MACRLC_UL_SCHEDULER_TYPE);
+      if (p_ul_sche && (p_ul_sche->paramflags & PARAMFLAG_PARAMSET)) {
+        uint32_t ul_scheduler_type = *p_ul_sche->uptr;
+        if (ul_scheduler_type <= SCHE_NS) {
+          RC.nrmac[j]->scheduler_type_ul = (scheduler_type_t)ul_scheduler_type;
+        } else {
+          LOG_W(NR_MAC,
+                "MAC instance %d: Invalid ul_scheduler_type %d in configuration, using default SCHE_PF\n",
+                j,
+                ul_scheduler_type);
+        }
+      }
+      LOG_I(NR_MAC,
+            "MAC instance %d: dl_scheduler_type=%d, ul_scheduler_type=%d\n",
+            j,
+            RC.nrmac[j]->scheduler_type_dl,
+            RC.nrmac[j]->scheduler_type_ul);
+
       if (strcmp(*gpd(params, np, MACRLC_TRANSPORT_N_PREFERENCE)->strptr, "local_RRC") == 0) {
         // check number of instances is same as RRC/PDCP
 
@@ -1716,6 +2003,12 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg, nr_cell_sched_t **out_cel
       cell->ulsch_max_frame_inactivity = *gpd(params, np, MACRLC_ULSCH_MAX_FRAME_INACTIVITY)->uptr;
       nrmac->stats_max_ue = *gpd(params, np, MACRLC_STATS_MAX_UE)->iptr;
       nrmac->print_ue_stats = nrmac->stats_max_ue > 0;
+      
+      // Initialize slice configuration (scheduler will be created in set_slice_config if slices are configured)
+      nrmac->slice_scheduler_dl = NULL;
+      nrmac->slice_scheduler_ul = NULL;
+      set_slice_config(nrmac);
+      nr_mac_init_scheduler(nrmac);
       NR_bler_options_t *dl_bler_options = &cell->dl_bler;
       dl_bler_options->upper = *gpd(params, np, MACRLC_DL_BLER_TARGET_UPPER)->dblptr;
       dl_bler_options->lower = *gpd(params, np, MACRLC_DL_BLER_TARGET_LOWER)->dblptr;

--- a/openair2/GNB_APP/gnb_paramdef.h
+++ b/openair2/GNB_APP/gnb_paramdef.h
@@ -96,6 +96,7 @@ typedef enum {
 #define GNB_CONFIG_STRING_NUM_DL_HARQPROCESSES          "num_dlharq"
 #define GNB_CONFIG_STRING_NUM_UL_HARQPROCESSES          "num_ulharq"
 #define GNB_CONFIG_STRING_UESS_AGG_LEVEL_LIST           "uess_agg_levels"
+#define GNB_CONFIG_STRING_CORESET_DURATION              "coreset_duration"
 #define GNB_CONFIG_STRING_CU_SIB_LIST                   "cu_sibs"
 #define GNB_CONFIG_STRING_DU_SIB_LIST                   "du_sibs"
 #define GNB_CONFIG_STRING_CONFIG_REP                    "CSI_report_type"
@@ -111,6 +112,7 @@ typedef enum {
 #define GNB_CONFIG_HLP_NUM_DL_HARQ                      "Set Num DL harq processes. Valid values 2,4,6,8,10,12,16,32. Default 16"
 #define GNB_CONFIG_HLP_NUM_UL_HARQ                      "Set Num UL harq processes. Valid values 16,32. Default 16"
 #define GNB_CONFIG_HLP_UESS_AGG_LEVEL_LIST              "List of aggregation levels with number of candidates per level. Element 0 - aggregation level 1"
+#define GNB_CONFIG_HLP_CORESET_DURATION                 "CORESET duration in OFDM symbols (1, 2 or 3). Replaces former BWP-size heuristic; default 1"
 #define GNB_CONFIG_HLP_CU_SIBS                          "List of CU generated SIBs to be transmitted"
 #define GNB_CONFIG_HLP_DU_SIBS                          "List of DU generated SIBs to be transmitted"
 #define GNB_CONFIG_HLP_CONFIG_REP                       "Define quantity for CSI report (options: ssb_rsrp, ssb_sinr and cri_rsrp)"
@@ -163,6 +165,7 @@ typedef enum {
 {GNB_CONFIG_STRING_CONFIG_REP, GNB_CONFIG_HLP_CONFIG_REP, 0,          .strptr=NULL, .defstrval="ssb_rsrp",        TYPE_STRING,    0},  \
 {GNB_CONFIG_STRING_1ST_ACTIVE_BWP,               NULL,   0,            .iptr=NULL,  .defintval=0,                 TYPE_INT,       0},  \
 {GNB_CONFIG_STRING_LIMIT_RSRP_REPORT,            NULL,   0,            .iptr=NULL,  .defintval=0,                 TYPE_INT,       0},  \
+{GNB_CONFIG_STRING_CORESET_DURATION, GNB_CONFIG_HLP_CORESET_DURATION, 0, .iptr=NULL, .defintval=1,               TYPE_INT,       0},  \
 }
 // clang-format on
 
@@ -207,10 +210,12 @@ typedef enum {
 #define GNB_CONFIG_REP_IDX              37
 #define GNB_1ST_ACTIVE_BWP_IDX          38
 #define GNB_LIMIT_RSRP_REPORT_IDX       39
+#define GNB_CORESET_DURATION_IDX        40
 
 #define TRACKING_AREA_CODE_OKRANGE {0x0001,0xFFFD}
 #define NUM_DL_HARQ_OKVALUES {2,4,6,8,10,12,16,32}
 #define NUM_UL_HARQ_OKVALUES {16,32}
+#define CORESET_DURATION_OKVALUES {1,2,3}
 
 #define GNBPARAMS_CHECK {                                         \
   { .s5 = { NULL } },                                             \
@@ -259,6 +264,7 @@ typedef enum {
              3 } }, \
   { .s5 = { NULL } },                                             \
   { .s5 = { NULL } },                                             \
+  { .s1 =  { config_check_intval, CORESET_DURATION_OKVALUES, 3 } }, \
 }
 
 /*-------------------------------------------------------------------------------------------------------------------------------------------------*/
@@ -596,6 +602,72 @@ typedef enum {
 #define SNSSAIPARAMS_CHECK {                                           \
   { .s2 = { config_check_intrange, SLICE_SERVICE_TYPE_OKRANGE } },        \
   { .s2 = { config_check_intrange, SLICE_DIFFERENTIATOR_TYPE_OKRANGE } }, \
+}
+
+/* Network Slice configuration */
+
+#define GNB_CONFIG_STRING_SLICES_LIST                   "Slices"
+
+#define GNB_CONFIG_STRING_SLICE_ID                       "slice_id"
+#define GNB_CONFIG_STRING_SLICE_SST                      "sst"
+#define GNB_CONFIG_STRING_SLICE_SD                       "sd"
+#define GNB_CONFIG_STRING_SLICE_DEDICATED_PRB_RATIO      "dedicated_prb_ratio"
+#define GNB_CONFIG_STRING_SLICE_MIN_PRB_RATIO            "min_prb_ratio"
+#define GNB_CONFIG_STRING_SLICE_MAX_PRB_RATIO            "max_prb_ratio"
+#define GNB_CONFIG_STRING_SLICE_DL_DEDICATED_PRB_RATIO   "dl_dedicated_prb_ratio"
+#define GNB_CONFIG_STRING_SLICE_DL_MIN_PRB_RATIO        "dl_min_prb_ratio"
+#define GNB_CONFIG_STRING_SLICE_DL_MAX_PRB_RATIO        "dl_max_prb_ratio"
+#define GNB_CONFIG_STRING_SLICE_UL_DEDICATED_PRB_RATIO  "ul_dedicated_prb_ratio"
+#define GNB_CONFIG_STRING_SLICE_UL_MIN_PRB_RATIO       "ul_min_prb_ratio"
+#define GNB_CONFIG_STRING_SLICE_UL_MAX_PRB_RATIO        "ul_max_prb_ratio"
+
+#define GNB_SLICE_ID_IDX                 0
+#define GNB_SLICE_SST_IDX               1
+#define GNB_SLICE_SD_IDX                2
+#define GNB_SLICE_DEDICATED_PRB_RATIO_IDX 3
+#define GNB_SLICE_MIN_PRB_RATIO_IDX     4
+#define GNB_SLICE_MAX_PRB_RATIO_IDX     5
+#define GNB_SLICE_DL_DEDICATED_PRB_RATIO_IDX 6
+#define GNB_SLICE_DL_MIN_PRB_RATIO_IDX     7
+#define GNB_SLICE_DL_MAX_PRB_RATIO_IDX     8
+#define GNB_SLICE_UL_DEDICATED_PRB_RATIO_IDX 9
+#define GNB_SLICE_UL_MIN_PRB_RATIO_IDX     10
+#define GNB_SLICE_UL_MAX_PRB_RATIO_IDX     11
+
+#define GNBSLICEPARAMS_DESC {                                                                  \
+/*   optname                               helpstr                 paramflags XXXptr     def val              type    numelt */ \
+  {GNB_CONFIG_STRING_SLICE_ID,            "slice identifier",             0, .iptr=NULL, .defintval=0,         TYPE_INT, 0},    \
+  {GNB_CONFIG_STRING_SLICE_SST,           "slice service type",           0, .uptr=NULL, .defuintval=1,        TYPE_UINT, 0},    \
+  {GNB_CONFIG_STRING_SLICE_SD,             "slice differentiator",         0, .uptr=NULL, .defuintval=0xffffff, TYPE_UINT, 0},   \
+  {GNB_CONFIG_STRING_SLICE_DEDICATED_PRB_RATIO, "dedicated PRB ratio (%)", 0, .dblptr=NULL, .defdblval=0.0,    TYPE_DOUBLE, 0}, \
+  {GNB_CONFIG_STRING_SLICE_MIN_PRB_RATIO, "minimum PRB ratio (%)",        0, .dblptr=NULL, .defdblval=0.0,    TYPE_DOUBLE, 0}, \
+  {GNB_CONFIG_STRING_SLICE_MAX_PRB_RATIO, "maximum PRB ratio (%)",       0, .dblptr=NULL, .defdblval=100.0, TYPE_DOUBLE, 0}, \
+  {GNB_CONFIG_STRING_SLICE_DL_DEDICATED_PRB_RATIO, "DL dedicated PRB ratio (%, -1=use dedicated_prb_ratio)", 0, .dblptr=NULL, .defdblval=-1.0, TYPE_DOUBLE, 0}, \
+  {GNB_CONFIG_STRING_SLICE_DL_MIN_PRB_RATIO, "DL minimum PRB ratio (%, -1=use min_prb_ratio)", 0, .dblptr=NULL, .defdblval=-1.0, TYPE_DOUBLE, 0}, \
+  {GNB_CONFIG_STRING_SLICE_DL_MAX_PRB_RATIO, "DL maximum PRB ratio (%, -1=use max_prb_ratio)", 0, .dblptr=NULL, .defdblval=-1.0, TYPE_DOUBLE, 0}, \
+  {GNB_CONFIG_STRING_SLICE_UL_DEDICATED_PRB_RATIO, "UL dedicated PRB ratio (%, -1=use dedicated_prb_ratio)", 0, .dblptr=NULL, .defdblval=-1.0, TYPE_DOUBLE, 0}, \
+  {GNB_CONFIG_STRING_SLICE_UL_MIN_PRB_RATIO, "UL minimum PRB ratio (%, -1=use min_prb_ratio)", 0, .dblptr=NULL, .defdblval=-1.0, TYPE_DOUBLE, 0}, \
+  {GNB_CONFIG_STRING_SLICE_UL_MAX_PRB_RATIO, "UL maximum PRB ratio (%, -1=use max_prb_ratio)", 0, .dblptr=NULL, .defdblval=-1.0, TYPE_DOUBLE, 0}, \
+}
+
+#define SLICE_ID_OKRANGE                 {0, 1023}
+#define SLICE_SST_OKRANGE                 {0, 255}
+#define SLICE_SD_OKRANGE                  {0, 0xffffff}
+#define SLICE_PRB_RATIO_OKRANGE           {0.0, 100.0}
+
+#define SLICEPARAMS_CHECK {                                           \
+  { .s2 = { config_check_intrange, SLICE_ID_OKRANGE } },                \
+  { .s2 = { config_check_intrange, SLICE_SST_OKRANGE } },                \
+  { .s2 = { config_check_intrange, SLICE_SD_OKRANGE } },                \
+  { .s5 = { NULL } }, /* dedicated_prb_ratio - no validation, checked in code */ \
+  { .s5 = { NULL } }, /* min_prb_ratio - no validation, checked in code */ \
+  { .s5 = { NULL } }, /* max_prb_ratio - no validation, checked in code */ \
+  { .s5 = { NULL } }, /* dl_* optional overrides */ \
+  { .s5 = { NULL } }, \
+  { .s5 = { NULL } }, \
+  { .s5 = { NULL } }, /* ul_* optional overrides */ \
+  { .s5 = { NULL } }, \
+  { .s5 = { NULL } }, \
 }
 
 /* AMF configuration parameters section name */

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch.c
@@ -699,23 +699,37 @@ bool commit_alloc(const nr_dl_sched_params_t *params, nr_dl_candidate_t *cand)
   return true;
 }
 
+/*! \brief Modular DL scheduler pipeline (collect → RI/PMI → beam → TDA → MCS → RB → dispatch).
+ *
+ * When called from network slicing (SCHE_NS), optional \p slice_prb and \p remainUEs_ext
+ * constrain intra-slice scheduling:
+ *  - slice_prb: PRB range from slice_prb_allocator; passed to nr_dl_proportional_fair
+ *  - remainUEs_ext: shared DCI budget decremented across all slices in the slot
+ * Pass both NULL for full-band SCHE_PF scheduling.
+ */
 static void nr_dl_schedule(gNB_MAC_INST *mac,
                            nr_cell_sched_t *cell,
                            post_process_pdsch_t *pp_pdsch,
                            NR_UE_info_t **UE_list,
                            int max_num_ue,
                            int num_beams,
-                           int n_rb_sched[num_beams])
+                           int n_rb_sched[num_beams],
+                           const slice_prb_range_t *slice_prb,
+                           int *remainUEs_ext)
 {
   frame_t frame = pp_pdsch->frame;
   slot_t slot = pp_pdsch->slot;
   NR_ServingCellConfigCommon_t *scc = cell->common_channels.ServingCellConfigCommon;
   int slots_per_frame = cell->frame_structure.numb_slots_frame;
+  const bool use_slice = (slice_prb != NULL);
 
   /* Step 1: Collect candidates */
   nr_dl_candidate_t candidates[MAX_MOBILES_PER_GNB] = {0};
   int n = collect_dl_candidates(cell, UE_list, candidates, MAX_MOBILES_PER_GNB, frame, slot);
   if (n == 0)
+    return;
+  /* NS: check slice_prb and remainUEs_ext are valid */
+  if (slice_prb != NULL && (slice_prb->num_prbs <= 0 || remainUEs_ext == NULL))
     return;
 
   /* Step 2: RI/PMI selection — sets sched_pdsch.nrOfLayers and pm_index per candidate */
@@ -746,7 +760,7 @@ static void nr_dl_schedule(gNB_MAC_INST *mac,
 
   /* Step 6: Sort by beam, then call RB allocation policy per beam */
   qsort(candidates, n, sizeof(*candidates), compare_beam_idx);
-
+  /* NS: tell the RB policy the absolute slice range and size for fair-share math. */
   nr_dl_sched_params_t params = {
       .mac = mac,
       .cell = cell,
@@ -757,10 +771,12 @@ static void nr_dl_schedule(gNB_MAC_INST *mac,
       .min_mcs = cell->dl_bler.min_mcs,
       .bler_lower = cell->dl_bler.lower,
       .bler_upper = cell->dl_bler.upper,
+      .slice_rb_start = use_slice ? slice_prb->start_prb : -1,
+      .slice_rb_end = use_slice ? slice_prb->end_prb : -1,
   };
   for (int b = 0; b < num_beams; b++) {
     params.vrb_map[b] = cell->common_channels.vrb_map[b];
-    params.n_rb_avail[b] = n_rb_sched[b];
+    params.n_rb_avail[b] = use_slice ? slice_prb->num_prbs : n_rb_sched[b];
   }
 
   int i = 0;
@@ -771,7 +787,31 @@ static void nr_dl_schedule(gNB_MAC_INST *mac,
       i++;
     int count = i - start;
 
-    mac->dl_rb_alloc(&params, candidates + start, count);
+    if (use_slice)
+      params.max_num_ue = remainUEs_ext[beam]; /* cap by DCIs left for later slices */
+    int n_sched = mac->dl_rb_alloc(&params, candidates + start, count);
+    if (use_slice)
+      remainUEs_ext[beam] -= n_sched;
+  }
+
+  /* Under NS, abort HARQ when a retx cannot be placed inside the slice PRB range. */
+  if (use_slice) {
+    for (int j = 0; j < n; j++) {
+      nr_dl_candidate_t *cand = &candidates[j];
+      if (!cand->is_retx || cand->scheduled || cand->skipped)
+        continue;
+      NR_UE_sched_ctrl_t *sched_ctrl = &cand->UE->UE_sched_ctrl;
+      int harq_pid = cand->retx_harq_pid;
+      LOG_D(NR_MAC,
+            "[UE %04x][%4d.%2d] DL retransmission could not be allocated (slice: abort HARQ)\n",
+            cand->rnti,
+            frame,
+            slot);
+      reset_beam_status(&cell->beam_info, frame, slot, cand->alloc_beam_dir, slots_per_frame, cand->alloc_new_beam);
+      remove_nr_list(&sched_ctrl->retrans_dl_harq, harq_pid);
+      abort_nr_dl_harq(cand->UE, harq_pid);
+      cand->skipped = true;
+    }
   }
 
   /* Release beam reservations for candidates the policy rejected (failed
@@ -859,7 +899,7 @@ static void nr_dl_schedule(gNB_MAC_INST *mac,
       const uint16_t num_log_ports = p->XP * p->N1 * p->N2;
       sched_pdsch.ant_port_idx.numSpatialStreamIndices = num_log_ports;
       const int start_stream_idx = cand->alloc_beam_idx * num_log_ports;
-      for (int i = 0; i < sched_pdsch.ant_port_idx.numSpatialStreamIndices;i++)
+      for (int i = 0; i < sched_pdsch.ant_port_idx.numSpatialStreamIndices; i++)
         sched_pdsch.ant_port_idx.spatialStreamIndices[i] = cell->radio_config.spatial_stream_index[start_stream_idx + i];
     }
 
@@ -867,6 +907,201 @@ static void nr_dl_schedule(gNB_MAC_INST *mac,
   }
 }
 
+/*! \brief Network slicing DL orchestrator (slice layer + intra-slice UE scheduler).
+ *
+ * Two-layer flow per beam, per slot:
+ *  1. Estimate per-slice traffic demand (RLC + HARQ retx) → slice_sch_update_require()
+ *  2. slice_sch_schedule() → contiguous PRB range per S-NSSAI
+ *  3. For each slice (rotating order): filter UEs by nssai, call nr_dl_schedule()
+ *     with the slice PRB range and shared remainUEs DCI budget.
+ *
+ * Intra-slice scheduling reuses nr_dl_proportional_fair with slice_rb_start/end.
+ * Falls back to full-band nr_dl_schedule() if no slice scheduler is configured.
+ */
+static void nr_dl_schedule_ns(gNB_MAC_INST *mac,
+                              nr_cell_sched_t *cell,
+                              post_process_pdsch_t *pp_pdsch,
+                              NR_UE_info_t **UE_list,
+                              int max_num_ue,
+                              int num_beams,
+                              int n_rb_sched[num_beams])
+{
+  if (mac->slice_scheduler_dl == NULL || slice_sch_get_num_slices(mac->slice_scheduler_dl) == 0) {
+    nr_dl_schedule(mac, cell, pp_pdsch, UE_list, max_num_ue, num_beams, n_rb_sched, NULL, NULL);
+    return;
+  }
+
+  frame_t frame = pp_pdsch->frame;
+  slot_t slot = pp_pdsch->slot;
+
+  int UEs_in_this_beam_count = 0;
+  NR_UE_info_t **UEs_in_this_beam = calloc(MAX_MOBILES_PER_GNB + 1, sizeof(NR_UE_info_t *));
+  if (UEs_in_this_beam == NULL) {
+    LOG_W(NR_MAC, "nr_dl_schedule_ns: OOM, falling back to PF\n");
+    nr_dl_schedule(mac, cell, pp_pdsch, UE_list, max_num_ue, num_beams, n_rb_sched, NULL, NULL);
+    return;
+  }
+
+  /* Shared DCI/UE budget across all slices (same as nr_ul_schedule_ns). */
+  int remainUEs[num_beams];
+  for (int i = 0; i < num_beams; i++)
+    remainUEs[i] = max_num_ue;
+
+  for (int beam_idx = 0; beam_idx < num_beams; beam_idx++) {
+    /* --- Slice layer: demand + PRB range allocation for this beam --- */
+    UEs_in_this_beam_count = 0;
+    memset(UEs_in_this_beam, 0, sizeof(NR_UE_info_t *) * (MAX_MOBILES_PER_GNB + 1));
+
+    // Create list of UEs that belong to this beam structure index
+    // Iterate through connected UEs and find those that map to beam structure index i
+    UE_iterator(UE_list, UE) {
+      if (UE->UE_beam_index == beam_idx) {
+        UEs_in_this_beam[UEs_in_this_beam_count] = UE;
+        UEs_in_this_beam_count++;
+      }
+      if (UEs_in_this_beam_count >= MAX_MOBILES_PER_GNB) {
+        break;
+      }
+    }
+    if (UEs_in_this_beam_count == 0)
+      continue;
+
+    // Update total PRBs for this beam
+    int total_prbs = n_rb_sched[beam_idx];
+    slice_sch_update_total_prbs(mac->slice_scheduler_dl, total_prbs);
+
+    // Find required PRBs for each slice
+    slice_scheduler_t *slice_scheduler = mac->slice_scheduler_dl;
+    int num_slices = slice_sch_get_num_slices(slice_scheduler);
+    /* RB policy needs at least min_grant_prb (and 5 for type-1 alloc). Tiny RLC
+     * STATUS must not report require in (0, min) or the allocator may cap the
+     * slice below a schedulable range. */
+    const int min_sched_prbs = max((int)cell->min_grant_prb, 5);
+    for (int s = 0; s < num_slices; s++) {
+      int required_prbs = 0;
+
+      const slice_nssai_t *slice_nssai = slice_sch_get_slice_nssai(slice_scheduler, s);
+      if (slice_nssai == NULL) {
+        continue;
+      }
+      // Iterate through UEs in this beam structure index
+      UE_iterator(UEs_in_this_beam, UE) {
+        // Iterate all logical channel configs (lcid) for this UE, including SRB/DRB
+        NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
+        nssai_t ue_slice = {0};
+        nr_mac_get_ue_effective_nssai(sched_ctrl, &ue_slice);
+        if (ue_slice.sst != slice_nssai->sst || ue_slice.sd != slice_nssai->sd)
+          continue;
+
+        int ue_required_prbs = 0;
+        bool srb_needs_dl = false;
+
+        for (int l = 0; l < seq_arr_size(&sched_ctrl->lc_config); ++l) {
+          const nr_lc_config_t *lc = seq_arr_at(&sched_ctrl->lc_config, l);
+          if (lc->suspended)
+            continue;
+
+          // Get RLC buffer status for this LCID
+          const int lcid = lc->lcid;
+          const uint16_t rnti = UE->rnti;
+          logical_chan_id_t ch = lcid;
+          nr_mac_rlc_status_ind(rnti, frame, 1, &ch, &sched_ctrl->rlc_status[lcid]);
+
+          /* SRB may have status_triggered with bytes_in_buffer still 0. */
+          if (lcid == UL_SCH_LCID_SRB1 || lcid == UL_SCH_LCID_SRB2) {
+            if (sched_ctrl->rlc_status[lcid].bytes_in_buffer > 0
+                || nr_rlc_am_status_triggered(rnti, lcid))
+              srb_needs_dl = true;
+          }
+
+          // Accumulate bytes for this UE's effective slice to calculate required PRBs.
+          if (sched_ctrl->rlc_status[lcid].bytes_in_buffer > 0) {
+            const int bytes_per_prb_estimate = 4 - 2;
+            int prbs_needed = (sched_ctrl->rlc_status[lcid].bytes_in_buffer + bytes_per_prb_estimate - 1) / bytes_per_prb_estimate;
+            ue_required_prbs += prbs_needed;
+          }
+        }
+        /* Pending DL HARQ retx must keep the original rbSize; count it so the
+         * slice PRB range does not shrink below what remapping needs. */
+        for (int harq_pid = sched_ctrl->retrans_dl_harq.head; harq_pid >= 0;
+             harq_pid = sched_ctrl->retrans_dl_harq.next[harq_pid]) {
+          ue_required_prbs += sched_ctrl->harq_processes[harq_pid].sched_pdsch.rbSize;
+        }
+        if (srb_needs_dl)
+          ue_required_prbs = max(ue_required_prbs, min_sched_prbs);
+        required_prbs += ue_required_prbs;
+      }
+      /* Any positive demand (incl. tiny DRB AM STATUS) must be schedulable. */
+      if (required_prbs > 0)
+        required_prbs = max(required_prbs, min_sched_prbs);
+      // Cap required PRBs at total PRBs available for this beam
+      if (required_prbs > total_prbs) {
+        required_prbs = total_prbs;
+      }
+
+      if (required_prbs > 0) {
+        // Get slice configuration to log ratios
+        float dedicated = 0.0f, min = 0.0f, max = 0.0f;
+        slice_sch_get_slice_config(slice_scheduler, slice_nssai->sst, slice_nssai->sd,
+                                   NULL, NULL, &dedicated, &min, &max);
+        LOG_D(NR_MAC, "Frame %d slot %d: Slice SST 0x%02x SD 0x%06x: --- Required PRBs %d, Config: dedicated=%.3f min=%.3f max=%.3f\n",
+              frame, slot, slice_nssai->sst, slice_nssai->sd, required_prbs, dedicated, min, max);
+      }
+      slice_sch_update_require(slice_scheduler, slice_nssai->sst, slice_nssai->sd, required_prbs);
+    }
+
+    // Run the four-pass slice PRB allocator (dedicated / min / max ratios).
+    slice_sch_schedule(slice_scheduler);
+
+    // Get the allocation result
+    int num_ranges = 0;
+    const slice_prb_range_t *allocation = slice_sch_get_allocation(slice_scheduler, &num_ranges);
+    if (allocation == NULL || num_ranges == 0)
+      continue;
+
+    /* Rotate slice order for fair access to shared remainUEs; PRB ranges are fixed. */
+    const int slots_per_frame = cell->frame_structure.numb_slots_frame;
+    const int start = (frame * slots_per_frame + slot) % num_ranges;
+
+    // Schedule UEs within each slice's PRB range (UE layer).
+    for (int i = 0; i < num_ranges; i++) {
+      const int s = (start + i) % num_ranges;
+
+      int UEs_in_this_slice_count = 0;
+      NR_UE_info_t **UEs_in_this_slice = calloc(MAX_MOBILES_PER_GNB + 1, sizeof(NR_UE_info_t *));
+      if (UEs_in_this_slice == NULL)
+        continue;
+      memset(UEs_in_this_slice, 0, sizeof(NR_UE_info_t *) * (MAX_MOBILES_PER_GNB + 1));
+      UE_iterator(UEs_in_this_beam, UE) {
+        nssai_t ue_slice = {0};
+        nr_mac_get_ue_effective_nssai(&UE->UE_sched_ctrl, &ue_slice);
+        if (ue_slice.sst == allocation[s].slice_id.sst && ue_slice.sd == allocation[s].slice_id.sd) {
+          UEs_in_this_slice[UEs_in_this_slice_count] = UE;
+          UEs_in_this_slice_count++;
+        }
+      }
+      if (UEs_in_this_slice_count == 0) {
+        free(UEs_in_this_slice);
+        continue;
+      }
+
+      nr_dl_schedule(mac, cell, pp_pdsch, UEs_in_this_slice, max_num_ue, num_beams, n_rb_sched, &allocation[s], remainUEs);
+      
+      free(UEs_in_this_slice);
+      UEs_in_this_slice = NULL;
+    }
+  }
+
+  free(UEs_in_this_beam);
+  UEs_in_this_beam = NULL;
+}
+
+/*! \brief DL preprocessor — entry point from nr_schedule_ue_spec().
+ *
+ * Single function for both SCHE_PF and SCHE_NS (selected by scheduler_type_dl from YAML).
+ * SCHE_PF: one nr_dl_schedule() over the full BWP.
+ * SCHE_NS:  nr_dl_schedule_ns() runs slice_prb_allocator per beam, then nr_dl_schedule()
+ *           once per slice with slice_prb + shared remainUEs DCI budget. */
 void nr_dlsch_preprocessor(gNB_MAC_INST *mac, nr_cell_sched_t *cell, post_process_pdsch_t *pp_pdsch)
 {
   NR_UEs_t *UE_info = &mac->UE_info;
@@ -885,7 +1120,11 @@ void nr_dlsch_preprocessor(gNB_MAC_INST *mac, nr_cell_sched_t *cell, post_proces
   static_assert(4 < MAX_DCI_CORESET, "cannot have more concurrent UEs than MAX_DCI_CORESET\n");
   int max_sched_ues = 4;
 
-  nr_dl_schedule(mac, cell, pp_pdsch, UE_info->connected_ue_list, max_sched_ues, num_beams, n_rb_sched);
+  if (mac->scheduler_type_dl == SCHE_NS)
+    nr_dl_schedule_ns(mac, cell, pp_pdsch, UE_info->connected_ue_list, max_sched_ues, num_beams, n_rb_sched);
+  else
+    /* slice_prb=NULL, remainUEs=NULL → full-band modular PF path */
+    nr_dl_schedule(mac, cell, pp_pdsch, UE_info->connected_ue_list, max_sched_ues, num_beams, n_rb_sched, NULL, NULL);
 }
 
 nfapi_nr_dl_tti_pdsch_pdu_rel15_t *prepare_pdsch_pdu(nfapi_nr_dl_tti_request_pdu_t *dl_tti_pdsch_pdu,

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch_default_policies.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_dlsch_default_policies.c
@@ -10,6 +10,11 @@
  * wired up at MAC init time.  They can be replaced at runtime by external
  * scheduler plug-ins without touching the core scheduling loop in
  * gNB_scheduler_dlsch.c.
+ *
+ * nr_dl_proportional_fair (dl_rb_alloc default) honours nr_dl_sched_params_t::slice_rb_start/end
+ * when SCHE_NS calls nr_dl_schedule() per slice:
+ *   nr_slice_rb_bounds() maps absolute slice PRBs → BWP-relative search range
+ *   get_rb_alloc_slice() places RBs only inside slice ∩ UE BWP
  */
 
 #include "common/utils/nr/nr_common.h"
@@ -183,6 +188,37 @@ static int compare_dl_pf_rb_ptrs(const void *a, const void *b)
   return (wa < wb) - (wa > wb);
 }
 
+/* RB allocation helper used by nr_dl_proportional_fair.
+ * SCHE_PF: slice_rb_start < 0 → search full UE BWP (same as legacy get_rb_alloc).
+ * SCHE_NS: intersect slice range from slice_prb_allocator with UE BWP, then search
+ *          only inside that intersection via get_rb_alloc_slice(). */
+static bool nr_dl_get_rb_alloc(const nr_dl_sched_params_t *params,
+                               const nr_dl_candidate_t *cand,
+                               int rbSize_min,
+                               int rbSize_max,
+                               const uint16_t *vrb_map,
+                               int *rbStart,
+                               int *rbSize)
+{
+  int slice_start, slice_end;
+  nr_slice_rb_bounds(params->slice_rb_start,
+                     params->slice_rb_end,
+                     cand->bwp_start,
+                     cand->bwp_size,
+                     &slice_start,
+                     &slice_end);
+  return get_rb_alloc_slice(rbSize_min,
+                            rbSize_max,
+                            cand->bwp_start,
+                            cand->bwp_size,
+                            vrb_map,
+                            cand->alloc_slbitmap,
+                            slice_start,
+                            slice_end,
+                            rbStart,
+                            rbSize);
+}
+
 int nr_dl_proportional_fair(const nr_dl_sched_params_t *params, nr_dl_candidate_t *candidates, int n_candidates)
 {
   const int min_rbSize = 5;
@@ -205,14 +241,7 @@ int nr_dl_proportional_fair(const nr_dl_sched_params_t *params, nr_dl_candidate_
     int needed_rbs = cand->retx_rbSize;
     uint16_t *vrb_map = params->vrb_map[cand->alloc_beam_idx];
     int rbStart, rbSize;
-    if (!get_rb_alloc(needed_rbs,
-                      cand->bwp_size,
-                      cand->bwp_start,
-                      cand->bwp_size,
-                      vrb_map,
-                      cand->alloc_slbitmap,
-                      &rbStart,
-                      &rbSize))
+    if (!nr_dl_get_rb_alloc(params, cand, needed_rbs, needed_rbs, vrb_map, &rbStart, &rbSize))
       continue;
 
     COMMIT_ALLOC(params, cand, rbStart, needed_rbs, cand->sched_pdsch.mcs, n_scheduled);
@@ -226,14 +255,7 @@ int nr_dl_proportional_fair(const nr_dl_sched_params_t *params, nr_dl_candidate_
 
     uint16_t *vrb_map = params->vrb_map[cand->alloc_beam_idx];
     int rbStart, rbSize;
-    if (!get_rb_alloc(min_rbSize,
-                      cand->bwp_size,
-                      cand->bwp_start,
-                      cand->bwp_size,
-                      vrb_map,
-                      cand->alloc_slbitmap,
-                      &rbStart,
-                      &rbSize))
+    if (!nr_dl_get_rb_alloc(params, cand, min_rbSize, min_rbSize, vrb_map, &rbStart, &rbSize))
       continue;
 
     COMMIT_ALLOC(params, cand, rbStart, min_rbSize, cand->sched_pdsch.mcs, n_scheduled);
@@ -241,8 +263,25 @@ int nr_dl_proportional_fair(const nr_dl_sched_params_t *params, nr_dl_candidate_
 
   /* BW is the same across all beams, just use beam 0 */
   int max_rbSize = params->n_rb_avail[0];
-  DevAssert(max_rbSize >= min_rbSize);
   int n_remain_ue = params->max_num_ue - n_scheduled;
+  if (n_remain_ue <= 0)
+    return n_scheduled;
+  /* NS can assign fewer PRBs than type-1 min (5); skip new-data PF rather than assert. */
+  if (max_rbSize < min_rbSize) {
+    static frame_t last_warn_frame = -1;
+    if (max_rbSize > 0 && params->frame != last_warn_frame) {
+      last_warn_frame = params->frame;
+      LOG_W(NR_MAC,
+            "%4d.%2d DL PF: slice [%d,%d) has %d PRBs < min %d, skip new-data\n",
+            params->frame,
+            params->slot,
+            params->slice_rb_start,
+            params->slice_rb_end,
+            max_rbSize,
+            min_rbSize);
+    }
+    return n_scheduled;
+  }
   // share RBs fairly between remaining allocatable UEs
   int n_rb_per_ue = max(min_rbSize, max_rbSize / n_remain_ue);
 
@@ -307,7 +346,7 @@ int nr_dl_proportional_fair(const nr_dl_sched_params_t *params, nr_dl_candidate_
     }
     int rbStart, rbSize;
     uint16_t *vrb_map = params->vrb_map[cand->alloc_beam_idx];
-    if (!get_rb_alloc(min_rbSize, rb_req, cand->bwp_start, cand->bwp_size, vrb_map, cand->alloc_slbitmap, &rbStart, &rbSize))
+    if (!nr_dl_get_rb_alloc(params, cand, min_rbSize, rb_req, vrb_map, &rbStart, &rbSize))
       continue;
 
     int mcs = cand->sched_pdsch.mcs;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -579,15 +579,21 @@ int get_cce_index(const nr_cell_sched_t *cell,
                   float pdcch_cl_adjust)
 {
   const uint32_t Y = get_Y(ss, slot, rnti);
+  int nr_of_candidates = 0;
+
   int agg_level_search_order[NUM_PDCCH_AGG_LEVELS];
   determine_aggregation_level_search_order(agg_level_search_order, pdcch_cl_adjust);
-  int nr_of_candidates;
+
+  /* Try ALs in preference order until a free candidate is found. */
+  int CCEIndex = -1;
   for (int i = 0; i < NUM_PDCCH_AGG_LEVELS; i++) {
     find_aggregation_candidates(aggregation_level, &nr_of_candidates, ss, 1 << agg_level_search_order[i]);
-    if (nr_of_candidates > 0)
+    if (nr_of_candidates == 0)
+      continue;
+    CCEIndex = find_pdcch_candidate(cell, *aggregation_level, nr_of_candidates, beam_idx, sched_pdcch, coreset, Y);
+    if (CCEIndex >= 0)
       break;
   }
-  int CCEIndex = find_pdcch_candidate(cell, *aggregation_level, nr_of_candidates, beam_idx, sched_pdcch, coreset, Y);
   return CCEIndex;
 }
 
@@ -757,18 +763,70 @@ int find_largest_free_block(const uint16_t *vrb_map, uint16_t slbitmap, int bwp_
   return best_len;
 }
 
-bool get_rb_alloc(int rbSize_min,
-                  int rbSize_max,
-                  int bwpStart,
-                  int bwpSize,
-                  const uint16_t *vrb_map,
-                  uint16_t sym_mask,
-                  int *rbStart_ptr,
-                  int *rbSize_ptr)
+/*! \brief Map absolute NS slice range to BWP-relative RB search bounds.
+ *
+ * Three coordinate layers on the carrier:
+ *  - slice_rb_start/end: absolute PRBs from slice_prb_allocator (cell-wide)
+ *  - bwp_start/size:     UE BWP on the carrier (may be smaller than the cell BW)
+ *  - slice_start/end_rel: intersection slice ∩ BWP, relative to bwp_start (for get_rb_alloc_slice)
+ *
+ * When slice_rb_start < 0 (SCHE_PF), returns (-1,-1) so get_rb_alloc_slice searches the full UE BWP.
+ */
+void nr_slice_rb_bounds(int slice_rb_start,
+                        int slice_rb_end,
+                        int bwp_start,
+                        int bwp_size,
+                        int *slice_start_rel,
+                        int *slice_end_rel)
 {
+  if (slice_rb_start < 0) {
+    /* PF path: no slice constraint — caller searches [0, bwp_size). */
+    *slice_start_rel = -1;
+    *slice_end_rel = -1;
+    return;
+  }
+  /* Convert absolute carrier PRBs to offsets inside this UE's BWP, then clip to BWP edges. */
+  int ws = slice_rb_start - bwp_start;
+  int we = slice_rb_end - bwp_start;
+  if (ws < 0)
+    ws = 0;
+  if (we > bwp_size)
+    we = bwp_size;
+  *slice_start_rel = ws;
+  *slice_end_rel = we;
+}
+
+/*! \brief Like get_rb_alloc() but limits contiguous RB search to a slice sub-range.
+ *
+ * bwpStart/bwpSize index the UE BWP inside vrb_map (unchanged from get_rb_alloc).
+ * slice_start_rel/slice_end_rel further restrict where free RBs may be taken:
+ * only [slice_start_rel, slice_end_rel) within that BWP is searched.
+ * Pass slice_start_rel < 0 to search the full UE BWP (SCHE_PF behaviour).
+ */
+bool get_rb_alloc_slice(int rbSize_min,
+                        int rbSize_max,
+                        int bwpStart,
+                        int bwpSize,
+                        const uint16_t *vrb_map,
+                        uint16_t sym_mask,
+                        int slice_start_rel,
+                        int slice_end_rel,
+                        int *rbStart_ptr,
+                        int *rbSize_ptr)
+{
+  if (slice_start_rel < 0) {
+    slice_start_rel = 0;
+    slice_end_rel = bwpSize;
+  } else {
+    slice_start_rel = max(0, min(slice_start_rel, bwpSize));
+    slice_end_rel = max(slice_start_rel, min(slice_end_rel, bwpSize));
+  }
+  if (slice_start_rel >= slice_end_rel)
+    return false;
+
   const uint16_t *bwp_map = &vrb_map[bwpStart];
-  int rbStart = 0;
-  while (rbStart + rbSize_min <= bwpSize) {
+  int rbStart = slice_start_rel;
+  while (rbStart + rbSize_min <= slice_end_rel) {
     // 1. Find the first free RB
     if ((bwp_map[rbStart] & sym_mask) != 0) {
       rbStart++;
@@ -777,6 +835,7 @@ bool get_rb_alloc(int rbSize_min,
 
     // 2. Measure contiguous block
     int current_limit = min(rbStart + rbSize_max, bwpSize);
+    current_limit = min(current_limit, slice_end_rel);
     int rbEnd = rbStart + 1;
     while (rbEnd < current_limit && (bwp_map[rbEnd] & sym_mask) == 0) {
       rbEnd++;
@@ -794,6 +853,28 @@ bool get_rb_alloc(int rbSize_min,
     rbStart = rbEnd + 1;
   }
   return false;
+}
+
+bool get_rb_alloc(int rbSize_min,
+                  int rbSize_max,
+                  int bwpStart,
+                  int bwpSize,
+                  const uint16_t *vrb_map,
+                  uint16_t sym_mask,
+                  int *rbStart_ptr,
+                  int *rbSize_ptr)
+{
+  /* Full UE BWP: equivalent to get_rb_alloc_slice with no slice constraint. */
+  return get_rb_alloc_slice(rbSize_min,
+                            rbSize_max,
+                            bwpStart,
+                            bwpSize,
+                            vrb_map,
+                            sym_mask,
+                            -1,
+                            -1,
+                            rbStart_ptr,
+                            rbSize_ptr);
 }
 
 const NR_DMRS_UplinkConfig_t *get_DMRS_UplinkConfig(const NR_PUSCH_Config_t *pusch_Config, const NR_tda_info_t *tda_info)
@@ -4119,6 +4200,8 @@ bool prepare_initial_ul_rrc_message(gNB_MAC_INST *mac, nr_cell_sched_t *cell, NR
   nr_rlc_add_srb(UE->rnti, bearer->servedRadioBearer->choice.srb_Identity, bearer);
   int priority = bearer->mac_LogicalChannelConfig->ul_SpecificParameters->priority;
   nr_lc_config_t c = {.lcid = bearer->logicalChannelIdentity, .priority = priority};
+  c.nssai.sst = 1;
+  c.nssai.sd = 0xffffff;
   nr_mac_add_lcid(&UE->UE_sched_ctrl, &c);
   return true;
 }
@@ -4326,6 +4409,46 @@ nr_lc_config_t *nr_mac_get_lc_config(NR_UE_sched_ctrl_t* sched_ctrl, int lcid)
     return elm.it;
   else
     return NULL;
+}
+
+void nr_mac_get_default_srb_nssai(nssai_t *nssai)
+{
+  DevAssert(nssai != NULL);
+  nssai->sst = 1;
+  nssai->sd = 0xffffff;
+}
+
+bool nr_mac_get_ue_first_drb_nssai(const NR_UE_sched_ctrl_t *sched_ctrl, nssai_t *nssai)
+{
+  DevAssert(sched_ctrl != NULL);
+  for (int i = 0; i < seq_arr_size(&sched_ctrl->lc_config); ++i) {
+    const nr_lc_config_t *lc = seq_arr_at(&sched_ctrl->lc_config, i);
+    if (lc->lcid < 3)
+      continue;
+    if (nssai != NULL)
+      *nssai = lc->nssai;
+    return true;
+  }
+  return false;
+}
+
+void nr_mac_get_ue_effective_nssai(const NR_UE_sched_ctrl_t *sched_ctrl, nssai_t *nssai)
+{
+  DevAssert(nssai != NULL);
+  if (!nr_mac_get_ue_first_drb_nssai(sched_ctrl, nssai))
+    nr_mac_get_default_srb_nssai(nssai);
+}
+
+void nr_mac_remap_ue_srbs_to_nssai(NR_UE_sched_ctrl_t *sched_ctrl, const nssai_t *nssai)
+{
+  DevAssert(sched_ctrl != NULL);
+  DevAssert(nssai != NULL);
+  for (int i = 0; i < seq_arr_size(&sched_ctrl->lc_config); ++i) {
+    nr_lc_config_t *lc = seq_arr_at(&sched_ctrl->lc_config, i);
+    if (lc->lcid >= 3)
+      continue;
+    lc->nssai = *nssai;
+  }
 }
 
 bool nr_mac_add_lcid(NR_UE_sched_ctrl_t* sched_ctrl, const nr_lc_config_t *c)

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_types.h
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_types.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the OAI Public License, Version 1.1  (the "License"); you may not use this file
+ * except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.openairinterface.org/?page_id=698
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+
+/*! \file gNB_scheduler_types.h
+ * \brief Scheduler algorithm type definitions
+ * \author
+ * \date 2024
+ * \version 1.0
+ * @ingroup _mac
+ */
+
+#ifndef GNB_SCHEDULER_TYPES_H__
+#define GNB_SCHEDULER_TYPES_H__
+
+/*!
+ * \brief Scheduler algorithm types
+ */
+typedef enum {
+  SCHE_PF = 0,  /*!< Proportional Fair — full BWP via nr_*_schedule(slice_prb=NULL) */
+  SCHE_NS = 1   /*!< Network slicing — slice_prb_allocator then per-slice nr_*_schedule() */
+} scheduler_type_t;
+
+#endif /* GNB_SCHEDULER_TYPES_H__ */

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -2140,6 +2140,12 @@ static int compare_ul_beam_idx(const void *a, const void *b)
   return ((const nr_ul_candidate_t *)a)->alloc_beam_idx - ((const nr_ul_candidate_t *)b)->alloc_beam_idx;
 }
 
+/*! \brief Modular UL scheduler pipeline (RI/TPMI → beam → TDA → MCS → RB → dispatch).
+ *
+ * \p slice_prb and \p remainUEs_ext are used when called from nr_ul_schedule_ns():
+ * RB search and fair-share are limited to the slice PRB range; remainUEs is shared
+ * across slices and decremented in the dispatch loop below. Both NULL for SCHE_PF.
+ */
 static int nr_ul_schedule(gNB_MAC_INST *nrmac,
                           nr_cell_sched_t *cell,
                           post_process_pusch_t *pp_pusch,
@@ -2150,10 +2156,16 @@ static int nr_ul_schedule(gNB_MAC_INST *nrmac,
                           int n_rb_sched[num_beams],
                           frame_t sched_frame,
                           slot_t sched_slot,
-                          int k2)
+                          int k2,
+                          const slice_prb_range_t *slice_prb,
+                          int *remainUEs_ext)
 {
+  if (slice_prb != NULL && (slice_prb->num_prbs <= 0 || remainUEs_ext == NULL))
+    return 0;
+
+  const bool use_slice = (slice_prb != NULL);
   int frame = pp_pusch->frame;
-  int slot = pp_pusch->slot;
+  slot_t slot = pp_pusch->slot;
   NR_ServingCellConfigCommon_t *scc = cell->common_channels.ServingCellConfigCommon;
   int slots_per_frame = cell->frame_structure.numb_slots_frame;
 
@@ -2185,18 +2197,25 @@ static int nr_ul_schedule(gNB_MAC_INST *nrmac,
     return 0;
 
   const int min_rb = cell->min_grant_prb;
-  int remainUEs[num_beams];
-  for (int i = 0; i < num_beams; i++)
-    remainUEs[i] = max_num_ue;
+  int remainUEs_local[num_beams];
+  int *remainUEs;
+  if (use_slice)
+    remainUEs = remainUEs_ext;
+  else {
+    remainUEs = remainUEs_local;
+    for (int i = 0; i < num_beams; i++)
+      remainUEs_local[i] = max_num_ue;
+  }
   int num_ue_sched = 0;
 
   /* Step 5: MCS selection — updates BLER-based MCS for all candidates
    * (including skipped ones, so the BLER ramp evolves even for unscheduled UEs). */
   nrmac->ul_mcs_select(cell, candidates, n_cand);
 
-  /* Step 6: Sort by beam, then call RB allocation policy per beam */
+  /* Step 6: RB allocation policy per beam */
   qsort(candidates, n_cand, sizeof(*candidates), compare_ul_beam_idx);
 
+  /* NS: tell the RB policy the absolute slice range and size for fair-share math. */
   nr_ul_sched_params_t params = {
       .mac = nrmac,
       .cell = cell,
@@ -2212,11 +2231,13 @@ static int nr_ul_schedule(gNB_MAC_INST *nrmac,
       .bler_upper = cell->ul_bler.upper,
       .bler_opts = &cell->ul_bler,
       .scc = scc,
+      .slice_rb_start = use_slice ? slice_prb->start_prb : -1,
+      .slice_rb_end = use_slice ? slice_prb->end_prb : -1,
   };
   const int index = ul_buffer_index(sched_frame, sched_slot, slots_per_frame, cell->vrb_map_UL_size);
   for (int b = 0; b < num_beams; b++) {
     params.vrb_map_UL[b] = &cell->common_channels.vrb_map_UL[b][index * MAX_BWP_SIZE];
-    params.n_rb_avail[b] = n_rb_sched[b];
+    params.n_rb_avail[b] = use_slice ? slice_prb->num_prbs : n_rb_sched[b];
   }
 
   int i = 0;
@@ -2230,7 +2251,30 @@ static int nr_ul_schedule(gNB_MAC_INST *nrmac,
       continue;
     int count = i - start;
 
+    if (use_slice)
+      params.max_num_ue = remainUEs[beam]; /* shared DCI budget across slices */
     nrmac->ul_rb_alloc(&params, candidates + start, count);
+  }
+
+  /* Under NS, abort HARQ when a retx cannot be placed inside the slice PRB range. */
+  if (use_slice) {
+    for (int j = 0; j < n_cand; j++) {
+      nr_ul_candidate_t *cand = &candidates[j];
+      if (!cand->is_retx || cand->scheduled || cand->skipped)
+        continue;
+      NR_UE_sched_ctrl_t *sched_ctrl = &cand->UE->UE_sched_ctrl;
+      int harq_pid = cand->retx_harq_pid;
+      LOG_D(NR_MAC,
+            "[UE %04x][%4d.%2d] UL retransmission could not be allocated (slice: abort HARQ)\n",
+            cand->rnti,
+            frame,
+            slot);
+      reset_beam_status(&cell->beam_info, frame, slot, cand->beam_index, slots_per_frame, cand->alloc_dci_beam_new);
+      reset_beam_status(&cell->beam_info, sched_frame, sched_slot, cand->beam_index, slots_per_frame, cand->alloc_sched_beam_new);
+      remove_nr_list(&sched_ctrl->retrans_ul_harq, harq_pid);
+      abort_nr_ul_harq(cand->UE, harq_pid);
+      cand->skipped = true;
+    }
   }
 
   /* Release beam reservations for candidates the policy rejected (failed
@@ -2778,8 +2822,278 @@ static int collect_ul_candidates(gNB_MAC_INST *mac,
   return numUE;
 }
 
+/*! \brief Subset of pre-collected UL candidates for one slice/beam (NS UE layer).
+ *
+ * Candidates are built once in nr_ulsch_preprocessor(); NS filters by effective
+ * nssai (nr_mac_get_ue_effective_nssai) and beam_index instead of re-collecting. */
+static int filter_ul_candidates_for_slice(const nr_ul_candidate_t *src,
+                                          int n_src,
+                                          int beam_idx,
+                                          const slice_prb_range_t *slice,
+                                          nr_ul_candidate_t *dst,
+                                          int max_dst)
+{
+  int n = 0;
+  for (int i = 0; i < n_src && n < max_dst; i++) {
+    if (src[i].beam_index != beam_idx)
+      continue;
+    nssai_t ue_slice = {0};
+    nr_mac_get_ue_effective_nssai(&src[i].UE->UE_sched_ctrl, &ue_slice);
+    if (ue_slice.sst != slice->slice_id.sst || ue_slice.sd != slice->slice_id.sd)
+      continue;
+    dst[n++] = src[i];
+  }
+  return n;
+}
+
+/*! \brief Run nr_ul_schedule() on a candidate subset (per-slice NS helper).
+ *
+ * Copies candidates before nr_ul_schedule() because the pipeline mutates them
+ * (skipped flags, alloc_* fields). Without a copy, scheduling slice B would see
+ * state left over from slice A in the same K2 iteration. */
+static int nr_ul_schedule_candidates(gNB_MAC_INST *nrmac,
+                                     nr_cell_sched_t *cell,
+                                     post_process_pusch_t *pp_pusch,
+                                     const nr_ul_candidate_t *candidates,
+                                     int n_cand,
+                                     int max_num_ue,
+                                     int num_beams,
+                                     int n_rb_sched[num_beams],
+                                     frame_t sched_frame,
+                                     slot_t sched_slot,
+                                     int k2,
+                                     const slice_prb_range_t *slice_prb,
+                                     int *remainUEs)
+{
+  if (n_cand == 0)
+    return 0;
+
+  nr_ul_candidate_t slice_cands[MAX_MOBILES_PER_GNB];
+  memcpy(slice_cands, candidates, sizeof(nr_ul_candidate_t) * n_cand);
+
+  return nr_ul_schedule(nrmac,
+                        cell,
+                        pp_pusch,
+                        slice_cands,
+                        n_cand,
+                        max_num_ue,
+                        num_beams,
+                        n_rb_sched,
+                        sched_frame,
+                        sched_slot,
+                        k2,
+                        slice_prb,
+                        remainUEs);
+}
+
+static int ul_ns_ue_slice_required_prbs(gNB_MAC_INST *nrmac,
+                                        const nr_cell_sched_t *cell,
+                                        NR_UE_info_t *UE,
+                                        const slice_nssai_t *slice_nssai,
+                                        int total_prbs,
+                                        frame_t frame,
+                                        slot_t slot)
+{
+  NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
+  nssai_t ue_slice = {0};
+  nr_mac_get_ue_effective_nssai(sched_ctrl, &ue_slice);
+  /* SRBs stay on the same slice as the UE DRB (effective NSSAI). */
+  if (ue_slice.sst != slice_nssai->sst || ue_slice.sd != slice_nssai->sd)
+    return 0;
+
+  int B = max(0, sched_ctrl->estimated_ul_buffer - sched_ctrl->sched_ul_bytes);
+
+  /* Also look at SRB1/SRB2 RLC. BSR alone can miss control-plane demand
+   * (e.g. after reestablishment), which previously left the slice at
+   * require=0 and starved SRB UL → RLC max RETX / RLF. */
+  int srb_bytes = 0;
+  for (int i = 0; i < seq_arr_size(&sched_ctrl->lc_config); ++i) {
+    const nr_lc_config_t *lc = seq_arr_at(&sched_ctrl->lc_config, i);
+    if (lc->suspended)
+      continue;
+    if (lc->lcid != UL_SCH_LCID_SRB1 && lc->lcid != UL_SCH_LCID_SRB2)
+      continue;
+    mac_rlc_status_resp_t st = {0};
+    logical_chan_id_t ch = lc->lcid;
+    nr_mac_rlc_status_ind(UE->rnti, frame, 1, &ch, &st);
+    if (st.bytes_in_buffer > 0)
+      srb_bytes += st.bytes_in_buffer;
+  }
+
+  const int bytes_per_prb_estimate = 2;
+  const int bytes = B + srb_bytes;
+  int required_prbs = bytes > 0 ? (bytes + bytes_per_prb_estimate - 1) / bytes_per_prb_estimate : 0;
+
+  /* Pending UL HARQ retx must keep the original rbSize; count it so the
+   * slice PRB range does not shrink below what remapping needs. */
+  for (int harq_pid = sched_ctrl->retrans_ul_harq.head; harq_pid >= 0;
+       harq_pid = sched_ctrl->retrans_ul_harq.next[harq_pid]) {
+    required_prbs += sched_ctrl->ul_harq_processes[harq_pid].sched_pusch.rbSize;
+  }
+
+  const bool do_sched = nr_UE_is_to_be_scheduled(&cell->frame_structure,
+                                                 UE,
+                                                 frame,
+                                                 slot,
+                                                 cell->ulsch_max_frame_inactivity);
+  /* Min grant when the UE should be scheduled or SRB RLC has pending bytes. */
+  if (do_sched || srb_bytes > 0)
+    required_prbs = max(required_prbs, (int)cell->min_grant_prb);
+
+  return min(required_prbs, total_prbs);
+}
+
+/*! \brief Network slicing UL orchestrator (slice layer + intra-slice UE scheduler).
+ *
+ * Same two-layer pattern as nr_dl_schedule_ns(): per beam, estimate slice demand,
+ * run slice_prb_allocator, then schedule each slice's UEs via nr_ul_schedule_candidates()
+ * with slice_rb_start/end and shared remainUEs. UL slice demand uses
+ * ul_ns_ue_slice_required_prbs(). Falls back to full-band scheduling if no slices.
+ *
+ * \p candidates / \p n_cand come from collect_ul_candidates() in the preprocessor
+ * (shared by PF and NS). NS does not collect again; it filters per slice instead.
+ */
+static int nr_ul_schedule_ns(gNB_MAC_INST *nrmac,
+                             nr_cell_sched_t *cell,
+                             post_process_pusch_t *pp_pusch,
+                             frame_t sched_frame,
+                             slot_t sched_slot,
+                             int k2,
+                             const nr_ul_candidate_t *candidates,
+                             int n_cand,
+                             int max_num_ue,
+                             int num_beams,
+                             int n_rb_sched[num_beams])
+{
+  if (n_cand == 0)
+    return 0;
+
+  if (nrmac->slice_scheduler_ul == NULL || slice_sch_get_num_slices(nrmac->slice_scheduler_ul) == 0) {
+    /* No slice config: treat NS like PF on the pre-collected candidate set. */
+    return nr_ul_schedule_candidates(nrmac,
+                                     cell,
+                                     pp_pusch,
+                                     candidates,
+                                     n_cand,
+                                     max_num_ue,
+                                     num_beams,
+                                     n_rb_sched,
+                                     sched_frame,
+                                     sched_slot,
+                                     k2,
+                                     NULL,
+                                     NULL);
+  }
+
+  const int slots_per_frame = cell->frame_structure.numb_slots_frame;
+
+  NR_UE_info_t **UEs_in_this_beam = calloc(MAX_MOBILES_PER_GNB + 1, sizeof(NR_UE_info_t *));
+  if (UEs_in_this_beam == NULL) {
+    LOG_W(NR_MAC, "nr_ul_schedule_ns: OOM, falling back to PF\n");
+    return nr_ul_schedule_candidates(nrmac,
+                                     cell,
+                                     pp_pusch,
+                                     candidates,
+                                     n_cand,
+                                     max_num_ue,
+                                     num_beams,
+                                     n_rb_sched,
+                                     sched_frame,
+                                     sched_slot,
+                                     k2,
+                                     NULL,
+                                     NULL);
+  }
+
+  int remainUEs[num_beams];
+  for (int i = 0; i < num_beams; i++)
+    remainUEs[i] = max_num_ue; /* shared across slices; decremented per nr_ul_schedule() */
+
+  int total_sched = 0;
+
+  for (int beam_idx = 0; beam_idx < num_beams; beam_idx++) {
+    /* --- Slice layer: demand + PRB range allocation for this beam --- */
+    int UEs_in_this_beam_count = 0;
+    memset(UEs_in_this_beam, 0, sizeof(NR_UE_info_t *) * (MAX_MOBILES_PER_GNB + 1));
+    UE_iterator(nrmac->UE_info.connected_ue_list, UE)
+    {
+      if (UE->UE_beam_index == beam_idx) {
+        UEs_in_this_beam[UEs_in_this_beam_count] = UE;
+        UEs_in_this_beam_count++;
+      }
+      if (UEs_in_this_beam_count >= MAX_MOBILES_PER_GNB)
+        break;
+    }
+    if (UEs_in_this_beam_count == 0)
+      continue;
+
+    int total_prbs = n_rb_sched[beam_idx];
+    slice_sch_update_total_prbs(nrmac->slice_scheduler_ul, total_prbs);
+
+    slice_scheduler_t *slice_scheduler = nrmac->slice_scheduler_ul;
+    int num_slices = slice_sch_get_num_slices(slice_scheduler);
+    for (int s = 0; s < num_slices; s++) {
+      int required_prbs = 0;
+      const slice_nssai_t *slice_nssai = slice_sch_get_slice_nssai(slice_scheduler, s);
+      if (slice_nssai == NULL)
+        continue;
+      UE_iterator(UEs_in_this_beam, UE) {
+        required_prbs += ul_ns_ue_slice_required_prbs(nrmac, cell, UE, slice_nssai, total_prbs, sched_frame, sched_slot);
+      }
+      if (required_prbs > total_prbs)
+        required_prbs = total_prbs;
+      slice_sch_update_require(slice_scheduler, slice_nssai->sst, slice_nssai->sd, required_prbs);
+    }
+
+    slice_sch_schedule(slice_scheduler);
+    int num_ranges = 0;
+    const slice_prb_range_t *allocation = slice_sch_get_allocation(slice_scheduler, &num_ranges);
+    if (allocation == NULL || num_ranges == 0)
+      continue;
+
+    /* Rotate slice order for fair access to shared remainUEs; PRB ranges are fixed. */
+    const int start = (sched_frame * slots_per_frame + sched_slot) % num_ranges;
+
+    /* UE layer: one modular PF run per slice inside its PRB range. */
+    for (int i = 0; i < num_ranges; i++) {
+      const int s = (start + i) % num_ranges;
+      if (allocation[s].num_prbs <= 0)
+        continue;
+
+      nr_ul_candidate_t slice_cands[MAX_MOBILES_PER_GNB];
+      int n_slice_cand = filter_ul_candidates_for_slice(candidates,
+                                                        n_cand,
+                                                        beam_idx,
+                                                        &allocation[s],
+                                                        slice_cands,
+                                                        MAX_MOBILES_PER_GNB);
+      if (n_slice_cand == 0)
+        continue;
+
+      total_sched += nr_ul_schedule_candidates(nrmac,
+                                               cell,
+                                               pp_pusch,
+                                               slice_cands,
+                                               n_slice_cand,
+                                               max_num_ue,
+                                               num_beams,
+                                               n_rb_sched,
+                                               sched_frame,
+                                               sched_slot,
+                                               k2,
+                                               &allocation[s],
+                                               remainUEs);
+    }
+  }
+
+  free(UEs_in_this_beam);
+  return total_sched;
+}
+
 void nr_ulsch_preprocessor(gNB_MAC_INST *nr_mac, nr_cell_sched_t *cell, post_process_pusch_t *pp_pusch)
 {
+  /* Outer loop: for each reachable UL slot (K2), collect once, then branch PF/NS.
+   * PF and NS share collect_ul_candidates(); only the orchestrator below differs. */
   int frame = pp_pusch->frame;
   int slot = pp_pusch->slot;
 
@@ -2854,16 +3168,43 @@ void nr_ulsch_preprocessor(gNB_MAC_INST *nr_mac, nr_cell_sched_t *cell, post_pro
     int len[num_beams];
     for (int i = 0; i < num_beams; i++)
       len[i] = bw;
-    int sched = nr_ul_schedule(nr_mac, cell, pp_pusch, candidates, n_cand, max_dci, num_beams, len, sched_frame, sched_slot, k2);
-    LOG_D(NR_MAC,
-          "run nr_ul_schedule() at %4d.%2d k2 %d (ULSCH at %4d.%2d) scheduled %d last_dl %d\n",
-          frame,
-          slot,
-          k2,
-          next->f,
-          next->s,
-          sched,
-          last_dl);
+
+    int sched;
+    if (nr_mac->scheduler_type_ul == SCHE_NS) {
+      /* Slice layer + per-slice nr_ul_schedule(); candidates filtered inside ns. */
+      sched = nr_ul_schedule_ns(nr_mac,
+                                cell,
+                                pp_pusch,
+                                sched_frame,
+                                sched_slot,
+                                k2,
+                                candidates,
+                                n_cand,
+                                max_dci,
+                                num_beams,
+                                len);
+      LOG_D(NR_MAC,
+            "run nr_ul_schedule_ns() at %4d.%2d k2 %d (ULSCH at %4d.%2d) scheduled %d last_dl %d\n",
+            frame,
+            slot,
+            k2,
+            next->f,
+            next->s,
+            sched,
+            last_dl);
+    } else {
+      /* Full-band modular PF on the same candidate snapshot. */
+      sched = nr_ul_schedule(nr_mac, cell, pp_pusch, candidates, n_cand, max_dci, num_beams, len, sched_frame, sched_slot, k2, NULL, NULL);
+      LOG_D(NR_MAC,
+            "run nr_ul_schedule() at %4d.%2d k2 %d (ULSCH at %4d.%2d) scheduled %d last_dl %d\n",
+            frame,
+            slot,
+            k2,
+            next->f,
+            next->s,
+            sched,
+            last_dl);
+    }
     /* if we did not schedule anything, and it's not the last slot, break. In
      * the case we did schedule or it's the last slot (see above!), continue
      * advancing till there is no TDA anymore */

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch_default_policies.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch_default_policies.c
@@ -8,6 +8,10 @@
  * These are the built-in defaults behind the UL scheduler function pointers.
  * Extracted from gNB_scheduler_ulsch.c to allow clean replacement by custom
  * scheduler plugins.
+ *
+ * nr_ul_proportional_fair honours nr_ul_sched_params_t::slice_rb_start/end when
+ * SCHE_NS schedules per slice via nr_ul_schedule_ns() → filter_ul_candidates_for_slice()
+ * → nr_ul_schedule_candidates() → nr_slice_rb_bounds() → get_rb_alloc_slice().
  */
 
 #include "gNB_scheduler_ulsch_default_policies.h"
@@ -228,6 +232,34 @@ static int compare_ul_pf_rb_ptrs(const void *a, const void *b)
   return (wa < wb) - (wa > wb);
 }
 
+/* RB allocation helper used by nr_ul_proportional_fair (same slice/BWP model as DL). */
+static bool nr_ul_get_rb_alloc(const nr_ul_sched_params_t *params,
+                               const nr_ul_candidate_t *cand,
+                               int rbSize_min,
+                               int rbSize_max,
+                               const uint16_t *vrb_map,
+                               int *rbStart,
+                               int *rbSize)
+{
+  int slice_start, slice_end;
+  nr_slice_rb_bounds(params->slice_rb_start,
+                     params->slice_rb_end,
+                     cand->bwp_start,
+                     cand->bwp_size,
+                     &slice_start,
+                     &slice_end);
+  return get_rb_alloc_slice(rbSize_min,
+                            rbSize_max,
+                            cand->bwp_start,
+                            cand->bwp_size,
+                            vrb_map,
+                            cand->alloc_slbitmap,
+                            slice_start,
+                            slice_end,
+                            rbStart,
+                            rbSize);
+}
+
 static void nr_ul_port_select_default(const nr_ul_sched_params_t *params, nr_ul_candidate_t *cand)
 {
   if (cand->is_retx) {
@@ -272,10 +304,9 @@ int nr_ul_proportional_fair(const nr_ul_sched_params_t *params, nr_ul_candidate_
 
     nr_ul_port_select_default(params, cand);
 
-    int rbStart;
+    int rbStart, rbSize;
     uint16_t *vrb_map = params->vrb_map_UL[cand->alloc_beam_idx];
-    int block_len = find_largest_free_block(vrb_map, cand->alloc_slbitmap, cand->bwp_start, cand->bwp_size, &rbStart);
-    if (block_len < cand->retx_rbSize)
+    if (!nr_ul_get_rb_alloc(params, cand, cand->retx_rbSize, cand->retx_rbSize, vrb_map, &rbStart, &rbSize))
       continue;
 
     COMMIT_UL_ALLOC(params, cand, rbStart, cand->retx_rbSize, cand->sched_pusch.mcs, n_scheduled);
@@ -290,9 +321,8 @@ int nr_ul_proportional_fair(const nr_ul_sched_params_t *params, nr_ul_candidate_
     nr_ul_port_select_default(params, cand);
 
     uint16_t *vrb_map = params->vrb_map_UL[cand->alloc_beam_idx];
-    int rbStart;
-    int block_len = find_largest_free_block(vrb_map, cand->alloc_slbitmap, cand->bwp_start, cand->bwp_size, &rbStart);
-    if (block_len < min_rb)
+    int rbStart, rbSize;
+    if (!nr_ul_get_rb_alloc(params, cand, min_rb, min_rb, vrb_map, &rbStart, &rbSize))
       continue;
 
     COMMIT_UL_ALLOC(params, cand, rbStart, min_rb, cand->sched_pusch.mcs, n_scheduled);
@@ -300,8 +330,25 @@ int nr_ul_proportional_fair(const nr_ul_sched_params_t *params, nr_ul_candidate_
 
   /* BW is the same across all beams, just use beam 0 */
   int max_rbSize = params->n_rb_avail[0];
-  DevAssert(max_rbSize >= min_rb);
   int n_remain_ue = params->max_num_ue - n_scheduled;
+  if (n_remain_ue <= 0)
+    return n_scheduled;
+  /* NS can assign fewer PRBs than type-1 min; skip new-data PF rather than assert. */
+  if (max_rbSize < min_rb) {
+    static frame_t last_warn_frame = -1;
+    if (max_rbSize > 0 && params->dci_frame != last_warn_frame) {
+      last_warn_frame = params->dci_frame;
+      LOG_W(NR_MAC,
+            "%4d.%2d UL PF: slice [%d,%d) has %d PRBs < min %d, skip new-data\n",
+            params->dci_frame,
+            params->dci_slot,
+            params->slice_rb_start,
+            params->slice_rb_end,
+            max_rbSize,
+            min_rb);
+    }
+    return n_scheduled;
+  }
   // share RBs fairly between remaining allocatable UEs
   int n_rb_per_ue = max(min_rb, max_rbSize / n_remain_ue);
 
@@ -381,7 +428,7 @@ int nr_ul_proportional_fair(const nr_ul_sched_params_t *params, nr_ul_candidate_
     }
     int rbStart, rbSize;
     uint16_t *vrb_map = params->vrb_map_UL[cand->alloc_beam_idx];
-    if (!get_rb_alloc(min_rb, rb_req, cand->bwp_start, cand->bwp_size, vrb_map, cand->alloc_slbitmap, &rbStart, &rbSize))
+    if (!nr_ul_get_rb_alloc(params, cand, min_rb, rb_req, vrb_map, &rbStart, &rbSize))
       continue;
     COMMIT_UL_ALLOC(params, cand, rbStart, rbSize, mcs, n_scheduled);
   }

--- a/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
@@ -93,6 +93,9 @@ void nr_schedule_ulsch(gNB_MAC_INST *nr_mac, nr_cell_sched_t *cell, frame_t fram
 /* \brief default UL preprocessor */
 void nr_ulsch_preprocessor(gNB_MAC_INST *nr_mac, nr_cell_sched_t *cell, post_process_pusch_t *pp_pusch);
 
+/* \brief bind pre_processor_dl/ul after slice / scheduler YAML is loaded */
+void nr_mac_init_scheduler(gNB_MAC_INST *mac);
+
 int check_sc_fdma_rbsize(long transform_precoding, uint16_t rb);
 
 void nr_mac_pcch_queue_init(NR_COMMON_channels_t *cc);
@@ -471,6 +474,26 @@ bool get_rb_alloc(int rbSize_min,
                   int *rbStart_ptr,
                   int *rbSize_ptr);
 
+/* Map absolute slice PRB range → BWP-relative bounds for get_rb_alloc_slice(). */
+void nr_slice_rb_bounds(int slice_rb_start,
+                        int slice_rb_end,
+                        int bwp_start,
+                        int bwp_size,
+                        int *slice_start_rel,
+                        int *slice_end_rel);
+
+/* Slice-bounded RB search; slice_start_rel < 0 selects the full UE BWP. */
+bool get_rb_alloc_slice(int rbSize_min,
+                        int rbSize_max,
+                        int bwpStart,
+                        int bwpSize,
+                        const uint16_t *vrb_map,
+                        uint16_t sym_mask,
+                        int slice_start_rel,
+                        int slice_end_rel,
+                        int *rbStart_ptr,
+                        int *rbSize_ptr);
+
 /* Scalar core of the BLER -> MCS adaptation rule. Single source of truth
  * for the activity-guard threshold and the lower/upper hysteresis. */
 int nr_adapt_mcs_from_bler(int current_mcs,
@@ -555,6 +578,10 @@ void reset_sc_info(NR_UE_ServingCell_Info_t *sc_info);
 bool nr_mac_add_lcid(NR_UE_sched_ctrl_t *sched_ctrl, const nr_lc_config_t *c);
 nr_lc_config_t *nr_mac_get_lc_config(NR_UE_sched_ctrl_t* sched_ctrl, int lcid);
 bool nr_mac_remove_lcid(NR_UE_sched_ctrl_t *sched_ctrl, long lcid);
+void nr_mac_get_default_srb_nssai(nssai_t *nssai);
+bool nr_mac_get_ue_first_drb_nssai(const NR_UE_sched_ctrl_t *sched_ctrl, nssai_t *nssai);
+void nr_mac_get_ue_effective_nssai(const NR_UE_sched_ctrl_t *sched_ctrl, nssai_t *nssai);
+void nr_mac_remap_ue_srbs_to_nssai(NR_UE_sched_ctrl_t *sched_ctrl, const nssai_t *nssai);
 
 bool nr_mac_get_new_rnti(NR_UEs_t *UEs, rnti_t *rnti);
 void nr_mac_update_pdcch_closed_loop_adjust(NR_UE_sched_ctrl_t *sched_ctrl, bool feedback_not_detected);

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
@@ -19,6 +19,7 @@
 #include "lib/f1ap_ue_context.h"
 
 #include "executables/softmodem-common.h"
+#include "slice_prb_allocator/slice_prb_allocator.h"
 
 #include "uper_decoder.h"
 #include "uper_encoder.h"
@@ -220,6 +221,11 @@ static NR_RLC_BearerConfig_t *get_bearerconfig_from_srb(const f1ap_srb_to_setup_
   return get_SRB_RLC_BearerConfig(get_lcid_from_srbid(srb->id), priority, bucket, rlc_config);
 }
 
+/*! \brief Get the first available NSSAI from slice scheduler configuration
+ *  \param mac MAC instance containing slice scheduler
+ *  \param nssai_out Output parameter for the first NSSAI (if found)
+ *  \return true if a slice is found and nssai_out is set, false otherwise
+ */
 static int handle_ue_context_srbs_setup(NR_UE_info_t *UE,
                                         int srbs_len,
                                         const f1ap_srb_to_setup_t *req_srbs,
@@ -238,6 +244,15 @@ static int handle_ue_context_srbs_setup(NR_UE_info_t *UE,
 
     int priority = rlc_BearerConfig->mac_LogicalChannelConfig->ul_SpecificParameters->priority;
     nr_lc_config_t c = {.lcid = rlc_BearerConfig->logicalChannelIdentity, .priority = priority};
+    nr_mac_get_ue_effective_nssai(&UE->UE_sched_ctrl, &c.nssai);
+
+    LOG_I(NR_MAC,
+          "UE ID %d SRB ID %d: assigning UE slice SST 0x%02x SD 0x%06x\n",
+          UE->rnti,
+          srb->id,
+          c.nssai.sst,
+          (unsigned)c.nssai.sd);
+
     nr_mac_add_lcid(&UE->UE_sched_ctrl, &c);
 
     (*resp_srbs)[i].id = srb->id;
@@ -307,10 +322,19 @@ static int handle_ue_context_drbs_setup(NR_UE_info_t *UE,
    * ue_context_*_response() */
   *resp_drbs = calloc(drbs_len, sizeof(**resp_drbs));
   AssertFatal(*resp_drbs != NULL, "out of memory\n");
+  bool has_drb = nr_mac_get_ue_first_drb_nssai(&UE->UE_sched_ctrl, NULL);
+  int accepted_drbs = 0;
   for (int i = 0; i < drbs_len; i++) {
     const f1ap_drb_to_setup_t *drb = &req_drbs[i];
+    if (has_drb) {
+      LOG_W(NR_MAC,
+            "UE %04x: ignoring DRB %d setup because single-DRB-per-UE policy is active\n",
+            UE->rnti,
+            (int)drb->id);
+      continue;
+    }
     AssertFatal(drb->qos_choice == F1AP_QOS_CHOICE_NR, "only NR QoS supported\n");
-    f1ap_drb_setup_t *resp_drb = &(*resp_drbs)[i];
+    f1ap_drb_setup_t *resp_drb = &(*resp_drbs)[accepted_drbs];
     NR_RLC_BearerConfig_t *rlc_BearerConfig = get_bearerconfig_from_drb(drb, rlc_config);
     if (UE->capability && UE->capability->rlc_Parameters && UE->capability->rlc_Parameters->ext2
         && UE->capability->rlc_Parameters->ext2->am_WithLongSN_RedCap_r17 == NULL) {
@@ -330,10 +354,23 @@ static int handle_ue_context_drbs_setup(NR_UE_info_t *UE,
     }
     c.priority = prio;
     nr_mac_add_lcid(&UE->UE_sched_ctrl, &c);
+    nr_mac_remap_ue_srbs_to_nssai(&UE->UE_sched_ctrl, &c.nssai);
+    has_drb = true;
+    accepted_drbs++;
 
     resp_drb->id = drb->id;
     resp_drb->lcid = malloc_or_fail(sizeof(*resp_drb->lcid));
     *resp_drb->lcid = c.lcid;
+    LOG_I(
+        NR_MAC,
+        "UE %04x DRB setup: DRB %d -> LCID %d, NSSAI SST=0x%02x SD=0x%06x, flows=%d, prio=%d\n",
+        UE->rnti,
+        (int)drb->id,
+        (int)c.lcid,
+        c.nssai.sst,
+        (unsigned)c.nssai.sd,
+        (int)drb->nr.flows_len,
+        (int)c.priority);
     // just put same number of tunnels in DL as in UL
     DevAssert(drb->up_ul_tnl_len == 1);
     resp_drb->up_dl_tnl_len = drb->up_ul_tnl_len;
@@ -353,7 +390,11 @@ static int handle_ue_context_drbs_setup(NR_UE_info_t *UE,
     int ret = ASN_SEQUENCE_ADD(&cellGroupConfig->rlc_BearerToAddModList->list, rlc_BearerConfig);
     DevAssert(ret == 0);
   }
-  return drbs_len;
+  if (accepted_drbs == 0) {
+    free(*resp_drbs);
+    *resp_drbs = NULL;
+  }
+  return accepted_drbs;
 }
 
 static int handle_ue_context_drbs_release(NR_UE_info_t *UE,
@@ -390,6 +431,9 @@ static int handle_ue_context_drbs_release(NR_UE_info_t *UE,
       DevAssert(ret == 0);
     }
   }
+  nssai_t srb_nssai = {0};
+  nr_mac_get_ue_effective_nssai(&UE->UE_sched_ctrl, &srb_nssai);
+  nr_mac_remap_ue_srbs_to_nssai(&UE->UE_sched_ctrl, &srb_nssai);
   return drbs_len;
 }
 
@@ -863,6 +907,8 @@ void ue_context_modification_request(const f1ap_ue_context_mod_req_t *req)
     if (UE->reestablish_rlc) {
       for (int i = 1; i < seq_arr_size(&UE->UE_sched_ctrl.lc_config); ++i) {
         nr_lc_config_t *c = seq_arr_at(&UE->UE_sched_ctrl.lc_config, i);
+        if (c->lcid == 1 || !c->suspended)
+          continue;
         c->suspended = false;
         LOG_I(NR_MAC, "UE %04x: Re-establishing RLC for LCID %d\n", UE->rnti, c->lcid);
         nr_rlc_reestablish_entity(req->gNB_DU_ue_id, c->lcid);

--- a/openair2/LAYER2/NR_MAC_gNB/main.c
+++ b/openair2/LAYER2/NR_MAC_gNB/main.c
@@ -19,6 +19,8 @@
 #include "NR_MAC_gNB/mac_proto.h"
 #include "NR_MAC_gNB/mac_rrc_ul.h"
 #include "NR_MAC_gNB/nr_mac_gNB.h"
+#include "NR_MAC_gNB/gNB_scheduler_types.h"
+#include "NR_MAC_gNB/slice_prb_allocator/slice_prb_allocator.h"
 #include "NR_PHY_INTERFACE/NR_IF_Module.h"
 #include "NR_RLC-BearerConfig.h"
 #include "NR_RadioBearerConfig.h"
@@ -102,11 +104,78 @@ static char *st_append(char *start, const char *end, const char *format, ...)
     return (char *)end;
 }
 
+static char *dump_slice_scheduler_stats(char *output,
+                                        const char *end,
+                                        const char *direction,
+                                        const slice_scheduler_t *scheduler)
+{
+  if (scheduler == NULL)
+    return output;
+
+  const int num_slices = slice_sch_get_num_slices(scheduler);
+  if (num_slices <= 0)
+    return output;
+
+  const int total_prbs = slice_sch_get_total_prbs(scheduler);
+  int num_stats = 0;
+  const slice_statistics_t *stats = slice_sch_get_all_statistics(scheduler, &num_stats);
+  if (stats == NULL || num_stats <= 0)
+    return output;
+
+  output = st_append(output, end, "NS %s PRB allocation (total PRBs %d):\n", direction, total_prbs);
+
+  for (int s = 0; s < num_stats; s++) {
+    const slice_statistics_t *st = &stats[s];
+    int require = 0;
+    float dedicated = 0.0f;
+    float min_ratio = 0.0f;
+    float max_ratio = 0.0f;
+    slice_sch_get_require(scheduler, st->slice_id.sst, st->slice_id.sd, &require);
+    slice_sch_get_slice_config(scheduler,
+                               st->slice_id.sst,
+                               st->slice_id.sd,
+                               NULL,
+                               NULL,
+                               &dedicated,
+                               &min_ratio,
+                               &max_ratio);
+
+    const double latest_pct = total_prbs > 0 ? 100.0 * (double)st->latest_num_prbs / (double)total_prbs : 0.0;
+    const double avg_pct = total_prbs > 0 ? 100.0 * (double)st->avg_num_prbs / (double)total_prbs : 0.0;
+
+    output = st_append(output,
+                       end,
+                       "  slice SST 0x%02x SD 0x%06x: latest %d PRBs [%d,%d) (%.1f%%) avg %.1f PRBs (%.1f%%) "
+                       "require %d dedicated/min/max %.0f/%.0f/%.0f%% samples %d\n",
+                       st->slice_id.sst,
+                       (unsigned)st->slice_id.sd,
+                       st->latest_num_prbs,
+                       st->latest_start_prb,
+                       st->latest_end_prb,
+                       latest_pct,
+                       (double)st->avg_num_prbs,
+                       avg_pct,
+                       require,
+                       dedicated * 100.0,
+                       min_ratio * 100.0,
+                       max_ratio * 100.0,
+                       st->sample_count);
+  }
+
+  return output;
+}
+
 size_t dump_mac_stats(gNB_MAC_INST *gNB, const nr_cell_sched_t *cell, char *output, size_t strlen, bool reset_rsrp)
 {
   const char *begin = output;
   const char *end = output + strlen;
 
+  /* this function is called from gNB_dlsch_ulsch_scheduler(), so assumes the
+   * scheduler to be locked*/
+  NR_SCHED_ENSURE_LOCKED(&gNB->sched_lock);
+
+  output = dump_slice_scheduler_stats(output, end, "UL", gNB->slice_scheduler_ul);
+  output = dump_slice_scheduler_stats(output, end, "DL", gNB->slice_scheduler_dl);
   UE_iterator(gNB->UE_info.connected_ue_list, UE) {
     if (UE->pcell != cell)
       continue;
@@ -122,6 +191,10 @@ size_t dump_mac_stats(gNB_MAC_INST *gNB, const nr_cell_sched_t *cell, char *outp
     } else {
       output = st_append(output, end, "(none)");
     }
+
+    nssai_t ue_slice = {0};
+    nr_mac_get_ue_effective_nssai(sched_ctrl, &ue_slice);
+    output = st_append(output, end, " SST 0x%02x SD 0x%06x", ue_slice.sst, (unsigned)ue_slice.sd);
 
     bool in_sync = !sched_ctrl->ul_failure;
     output = st_append(output,
@@ -303,6 +376,8 @@ void mac_top_init_gNB(ngran_node_t node_type,
 
       uid_linear_allocator_init(&RC.nrmac[i]->UE_info.uid_allocator);
 
+      RC.nrmac[i]->scheduler_type_dl = SCHE_PF;
+      RC.nrmac[i]->scheduler_type_ul = SCHE_PF;
       RC.nrmac[i]->ul_ri_tpmi_select = nr_ul_ri_tpmi_select_default;
       RC.nrmac[i]->ul_tda_select = nr_ul_tda_select_default;
       RC.nrmac[i]->ul_beam_select = nr_ul_beam_select_default;
@@ -315,13 +390,12 @@ void mac_top_init_gNB(ngran_node_t node_type,
         RC.nrmac[i]->pre_processor_dl = nr_preprocessor_phytest;
         RC.nrmac[i]->pre_processor_ul = nr_ul_preprocessor_phytest;
       } else {
-        RC.nrmac[i]->pre_processor_dl = nr_dlsch_preprocessor;
-        RC.nrmac[i]->pre_processor_ul = nr_ulsch_preprocessor;
         RC.nrmac[i]->dl_ri_pmi_select = nr_dl_ri_pmi_select_default;
         RC.nrmac[i]->dl_mcs_select = nr_dl_mcs_select_default;
         RC.nrmac[i]->dl_beam_select = nr_dl_beam_select_default;
         RC.nrmac[i]->dl_tda_select = nr_dl_tda_select_default;
         RC.nrmac[i]->dl_rb_alloc = nr_dl_proportional_fair;
+        nr_mac_init_scheduler(RC.nrmac[i]);
       }
       if (!IS_SOFTMODEM_NOSTATS)
         threadCreate(&RC.nrmac[i]->stats_thread,
@@ -350,6 +424,25 @@ void mac_top_init_gNB(ngran_node_t node_type,
   srand48(0);
 }
 
+/*! \brief Bind DL/UL preprocessors after gNB YAML is loaded (re-called from
+ * gnb_config.c after set_slice_config()).
+ *
+ * Always wires nr_dlsch_preprocessor / nr_ulsch_preprocessor. PF vs NS is not
+ * selected here — each preprocessor checks scheduler_type_dl/ul at runtime so
+ * dl_scheduler_type and ul_scheduler_type can differ (e.g. NSUL, NSDL). */
+void nr_mac_init_scheduler(gNB_MAC_INST *mac)
+{
+  if (get_softmodem_params()->phy_test)
+    return;
+
+  mac->pre_processor_dl = nr_dlsch_preprocessor;
+  mac->pre_processor_ul = nr_ulsch_preprocessor;
+  LOG_I(NR_MAC,
+        "MAC scheduler preprocessors: DL=%s UL=%s\n",
+        mac->scheduler_type_dl == SCHE_NS ? "SCHE_NS" : "SCHE_PF",
+        mac->scheduler_type_ul == SCHE_NS ? "SCHE_NS" : "SCHE_PF");
+}
+
 void mac_top_destroy_gNB(gNB_MAC_INST *mac)
 {
   for (size_t i = 0; i < sizeofArray(mac->cells); i++) {
@@ -373,6 +466,15 @@ void mac_top_destroy_gNB(gNB_MAC_INST *mac)
     free_f1ap_setup_response(mac->f1_config.setup_resp);
   free(mac->f1_config.setup_resp);
   free(mac->positioning_config);
+
+  if (mac->slice_scheduler_dl != NULL) {
+    slice_sch_destroy(mac->slice_scheduler_dl);
+    mac->slice_scheduler_dl = NULL;
+  }
+  if (mac->slice_scheduler_ul != NULL) {
+    slice_sch_destroy(mac->slice_scheduler_ul);
+    mac->slice_scheduler_ul = NULL;
+  }
 }
 
 void nr_mac_send_f1_setup_req(void)

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -23,6 +23,8 @@
 #include "common/utils/ds/spsc_q.h"
 #include "openair2/LAYER2/nr_rlc/nr_rlc_configuration.h"
 #include "openair2/LAYER2/NR_MAC_gNB/nr_pos_ue_context.h"
+#include "gNB_scheduler_types.h"
+#include "NR_MAC_gNB/slice_prb_allocator/slice_prb_allocator.h"
 
 #define NR_SCHED_LOCK(lock)                                        \
   do {                                                             \
@@ -35,6 +37,10 @@
     int rc = pthread_mutex_unlock(lock);                           \
     AssertFatal(rc == 0, "error while locking scheduler mutex, pthread_mutex_unlock() returned %d\n", rc); \
   } while (0)
+
+#define NR_SCHED_ENSURE_LOCKED(lock)                               \
+  AssertFatal(pthread_mutex_trylock(lock) == EBUSY,                 \
+              "this function should be called with the scheduler mutex locked\n")
 
 /* Commmon */
 #include "COMMON/f1ap_messages_types.h"
@@ -214,6 +220,9 @@ typedef struct nr_mac_config_s {
   int nb_bfw[2];
   int32_t *bw_list;
   int num_agg_level_candidates[NUM_PDCCH_AGG_LEVELS];
+  /// CORESET duration in OFDM symbols (1..3), from gNB config "coreset_duration".
+  /// Replaces the old heuristic (2 symbols if BWP < 48 PRBs, else 1). Default 1.
+  int coreset_duration;
   nr_redcap_config_t *redcap;
   nr_ptrs_config_t *ptrs;
   nr_config_report_type_t report_type;
@@ -887,6 +896,11 @@ typedef struct {
 #define UE_iterator(BaSe, VaR) for (NR_UE_info_t **VaR##pptr = BaSe, *VaR = *VaR##pptr; VaR; VaR = *(++VaR##pptr))
 #define FOR_EACH_CANDIDATE(VaR, ArR, N) for (__typeof__(*(ArR)) *VaR = (ArR); VaR < (ArR) + (N); VaR++)
 
+/* Note: Network slice PRB ratios are managed by slice_scheduler_dl / slice_scheduler_ul.
+ * Use slice_prb_allocator.h functions to access slice configurations.
+ * The old network_slice_t and network_slice_info_t structures have been removed.
+ */
+
 typedef struct {
   /// current frame
   frame_t frame;
@@ -925,10 +939,12 @@ struct nr_dl_sched_params {
   int num_beams; ///< number of beams
   int max_num_ue; ///< max UEs to schedule
   uint16_t *vrb_map[MAX_NUM_BEAM_PERIODS]; ///< per-beam VRB maps [275], mutable
-  int n_rb_avail[MAX_NUM_BEAM_PERIODS]; ///< available RBs per beam
+  int n_rb_avail[MAX_NUM_BEAM_PERIODS]; ///< available RBs per beam (slice num_prbs under NS)
   int min_mcs; ///< minimum MCS from BLER config
   float bler_lower; ///< BLER lower threshold (increase MCS if below)
   float bler_upper; ///< BLER upper threshold (decrease MCS if above)
+  int slice_rb_start; ///< NS: absolute carrier PRB start of slice range; -1 = full BWP (SCHE_PF)
+  int slice_rb_end; ///< NS: absolute carrier PRB end (exclusive); -1 = full BWP
 };
 
 /// Per-UE scheduling candidate — read-only inputs for the policy function.
@@ -1050,6 +1066,8 @@ typedef struct nr_ul_sched_params {
   float bler_upper;
   const NR_ServingCellConfigCommon_t *scc;
   const NR_bler_options_t *bler_opts; ///< UL BLER options (for adapt_ul_mcs)
+  int slice_rb_start; ///< NS: absolute PRB start of slice range; -1 = full BWP (SCHE_PF)
+  int slice_rb_end; ///< NS: absolute PRB end (exclusive); -1 = full BWP
 } nr_ul_sched_params_t;
 
 struct nr_ul_candidate {
@@ -1334,6 +1352,14 @@ typedef struct gNB_MAC_INST_s {
   nr_pp_impl_dl pre_processor_dl;
   /// UL preprocessor for differentiated scheduling
   nr_pp_impl_ul pre_processor_ul;
+  /// DL scheduler algorithm type
+  scheduler_type_t scheduler_type_dl;
+  /// UL scheduler algorithm type
+  scheduler_type_t scheduler_type_ul;
+  /// Slice PRB allocator for DL (ratios from dedicated_prb_ratio / dl_* in gNB config)
+  slice_scheduler_t *slice_scheduler_dl;
+  /// Slice PRB allocator for UL (ratios from dedicated_prb_ratio / ul_* in gNB config)
+  slice_scheduler_t *slice_scheduler_ul;
 
   /// DL scheduling pipeline function pointers
   nr_dl_ri_pmi_select_fn dl_ri_pmi_select;

--- a/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
@@ -1055,7 +1055,7 @@ void nr_rrc_config_dl_tda(NR_PDSCH_TimeDomainResourceAllocationList_t *pdsch_Tim
   //timedomainresourceallocation->k0 = calloc(1,sizeof(*timedomainresourceallocation->k0));
   //*timedomainresourceallocation->k0 = 0;
   timedomainresourceallocation->mappingType = NR_PDSCH_TimeDomainResourceAllocation__mappingType_typeA;
-  timedomainresourceallocation->startSymbolAndLength = get_SLIV(len_coreset,14-len_coreset); // basic slot configuration starting in symbol 1 til the end of the slot
+  timedomainresourceallocation->startSymbolAndLength = get_SLIV(len_coreset,14-len_coreset); // basic slot configuration starting after CORESET til the end of the slot
   asn1cSeqAdd(&pdsch_TimeDomainAllocationList->list, timedomainresourceallocation);
   // setting TDA for CSI-RS symbol with index 1
   NR_PDSCH_TimeDomainResourceAllocation_t *timedomainresourceallocation1 = CALLOC(1,sizeof(NR_PDSCH_TimeDomainResourceAllocation_t));

--- a/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/.gitignore
+++ b/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/.gitignore
@@ -1,0 +1,11 @@
+# Build artifacts
+test_slice_prb_allocator
+*.o
+*.a
+*.so
+
+# Editor files
+*~
+*.swp
+*.swo
+.DS_Store

--- a/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/Makefile
+++ b/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/Makefile
@@ -1,0 +1,30 @@
+# Makefile for Network Slice PRB Allocator
+
+CC = gcc
+CFLAGS = -Wall -Wextra -std=c11 -O2 -g
+LDFLAGS = -lm
+
+# Source files
+SRC = slice_prb_allocator.c
+TEST_SRC = test_slice_prb_allocator.c
+TEST_TARGET = test_slice_prb_allocator
+
+# Default target
+all: test
+
+# Build test executable
+test: $(TEST_TARGET)
+
+$(TEST_TARGET): $(SRC) $(TEST_SRC)
+	$(CC) $(CFLAGS) $(TEST_SRC) $(SRC) -o $(TEST_TARGET) $(LDFLAGS)
+
+# Run tests
+run: test
+	./$(TEST_TARGET)
+
+# Clean build artifacts
+clean:
+	rm -f $(TEST_TARGET)
+
+# Phony targets
+.PHONY: all test run clean

--- a/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/README.md
+++ b/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/README.md
@@ -1,0 +1,916 @@
+# Network Slice PRB Range Allocation Algorithm
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Quick Start](#quick-start)
+3. [Algorithm Description](#algorithm-description)
+4. [Detailed Algorithm Explanation](#detailed-algorithm-explanation)
+5. [Usage Examples](#usage-examples)
+6. [Test Coverage](#test-coverage)
+7. [Integration](#integration)
+8. [Performance](#performance)
+9. [References](#references)
+
+---
+
+## Overview
+
+This module implements a **four-pass algorithm** for allocating Physical Resource Blocks (PRBs) to network slices based on dedicated, minimum, and maximum PRB ratios, with optional PRB requirement-based prioritization. The algorithm is designed for frequency-domain network slicing in 5G NR systems.
+
+### PRB Ratio Definitions
+
+Before understanding the algorithm, it's crucial to understand the three types of PRB ratios:
+
+#### 1. `dedicated_prb_ratio` (Dedicated PRB Ratio)
+- **Definition**: Non-shareable, guaranteed PRB allocation that is always reserved for the slice
+- **Range**: 0.0 to 1.0 (0% to 100%)
+- **Behavior**: 
+  - Allocated in **Pass 1** before any other allocation
+  - **Always reserved** - cannot be shared with other slices, even if the slice doesn't need it
+  - If total dedicated allocations exceed 100%, all are scaled down proportionally
+- **Use Case**: Critical slices that need guaranteed isolation (e.g., URLLC for ultra-low latency)
+- **Example**: `dedicated_prb_ratio = 0.20` means 20% of PRBs are always reserved for this slice
+
+#### 2. `min_prb_ratio` (Minimum PRB Ratio)
+- **Definition**: Minimum guaranteed PRB allocation that the slice should receive when it needs resources
+- **Range**: 0.0 to 1.0 (0% to 100%), must be ≥ `dedicated_prb_ratio`
+- **Behavior**:
+  - The difference `(min_prb_ratio - dedicated_prb_ratio)` represents **prioritized but shareable** resources
+  - **If slice needs it** (based on `required_prbs`): Slice gets priority to use these resources
+  - **If slice doesn't need it**: Other slices can use these resources
+  - Allocated in **Pass 2** based on actual need (`required_prbs`)
+  - Must be ≥ `dedicated_prb_ratio` (dedicated is part of the minimum)
+- **Use Case**: Slices that need guaranteed minimum bandwidth when they have traffic
+- **Example**: 
+  - `dedicated_prb_ratio = 0.20`, `min_prb_ratio = 0.30`
+  - 20% is always reserved (dedicated)
+  - 10% is prioritized - slice gets it if needed, otherwise shareable
+
+#### 3. `max_prb_ratio` (Maximum PRB Ratio)
+- **Definition**: Hard upper limit on PRB allocation that a slice can never exceed
+- **Range**: 0.0 to 1.0 (0% to 100%), must be ≥ `min_prb_ratio`
+- **Behavior**:
+  - The difference `(max_prb_ratio - min_prb_ratio)` represents **fully shared resources**
+  - These resources are **shared between all slices** and distributed proportionally
+  - Enforced as a **hard limit** in all passes (Pass 1, 2, and 3)
+  - Slice can grow up to this limit in Pass 3 if resources are available
+  - Never exceeded, even if more PRBs are available
+- **Use Case**: Allowing slices to share additional resources beyond their minimum guarantees
+- **Example**: 
+  - `min_prb_ratio = 0.30`, `max_prb_ratio = 0.50`
+  - 30% is minimum (dedicated + prioritized)
+  - 20% is shared - can be used by any slice up to their max limit
+
+#### Relationship Between Ratios
+
+The ratios must satisfy: **`dedicated_prb_ratio ≤ min_prb_ratio ≤ max_prb_ratio`**
+
+**Three-Tier Resource Model**:
+1. **Dedicated** (`dedicated_prb_ratio`): Always reserved, non-shareable (Pass 1)
+2. **Prioritized** (`min_prb_ratio - dedicated_prb_ratio`): Prioritized but shareable - slice gets priority if needed based on `required_prbs` (Pass 2)
+3. **Shared** (`max_prb_ratio - min_prb_ratio`): Fully shared - distributed proportionally among all slices (Pass 3)
+
+**Example Configuration**:
+```
+Slice 1 (URLLC):
+  dedicated_prb_ratio = 0.20  (20% always reserved, non-shareable)
+  min_prb_ratio = 0.20        (20% total: 20% dedicated + 0% prioritized)
+  max_prb_ratio = 0.40        (20% shared resources: 40% - 20%)
+
+Slice 2 (eMBB):
+  dedicated_prb_ratio = 0.10  (10% always reserved, non-shareable)
+  min_prb_ratio = 0.30        (30% total: 10% dedicated + 20% prioritized)
+  max_prb_ratio = 0.60        (30% shared resources: 60% - 30%)
+
+Resource breakdown (for 100 PRBs):
+- Slice 1: 20 PRBs dedicated, 0 PRBs prioritized, 20 PRBs shared (max 40)
+- Slice 2: 10 PRBs dedicated, 20 PRBs prioritized, 30 PRBs shared (max 60)
+- Total: 30 PRBs dedicated, 20 PRBs prioritized, 50 PRBs shared
+```
+
+### Slice Identifier Structure
+
+Slice identifiers use the `slice_nssai_t` struct with SST (Slice/Service Type) and SD (Slice Differentiator) bit fields, following the 5G S-NSSAI (Single Network Slice Selection Assistance Information) format:
+
+```c
+typedef struct {
+  uint32_t sst : 8;   // Slice/Service Type (0-255)
+  uint32_t sd : 24;   // Slice Differentiator (0-0xffffff)
+} slice_nssai_t;
+```
+
+**Note**: This is named `slice_nssai_t` to avoid conflict with OAI's existing `slice_id_t` (uint8_t) in `platform_types.h`.
+
+**Helper Functions**:
+- `slice_nssai_create(sst, sd)`: Create a `slice_nssai_t` from SST and SD values
+- `slice_nssai_from_int(id)`: Convert an integer to `slice_nssai_t` (sets `sst=id`, `sd=0`)
+- `slice_nssai_eq(sid1, sid2)`: Compare two `slice_nssai_t` structures
+- `slice_nssai_eq_int(sid, id)`: Compare `slice_nssai_t` with an integer (compares SST only)
+
+**Example**:
+```c
+// Create slice ID with SST=1, SD=0
+slice_nssai_t slice1 = slice_nssai_create(1, 0);
+
+// Create from integer (for backward compatibility)
+slice_nssai_t slice2 = slice_nssai_from_int(2);  // SST=2, SD=0
+
+// Compare slice IDs
+if (slice_nssai_eq(&slice1, &slice2)) {
+    // Slices match
+}
+```
+
+### Key Features
+
+- **Three-Tier Allocation**: Dedicated (non-shareable) → Prioritized (shareable with priority) → Shared (fully shareable)
+- **Hard Limits**: `max_prb_ratio` always enforced; `min_prb_ratio` guaranteed when resources available
+- **Contiguous Allocation**: PRBs allocated contiguously for frequency-domain slicing
+- **Proportional Scaling**: Handles over-allocation with fair proportional distribution
+- **PRB Requirements**: Optional `required_prbs` enables priority-based allocation
+- **5G S-NSSAI Support**: Slice identifiers use SST and SD bit fields following 3GPP standards
+
+---
+
+## Quick Start
+
+### Directory Structure
+
+```
+slice_prb_allocator/
+├── slice_prb_allocator.h          # Header file with data structures and function declarations
+├── slice_prb_allocator.c          # Implementation of the allocation algorithm
+├── test_slice_prb_allocator.c     # Comprehensive unit tests
+├── Makefile                       # Build configuration
+├── README.md                      # This file (comprehensive documentation)
+└── .gitignore                     # Git ignore file
+```
+
+### Compilation
+
+**Using Makefile (recommended):**
+```bash
+cd slice_prb_allocator
+make          # Build test executable
+make run      # Build and run tests
+make clean    # Clean build artifacts
+```
+
+**Manual compilation:**
+```bash
+cd slice_prb_allocator
+gcc -Wall -Wextra -std=c11 -O2 -g test_slice_prb_allocator.c slice_prb_allocator.c -o test_slice_prb_allocator -lm
+./test_slice_prb_allocator
+```
+
+### Basic Usage
+
+```c
+#include "slice_prb_allocator.h"
+
+// Prepare input
+slice_alloc_input_t input = {0};
+// Slice 1: SST=1, SD=0 (eMBB slice)
+input.slices[0].slice_id = slice_nssai_create(1, 0);
+input.slices[0].dedicated_prb_ratio = 0.33f;
+input.slices[0].min_prb_ratio = 0.33f;
+input.slices[0].max_prb_ratio = 0.50f;
+input.slices[0].required_prbs = 40;  // Optional: PRB requirement (0 = not used)
+
+// Slice 2: SST=2, SD=0 (URLLC slice)
+input.slices[1].slice_id = slice_nssai_create(2, 0);
+input.slices[1].dedicated_prb_ratio = 0.20f;
+input.slices[1].min_prb_ratio = 0.20f;
+input.slices[1].max_prb_ratio = 0.50f;
+input.slices[1].required_prbs = 30;  // Optional: PRB requirement
+
+input.num_slices = 2;
+input.total_prbs = 106;
+
+// Allocate PRBs
+slice_alloc_result_t result = {0};
+int num_active = calculate_slice_prb_ranges(&input, &result);
+
+// Use results
+for (int s = 0; s < MAX_NUM_SLICES; ++s) {
+    if (result.ranges[s].num_prbs > 0) {
+        printf("Slice (SST=%d, SD=%u): PRBs [%d, %d) (%d PRBs)\n",
+               result.ranges[s].slice_id.sst,
+               result.ranges[s].slice_id.sd,
+               result.ranges[s].start_prb,
+               result.ranges[s].end_prb,
+               result.ranges[s].num_prbs);
+    }
+}
+```
+
+**Note**: Slice identifiers use the `slice_nssai_t` struct with SST (Slice/Service Type, 8 bits, 0-255) and SD (Slice Differentiator, 24 bits, 0-0xffffff) bit fields, following the 5G S-NSSAI (Single Network Slice Selection Assistance Information) format.
+
+---
+
+## Algorithm Description
+
+The algorithm implements a **three-tier resource allocation model** in **four passes**:
+
+### Four-Pass Algorithm
+
+### Pass 1: Dedicated PRB Allocation
+- Allocates dedicated (non-shareable) PRBs to each slice with active UEs
+- If total dedicated allocations exceed available PRBs, they are scaled down proportionally
+- Ensures `dedicated_prb_ratio <= min_prb_ratio <= max_prb_ratio`
+
+### Pass 2: Prioritized Resource Distribution
+- Distributes prioritized resources (`min - dedicated`) to slices that need them
+- Based on `required_prbs`: only allocates if `required_prbs > current_allocation`
+- If slice doesn't need prioritized resources, they remain available for Pass 3
+- Respects `max_prb_ratio` as a hard limit during allocation
+
+### Pass 3: Shared Resource Distribution
+- Distributes shared resources (`max - min`) among all slices
+- Fully shareable - distributed proportionally based on:
+  - PRB requirements (`required_prbs`) if specified, or
+  - Remaining capacity (up to max limit) if no requirements
+- Each slice can grow up to its `max_prb_ratio` limit
+
+### Pass 4: Contiguous Range Assignment
+- Assigns contiguous PRB ranges to each slice
+- Ranges are non-overlapping and cover all allocated PRBs
+
+### Algorithm Flow
+
+```
+┌─────────────────────────────────────────────────────────┐
+│              Three-Tier Resource Allocation              │
+│  Dedicated → Prioritized → Shared → Contiguous Ranges   │
+└─────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+        ┌───────────────────────────────────┐
+        │  Pass 1: Dedicated Resources      │
+        │  - Allocate non-shareable PRBs      │
+        │  - Always reserved (dedicated)     │
+        │  - Scale down if exceeds total     │
+        └───────────────┬───────────────────┘
+                        │
+                        ▼
+        ┌───────────────────────────────────┐
+        │  Pass 2: Prioritized Resources     │
+        │  - Allocate if slice needs them    │
+        │  - Based on required_prbs          │
+        │  - Shareable if slice doesn't need│
+        └───────────────┬───────────────────┘
+                        │
+                        ▼
+        ┌───────────────────────────────────┐
+        │  Pass 3: Shared Resources          │
+        │  - Fully shared between slices     │
+        │  - Distributed proportionally      │
+        │  - Up to max_prb_ratio limit       │
+        └───────────────┬───────────────────┘
+                        │
+                        ▼
+        ┌───────────────────────────────────┐
+        │  Pass 4: Contiguous Range Assign  │
+        │  - Assign [start, end) ranges     │
+        │  - Ensure no gaps or overlaps     │
+        └───────────────────────────────────┘
+```
+
+---
+
+## Detailed Algorithm Explanation
+
+### Problem Statement
+
+Given:
+- **N** network slices, each with:
+  - `dedicated_prb_ratio`: Non-shareable PRB allocation (0.0 - 1.0)
+  - `min_prb_ratio`: Minimum guaranteed PRB allocation (0.0 - 1.0)
+  - `max_prb_ratio`: Maximum allowed PRB allocation (0.0 - 1.0)
+  - `required_prbs`: Optional current PRB requirement (0 = not used)
+- **Total PRBs**: Total number of available PRBs (e.g., 106 for typical 5G NR)
+
+Find:
+- Contiguous PRB ranges `[start_prb, end_prb)` for each slice
+- Allocation must satisfy:
+  1. `dedicated_prb_ratio ≤ min_prb_ratio ≤ max_prb_ratio`
+  2. Each slice gets at least `dedicated_prb_ratio`
+  3. Each slice gets at least `min_prb_ratio` when resources are available
+  4. No slice exceeds `max_prb_ratio` (hard limit)
+  5. All PRBs are allocated (no gaps)
+  6. Ranges are contiguous and non-overlapping
+
+### Pass 1: Dedicated PRB Allocation
+
+**Purpose**: Allocate non-shareable dedicated PRBs to each slice.
+
+**Steps**:
+1. For each slice:
+   - Calculate `dedicated_prbs = total_prbs × dedicated_prb_ratio`
+   - Calculate `min_prbs = total_prbs × min_prb_ratio`
+   - Calculate `max_prbs = total_prbs × max_prb_ratio`
+   - Ensure `min_prbs ≥ dedicated_prbs` (adjust if needed)
+   - Ensure `dedicated_prbs ≤ max_prbs` (cap if needed)
+   - Allocate `dedicated_prbs` to the slice
+   - Add to `allocated_prbs` counter
+
+2. **Over-allocation Check**:
+   - If `allocated_prbs > total_prbs`:
+     - Calculate scale factor: `scale = total_prbs / allocated_prbs`
+     - Scale down each slice's allocation proportionally
+     - Recalculate `allocated_prbs`
+
+**Example**:
+```
+Total PRBs: 100
+Slice 1: dedicated = 60% → 60 PRBs
+Slice 2: dedicated = 60% → 60 PRBs
+Total allocated: 120 PRBs > 100 PRBs
+
+Scale factor: 100/120 = 0.833
+Slice 1: 60 × 0.833 = 50 PRBs
+Slice 2: 60 × 0.833 = 50 PRBs
+Total: 100 PRBs ✓
+```
+
+**Why Scale Down?**
+- **Fairness**: Each slice gets a proportional share of its dedicated request
+- **No Starvation**: No slice gets zero PRBs if it requested dedicated resources
+- **Consistency**: The relative ratios between slices are preserved
+
+**Mathematical Formulation**:
+```
+If Σ(dedicated_i) > total_prbs:
+  scale = total_prbs / Σ(dedicated_i)
+  allocated_i = dedicated_i × scale
+```
+
+### Pass 2: Minimum Guarantee Distribution (Prioritized Resources)
+
+**Purpose**: Allocate prioritized resources (`min_prb_ratio - dedicated_prb_ratio`) to slices that need them based on `required_prbs`.
+
+**Important Semantics**: 
+- **Dedicated** (`dedicated_prb_ratio`): Always reserved, non-shareable (allocated in Pass 1)
+- **Prioritized** (`min_prb_ratio - dedicated_prb_ratio`): Shareable but prioritized
+  - **Common Rule**: Pass 2 allocates up to `min(required_prbs, min_prb_ratio)` (within the prioritized portion)
+  - If `required_prbs < min_prb_ratio`: Allocate up to `required_prbs` in Pass 2, remaining prioritized resources (`min_prb_ratio - required_prbs`) are available for Pass 3
+  - If `required_prbs ≥ min_prb_ratio`: Allocate up to `min_prb_ratio` in Pass 2
+
+**Example**: If a slice has `dedicated_prb_ratio = 0.20` and `min_prb_ratio = 0.30`:
+- 20% is dedicated (always reserved, Pass 1)
+- 10% is prioritized (Pass 2) - slice gets it if `required_prbs` indicates need, otherwise shareable
+
+**Steps**:
+1. Calculate `remaining_prbs = total_prbs - allocated_prbs`
+
+2. **Calculate Prioritized Resource Needs** (common rule: allocate up to `min(required_prbs, min_prb_ratio)`):
+   - For each active slice:
+     - `min_prbs = total_prbs × min_prb_ratio` (total minimum target)
+     - `dedicated_prbs = total_prbs × dedicated_prb_ratio` (already allocated in Pass 1)
+     - `prioritized_prbs = min_prbs - dedicated_prbs` (prioritized but shareable portion)
+     - **Common Rule**: `target_prbs = min(required_prbs, min_prbs)` (if `required_prbs = 0`, then `target_prbs = 0`)
+     - **Check if slice needs prioritized resources**:
+       - If `target_prbs > current_allocation` and `prioritized_prbs > 0`:
+         - `prioritized_needed = min(prioritized_prbs, target_prbs - current_allocation)`
+         - Add to `total_prioritized_needed`
+       - If `target_prbs ≤ current_allocation` (slice doesn't need more):
+         - Slice doesn't claim prioritized resources (they remain shareable for Pass 3)
+
+3. **Allocate Prioritized Resources**:
+   - If `total_prioritized_needed > 0`:
+     - Calculate scale: `scale = min(1.0, remaining_prbs / total_prioritized_needed)`
+     - For each slice that needs prioritized resources:
+       - Calculate `additional = prioritized_needed × scale`
+       - **Critical Check**: Ensure `current + additional ≤ max_prbs` (respect max limit)
+       - **Critical Check**: Ensure `current + additional ≤ target_prbs` (where `target_prbs = min(required_prbs, min_prbs)`)
+       - If adding `additional` would exceed limits, cap appropriately
+       - Allocate `additional` PRBs (capped if needed)
+       - Update `allocated_prbs` and `remaining_prbs`
+   - **Note**: If a slice doesn't need prioritized resources (`target_prbs ≤ current_allocation`), those resources remain available for Pass 3
+   - **Note**: If `required_prbs < min_prb_ratio`, the remaining prioritized resources (`min_prb_ratio - required_prbs`) are available for Pass 3
+
+**Example 1: Common Rule - Allocate up to min(required_prbs, min_prb_ratio)**:
+```
+After Pass 1:
+Slice 1: 20 PRBs (dedicated), min = 30 PRBs, max = 50 PRBs, required = 35 PRBs
+Slice 2: 10 PRBs (dedicated), min = 25 PRBs, max = 50 PRBs, required = 30 PRBs
+Remaining: 70 PRBs
+
+Common Rule: target = min(required_prbs, min_prb_ratio)
+Slice 1: target = min(35, 30) = 30 PRBs, current = 20, needs 10 PRBs
+Slice 2: target = min(30, 25) = 25 PRBs, current = 10, needs 15 PRBs
+
+Prioritized resources (min - dedicated):
+Slice 1: 30 - 20 = 10 PRBs prioritized → needs 10 (within prioritized portion)
+Slice 2: 25 - 10 = 15 PRBs prioritized → needs 15 (within prioritized portion)
+Total prioritized needed: 25 PRBs
+
+Available: 70 PRBs > 25 PRBs needed
+Scale = 1.0
+
+Slice 1: 20 + 10 = 30 PRBs (reaches target = 30, remaining 5 needed in Pass 3)
+Slice 2: 10 + 15 = 25 PRBs (reaches target = 25, remaining 5 needed in Pass 3)
+Remaining: 70 - 25 = 45 PRBs (available for Pass 3)
+```
+
+**Example 2: Common Rule - required_prbs < min_prb_ratio**:
+```
+After Pass 1:
+Slice 1: 20 PRBs (dedicated), min = 30 PRBs, max = 50 PRBs, required = 15 PRBs
+Slice 2: 10 PRBs (dedicated), min = 25 PRBs, max = 50 PRBs, required = 30 PRBs
+Remaining: 70 PRBs
+
+Common Rule: target = min(required_prbs, min_prb_ratio)
+Slice 1: target = min(15, 30) = 15 PRBs, current = 20, doesn't need more (target ≤ current)
+Slice 2: target = min(30, 25) = 25 PRBs, current = 10, needs 15 PRBs
+
+Prioritized resources (min - dedicated):
+Slice 1: 30 - 20 = 10 PRBs prioritized → not needed (target ≤ current), available for Pass 3
+Slice 2: 25 - 10 = 15 PRBs prioritized → needs 15 (within prioritized portion)
+Total prioritized needed: 15 PRBs (only slice 2 needs it)
+
+Available: 70 PRBs > 15 PRBs needed
+Scale = 1.0
+
+Slice 1: 20 PRBs (no change, target = 15 already met)
+Slice 2: 10 + 15 = 25 PRBs (reaches target = 25, remaining 5 needed in Pass 3)
+Remaining: 70 - 15 = 55 PRBs (slice 1's prioritized 10 PRBs + 45 PRBs available for Pass 3)
+```
+
+**Example 3: Common Rule - required_prbs = 0 (no allocation in Pass 2)**:
+```
+After Pass 1:
+Slice 0: 0 PRBs (dedicated), min = 0 PRBs, max = 95 PRBs, required = 4 PRBs
+Slice 1: 10 PRBs (dedicated), min = 10 PRBs, max = 95 PRBs, required = 0 PRBs
+Slice 2: 29 PRBs (dedicated), min = 67 PRBs, max = 95 PRBs, required = 0 PRBs
+Remaining: 26 PRBs
+
+Common Rule: target = min(required_prbs, min_prb_ratio)
+Slice 0: target = min(4, 0) = 0 PRBs (no allocation in Pass 2, handled in Pass 3)
+Slice 1: target = min(0, 10) = 0 PRBs (no allocation in Pass 2, prioritized resources available for Pass 3)
+Slice 2: target = min(0, 67) = 0 PRBs (no allocation in Pass 2, prioritized resources available for Pass 3)
+
+Total prioritized needed: 0 PRBs (all slices have required_prbs = 0 or min = 0)
+
+Available for Pass 2: 26 PRBs, but nothing to allocate
+Remaining after Pass 2: 26 PRBs
+
+Pass 3: Slice 0 will get PRBs based on required_prbs = 4
+```
+
+**Example 4: Common Rule - required_prbs > min_prb_ratio**:
+```
+After Pass 1:
+Slice 1: 20 PRBs (dedicated), min = 30 PRBs, max = 50 PRBs, required = 40 PRBs
+Slice 2: 10 PRBs (dedicated), min = 25 PRBs, max = 50 PRBs, required = 35 PRBs
+Remaining: 70 PRBs
+
+Common Rule: target = min(required_prbs, min_prb_ratio)
+Slice 1: target = min(40, 30) = 30 PRBs, current = 20, needs 10 PRBs
+Slice 2: target = min(35, 25) = 25 PRBs, current = 10, needs 15 PRBs
+
+Prioritized resources (min - dedicated):
+Slice 1: 30 - 20 = 10 PRBs prioritized → needs 10 (within prioritized portion)
+Slice 2: 25 - 10 = 15 PRBs prioritized → needs 15 (within prioritized portion)
+Total prioritized needed: 25 PRBs
+
+Available: 70 PRBs > 25 PRBs needed
+Scale = 1.0
+
+Slice 1: 20 + 10 = 30 PRBs (reaches target = 30, remaining 10 needed in Pass 3)
+Slice 2: 10 + 15 = 25 PRBs (reaches target = 25, remaining 10 needed in Pass 3)
+Remaining: 70 - 25 = 45 PRBs (available for Pass 3)
+```
+
+**Example 5: Max Limit Constraint**:
+```
+After Pass 1:
+Slice 1: 20 PRBs (dedicated), min = 30 PRBs, max = 25 PRBs, required = 35 PRBs
+Slice 2: 10 PRBs (dedicated), min = 25 PRBs, max = 50 PRBs, required = 30 PRBs
+Remaining: 70 PRBs
+
+Prioritized needs:
+Slice 1: needs 15 PRBs (35 - 20), but max = 25, so can only add 5
+Slice 2: needs 20 PRBs (30 - 10), prioritized = 15, so needs 15
+Total prioritized needed: 20 PRBs (5 + 15)
+
+Available: 70 PRBs > 20 PRBs needed
+Scale = 1.0
+
+Slice 1: 20 + 5 = 25 PRBs (capped at max, can't meet required)
+Slice 2: 10 + 15 = 25 PRBs (gets prioritized resources)
+Remaining: 70 - 20 = 50 PRBs
+```
+
+**Key Rules for Pass 2**:
+- **Common Rule**: Allocate up to `min(required_prbs, min_prb_ratio)` (within the prioritized portion)
+  - Calculate `target_prbs = min(required_prbs, min_prb_ratio)` (if `required_prbs = 0`, then `target_prbs = 0`)
+  - Allocate up to `target_prbs` in Pass 2
+  - If `required_prbs < min_prb_ratio`: Remaining prioritized resources (`min_prb_ratio - required_prbs`) are available for Pass 3
+- Never exceed `max_prb_ratio` in any pass
+
+**Key Points**:
+- Prioritized resources are only allocated if `required_prbs > current_allocation`
+- If slice doesn't need prioritized resources, they remain available for Pass 3 (shared)
+- Proportional scaling ensures fairness when resources are constrained
+- Max limit is always enforced (may prevent meeting prioritized need)
+- Backward compatible: if `required_prbs == 0`, uses traditional min guarantee logic
+
+### Pass 3: Shared Resource Distribution
+
+**Purpose**: Distribute shared resources (`max_prb_ratio - min_prb_ratio`) among all slices proportionally.
+
+**Important Semantics**:
+- **Shared resources** (`max - min`) are fully shareable between all slices
+- These resources are distributed proportionally based on:
+  - PRB requirements (`required_prbs`) if specified, or
+  - Remaining capacity (up to max limit) if no requirements
+- Each slice can grow up to its `max_prb_ratio` limit
+- Resources are shared fairly among all slices that haven't reached their max
+
+**Steps**:
+1. **Calculate Remaining Capacity** (shared resources available):
+   - For each active slice:
+     - `max_prbs = total_prbs × max_prb_ratio`
+     - `can_add = max_prbs - current_allocation` (shared resources this slice can use)
+     - If `can_add > 0`, add to `total_capacity`
+
+2. **Calculate PRB Deficits** (if requirements specified):
+   - For each active slice with `required_prbs > 0`:
+     - `prb_deficit = required_prbs - current_allocation`
+     - If `prb_deficit > 0`, add to `total_prb_deficit`
+
+3. **Allocation Strategy**:
+   - **If PRB requirements exist**: Allocate shared resources based on PRB deficits (slices with higher deficits get priority)
+   - **Otherwise**: Allocate shared resources proportionally based on remaining capacity
+   - In both cases, respect `max_prb_ratio` limits (shared resources are bounded by max)
+
+**Example 1: Shared Resources with PRB Requirements**:
+```
+After Pass 2:
+Slice 1: 30 PRBs (dedicated + prioritized), min = 30 PRBs, max = 50 PRBs, required = 45 PRBs
+Slice 2: 25 PRBs (dedicated + prioritized), min = 25 PRBs, max = 50 PRBs, required = 35 PRBs
+Remaining: 45 PRBs (shared resources)
+
+Shared resources available:
+Slice 1: can_add = 50 - 30 = 20 PRBs (shared)
+Slice 2: can_add = 50 - 25 = 25 PRBs (shared)
+Total shared capacity: 45 PRBs
+
+PRB deficits:
+Slice 1: 45 - 30 = 15 PRBs needed
+Slice 2: 35 - 25 = 10 PRBs needed
+Total deficit: 25 PRBs
+
+Allocate shared resources based on deficits (proportional, capped at deficit):
+Slice 1: (15/25) × 45 = 27 PRBs, but:
+  - Capped at deficit: min(27, 15) = 15 PRBs
+  - Capped at capacity: min(15, 20) = 15 PRBs
+  → 30 + 15 = 45 PRBs (meets requirement)
+Slice 2: (10/25) × 45 = 18 PRBs, but:
+  - Capped at deficit: min(18, 10) = 10 PRBs
+  - Capped at capacity: min(10, 25) = 10 PRBs
+  → 25 + 10 = 35 PRBs (meets requirement)
+Allocated: 15 + 10 = 25 PRBs
+Remaining: 45 - 25 = 20 PRBs
+
+Distribute remaining 20 PRBs proportionally (based on capacity):
+Slice 1: can_add = 50 - 45 = 5 PRBs
+Slice 2: can_add = 50 - 35 = 15 PRBs
+Total capacity: 20 PRBs
+Slice 1: (5/20) × 20 = 5 PRBs → 45 + 5 = 50 PRBs (at max)
+Slice 2: (15/20) × 20 = 15 PRBs → 35 + 15 = 50 PRBs (at max)
+```
+
+**Example 2: Shared Resources without PRB Requirements**:
+```
+After Pass 2:
+Slice 1: 30 PRBs, min = 30 PRBs, max = 50 PRBs, required = 0 (not specified)
+Slice 2: 25 PRBs, min = 25 PRBs, max = 50 PRBs, required = 0 (not specified)
+Remaining: 45 PRBs (shared resources)
+
+Shared resources available:
+Slice 1: can_add = 50 - 30 = 20 PRBs
+Slice 2: can_add = 50 - 25 = 25 PRBs
+Total shared capacity: 45 PRBs
+
+Distribute shared resources proportionally:
+Slice 1: (20/45) × 45 = 20 PRBs → 30 + 20 = 50 PRBs (at max)
+Slice 2: (25/45) × 45 = 25 PRBs → 25 + 25 = 50 PRBs (at max)
+```
+
+**Key Points**:
+- Shared resources are distributed proportionally based on remaining capacity or PRB deficits
+- Slices with more remaining capacity (closer to max) get proportionally more
+- Ensures efficient resource utilization and fairness
+
+### Pass 4: Contiguous Range Assignment
+
+**Purpose**: Assign contiguous PRB ranges `[start_prb, end_prb)` to each slice.
+
+**Steps**:
+1. Initialize `current_prb = 0`
+2. For each slice (in order) with `num_prbs > 0`:
+   - `start_prb = current_prb`
+   - `end_prb = current_prb + num_prbs`
+   - `current_prb = end_prb`
+
+**Result**: Non-overlapping, contiguous ranges covering all PRBs.
+
+**Example**:
+```
+After Pass 3:
+Slice 1: 50 PRBs
+Slice 2: 50 PRBs
+
+Range assignment:
+Slice 1: [0, 50)   → PRBs 0-49
+Slice 2: [50, 100) → PRBs 50-99
+Total: 100 PRBs ✓
+```
+
+---
+
+## Usage Examples
+
+### Example 0: OOP-like Scheduler Interface
+
+The module provides an OOP-like interface for managing slices dynamically:
+
+```c
+#include "slice_prb_allocator.h"
+
+// Create scheduler
+slice_scheduler_t *sch = slice_sch_create(106);  // 106 total PRBs
+
+// Add slices with SST and SD
+// Slice 1: SST=1, SD=0 (eMBB)
+slice_sch_add_slice(sch, 1, 0, 0.33f, 0.33f, 0.50f, 0);
+
+// Slice 2: SST=2, SD=0 (URLLC)
+slice_sch_add_slice(sch, 2, 0, 0.20f, 0.20f, 0.50f, 0);
+
+// Schedule allocation
+slice_sch_schedule(sch);
+
+// Get allocation results
+int num_ranges = 0;
+const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+for (int i = 0; i < num_ranges; ++i) {
+    printf("Slice (SST=%d, SD=%u): PRBs [%d, %d) (%d PRBs)\n",
+           ranges[i].slice_id.sst,
+           ranges[i].slice_id.sd,
+           ranges[i].start_prb,
+           ranges[i].end_prb,
+           ranges[i].num_prbs);
+}
+
+// Get statistics for a specific slice
+slice_statistics_t stats;
+if (slice_sch_get_slice_statistics(sch, 1, 0, &stats) == 0) {
+    printf("Slice (SST=%d, SD=%u): avg PRBs=%.1f\n",
+           stats.slice_id.sst, stats.slice_id.sd, stats.avg_num_prbs);
+}
+
+// Update PRB requirement for a slice
+slice_sch_update_require(sch, 1, 0, 40);
+
+// Delete a slice
+slice_sch_del_slice(sch, 2, 0);
+
+// Cleanup
+slice_sch_destroy(sch);
+```
+
+### Example 1: Basic Two-Slice Allocation
+
+**Input**:
+- Total PRBs: 100
+- Slice 1: dedicated=30%, min=30%, max=50%
+- Slice 2: dedicated=20%, min=20%, max=50%
+
+**Result**: Both slices get 50 PRBs each, respecting their maximum limits.
+
+### Example 2: Dedicated Exceeds Total
+
+**Input**:
+- Total PRBs: 100
+- Slice 1: dedicated=60%, min=60%, max=60%
+- Slice 2: dedicated=60%, min=60%, max=60%
+
+**Result**: Fair 50/50 split despite both requesting 60% (proportional scaling).
+
+### Example 3: Real-World 106 PRB Scenario
+
+**Input**:
+- Total PRBs: 106 (typical 5G NR bandwidth)
+- Slice 1 (eMBB): dedicated=33%, min=33%, max=50%
+- Slice 2 (URLLC): dedicated=20%, min=20%, max=50%
+
+**Result**: Both slices get 53 PRBs (50% each), maximizing resource utilization.
+
+### Example 4: With PRB Requirements
+
+**Input**:
+- Total PRBs: 100
+- Slice 1: dedicated=30%, min=30%, max=50%, required_prbs=45
+- Slice 2: dedicated=20%, min=20%, max=50%, required_prbs=35
+
+**Result**: 
+- Pass 1: Slice 1 gets 30 PRBs, Slice 2 gets 20 PRBs
+- Pass 2: Both meet minimums (Slice 1: 30→30, Slice 2: 20→20)
+- Pass 3: Allocate based on PRB deficits (Slice 1 needs 15 more, Slice 2 needs 15 more)
+  - Slice 1: 30 + 15 = 45 PRBs (meets requirement)
+  - Slice 2: 20 + 15 = 35 PRBs (meets requirement)
+  - Remaining: 20 PRBs distributed proportionally up to max
+
+---
+
+## Test Coverage
+
+The unit tests cover:
+
+1. **Basic allocation** - Two slices with different ratios
+2. **Single slice** - All PRBs allocated to one slice
+3. **No active UEs** - Slices without active UEs get no PRBs
+4. **Multiple slices** - Three slices with different ratios
+5. **Dedicated exceeds total** - Proportional scaling when dedicated > 100%
+6. **Max ratio enforcement** - Hard limit on maximum PRBs
+7. **Validation** - Input validation and error handling
+8. **Edge cases** - Zero PRBs, invalid ratios, etc.
+9. **Real-world scenario** - 106 PRBs with 2 slices (typical 5G NR)
+
+Run tests with:
+```bash
+make run
+```
+
+---
+
+## Edge Cases and Handling
+
+1. **No Active UEs**: Slice is skipped, gets 0 PRBs
+2. **Dedicated = Min = Max**: Static allocation, Pass 1 handles all
+3. **Minimums Exceed Total**: Proportional scaling in Pass 2
+4. **Maximum Limits Prevent Full Allocation**: Pass 3 respects max limits
+5. **Single Slice**: Gets all PRBs up to max limit
+6. **Dedicated > Total**: Proportional scaling in Pass 1
+7. **Max < Min**: Max limit takes precedence
+8. **Rounding Errors**: Handled with proper rounding (`.5` offset)
+
+---
+
+## Algorithm Constraints and Verification
+
+### Constraint Validation
+
+1. **Ratio Relationships**: `dedicated_prb_ratio ≤ min_prb_ratio ≤ max_prb_ratio`
+   - Validated in `validate_slice_config()`
+   - Ensures logical consistency of slice configuration
+
+2. **Ratio Range**: All ratios must be in [0.0, 1.0]
+   - Validated in `validate_slice_config()`
+   - Prevents invalid percentage values
+
+3. **Total Allocation**: Sum of allocated PRBs equals `total_prbs`
+   - Verified in Pass 4: all PRBs are allocated contiguously
+   - No gaps or unallocated PRBs
+
+4. **Contiguous Ranges**: PRB ranges are contiguous and non-overlapping
+   - Ensured in Pass 4: ranges are assigned sequentially
+   - `end_prb` of slice N = `start_prb` of slice N+1
+
+5. **Hard Limits**: `max_prb_ratio` is never exceeded
+   - Enforced in Pass 1, 2, and 3
+   - Checked before every allocation: `if (allocated + additional > max_prbs)`
+
+### Algorithm Correctness Verification
+
+#### Pass 1 Verification
+- ✅ Allocates `dedicated_prb_ratio` to each active slice
+- ✅ Handles over-allocation with proportional scaling
+- ✅ Ensures `dedicated ≤ max` (capped if needed)
+- ✅ Ensures `min ≥ dedicated` (adjusted if needed)
+
+#### Pass 2 Verification
+- ✅ Allocates prioritized resources based on `required_prbs` (only if slice needs them)
+- ✅ Handles insufficient resources with proportional scaling
+- ✅ Respects `max_prb_ratio` limit (may prevent meeting prioritized need if max < min)
+- ✅ Updates state correctly (`allocated_prbs`, `remaining_prbs`)
+- ✅ Prioritized resources not claimed remain available for Pass 3
+
+#### Pass 3 Verification
+- ✅ Considers PRB requirements when specified (`required_prbs > 0`)
+- ✅ Falls back to capacity-based allocation when no requirements
+- ✅ Respects `max_prb_ratio` limit in all cases
+- ✅ Distributes all remaining PRBs when possible
+
+#### Pass 4 Verification
+- ✅ Assigns contiguous, non-overlapping ranges
+- ✅ Covers all allocated PRBs (no gaps)
+- ✅ Maintains correct `start_prb` and `end_prb` relationships
+
+---
+
+## Integration
+
+This algorithm is extracted from the OAI gNB MAC scheduler (`gNB_scheduler_dlsch.c`). To integrate:
+
+1. Include the header file in your scheduler:
+   ```c
+   #include "slice_prb_allocator.h"
+   ```
+
+2. Convert OAI slice structures to `slice_config_t`:
+   ```c
+   slice_config_t slice_config;
+   // Create slice_nssai_t from SST and SD (or use slice_nssai_from_int() for backward compatibility)
+   slice_config.slice_id = slice_nssai_create(oai_slice->sst, oai_slice->sd);
+   // Or if you have an integer slice_id: slice_config.slice_id = slice_nssai_from_int(oai_slice->slice_id);
+   slice_config.dedicated_prb_ratio = oai_slice->dedicated_prb_ratio;
+   slice_config.min_prb_ratio = oai_slice->min_prb_ratio;
+   slice_config.max_prb_ratio = oai_slice->max_prb_ratio;
+   slice_config.required_prbs = calculate_current_prb_requirement(oai_slice);
+   ```
+
+3. Call `calculate_slice_prb_ranges()` with appropriate input
+
+4. Use the resulting PRB ranges for frequency-domain scheduling
+
+---
+
+## Performance
+
+### Complexity Analysis
+
+**Time Complexity**:
+- **Pass 1**: O(N) - Single loop through slices
+- **Pass 2**: O(N) - Calculate needs, then allocate
+- **Pass 3**: O(N) - Calculate capacity/deficits, then distribute
+- **Pass 4**: O(N) - Assign ranges
+- **Total**: **O(N)** where N is the number of slices
+
+**Space Complexity**:
+- **Input**: O(N) - Array of slice configurations
+- **Output**: O(N) - Array of PRB ranges
+- **Temporary variables**: O(1) - Counters and accumulators
+- **Total**: **O(N)** for storing results
+
+### Practical Performance
+
+For typical use cases:
+- **N = 2-6 slices** (common in 5G networks)
+- **Total PRBs = 100-106** (typical bandwidths)
+- **Execution time**: < 1 microsecond on modern CPUs
+- **Memory**: < 1 KB for all data structures
+
+---
+
+## Algorithm Properties
+
+### Correctness Guarantees
+
+1. **Constraint Satisfaction**:
+   - ✅ `dedicated_prb_ratio ≤ min_prb_ratio ≤ max_prb_ratio` (validated)
+   - ✅ All allocations ≤ `max_prb_ratio` (hard limit enforced)
+   - ✅ All allocations ≥ `dedicated_prb_ratio` (when resources available)
+
+2. **Completeness**:
+   - ✅ All PRBs are allocated (no gaps)
+   - ✅ Ranges are contiguous and non-overlapping
+
+3. **Fairness**:
+   - ✅ Proportional scaling when resources are constrained
+   - ✅ No slice gets zero if it has active UEs and requested resources
+   - ✅ PRB requirements are considered when specified
+
+### Invariants
+
+Throughout the algorithm, the following invariants are maintained:
+
+1. `Σ(allocated_i) ≤ total_prbs` (never over-allocate)
+2. `allocated_i ≤ max_prbs_i` (respect maximum limits)
+3. `allocated_i ≥ dedicated_prbs_i` (when possible)
+4. `remaining_prbs = total_prbs - Σ(allocated_i)` (consistent accounting)
+
+---
+
+## References
+
+- **3GPP TS 38.300**: NR and NG-RAN Overall Description
+- **3GPP TS 38.321**: NR Medium Access Control (MAC) protocol specification
+- **OAI RAN**: OpenAirInterface Radio Access Network
+
+---
+
+## Conclusion
+
+The Network Slice PRB Allocation Algorithm provides a robust, fair, and efficient mechanism for distributing PRB resources among network slices. Its four-pass design ensures:
+
+- **Predictability**: Dedicated and minimum guarantees
+- **Flexibility**: Maximum limits allow dynamic sharing
+- **Efficiency**: Proportional distribution maximizes utilization
+- **Correctness**: Hard limits and constraints are always respected
+- **Adaptability**: PRB requirements allow priority-based allocation
+
+The algorithm is designed for real-time execution in 5G NR MAC schedulers, with O(N) complexity suitable for typical network configurations.

--- a/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/slice_prb_allocator.c
+++ b/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/slice_prb_allocator.c
@@ -1,0 +1,1033 @@
+/*!
+ * \file slice_prb_allocator.c
+ * \brief Implementation of Network Slice PRB Range Allocation Algorithm
+ */
+
+#include "slice_prb_allocator.h"
+#include "slice_prb_allocator_internal.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+/*! \brief Minimum capacity for dynamic slice arrays */
+#define MIN_CAPACITY 8
+
+/*! \brief Exponential moving average alpha factor (0.1 = 10% weight for new value) */
+#define STATS_EMA_ALPHA 0.1f
+
+/*! \brief Helper: Get minimum of two integers */
+static inline int min_int(int a, int b) {
+  return (a < b) ? a : b;
+}
+
+
+
+slice_alloc_input_t* allocate_slice_input(int num_slices) {
+  if (num_slices < 0) {
+    return NULL;
+  }
+  size_t size = sizeof(slice_alloc_input_t) + num_slices * sizeof(slice_config_t);
+  slice_alloc_input_t *input = (slice_alloc_input_t*)calloc(1, size);
+  if (input != NULL) {
+    input->num_slices = num_slices;
+  }
+  return input;
+}
+
+slice_alloc_result_t* allocate_slice_result(int num_slices) {
+  if (num_slices < 0) {
+    return NULL;
+  }
+  size_t size = sizeof(slice_alloc_result_t) + num_slices * sizeof(slice_prb_range_t);
+  slice_alloc_result_t *result = (slice_alloc_result_t*)calloc(1, size);
+  return result;
+}
+
+void free_slice_input(slice_alloc_input_t *input) {
+  if (input != NULL) {
+    free(input);
+  }
+}
+
+void free_slice_result(slice_alloc_result_t *result) {
+  if (result != NULL) {
+    free(result);
+  }
+}
+
+/*! \brief Helper: Find slice index by SST and SD */
+static int find_slice_index(const slice_scheduler_t *obj, uint8_t sst, uint32_t sd) {
+  if (obj == NULL || obj->input == NULL) {
+    return -1;
+  }
+  for (int i = 0; i < obj->input->num_slices; ++i) {
+    // Compare with slice_nssai_t from slice_config
+    if (obj->input->slices[i].slice_id.sst == sst && 
+        obj->input->slices[i].slice_id.sd == sd) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+
+/* ============================================================================
+ * Legacy Functions (kept for backward compatibility)
+ * ============================================================================ */
+
+bool validate_slice_config(const slice_alloc_input_t *input) {
+  if (input == NULL) {
+    return false;
+  }
+  
+  if (input->num_slices < 0) {
+    return false;
+  }
+  
+  if (input->total_prbs <= 0) {
+    return false;
+  }
+  
+  // Validate each slice configuration
+  for (int s = 0; s < input->num_slices; ++s) {
+    const slice_config_t *slice = &input->slices[s];
+    
+    // Validate ratios are in [0.0, 1.0]
+    if (slice->dedicated_prb_ratio < 0.0 || slice->dedicated_prb_ratio > 1.0) {
+      return false;
+    }
+    if (slice->min_prb_ratio < 0.0 || slice->min_prb_ratio > 1.0) {
+      return false;
+    }
+    if (slice->max_prb_ratio < 0.0 || slice->max_prb_ratio > 1.0) {
+      return false;
+    }
+    
+    // Validate ratio relationships: dedicated <= min <= max
+    // Note: We allow max < min as an edge case (max takes precedence)
+    // In this case, we only require dedicated <= max (the effective limit)
+    if (slice->min_prb_ratio <= slice->max_prb_ratio) {
+      // Normal case: min <= max, so dedicated <= min <= max
+      if (slice->dedicated_prb_ratio > slice->min_prb_ratio) {
+        return false;
+      }
+    } else {
+      // Edge case: max < min, so we only require dedicated <= max
+      if (slice->dedicated_prb_ratio > slice->max_prb_ratio) {
+        return false;
+      }
+    }
+  }
+
+  float sum_dedicated = 0.0f;
+  float sum_min = 0.0f;
+  for (int s = 0; s < input->num_slices; ++s) {
+    const slice_config_t *slice = &input->slices[s];
+    sum_dedicated += slice->dedicated_prb_ratio;
+    sum_min += slice->min_prb_ratio;
+  }
+  if (sum_dedicated > 1.0f + 1e-6f || sum_min > 1.0f + 1e-6f) {
+    return false;
+  }
+  
+  return true;
+}
+
+int pass1_allocate_dedicated(const slice_alloc_input_t *input, slice_alloc_result_t *result,
+                              int *allocated_prbs) {
+  if (input == NULL || result == NULL || allocated_prbs == NULL) {
+    return -1;
+  }
+  
+  *allocated_prbs = 0;
+  int total_prbs = input->total_prbs;
+  
+  // Allocate dedicated PRBs (non-shareable) to all slices
+  
+  for (int s = 0; s < input->num_slices; ++s) {
+    const slice_config_t *slice = &input->slices[s];
+    
+    int dedicated_prbs = (int)(total_prbs * slice->dedicated_prb_ratio + 0.5);
+    int min_prbs = (int)(total_prbs * slice->min_prb_ratio + 0.5);
+    int max_prbs = (int)(total_prbs * slice->max_prb_ratio + 0.5);
+    
+    // Ensure min >= dedicated
+    if (min_prbs < dedicated_prbs) {
+      min_prbs = dedicated_prbs;
+    }
+    
+    // Ensure dedicated doesn't exceed max
+    if (dedicated_prbs > max_prbs) {
+      dedicated_prbs = max_prbs;
+    }
+    
+    result->ranges[s].num_prbs = dedicated_prbs;
+    *allocated_prbs += dedicated_prbs;
+  }
+  
+  // If dedicated allocations exceed total, scale them down proportionally
+  if (*allocated_prbs > total_prbs) {
+    float scale = (float)total_prbs / *allocated_prbs;
+    *allocated_prbs = 0;
+    for (int s = 0; s < input->num_slices; ++s) {
+      if (result->ranges[s].num_prbs > 0) {
+        result->ranges[s].num_prbs = (int)(result->ranges[s].num_prbs * scale + 0.5);
+        *allocated_prbs += result->ranges[s].num_prbs;
+      }
+    }
+  }
+  
+  return 0;
+}
+
+int pass2_allocate_prioritized(const slice_alloc_input_t *input, slice_alloc_result_t *result,
+                                int *allocated_prbs, int *remaining_prbs) {
+  if (input == NULL || result == NULL || allocated_prbs == NULL || remaining_prbs == NULL) {
+    return -1;
+  }
+  
+  if (*remaining_prbs <= 0) {
+    return 0; // Nothing to allocate
+  }
+  
+  int total_prbs = input->total_prbs;
+  int total_prioritized_needed = 0;
+  
+  // Calculate total prioritized resources needed (common rule: allocate up to min(required_prbs, min_prb_ratio))
+  for (int s = 0; s < input->num_slices; ++s) {
+    const slice_config_t *slice = &input->slices[s];
+    int min_prbs = (int)(total_prbs * slice->min_prb_ratio + 0.5);
+    int dedicated_prbs = (int)(total_prbs * slice->dedicated_prb_ratio + 0.5);
+    int prioritized_prbs = min_prbs - dedicated_prbs; // Prioritized but shareable portion
+    
+    // Common rule: target = min(required_prbs, min_prb_ratio)
+    // If required_prbs = 0, target = 0 (no allocation in Pass 2)
+    int target_prbs = (slice->required_prbs > 0) ? 
+                       ((slice->required_prbs < min_prbs) ? slice->required_prbs : min_prbs) : 0;
+    
+    if (target_prbs > result->ranges[s].num_prbs && prioritized_prbs > 0) {
+      int prioritized_needed = target_prbs - result->ranges[s].num_prbs;
+      // Don't exceed the prioritized portion (min - dedicated)
+      if (prioritized_needed > prioritized_prbs) {
+        prioritized_needed = prioritized_prbs;
+      }
+      if (prioritized_needed > 0) {
+        total_prioritized_needed += prioritized_needed;
+      }
+    }
+    // If target_prbs <= current_allocation, slice doesn't need prioritized resources
+    // (they remain shareable for other slices)
+  }
+  
+  // Allocate prioritized resources to slices that need them
+  if (total_prioritized_needed > 0) {
+    float scale = (float)(*remaining_prbs) / total_prioritized_needed;
+    if (scale > 1.0) {
+      scale = 1.0; // Can't allocate more than needed
+    }
+    
+    for (int s = 0; s < input->num_slices; ++s) {
+      const slice_config_t *slice = &input->slices[s];
+      int min_prbs = (int)(total_prbs * slice->min_prb_ratio + 0.5);
+      int dedicated_prbs = (int)(total_prbs * slice->dedicated_prb_ratio + 0.5);
+      int prioritized_prbs = min_prbs - dedicated_prbs;
+      int max_prbs = (int)(total_prbs * slice->max_prb_ratio + 0.5);
+      
+      // Common rule: target = min(required_prbs, min_prb_ratio)
+      // If required_prbs = 0, target = 0 (no allocation in Pass 2)
+      int target_prbs = (slice->required_prbs > 0) ? 
+                         ((slice->required_prbs < min_prbs) ? slice->required_prbs : min_prbs) : 0;
+      
+      int prioritized_needed = 0;
+      if (target_prbs > result->ranges[s].num_prbs && prioritized_prbs > 0) {
+        prioritized_needed = target_prbs - result->ranges[s].num_prbs;
+        // Don't exceed the prioritized portion (min - dedicated)
+        if (prioritized_needed > prioritized_prbs) {
+          prioritized_needed = prioritized_prbs;
+        }
+      }
+      
+      if (prioritized_needed > 0) {
+        int additional = (int)(prioritized_needed * scale + 0.5);
+        // Ensure we don't exceed max_prb_ratio
+        if (result->ranges[s].num_prbs + additional > max_prbs) {
+          additional = max_prbs - result->ranges[s].num_prbs;
+        }
+        // Ensure we don't exceed target_prbs (min(required_prbs, min_prb_ratio))
+        if (result->ranges[s].num_prbs + additional > target_prbs) {
+          additional = target_prbs - result->ranges[s].num_prbs;
+        }
+        if (additional > 0) {
+          result->ranges[s].num_prbs += additional;
+          *allocated_prbs += additional;
+          *remaining_prbs -= additional;
+        }
+      }
+    }
+  }
+  
+  return 0;
+}
+
+/*! \brief Slice participates in Pass 3 shared pool (traffic-driven only).
+ *  min_prb_ratio is enforced in Pass 2 when required_prbs > 0; it must not
+ *  pull idle slices into Pass 3. */
+static bool pass3_slice_eligible(const slice_config_t *slice)
+{
+  return slice->required_prbs > 0;
+}
+
+/*! \brief Slice can still absorb PRBs (below max and below require when set) */
+static bool pass3_slice_wants_more(const slice_config_t *slice, int num_prbs, int max_prbs)
+{
+  if (!pass3_slice_eligible(slice)) {
+    return false;
+  }
+  if (num_prbs >= max_prbs) {
+    return false;
+  }
+  if (slice->required_prbs > 0 && num_prbs >= slice->required_prbs) {
+    return false;
+  }
+  return true;
+}
+
+/*! \brief Maximum PRBs this slice will accept in the current round */
+static int pass3_slice_accept_limit(const slice_config_t *slice, int num_prbs, int max_prbs)
+{
+  const int can_add = max_prbs - num_prbs;
+  if (can_add <= 0) {
+    return 0;
+  }
+  if (slice->required_prbs > 0) {
+    const int deficit = slice->required_prbs - num_prbs;
+    if (deficit <= 0) {
+      return 0;
+    }
+    return min_int(deficit, can_add);
+  }
+  return can_add;
+}
+
+/*! \brief Distribute pool across active slices proportional to max_prbs weights (integer PRBs) */
+static void pass3_distribute_by_max_weights(int pool,
+                                            int num_slices,
+                                            const bool active[],
+                                            const int max_prbs[],
+                                            int shares[],
+                                            float *remainder)
+{
+  if (pool <= 0) {
+    return;
+  }
+
+  int sum_max = 0;
+  for (int s = 0; s < num_slices; ++s) {
+    if (active[s]) {
+      sum_max += max_prbs[s];
+    }
+  }
+  if (sum_max <= 0) {
+    return;
+  }
+
+  int assigned = 0;
+  for (int s = 0; s < num_slices; ++s) {
+    shares[s] = 0;
+    if (!active[s]) {
+      remainder[s] = 0.0f;
+      continue;
+    }
+    const float exact = (float)pool * (float)max_prbs[s] / (float)sum_max;
+    shares[s] = (int)exact;
+    remainder[s] = exact - (float)shares[s];
+    assigned += shares[s];
+  }
+
+  int leftover = pool - assigned;
+  while (leftover > 0) {
+    int best_s = -1;
+    float best_rem = -1.0f;
+    for (int s = 0; s < num_slices; ++s) {
+      if (!active[s]) {
+        continue;
+      }
+      if (remainder[s] > best_rem) {
+        best_rem = remainder[s];
+        best_s = s;
+      }
+    }
+    if (best_s < 0) {
+      break;
+    }
+    shares[best_s]++;
+    remainder[best_s] = 0.0f;
+    leftover--;
+  }
+}
+
+int pass3_allocate_shared(const slice_alloc_input_t *input, slice_alloc_result_t *result,
+                          int *allocated_prbs, int *remaining_prbs) {
+  if (input == NULL || result == NULL || allocated_prbs == NULL || remaining_prbs == NULL) {
+    return -1;
+  }
+
+  if (*remaining_prbs <= 0 || input->num_slices <= 0) {
+    return 0;
+  }
+
+  const int num_slices = input->num_slices;
+  const int total_prbs = input->total_prbs;
+  int remain = *remaining_prbs;
+
+  bool *active = (bool *)calloc((size_t)num_slices, sizeof(bool));
+  int *max_prbs_cap = (int *)calloc((size_t)num_slices, sizeof(int));
+  int *shares = (int *)calloc((size_t)num_slices, sizeof(int));
+  float *remainder = (float *)calloc((size_t)num_slices, sizeof(float));
+  if (active == NULL || max_prbs_cap == NULL || shares == NULL || remainder == NULL) {
+    free(active);
+    free(max_prbs_cap);
+    free(shares);
+    free(remainder);
+    return -1;
+  }
+
+  for (int s = 0; s < num_slices; ++s) {
+    max_prbs_cap[s] = (int)(total_prbs * input->slices[s].max_prb_ratio + 0.5);
+    active[s] = pass3_slice_wants_more(&input->slices[s], result->ranges[s].num_prbs, max_prbs_cap[s]);
+  }
+
+  const int max_iterations = num_slices + 1;
+  for (int iter = 0; iter < max_iterations && remain > 0; ++iter) {
+    int num_active = 0;
+    int sum_max_active = 0;
+    for (int s = 0; s < num_slices; ++s) {
+      if (active[s]) {
+        num_active++;
+        sum_max_active += max_prbs_cap[s];
+      }
+    }
+    if (num_active == 0 || sum_max_active <= 0) {
+      break;
+    }
+
+    pass3_distribute_by_max_weights(remain, num_slices, active, max_prbs_cap, shares, remainder);
+
+    int round_unused = 0;
+    int round_allocated = 0;
+
+    for (int s = 0; s < num_slices; ++s) {
+      if (!active[s]) {
+        continue;
+      }
+
+      const slice_config_t *slice = &input->slices[s];
+      const int accept_limit = pass3_slice_accept_limit(slice, result->ranges[s].num_prbs, max_prbs_cap[s]);
+      const int actual = min_int(shares[s], accept_limit);
+
+      if (actual > 0) {
+        result->ranges[s].num_prbs += actual;
+        *allocated_prbs += actual;
+        round_allocated += actual;
+      }
+
+      const int unused = shares[s] - actual;
+      if (unused > 0) {
+        round_unused += unused;
+      }
+
+      if (!pass3_slice_wants_more(slice, result->ranges[s].num_prbs, max_prbs_cap[s])) {
+        active[s] = false;
+      }
+    }
+
+    remain = round_unused;
+
+    if (round_allocated == 0 && round_unused == 0) {
+      break;
+    }
+  }
+
+  *remaining_prbs = remain;
+  free(active);
+  free(max_prbs_cap);
+  free(shares);
+  free(remainder);
+  return 0;
+}
+
+int pass4_assign_ranges(const slice_alloc_input_t *input, slice_alloc_result_t *result) {
+  if (input == NULL || result == NULL) {
+    return -1;
+  }
+  
+  // Assign PRB ranges (contiguous allocation)
+  // Include all slices, even those with 0 PRBs, so they appear in the result
+  int current_prb = 0;
+  for (int s = 0; s < input->num_slices; ++s) {
+    if (result->ranges[s].num_prbs > 0) {
+      result->ranges[s].start_prb = current_prb;
+      result->ranges[s].end_prb = current_prb + result->ranges[s].num_prbs;
+      current_prb = result->ranges[s].end_prb;
+    } else {
+      // Assign [0, 0) range for slices with 0 PRBs so they appear in the result
+      result->ranges[s].start_prb = 0;
+      result->ranges[s].end_prb = 0;
+    }
+  }
+  
+  return 0;
+}
+
+int calculate_slice_prb_ranges(const slice_alloc_input_t *input, slice_alloc_result_t *result) {
+  if (input == NULL || result == NULL) {
+    return -1;
+  }
+  
+  if (!validate_slice_config(input)) {
+    return -1;
+  }
+  
+  // Initialize result fields (but not the flexible array - it's already zeroed by caller)
+  result->total_allocated_prbs = 0;
+  
+  if (input->num_slices == 0) {
+    return 0;
+  }
+  
+  int allocated_prbs = 0;
+  int total_prbs = input->total_prbs;
+  
+  // Initialize ranges
+  for (int s = 0; s < input->num_slices; ++s) {
+    result->ranges[s].slice_id = input->slices[s].slice_id;
+    result->ranges[s].start_prb = 0;
+    result->ranges[s].end_prb = 0;
+    result->ranges[s].num_prbs = 0;
+  }
+  
+  // Pass 1: Allocate dedicated PRBs
+  if (pass1_allocate_dedicated(input, result, &allocated_prbs) != 0) {
+    return -1;
+  }
+  
+  // Pass 2: Allocate prioritized resources
+  int remaining_prbs = total_prbs - allocated_prbs;
+  if (remaining_prbs > 0) {
+    if (pass2_allocate_prioritized(input, result, &allocated_prbs, &remaining_prbs) != 0) {
+      return -1;
+    }
+  }
+  
+  // Pass 3: Allocate shared resources
+  if (remaining_prbs > 0) {
+    if (pass3_allocate_shared(input, result, &allocated_prbs, &remaining_prbs) != 0) {
+      return -1;
+    }
+  }
+  
+  // Pass 4: Assign contiguous ranges
+  if (pass4_assign_ranges(input, result) != 0) {
+    return -1;
+  }
+  
+  result->total_allocated_prbs = allocated_prbs;
+  
+  // Return number of slices
+  return input->num_slices;
+}
+
+void print_slice_allocation(const slice_alloc_result_t *result, int num_slices) {
+  if (result == NULL) {
+    return;
+  }
+  
+  if (num_slices < 0) {
+    return;
+  }
+  
+  printf("=== Slice PRB Allocation Result ===\n");
+  printf("Total Allocated PRBs: %d\n", result->total_allocated_prbs);
+  
+  // Iterate through all slices and print all of them (including those with 0 PRBs)
+  for (int s = 0; s < num_slices; ++s) {
+    printf("Slice (SST=%d, SD=%u): PRBs [%d, %d) (%d PRBs)\n",
+           result->ranges[s].slice_id.sst,
+           result->ranges[s].slice_id.sd,
+           result->ranges[s].start_prb,
+           result->ranges[s].end_prb,
+           result->ranges[s].num_prbs);
+  }
+  printf("\n");
+}
+
+/* ============================================================================
+ * OOP-like Scheduler Interface Implementation
+ * ============================================================================ */
+
+slice_scheduler_t* slice_sch_create(int total_prbs) {
+  if (total_prbs <= 0) {
+    return NULL;
+  }
+  
+  slice_scheduler_t *obj = (slice_scheduler_t*)calloc(1, sizeof(slice_scheduler_t));
+  if (obj == NULL) {
+    return NULL;
+  }
+  
+  obj->slices_capacity = MIN_CAPACITY; // Initial capacity
+  obj->result_valid = false;
+  
+  // Allocate input structure
+  obj->input = allocate_slice_input(obj->slices_capacity);
+  if (obj->input == NULL) {
+    free(obj);
+    return NULL;
+  }
+  obj->input->num_slices = 0;
+  obj->input->total_prbs = total_prbs;
+  
+  // Allocate result structure
+  obj->result = allocate_slice_result(obj->slices_capacity);
+  if (obj->result == NULL) {
+    free_slice_input(obj->input);
+    free(obj);
+    return NULL;
+  }
+  
+  // Allocate statistics array
+  obj->statistics = (slice_statistics_t*)calloc(obj->slices_capacity, sizeof(slice_statistics_t));
+  if (obj->statistics == NULL) {
+    free_slice_result(obj->result);
+    free_slice_input(obj->input);
+    free(obj);
+    return NULL;
+  }
+  
+  return obj;
+}
+
+void slice_sch_destroy(slice_scheduler_t *obj) {
+  if (obj != NULL) {
+    if (obj->input != NULL) {
+      free_slice_input(obj->input);
+    }
+    if (obj->result != NULL) {
+      free_slice_result(obj->result);
+    }
+    if (obj->statistics != NULL) {
+      free(obj->statistics);
+    }
+    free(obj);
+  }
+}
+
+int slice_sch_add_slice(slice_scheduler_t *obj, uint8_t sst, uint32_t sd, float dedicated,
+                        float min, float max, int require) {
+  if (obj == NULL || obj->input == NULL) {
+    return -1;
+  }
+  
+  // Validate ratios
+  if (dedicated < 0.0 || dedicated > 1.0 ||
+      min < 0.0 || min > 1.0 ||
+      max < 0.0 || max > 1.0) {
+    return -1;
+  }
+  
+  // Validate ratio relationships
+  if (min <= max) {
+    if (dedicated > min) {
+      return -1;
+    }
+  } else {
+    if (dedicated > max) {
+      return -1;
+    }
+  }
+  
+  // Validate require
+  if (require < 0) {
+    return -1;
+  }
+  
+  // Check if slice already exists - if so, update it
+  int existing_idx = find_slice_index(obj, sst, sd);
+  if (existing_idx >= 0) {
+    // Update existing slice parameters
+    slice_config_t *slice = &obj->input->slices[existing_idx];
+    slice->dedicated_prb_ratio = dedicated;
+    slice->min_prb_ratio = min;
+    slice->max_prb_ratio = max;
+    slice->required_prbs = require;
+    
+    // Note: Statistics are preserved for the existing slice
+    obj->result_valid = false; // Invalidate result since configuration changed
+    
+    return 0; // Successfully updated
+  }
+  
+  // Reallocate if needed
+  if (obj->input->num_slices >= obj->slices_capacity) {
+    int new_capacity = obj->slices_capacity * 2;
+    
+    // Reallocate input structure (preserves num_slices, total_prbs, and existing slices)
+    size_t input_size = sizeof(slice_alloc_input_t) + new_capacity * sizeof(slice_config_t);
+    slice_alloc_input_t *new_input = (slice_alloc_input_t*)realloc(obj->input, input_size);
+    if (new_input == NULL) {
+      return -1; // Allocation failed
+    }
+    
+    // Reallocate result structure
+    size_t result_size = sizeof(slice_alloc_result_t) + new_capacity * sizeof(slice_prb_range_t);
+    slice_alloc_result_t *new_result = (slice_alloc_result_t*)realloc(obj->result, result_size);
+    if (new_result == NULL) {
+      // If result realloc fails, try to restore input to original size
+      // (though this might also fail, but we try)
+      size_t old_input_size = sizeof(slice_alloc_input_t) + obj->slices_capacity * sizeof(slice_config_t);
+      slice_alloc_input_t *old_input = (slice_alloc_input_t*)realloc(new_input, old_input_size);
+      if (old_input != NULL) {
+        obj->input = old_input;
+      }
+      return -1; // Allocation failed
+    }
+    
+    // Reallocate statistics array
+    slice_statistics_t *new_statistics = (slice_statistics_t*)realloc(obj->statistics, 
+                                                                       new_capacity * sizeof(slice_statistics_t));
+    if (new_statistics == NULL) {
+      // If statistics realloc fails, try to restore input and result
+      size_t old_input_size = sizeof(slice_alloc_input_t) + obj->slices_capacity * sizeof(slice_config_t);
+      size_t old_result_size = sizeof(slice_alloc_result_t) + obj->slices_capacity * sizeof(slice_prb_range_t);
+      slice_alloc_input_t *old_input = (slice_alloc_input_t*)realloc(new_input, old_input_size);
+      slice_alloc_result_t *old_result = (slice_alloc_result_t*)realloc(new_result, old_result_size);
+      if (old_input != NULL) {
+        obj->input = old_input;
+      }
+      if (old_result != NULL) {
+        obj->result = old_result;
+      }
+      return -1; // Allocation failed
+    }
+    
+    // All reallocs succeeded, update pointers and capacity
+    obj->input = new_input;
+    obj->result = new_result;
+    obj->statistics = new_statistics;
+    obj->slices_capacity = new_capacity;
+  }
+  
+  // Add the slice (new slice, not existing)
+  slice_config_t *slice = &obj->input->slices[obj->input->num_slices];
+  slice->slice_id = slice_nssai_create(sst, sd);
+  slice->dedicated_prb_ratio = dedicated;
+  slice->min_prb_ratio = min;
+  slice->max_prb_ratio = max;
+  slice->required_prbs = require;
+  
+  // Initialize statistics for the new slice
+  slice_statistics_t *stats = &obj->statistics[obj->input->num_slices];
+  stats->slice_id = slice_nssai_create(sst, sd);
+  stats->latest_start_prb = 0;
+  stats->latest_end_prb = 0;
+  stats->latest_num_prbs = 0;
+  stats->avg_start_prb = 0.0f;
+  stats->avg_end_prb = 0.0f;
+  stats->avg_num_prbs = 0.0f;
+  stats->sample_count = 0;
+  
+  obj->input->num_slices++;
+  obj->result_valid = false; // Invalidate result
+  
+  return 0;
+}
+
+int slice_sch_del_slice(slice_scheduler_t *obj, uint8_t sst, uint32_t sd) {
+  if (obj == NULL || obj->input == NULL) {
+    return -1;
+  }
+  
+  int idx = find_slice_index(obj, sst, sd);
+  if (idx < 0) {
+    // Slice not found - return success (idempotent: desired state already achieved)
+    return 0;
+  }
+  
+  // Shift remaining slices to fill the gap
+  for (int i = idx; i < obj->input->num_slices - 1; ++i) {
+    obj->input->slices[i] = obj->input->slices[i + 1];
+    // Also shift statistics
+    obj->statistics[i] = obj->statistics[i + 1];
+  }
+  
+  obj->input->num_slices--;
+  obj->result_valid = false; // Invalidate result
+  
+  // Shrink array if capacity is much larger than needed
+  // Shrink when using less than 25% of capacity, but keep minimum capacity
+  if (obj->slices_capacity > MIN_CAPACITY && obj->input->num_slices < obj->slices_capacity / 4) {
+    int new_capacity = obj->slices_capacity / 2;
+    // Ensure new capacity is at least MIN_CAPACITY and at least num_slices
+    if (new_capacity < MIN_CAPACITY) {
+      new_capacity = MIN_CAPACITY;
+    }
+    if (new_capacity < obj->input->num_slices) {
+      new_capacity = obj->input->num_slices;
+    }
+    
+    // Reallocate input structure (preserves num_slices, total_prbs, and existing slices)
+    size_t input_size = sizeof(slice_alloc_input_t) + new_capacity * sizeof(slice_config_t);
+    slice_alloc_input_t *new_input = (slice_alloc_input_t*)realloc(obj->input, input_size);
+    if (new_input != NULL) {
+      // Reallocate result structure
+      size_t result_size = sizeof(slice_alloc_result_t) + new_capacity * sizeof(slice_prb_range_t);
+      slice_alloc_result_t *new_result = (slice_alloc_result_t*)realloc(obj->result, result_size);
+      if (new_result != NULL) {
+        // Reallocate statistics array
+        slice_statistics_t *new_statistics = (slice_statistics_t*)realloc(obj->statistics,
+                                                                           new_capacity * sizeof(slice_statistics_t));
+        if (new_statistics != NULL) {
+          // All reallocs succeeded, update pointers and capacity
+          obj->input = new_input;
+          obj->result = new_result;
+          obj->statistics = new_statistics;
+          obj->slices_capacity = new_capacity;
+        }
+        // If statistics realloc fails, keep input and result at new size
+        // This is acceptable since we're shrinking
+      }
+      // If result realloc fails, keep input at new size (input realloc already succeeded)
+      // This is acceptable since we're shrinking and the result will be recalculated on next schedule
+    }
+    // If realloc fails, continue with existing capacity (not a critical error)
+  }
+  
+  return 0;
+}
+
+int slice_sch_update_require(slice_scheduler_t *obj, uint8_t sst, uint32_t sd, int require) {
+  if (obj == NULL || obj->input == NULL) {
+    return -1;
+  }
+  
+  if (require < 0) {
+    return -1;
+  }
+  
+  int idx = find_slice_index(obj, sst, sd);
+  if (idx < 0) {
+    return -1; // Slice not found
+  }
+  
+  obj->input->slices[idx].required_prbs = require;
+  obj->result_valid = false; // Invalidate result
+  
+  return 0;
+}
+
+int slice_sch_get_require(const slice_scheduler_t *obj, uint8_t sst, uint32_t sd, int *require) {
+  if (obj == NULL || obj->input == NULL || require == NULL) {
+    return -1;
+  }
+  
+  int idx = find_slice_index(obj, sst, sd);
+  if (idx < 0) {
+    return -1; // Slice not found
+  }
+  
+  *require = obj->input->slices[idx].required_prbs;
+  
+  return 0;
+}
+
+int slice_sch_update_total_prbs(slice_scheduler_t *obj, int total_prbs) {
+  if (obj == NULL || obj->input == NULL) {
+    return -1;
+  }
+  
+  if (total_prbs <= 0) {
+    return -1;
+  }
+  
+  obj->input->total_prbs = total_prbs;
+  obj->result_valid = false; // Invalidate result
+  
+  return 0;
+}
+
+int slice_sch_schedule(slice_scheduler_t *obj) {
+  if (obj == NULL || obj->input == NULL || obj->result == NULL) {
+    return -1;
+  }
+  
+  if (obj->input->num_slices == 0) {
+    obj->result->total_allocated_prbs = 0;
+    obj->result_valid = true;
+    return 0;
+  }
+  
+  // Validate configuration
+  if (!validate_slice_config(obj->input)) {
+    return -1;
+  }
+  
+  // Use functional implementation directly on obj->input and obj->result
+  int ret = calculate_slice_prb_ranges(obj->input, obj->result);
+  if (ret < 0) {
+    return -1;
+  }
+  
+  // Update statistics for each slice
+  // Note: result->ranges is indexed by slice index (same as input->slices)
+  for (int s = 0; s < obj->input->num_slices; ++s) {
+    slice_statistics_t *stats = &obj->statistics[s];
+    
+    // Always update latest values (whether allocation is 0 or not)
+    stats->latest_start_prb = obj->result->ranges[s].start_prb;
+    stats->latest_end_prb = obj->result->ranges[s].end_prb;
+    stats->latest_num_prbs = obj->result->ranges[s].num_prbs;
+    
+    // Always update moving averages using exponential moving average (EMA)
+    // This includes cases where the slice gets 0 PRBs, so the average reflects
+    // the true average allocation over all scheduling decisions
+    if (stats->sample_count == 0) {
+      // First sample: initialize averages
+      stats->avg_start_prb = (float)stats->latest_start_prb;
+      stats->avg_end_prb = (float)stats->latest_end_prb;
+      stats->avg_num_prbs = (float)stats->latest_num_prbs;
+    } else {
+      // Update EMA: new_avg = alpha * new_value + (1 - alpha) * old_avg
+      stats->avg_start_prb = STATS_EMA_ALPHA * (float)stats->latest_start_prb + 
+                             (1.0f - STATS_EMA_ALPHA) * stats->avg_start_prb;
+      stats->avg_end_prb = STATS_EMA_ALPHA * (float)stats->latest_end_prb + 
+                           (1.0f - STATS_EMA_ALPHA) * stats->avg_end_prb;
+      stats->avg_num_prbs = STATS_EMA_ALPHA * (float)stats->latest_num_prbs + 
+                            (1.0f - STATS_EMA_ALPHA) * stats->avg_num_prbs;
+    }
+    // Always increment sample_count to track all scheduling decisions
+    stats->sample_count++;
+  }
+  
+  obj->result_valid = true;
+  
+  return 0;
+}
+
+const slice_prb_range_t* slice_sch_get_allocation(const slice_scheduler_t *obj, int *num_ranges) {
+  if (obj == NULL || num_ranges == NULL || obj->result == NULL) {
+    return NULL;
+  }
+  
+  if (!obj->result_valid) {
+    return NULL; // Result not valid, need to call schedule first
+  }
+  
+  *num_ranges = obj->input->num_slices;
+  return obj->result->ranges;
+}
+
+int slice_sch_get_stats(const slice_scheduler_t *obj, int *num_active_slices, int *total_allocated_prbs) {
+  if (obj == NULL || num_active_slices == NULL || total_allocated_prbs == NULL || obj->result == NULL) {
+    return -1;
+  }
+  
+  if (!obj->result_valid) {
+    return -1; // Result not valid, need to call schedule first
+  }
+  
+  *num_active_slices = obj->input->num_slices;
+  *total_allocated_prbs = obj->result->total_allocated_prbs;
+  
+  return 0;
+}
+
+int slice_sch_get_slice_statistics(const slice_scheduler_t *obj, uint8_t sst, uint32_t sd, slice_statistics_t *stats) {
+  if (obj == NULL || obj->statistics == NULL || stats == NULL) {
+    return -1;
+  }
+  
+  // Find the slice index
+  int idx = find_slice_index(obj, sst, sd);
+  if (idx < 0) {
+    return -1; // Slice not found
+  }
+  
+  // Copy statistics
+  *stats = obj->statistics[idx];
+  
+  return 0;
+}
+
+const slice_statistics_t* slice_sch_get_all_statistics(const slice_scheduler_t *obj, int *num_stats) {
+  if (obj == NULL || num_stats == NULL || obj->statistics == NULL || obj->input == NULL) {
+    return NULL;
+  }
+  
+  *num_stats = obj->input->num_slices;
+  return obj->statistics;
+}
+
+int slice_sch_get_num_slices(const slice_scheduler_t *obj) {
+  if (obj == NULL || obj->input == NULL) {
+    return -1;
+  }
+  
+  return obj->input->num_slices;
+}
+
+int slice_sch_get_total_prbs(const slice_scheduler_t *obj) {
+  if (obj == NULL || obj->input == NULL) {
+    return -1;
+  }
+  
+  return obj->input->total_prbs;
+}
+
+int slice_sch_get_slice_config(const slice_scheduler_t *obj, uint8_t sst, uint32_t sd,
+                               uint8_t *sst_out, uint32_t *sd_out,
+                               float *dedicated_out, float *min_out, float *max_out) {
+  if (obj == NULL || obj->input == NULL) {
+    return -1;
+  }
+  
+  // Find the slice index
+  int idx = find_slice_index(obj, sst, sd);
+  if (idx < 0) {
+    return -1; // Slice not found
+  }
+  
+  // Get the slice configuration
+  const slice_config_t *slice = &obj->input->slices[idx];
+  
+  // Output the values if pointers are provided
+  if (sst_out != NULL) {
+    *sst_out = slice->slice_id.sst;
+  }
+  if (sd_out != NULL) {
+    *sd_out = slice->slice_id.sd;
+  }
+  if (dedicated_out != NULL) {
+    *dedicated_out = slice->dedicated_prb_ratio;
+  }
+  if (min_out != NULL) {
+    *min_out = slice->min_prb_ratio;
+  }
+  if (max_out != NULL) {
+    *max_out = slice->max_prb_ratio;
+  }
+  
+  return 0;
+}
+
+const slice_nssai_t* slice_sch_get_slice_nssai(const slice_scheduler_t *obj, int slice_index) {
+  if (obj == NULL || obj->input == NULL) {
+    return NULL;
+  }
+  
+  if (slice_index < 0 || slice_index >= obj->input->num_slices) {
+    return NULL;
+  }
+  
+  return &obj->input->slices[slice_index].slice_id;
+}

--- a/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/slice_prb_allocator.h
+++ b/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/slice_prb_allocator.h
@@ -1,0 +1,239 @@
+/*!
+ * \file slice_prb_allocator.h
+ * \brief Network Slice PRB Range Allocation Algorithm - Public OOP Interface
+ * 
+ * This is the public API for the Network Slice PRB Range Allocation Algorithm.
+ * Normal OAI users should use the OOP-like scheduler interface provided here.
+ * 
+ * For internal functional implementation, see slice_prb_allocator_internal.h
+ *
+ * MAC integration: gNB YAML Slices block → set_slice_config() creates
+ * slice_scheduler_dl / slice_scheduler_ul on the MAC instance. Each slot,
+ * nr_dl_schedule_ns() / nr_ul_schedule_ns() call slice_sch_update_require(),
+ * slice_sch_schedule(), then pass slice_prb_range_t to nr_*_schedule() for
+ * intra-slice UE scheduling.
+ */
+
+#ifndef SLICE_PRB_ALLOCATOR_H
+#define SLICE_PRB_ALLOCATOR_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>  /* For NULL */
+
+/*! \brief Slice identifier with SST and SD bit fields (S-NSSAI)
+ *  \note This is named slice_nssai_t to avoid conflict with OAI's slice_id_t (uint8_t) in platform_types.h
+ */
+typedef struct {
+  uint32_t sst : 8;   /*!< Slice/Service Type (8 bits, 0-255) */
+  uint32_t sd : 24;   /*!< Slice Differentiator (24 bits, 0-0xffffff) */
+} slice_nssai_t;
+
+/*! \brief Helper: Create slice_nssai_t from SST and SD values
+ *  \param sst Slice/Service Type (0-255)
+ *  \param sd Slice Differentiator (0-0xffffff)
+ *  \return slice_nssai_t structure
+ */
+static inline slice_nssai_t slice_nssai_create(uint8_t sst, uint32_t sd) {
+  slice_nssai_t id = {.sst = sst, .sd = sd & 0xffffff};
+  return id;
+}
+
+/*! \brief Helper: Create slice_nssai_t from integer (treats int as simple ID, sets sst=int, sd=0)
+ *  \param id Integer slice identifier
+ *  \return slice_nssai_t structure
+ */
+static inline slice_nssai_t slice_nssai_from_int(int id) {
+  slice_nssai_t sid = {.sst = (uint8_t)(id & 0xff), .sd = 0};
+  return sid;
+}
+
+/*! \brief Helper: Compare slice_nssai_t with integer slice_id
+ *  \param sid slice_nssai_t structure
+ *  \param id Integer slice identifier
+ *  \return true if they match (based on sst field), false otherwise
+ */
+static inline bool slice_nssai_eq_int(const slice_nssai_t *sid, int id) {
+  return (sid != NULL && sid->sst == (id & 0xff) && sid->sd == 0);
+}
+
+/*! \brief Helper: Compare two slice_nssai_t structures
+ *  \param sid1 First slice_nssai_t structure
+ *  \param sid2 Second slice_nssai_t structure
+ *  \return true if they match, false otherwise
+ */
+static inline bool slice_nssai_eq(const slice_nssai_t *sid1, const slice_nssai_t *sid2) {
+  return (sid1 != NULL && sid2 != NULL && 
+          sid1->sst == sid2->sst && sid1->sd == sid2->sd);
+}
+
+/*! \brief PRB range allocation result for a slice (used in OOP interface) */
+typedef struct {
+  slice_nssai_t slice_id;  /*!< Slice ID with SST and SD */
+  int start_prb;  /*!< Inclusive start PRB index */
+  int end_prb;    /*!< Exclusive end PRB index (end_prb - start_prb = num_prbs) */
+  int num_prbs;   /*!< Number of PRBs allocated */
+} slice_prb_range_t;
+
+/* ============================================================================
+ * OOP-like Scheduler Interface
+ * ============================================================================ */
+
+/*! \brief Statistics for a single slice */
+typedef struct {
+  slice_nssai_t slice_id;                    /*!< Slice ID with SST and SD */
+  int latest_start_prb;                    /*!< Latest start PRB index */
+  int latest_end_prb;                      /*!< Latest end PRB index */
+  int latest_num_prbs;                     /*!< Latest number of PRBs */
+  float avg_start_prb;                     /*!< Moving average of start PRB */
+  float avg_end_prb;                       /*!< Moving average of end PRB */
+  float avg_num_prbs;                      /*!< Moving average of number of PRBs */
+  int sample_count;                        /*!< Number of samples for moving average */
+} slice_statistics_t;
+
+/* Forward declarations for internal structures (opaque to users) */
+typedef struct slice_alloc_input slice_alloc_input_t;
+typedef struct slice_alloc_result slice_alloc_result_t;
+
+/*! \brief Slice scheduler object that manages slices and allocations */
+typedef struct {
+  slice_alloc_input_t *input;              /*!< Internal: Input structure with slice configurations */
+  slice_alloc_result_t *result;            /*!< Internal: Result structure with PRB allocations */
+  slice_statistics_t *statistics;          /*!< Statistics for each slice */
+  int slices_capacity;                     /*!< Current capacity for reallocation */
+  bool result_valid;                       /*!< Whether the result is up-to-date */
+} slice_scheduler_t;
+
+/*! \brief Create and initialize a new slice scheduler
+ *  \param total_prbs Total number of PRBs available
+ *  \return Pointer to initialized scheduler, or NULL on error
+ */
+slice_scheduler_t* slice_sch_create(int total_prbs);
+
+/*! \brief Destroy a slice scheduler and free resources
+ *  \param obj Pointer to scheduler object (can be NULL)
+ */
+void slice_sch_destroy(slice_scheduler_t *obj);
+
+/*! \brief Add or update a slice in the scheduler
+ *  \param obj Scheduler object
+ *  \param sst Slice/Service Type (0-255)
+ *  \param sd Slice Differentiator (0-0xffffff)
+ *  \param dedicated Dedicated PRB ratio (0.0-1.0)
+ *  \param min Minimum PRB ratio (0.0-1.0)
+ *  \param max Maximum PRB ratio (0.0-1.0)
+ *  \param require Current PRB requirement (0 = not used)
+ *  \return 0 on success (added or updated), -1 on error
+ *  \note If a slice with the same SST/SD already exists, its parameters will be updated.
+ *        Statistics for existing slices are preserved.
+ */
+int slice_sch_add_slice(slice_scheduler_t *obj, uint8_t sst, uint32_t sd, float dedicated,
+                        float min, float max, int require);
+
+/*! \brief Delete a slice from the scheduler
+ *  \param obj Scheduler object
+ *  \param sst Slice/Service Type (0-255)
+ *  \param sd Slice Differentiator (0-0xffffff)
+ *  \return 0 on success (deleted or already doesn't exist), -1 on error
+ *  \note This operation is idempotent: deleting a non-existing slice returns success
+ *        since the desired state (slice not in scheduler) is already achieved.
+ */
+int slice_sch_del_slice(slice_scheduler_t *obj, uint8_t sst, uint32_t sd);
+
+/*! \brief Update the PRB requirement for a slice
+ *  \param obj Scheduler object
+ *  \param sst Slice/Service Type (0-255)
+ *  \param sd Slice Differentiator (0-0xffffff)
+ *  \param require New PRB requirement (0 = not used)
+ *  \return 0 on success, -1 on error (slice not found)
+ */
+int slice_sch_update_require(slice_scheduler_t *obj, uint8_t sst, uint32_t sd, int require);
+
+/*! \brief Get the PRB requirement for a slice
+ *  \param obj Scheduler object
+ *  \param sst Slice/Service Type (0-255)
+ *  \param sd Slice Differentiator (0-0xffffff)
+ *  \param require Output: PRB requirement (0 = not used)
+ *  \return 0 on success, -1 on error (slice not found)
+ */
+int slice_sch_get_require(const slice_scheduler_t *obj, uint8_t sst, uint32_t sd, int *require);
+
+/*! \brief Update the total PRBs available for allocation
+ *  \param obj Scheduler object
+ *  \param total_prbs New total number of PRBs (must be > 0)
+ *  \return 0 on success, -1 on error
+ */
+int slice_sch_update_total_prbs(slice_scheduler_t *obj, int total_prbs);
+
+/*! \brief Perform scheduling/allocation of PRBs to slices
+ *  \param obj Scheduler object
+ *  \return 0 on success, -1 on error
+ */
+int slice_sch_schedule(slice_scheduler_t *obj);
+
+/*! \brief Get the current allocation result (const)
+ *  \param obj Scheduler object
+ *  \param num_ranges Output: Number of ranges in the result
+ *  \return Pointer to const array of PRB ranges, or NULL on error
+ */
+const slice_prb_range_t* slice_sch_get_allocation(const slice_scheduler_t *obj, int *num_ranges);
+
+/*! \brief Get allocation statistics
+ *  \param obj Scheduler object
+ *  \param num_active_slices Output: Number of slices (all slices are considered active)
+ *  \param total_allocated_prbs Output: Total allocated PRBs
+ *  \return 0 on success, -1 on error
+ */
+int slice_sch_get_stats(const slice_scheduler_t *obj, int *num_active_slices, int *total_allocated_prbs);
+
+/*! \brief Get statistics for a specific slice
+ *  \param obj Scheduler object
+ *  \param sst Slice/Service Type (0-255)
+ *  \param sd Slice Differentiator (0-0xffffff)
+ *  \param stats Output: Statistics structure (can be NULL to just check existence)
+ *  \return 0 on success, -1 if slice not found
+ */
+int slice_sch_get_slice_statistics(const slice_scheduler_t *obj, uint8_t sst, uint32_t sd, slice_statistics_t *stats);
+
+/*! \brief Get all slice statistics
+ *  \param obj Scheduler object
+ *  \param num_stats Output: Number of statistics entries
+ *  \return Pointer to statistics array, or NULL on error
+ */
+const slice_statistics_t* slice_sch_get_all_statistics(const slice_scheduler_t *obj, int *num_stats);
+
+/*! \brief Get number of slices in the scheduler
+ *  \param obj Scheduler object
+ *  \return Number of slices, or -1 on error
+ */
+int slice_sch_get_num_slices(const slice_scheduler_t *obj);
+
+/*! \brief Get total PRBs available for allocation
+ *  \param obj Scheduler object
+ *  \return Total number of PRBs, or -1 on error
+ */
+int slice_sch_get_total_prbs(const slice_scheduler_t *obj);
+
+/*! \brief Get slice configuration by SST and SD
+ *  \param obj Scheduler object
+ *  \param sst Slice/Service Type (0-255)
+ *  \param sd Slice Differentiator (0-0xffffff)
+ *  \param sst_out Output: SST (can be NULL)
+ *  \param sd_out Output: SD (can be NULL)
+ *  \param dedicated_out Output: Dedicated PRB ratio (can be NULL)
+ *  \param min_out Output: Minimum PRB ratio (can be NULL)
+ *  \param max_out Output: Maximum PRB ratio (can be NULL)
+ *  \return 0 on success, -1 if slice not found
+ */
+int slice_sch_get_slice_config(const slice_scheduler_t *obj, uint8_t sst, uint32_t sd,
+                               uint8_t *sst_out, uint32_t *sd_out,
+                               float *dedicated_out, float *min_out, float *max_out);
+
+/*! \brief Get slice NSSAI by index
+ *  \param obj Scheduler object
+ *  \param slice_index Slice index (0-based)
+ *  \return Pointer to slice_nssai_t, or NULL on error
+ */
+const slice_nssai_t* slice_sch_get_slice_nssai(const slice_scheduler_t *obj, int slice_index);
+
+#endif /* SLICE_PRB_ALLOCATOR_H */

--- a/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/slice_prb_allocator_internal.h
+++ b/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/slice_prb_allocator_internal.h
@@ -1,0 +1,143 @@
+/*!
+ * \file slice_prb_allocator_internal.h
+ * \brief Internal Network Slice PRB Range Allocation Algorithm (Functional Implementation)
+ * 
+ * This header contains the internal functional implementation of the PRB allocation algorithm.
+ * It is intended for internal use only and should not be included by normal OAI users.
+ * 
+ * For public API, use slice_prb_allocator.h instead.
+ */
+
+#ifndef SLICE_PRB_ALLOCATOR_INTERNAL_H
+#define SLICE_PRB_ALLOCATOR_INTERNAL_H
+
+#include "slice_prb_allocator.h"  // For slice_prb_range_t
+#include <stdint.h>
+#include <stdbool.h>
+
+/*! \brief Network slice configuration */
+typedef struct {
+  slice_nssai_t slice_id;       /*!< Slice identifier with SST and SD */
+  float dedicated_prb_ratio; /*!< Dedicated PRB ratio (0.0-1.0), non-shareable */
+  float min_prb_ratio;       /*!< Minimum PRB ratio (0.0-1.0), guaranteed */
+  float max_prb_ratio;       /*!< Maximum PRB ratio (0.0-1.0), hard limit */
+  int required_prbs;         /*!< Current PRB requirement for this slice (0 = not used, all symbols allocated) */
+} slice_config_t;
+
+/* Note: slice_prb_range_t is defined in slice_prb_allocator.h (public header) */
+
+/*! \brief Input parameters for PRB allocation */
+struct slice_alloc_input {
+  int num_slices;                          /*!< Number of configured slices */
+  int total_prbs;                          /*!< Total number of PRBs available */
+  slice_config_t slices[];                 /*!< Flexible array member: slice configurations */
+};
+
+/*! \brief Output result of PRB allocation */
+struct slice_alloc_result {
+  int total_allocated_prbs;                /*!< Total PRBs allocated (should equal total_prbs) */
+  slice_prb_range_t ranges[];              /*!< Flexible array member: PRB ranges for each slice */
+};
+
+/* Type aliases (matching forward declarations in public header) */
+typedef struct slice_alloc_input slice_alloc_input_t;
+typedef struct slice_alloc_result slice_alloc_result_t;
+
+/*! \brief Allocate slice_alloc_input_t with flexible array member
+ *  \param num_slices Number of slices
+ *  \return Allocated structure or NULL on error
+ *  \note Caller must free with free_slice_input()
+ */
+slice_alloc_input_t* allocate_slice_input(int num_slices);
+
+/*! \brief Allocate slice_alloc_result_t with flexible array member
+ *  \param num_slices Number of slices (for array size)
+ *  \return Allocated structure or NULL on error
+ *  \note Caller must free with free_slice_result()
+ */
+slice_alloc_result_t* allocate_slice_result(int num_slices);
+
+/*! \brief Free slice_alloc_input_t
+ *  \param input Structure to free (can be NULL)
+ */
+void free_slice_input(slice_alloc_input_t *input);
+
+/*! \brief Free slice_alloc_result_t
+ *  \param result Structure to free (can be NULL)
+ */
+void free_slice_result(slice_alloc_result_t *result);
+
+/*! \brief Calculate PRB ranges for each slice
+ *  \param input Input parameters (slice configs, total PRBs, PRB requirements)
+ *  \param result Output result (PRB ranges for each slice)
+ *  \return Number of slices with allocated PRBs, or -1 on error
+ * 
+ *  Algorithm:
+ *  1. Allocate dedicated PRBs to all slices
+ *  2. If dedicated allocations exceed total, scale them down proportionally
+ *  3. Distribute remaining PRBs to meet minimum guarantees
+ *  4. Distribute any remaining PRBs considering PRB requirements (slices with higher
+ *     PRB needs get priority, up to their maximum limits)
+ *  5. Assign contiguous PRB ranges
+ * 
+ *  Note: If required_prbs is 0 for a slice, requirement-based allocation is not used
+ *        for that slice and algorithm falls back to proportional distribution.
+ *  Note: Input and result structures must be allocated with allocate_slice_input()
+ *        and allocate_slice_result() respectively.
+ */
+int calculate_slice_prb_ranges(const slice_alloc_input_t *input, slice_alloc_result_t *result);
+
+/*! \brief Validate slice configuration
+ *  \param input Input parameters to validate
+ *  \return true if valid, false otherwise
+ */
+bool validate_slice_config(const slice_alloc_input_t *input);
+
+/*! \brief Print allocation result (for debugging)
+ *  \param result Allocation result to print
+ *  \param num_slices Number of slices in the input (to know array size)
+ */
+void print_slice_allocation(const slice_alloc_result_t *result, int num_slices);
+
+/*! \brief Pass 1: Allocate dedicated PRBs (non-shareable)
+ *  \param input Input parameters
+ *  \param result Result structure (will be updated with dedicated allocations)
+ *  \param allocated_prbs Output: Total PRBs allocated after this pass
+ *  \return 0 on success, -1 on error
+ */
+int pass1_allocate_dedicated(const slice_alloc_input_t *input, slice_alloc_result_t *result,
+                              int *allocated_prbs);
+
+/*! \brief Pass 2: Allocate prioritized resources (min - dedicated) based on required_prbs
+ *  \param input Input parameters
+ *  \param result Result structure (will be updated with prioritized allocations)
+ *  \param allocated_prbs Input/Output: Current allocated PRBs, updated after this pass
+ *  \param remaining_prbs Input/Output: Remaining PRBs, updated after this pass
+ *  \return 0 on success, -1 on error
+ */
+int pass2_allocate_prioritized(const slice_alloc_input_t *input, slice_alloc_result_t *result,
+                                int *allocated_prbs, int *remaining_prbs);
+
+/*! \brief Pass 3: Allocate shared resources recursively by max_prb_ratio weights
+ *
+ *  Repeatedly splits the remaining pool across active slices proportional to each
+ *  slice's max PRB cap (max_s / sum(max_s)). A slice that hits require or max
+ *  leaves the active set; unused share from that round is returned to the pool.
+ *
+ *  \param input Input parameters
+ *  \param result Result structure (will be updated with shared allocations)
+ *  \param allocated_prbs Input/Output: Current allocated PRBs, updated after this pass
+ *  \param remaining_prbs Input/Output: Remaining PRBs, updated after this pass
+ *  \return 0 on success, -1 on error
+ */
+int pass3_allocate_shared(const slice_alloc_input_t *input, slice_alloc_result_t *result,
+                          int *allocated_prbs, int *remaining_prbs);
+
+/*! \brief Pass 4: Assign contiguous PRB ranges
+ *  \param input Input parameters
+ *  \param result Result structure (will be updated with start_prb and end_prb)
+ *  \return 0 on success, -1 on error
+ */
+int pass4_assign_ranges(const slice_alloc_input_t *input, slice_alloc_result_t *result);
+
+#endif /* SLICE_PRB_ALLOCATOR_INTERNAL_H */

--- a/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/test.md
+++ b/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/test.md
@@ -1,0 +1,294 @@
+# Test Suite Documentation
+
+This document describes all test cases for the Network Slice PRB Allocation Algorithm.
+
+## Test Organization
+
+The test suite is organized into several categories:
+1. **Individual Pass Tests** - Test each pass function in isolation
+2. **Pass Edge Case Tests** - Test edge cases for each pass
+3. **Integrated Tests** - Test the full algorithm end-to-end
+4. **Integration Edge Case Tests** - Test edge cases spanning multiple passes
+
+## Test Categories
+
+### Individual Pass Tests
+
+These tests verify each pass function works correctly in isolation.
+
+#### Test 1: `test_pass1_dedicated`
+- **Purpose**: Test Pass 1 (dedicated allocation) in isolation
+- **Input**: 2 slices, dedicated=30% and 20%, total=100 PRBs
+- **Expected**: 
+  - Slice 1 gets 30 PRBs, Slice 2 gets 20 PRBs
+  - Total allocated: 50 PRBs
+- **Edge Case**: Also tests scaling when dedicated exceeds total (60% + 60% = 120%)
+  - Expected: Proportional scaling to 50/50 split
+
+#### Test 2: `test_pass2_prioritized`
+- **Purpose**: Test Pass 2 (prioritized allocation) in isolation
+- **Input**: After Pass 1, slices need prioritized resources based on `required_prbs`
+- **Expected**:
+  - Slice 1: 20 (dedicated) + 10 (prioritized) = 30 PRBs
+  - Slice 2: 10 (dedicated) + 15 (prioritized) = 25 PRBs
+  - Total allocated: 55 PRBs, Remaining: 45 PRBs
+
+#### Test 3: `test_pass3_shared`
+- **Purpose**: Test Pass 3 (shared allocation) in isolation
+- **Input**: After Pass 1+2, 45 PRBs remaining (shared resources)
+- **Expected**: Shared resources distributed based on PRB deficits or capacity
+- **Verification**: All PRBs allocated, slices grow up to max limits
+
+#### Test 4: `test_pass4_ranges`
+- **Purpose**: Test Pass 4 (range assignment) in isolation
+- **Input**: PRBs already allocated: Slice 1=30, Slice 2=20, Slice 3=50
+- **Expected**: Contiguous ranges [0,30), [30,50), [50,100)
+- **Verification**: Ranges are contiguous and non-overlapping
+
+### Pass 1 Edge Case Tests
+
+#### Test 5: `test_pass1_dedicated_static_allocation`
+- **Purpose**: Test Pass 1 with dedicated = min = max (static allocation)
+- **Input**: 2 slices, all ratios = 50%
+- **Expected**: 
+  - Both slices get 50 PRBs
+  - All 100 PRBs allocated in Pass 1
+  - No scaling needed
+
+#### Test 6: `test_pass1_max_less_than_dedicated`
+- **Purpose**: Test Pass 1 when max < dedicated (invalid config, but should handle gracefully)
+- **Input**: Slice with dedicated=50%, max=30%
+- **Expected**: Dedicated is capped at max (30 PRBs)
+- **Verification**: Algorithm handles invalid config gracefully
+
+#### Test 7: `test_pass1_zero_dedicated`
+- **Purpose**: Test Pass 1 with zero dedicated (slice still active)
+- **Input**: Slice with dedicated=0%, min=30%, max=50%
+- **Expected**: 
+  - Slice gets 0 PRBs in Pass 1
+  - Slice is still counted as active
+  - PRBs allocated in later passes
+
+### Pass 2 Edge Case Tests
+
+#### Test 8: `test_pass2_slice_doesnt_need_prioritized`
+- **Purpose**: Test Pass 2 when slice doesn't need prioritized resources
+- **Input**: 
+  - Slice 1: required=15, current=20 (doesn't need prioritized)
+  - Slice 2: required=30, current=10 (needs prioritized)
+- **Expected**:
+  - Slice 1: No change (20 PRBs)
+  - Slice 2: Gets prioritized (25 PRBs)
+  - Slice 1's prioritized resources remain available for Pass 3
+
+#### Test 9: `test_pass2_insufficient_prioritized`
+- **Purpose**: Test Pass 2 with insufficient prioritized resources
+- **Input**: 
+  - Slice 1 needs 30 prioritized, Slice 2 needs 30 prioritized
+  - Only 40 PRBs available (need 60)
+- **Expected**: Proportional scaling
+  - Slice 1: 20 + 20 = 40 PRBs
+  - Slice 2: 10 + 20 = 30 PRBs
+  - Scale factor: 40/60 = 0.667
+
+#### Test 10: `test_pass2_max_less_than_min`
+- **Purpose**: Test Pass 2 when max < min (max takes precedence)
+- **Input**: Slice with dedicated=20%, min=50%, max=30%
+- **Expected**: 
+  - Allocation capped at max (30 PRBs)
+  - Min (50 PRBs) not fully met
+  - Max limit takes precedence
+
+### Pass 3 Edge Case Tests
+
+#### Test 11: `test_pass3_no_prb_requirements`
+- **Purpose**: Test Pass 3 without PRB requirements (capacity-based only)
+- **Input**: 
+  - Slice 1: 30 PRBs, max=50, can_add=20
+  - Slice 2: 20 PRBs, max=50, can_add=30
+  - 50 PRBs remaining, no `required_prbs` specified
+- **Expected**: Proportional distribution based on capacity
+  - Slice 1: 30 + 20 = 50 PRBs
+  - Slice 2: 20 + 30 = 50 PRBs
+
+#### Test 12: `test_pass3_all_slices_at_max`
+- **Purpose**: Test Pass 3 when all slices are at max limit
+- **Input**: 
+  - Slice 1: 50 PRBs (at max=50)
+  - Slice 2: 30 PRBs (at max=30)
+  - 20 PRBs remaining
+- **Expected**: 
+  - No allocation possible
+  - 20 PRBs remain unallocated
+  - All slices stay at their max
+
+### Pass 4 Edge Case Tests
+
+#### Test 13: `test_pass4_empty_result`
+- **Purpose**: Test Pass 4 with no PRBs allocated
+- **Input**: All slices have num_prbs = 0
+- **Expected**: 
+  - No ranges assigned
+  - No errors
+  - All start_prb and end_prb = 0
+
+#### Test 14: `test_pass4_single_slice`
+- **Purpose**: Test Pass 4 with single slice
+- **Input**: Single slice with 100 PRBs
+- **Expected**: Range [0, 100)
+
+### Integrated Tests (Full Algorithm)
+
+#### Test 15: `test_basic_two_slices`
+- **Purpose**: Basic two-slice allocation with different ratios
+- **Input**: 2 slices, dedicated=30%/20%, min=30%/20%, max=50%/50%
+- **Expected**: Both slices get 50 PRBs each (at max limits)
+
+#### Test 16: `test_single_slice_all_prbs`
+- **Purpose**: Single slice gets all PRBs
+- **Input**: 1 slice, dedicated=100%, min=100%, max=100%
+- **Expected**: Slice gets all 100 PRBs
+
+#### Test 17: `test_no_active_ues`
+- **Purpose**: Slices with zero ratios get no PRBs
+- **Input**: 2 slices with zero ratios
+- **Expected**: Both slices get 0 PRBs
+
+#### Test 18: `test_multiple_slices_different_ratios`
+- **Purpose**: Multiple slices with different ratios
+- **Input**: 3 slices with varying ratios
+- **Expected**: Proportional allocation respecting max limits
+
+#### Test 19: `test_dedicated_exceeds_total`
+- **Purpose**: Dedicated allocations exceed total PRBs
+- **Input**: 2 slices, both dedicated=60%
+- **Expected**: Proportional scaling to 50/50 split
+
+#### Test 20: `test_max_ratio_enforcement`
+- **Purpose**: Max ratio is enforced as hard limit
+- **Input**: Slices with max limits
+- **Expected**: No slice exceeds its max_prb_ratio
+
+#### Test 21: `test_validation`
+- **Purpose**: Input validation
+- **Input**: Invalid configurations (ratios out of range, invalid relationships)
+- **Expected**: Validation fails, function returns error
+
+#### Test 22: `test_zero_total_prbs`
+- **Purpose**: Zero total PRBs
+- **Input**: total_prbs = 0
+- **Expected**: Validation fails
+
+#### Test 23: `test_real_world_106_prbs`
+- **Purpose**: Real-world scenario with 106 PRBs (typical 5G NR)
+- **Input**: 2 slices, total=106 PRBs
+- **Expected**: Both slices get 53 PRBs each (50% each)
+
+### Integration Edge Case Tests
+
+#### Test 24: `test_integration_max_less_than_min`
+- **Purpose**: Full algorithm with max < min (edge case)
+- **Input**: Slice with dedicated=20%, min=50%, max=30%
+- **Expected**: 
+  - Max takes precedence
+  - Slice gets 30 PRBs (capped at max)
+  - Min (50 PRBs) not fully met
+
+#### Test 25: `test_integration_all_slices_no_prioritized_need`
+- **Purpose**: All slices don't need prioritized resources
+- **Input**: 
+  - Slice 1: required=15, current=20 (doesn't need)
+  - Slice 2: required=5, current=10 (doesn't need)
+- **Expected**: 
+  - Pass 2: No prioritized allocation
+  - Pass 3: All remaining PRBs distributed as shared resources
+  - All 100 PRBs allocated
+
+## Test Coverage Summary
+
+### Pass 1 Coverage
+- ✅ Normal dedicated allocation
+- ✅ Proportional scaling when exceeds total
+- ✅ Static allocation (dedicated = min = max)
+- ✅ Max < dedicated (capping)
+- ✅ Zero dedicated
+- ✅ Single slice
+- ✅ Multiple slices
+
+### Pass 2 Coverage
+- ✅ Normal prioritized allocation
+- ✅ Slice doesn't need prioritized (shareable)
+- ✅ Insufficient prioritized resources (proportional scaling)
+- ✅ Max < min (max takes precedence)
+- ✅ No required_prbs (fallback to traditional min)
+- ✅ Multiple slices with different needs
+
+### Pass 3 Coverage
+- ✅ PRB requirement-based allocation
+- ✅ Capacity-based allocation (no requirements)
+- ✅ All slices at max (cannot allocate)
+- ✅ Single slice with shared resources
+- ✅ Multiple slices with varying capacities
+
+### Pass 4 Coverage
+- ✅ Normal range assignment
+- ✅ Multiple slices
+- ✅ Single slice
+- ✅ Empty result (no PRBs)
+- ✅ Contiguous and non-overlapping ranges
+
+### Integration Coverage
+- ✅ Full algorithm with all passes
+- ✅ Edge cases spanning multiple passes
+- ✅ Real-world scenarios
+- ✅ Invalid configurations
+- ✅ Boundary conditions
+
+## Running Tests
+
+```bash
+cd slice_prb_allocator
+make run
+```
+
+Or manually:
+```bash
+make
+./test_slice_prb_allocator
+```
+
+## Test Output
+
+Each test prints:
+- Test purpose and expected behavior
+- Input configuration
+- Allocation result
+- Verification steps
+- Pass/fail status
+
+## Test Statistics
+
+- **Total Tests**: 25
+- **Individual Pass Tests**: 4
+- **Pass Edge Case Tests**: 9
+- **Integrated Tests**: 9
+- **Integration Edge Case Tests**: 2
+- **Coverage**: All edge cases and normal scenarios
+
+## Edge Cases Covered
+
+1. ✅ Dedicated exceeds total (scaling)
+2. ✅ Max < min (max takes precedence)
+3. ✅ Max < dedicated (capping)
+4. ✅ Min < dedicated (adjustment)
+5. ✅ Zero dedicated
+6. ✅ Static allocation (dedicated = min = max)
+7. ✅ Slice doesn't need prioritized resources
+8. ✅ Insufficient prioritized resources
+9. ✅ All slices at max limit
+10. ✅ No PRB requirements
+11. ✅ Empty result
+12. ✅ Single slice
+13. ✅ No active UEs
+14. ✅ Invalid configurations
+15. ✅ Zero total PRBs

--- a/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/test_slice_prb_allocator.c
+++ b/openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/test_slice_prb_allocator.c
@@ -1,0 +1,3464 @@
+/*!
+ * \file test_slice_prb_allocator.c
+ * \brief Unit tests for Network Slice PRB Range Allocation Algorithm
+ * 
+ * Compile with:
+ *   gcc -Wall -Wextra -std=c11 -O2 -g test_slice_prb_allocator.c slice_prb_allocator.c -o test_slice_prb_allocator -lm
+ * 
+ * Run with:
+ *   ./test_slice_prb_allocator
+ */
+
+#include "slice_prb_allocator.h"
+#include "slice_prb_allocator_internal.h"  // Tests need access to functional implementation
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <math.h>
+#include <limits.h>
+
+#define ASSERT_EQ(a, b, msg) do { \
+  if ((a) != (b)) { \
+    fprintf(stderr, "FAIL: %s: expected %d, got %d\n", (msg), (b), (a)); \
+    exit(1); \
+  } \
+} while(0)
+
+#define ASSERT_FLOAT_EQ(a, b, msg) do { \
+  if (fabsf((float)(a) - (float)(b)) > 0.0001f) { \
+    fprintf(stderr, "FAIL: %s: expected %.6f, got %.6f\n", (msg), (float)(b), (float)(a)); \
+    exit(1); \
+  } \
+} while(0)
+
+#define ASSERT_GE(a, b, msg) do { \
+  if ((a) < (b)) { \
+    fprintf(stderr, "FAIL: %s: expected >= %d, got %d\n", (msg), (b), (a)); \
+    exit(1); \
+  } \
+} while(0)
+
+#define ASSERT_LE(a, b, msg) do { \
+  if ((a) > (b)) { \
+    fprintf(stderr, "FAIL: %s: expected <= %d, got %d\n", (msg), (b), (a)); \
+    exit(1); \
+  } \
+} while(0)
+
+#define ASSERT_GT(a, b, msg) do { \
+  if ((a) <= (b)) { \
+    fprintf(stderr, "FAIL: %s: expected > %d, got %d\n", (msg), (b), (a)); \
+    exit(1); \
+  } \
+} while(0)
+
+#define ASSERT_TRUE(cond, msg) do { \
+  if (!(cond)) { \
+    fprintf(stderr, "FAIL: %s\n", (msg)); \
+    exit(1); \
+  } \
+} while(0)
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+/* Helper function to print slice configuration */
+static void print_slice_config(const slice_config_t *slice, int idx) {
+  printf("    Slice %d (SST=%d, SD=%u):\n", idx, slice->slice_id.sst, slice->slice_id.sd);
+  printf("      Dedicated: %.1f%%, Min: %.1f%%, Max: %.1f%%, Required PRBs: %d",
+         slice->dedicated_prb_ratio * 100.0,
+         slice->min_prb_ratio * 100.0,
+         slice->max_prb_ratio * 100.0,
+         slice->required_prbs);
+  printf("\n");
+}
+
+/* Helper function to print allocation result with required PRBs */
+static void print_allocation_result_with_required(const slice_alloc_result_t *result, 
+                                                   const slice_alloc_input_t *input, 
+                                                   int total_prbs) {
+  printf("  Allocation Result:\n");
+  printf("    Total Allocated: %d / %d PRBs\n", result->total_allocated_prbs, total_prbs);
+  printf("    Per-Slice Allocation:\n");
+  int max_slices = (input != NULL) ? input->num_slices : input->num_slices;
+  for (int s = 0; s < max_slices; ++s) {
+    float percentage = (result->ranges[s].num_prbs > 0) ? 
+                        (float)result->ranges[s].num_prbs / total_prbs * 100.0 : 0.0;
+    // Find the corresponding slice config to get required_prbs
+    int required_prbs = 0;
+    for (int i = 0; i < input->num_slices; ++i) {
+      if (slice_nssai_eq(&result->ranges[s].slice_id, &input->slices[i].slice_id)) {
+        required_prbs = input->slices[i].required_prbs;
+        break;
+      }
+    }
+    printf("      Slice (SST=%d, SD=%u): PRBs [%d, %d) = %d PRBs", 
+           result->ranges[s].slice_id.sst,
+           result->ranges[s].slice_id.sd,
+           result->ranges[s].start_prb,
+           result->ranges[s].end_prb,
+           result->ranges[s].num_prbs);
+    if (result->ranges[s].num_prbs > 0) {
+      printf(" (%.1f%%)", percentage);
+    }
+    if (required_prbs > 0) {
+      printf(", Required: %d PRBs", required_prbs);
+    }
+    printf("\n");
+  }
+}
+
+/* Helper function to print OOP scheduler allocation result */
+static void print_oop_allocation_result(const slice_scheduler_t *obj, int total_prbs) {
+  if (obj == NULL) {
+    return;
+  }
+  
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(obj, &num_ranges);
+  
+  if (ranges == NULL) {
+    printf("  Allocation Result: Not available (schedule not called or invalid)\n");
+    return;
+  }
+  
+  int num_active = 0;
+  int total_allocated = 0;
+  slice_sch_get_stats(obj, &num_active, &total_allocated);
+  
+  printf("  Allocation Result:\n");
+  printf("    Active Slices: %d\n", num_active);
+  printf("    Total Allocated: %d / %d PRBs\n", total_allocated, total_prbs);
+  printf("    Per-Slice Allocation:\n");
+  
+  for (int s = 0; s < num_ranges; ++s) {
+    if (ranges[s].num_prbs > 0) {
+      float percentage = (float)ranges[s].num_prbs / total_prbs * 100.0;
+      // Find the corresponding slice config to get required_prbs
+      int required_prbs = 0;
+      if (obj->input != NULL) {
+        for (int i = 0; i < obj->input->num_slices; ++i) {
+          if (slice_nssai_eq(&ranges[s].slice_id, &obj->input->slices[i].slice_id)) {
+            required_prbs = obj->input->slices[i].required_prbs;
+            break;
+          }
+        }
+      }
+      printf("      Slice (SST=%d, SD=%u): PRBs [%d, %d) = %d PRBs (%.1f%%)", 
+             ranges[s].slice_id.sst,
+             ranges[s].slice_id.sd,
+             ranges[s].start_prb,
+             ranges[s].end_prb,
+             ranges[s].num_prbs,
+             percentage);
+      if (required_prbs > 0) {
+        printf(", Required: %d PRBs", required_prbs);
+      }
+      printf("\n");
+    }
+  }
+}
+
+#define TEST(name) \
+  do { \
+    printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"); \
+    printf("Test %d: %s\n", tests_run + 1, #name); \
+    printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"); \
+    tests_run++; \
+    test_##name(); \
+    tests_passed++; \
+    printf("  ✓ PASS\n\n"); \
+  } while(0)
+
+/* Helper macro to allocate and initialize test structures */
+#define ALLOCATE_TEST_STRUCTURES(num_slices, input_var, result_var) \
+  slice_alloc_input_t *input_var = allocate_slice_input(num_slices); \
+  slice_alloc_result_t *result_var = allocate_slice_result(num_slices); \
+  if (input_var == NULL || result_var == NULL) { \
+    fprintf(stderr, "FAIL: Memory allocation failed\n"); \
+    if (input_var) free_slice_input(input_var); \
+    if (result_var) free_slice_result(result_var); \
+    exit(1); \
+  }
+
+/* Test 1: Basic allocation with two slices */
+static void test_basic_two_slices(void) {
+  printf("  Purpose: Test basic two-slice allocation with different ratios\n");
+  printf("  Expected: Dedicated PRBs only when require=0 (min does not idle-allocate)\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  // Slice 1: 30% dedicated, 30% min, 50% max
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.30f;
+  input->slices[0].min_prb_ratio = 0.30f;
+  input->slices[0].max_prb_ratio = 0.50f;
+  
+  // Slice 2: 20% dedicated, 20% min, 50% max
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.20f;
+  input->slices[1].min_prb_ratio = 0.20f;
+  input->slices[1].max_prb_ratio = 0.50f;
+  
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  print_slice_config(&input->slices[0], 0);
+  print_slice_config(&input->slices[1], 1);
+  printf("\n");
+  
+  int ret = calculate_slice_prb_ranges(input, result);
+  
+  print_allocation_result_with_required(result, input, input->total_prbs);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 2, "Should allocate to 2 slices");
+  ASSERT_EQ(result->total_allocated_prbs, 50, "Only dedicated PRBs without require");
+  
+  // Check slice 1: dedicated 30% only
+  printf("    ✓ Slice 1: %d PRBs (expected: 30 dedicated)\n", result->ranges[0].num_prbs);
+  ASSERT_EQ(result->ranges[0].num_prbs, 30, "Slice 1 should get 30 dedicated PRBs");
+  ASSERT_EQ(result->ranges[0].slice_id.sst, 1, "Slice 1 SST should be 1");
+  ASSERT_EQ(result->ranges[0].slice_id.sd, 0, "Slice 1 SD should be 0");
+  ASSERT_EQ(result->ranges[0].start_prb, 0, "Slice 1 should start at PRB 0");
+  ASSERT_EQ(result->ranges[0].end_prb, result->ranges[0].start_prb + result->ranges[0].num_prbs,
+            "Slice 1 end_prb should be start_prb + num_prbs");
+  
+  // Check slice 2: dedicated 20% only
+  printf("    ✓ Slice 2: %d PRBs (expected: 20 dedicated)\n", result->ranges[1].num_prbs);
+  ASSERT_EQ(result->ranges[1].num_prbs, 20, "Slice 2 should get 20 dedicated PRBs");
+  ASSERT_EQ(result->ranges[1].slice_id.sst, 2, "Slice 2 SST should be 2");
+  ASSERT_EQ(result->ranges[1].slice_id.sd, 0, "Slice 2 SD should be 0");
+  ASSERT_EQ(result->ranges[1].start_prb, result->ranges[0].end_prb,
+            "Slice 2 should start where slice 1 ends");
+  ASSERT_EQ(result->ranges[1].end_prb, result->ranges[1].start_prb + result->ranges[1].num_prbs,
+            "Slice 2 end_prb should be start_prb + num_prbs");
+  
+  // Check that ranges don't overlap
+  ASSERT_EQ(result->ranges[0].end_prb, result->ranges[1].start_prb,
+            "Slice ranges should be contiguous");
+  
+  // Total should equal dedicated sum
+  ASSERT_EQ(result->ranges[0].num_prbs + result->ranges[1].num_prbs, 50,
+            "Total PRBs should equal dedicated sum");
+  printf("    ✓ Ranges are contiguous: [%d, %d) and [%d, %d)\n",
+         result->ranges[0].start_prb, result->ranges[0].end_prb,
+         result->ranges[1].start_prb, result->ranges[1].end_prb);
+  
+  free_slice_input(input);
+  free_slice_result(result);
+}
+
+/* Test 2: Single slice with all PRBs */
+static void test_single_slice_all_prbs(void) {
+  printf("  Purpose: Test single slice that gets all available PRBs\n");
+  printf("  Expected: Single slice gets 100%% of PRBs (106 PRBs)\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(1, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 1.0f;
+  input->slices[0].min_prb_ratio = 1.0f;
+  input->slices[0].max_prb_ratio = 1.0f;
+  
+  input->total_prbs = 106;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  print_slice_config(&input->slices[0], 0);
+  printf("\n");
+  
+  int ret = calculate_slice_prb_ranges(input, result);
+  
+  print_allocation_result_with_required(result, input, input->total_prbs);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 1, "Should allocate to 1 slice");
+  ASSERT_EQ(result->ranges[0].num_prbs, 106, "Slice should get all 106 PRBs");
+  ASSERT_EQ(result->ranges[0].start_prb, 0, "Should start at PRB 0");
+  ASSERT_EQ(result->ranges[0].end_prb, 106, "Should end at PRB 106");
+  ASSERT_EQ(result->total_allocated_prbs, 106, "Should allocate all PRBs");
+  printf("    ✓ Slice gets all %d PRBs: [%d, %d)\n",
+         result->ranges[0].num_prbs, result->ranges[0].start_prb, result->ranges[0].end_prb);
+  
+  free_slice_input(input);
+  free_slice_result(result);
+}
+
+/* Test 3: Slice with no active UEs should get no PRBs */
+static void test_no_active_ues(void) {
+  printf("  Purpose: Test that slices with zero ratios get no PRBs\n");
+  printf("  Expected: Slice with zero ratios gets 0 PRBs\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(1, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.0f;
+  input->slices[0].min_prb_ratio = 0.0f;
+  input->slices[0].max_prb_ratio = 0.0f;
+  
+  input->num_slices = 1;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  print_slice_config(&input->slices[0], 0);
+  printf("    Note: Slice has zero ratios, so it should get 0 PRBs\n\n");
+  
+  int ret = calculate_slice_prb_ranges(input, result);
+  
+  print_allocation_result_with_required(result, input, input->total_prbs);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 1, "Should return 1 slice");
+  ASSERT_EQ(result->ranges[0].num_prbs, 0, "Slice with zero ratios should get 0 PRBs");
+  ASSERT_EQ(result->total_allocated_prbs, 0, "Should allocate 0 PRBs");
+  printf("    ✓ Slice with zero ratios correctly gets 0 PRBs\n");
+  
+  free_slice_input(input);
+  free_slice_result(result);
+}
+
+/* Test 4: Multiple slices with different ratios */
+static void test_multiple_slices_different_ratios(void) {
+  printf("  Purpose: Test allocation with 3 slices having different dedicated/min/max ratios\n");
+  printf("  Expected: Dedicated PRBs only when require=0\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(3, input, result);
+  
+  // Slice 1: 10% dedicated, 20% min, 40% max
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.10f;
+  input->slices[0].min_prb_ratio = 0.20f;
+  input->slices[0].max_prb_ratio = 0.40f;
+  
+  // Slice 2: 15% dedicated, 25% min, 50% max
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.15f;
+  input->slices[1].min_prb_ratio = 0.25f;
+  input->slices[1].max_prb_ratio = 0.50f;
+  
+  // Slice 3: 5% dedicated, 10% min, 30% max
+  input->slices[2].slice_id = slice_nssai_from_int(3);
+  input->slices[2].dedicated_prb_ratio = 0.05f;
+  input->slices[2].min_prb_ratio = 0.10f;
+  input->slices[2].max_prb_ratio = 0.30f;
+  
+  input->num_slices = 3;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  print_slice_config(&input->slices[0], 0);
+  print_slice_config(&input->slices[1], 1);
+  print_slice_config(&input->slices[2], 2);
+  printf("\n");
+  
+  int ret = calculate_slice_prb_ranges(input, result);
+  
+  print_allocation_result_with_required(result, input, input->total_prbs);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 3, "Should allocate to 3 slices");
+  ASSERT_EQ(result->total_allocated_prbs, 30, "Only dedicated PRBs (10+15+5) without require");
+  
+  printf("    ✓ Slice 1: %d PRBs (expected: 10 dedicated)\n", result->ranges[0].num_prbs);
+  ASSERT_EQ(result->ranges[0].num_prbs, 10, "Slice 1 dedicated");
+  
+  printf("    ✓ Slice 2: %d PRBs (expected: 15 dedicated)\n", result->ranges[1].num_prbs);
+  ASSERT_EQ(result->ranges[1].num_prbs, 15, "Slice 2 dedicated");
+  
+  printf("    ✓ Slice 3: %d PRBs (expected: 5 dedicated)\n", result->ranges[2].num_prbs);
+  ASSERT_EQ(result->ranges[2].num_prbs, 5, "Slice 3 dedicated");
+  
+  // Check contiguous allocation
+  ASSERT_EQ(result->ranges[0].end_prb, result->ranges[1].start_prb,
+            "Slice 1 and 2 should be contiguous");
+  ASSERT_EQ(result->ranges[1].end_prb, result->ranges[2].start_prb,
+            "Slice 2 and 3 should be contiguous");
+  
+  // Total should equal 100
+  int total = result->ranges[0].num_prbs + result->ranges[1].num_prbs + result->ranges[2].num_prbs;
+  ASSERT_EQ(total, 30, "Total PRBs should equal dedicated sum");
+  printf("    ✓ Ranges are contiguous: [%d, %d), [%d, %d), [%d, %d)\n",
+         result->ranges[0].start_prb, result->ranges[0].end_prb,
+         result->ranges[1].start_prb, result->ranges[1].end_prb,
+         result->ranges[2].start_prb, result->ranges[2].end_prb);
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test 5: Invalid config — sum(min) > 100% */
+static void test_dedicated_exceeds_total(void) {
+  printf("  Purpose: Reject configurations where sum(min) exceeds 100%%\n");
+  printf("  Expected: validate_slice_config / calculate_slice_prb_ranges fail\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.60f;
+  input->slices[0].min_prb_ratio = 0.60f;
+  input->slices[0].max_prb_ratio = 0.60f;
+  
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.60f;
+  input->slices[1].min_prb_ratio = 0.60f;
+  input->slices[1].max_prb_ratio = 0.60f;
+  
+  input->num_slices = 2;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  print_slice_config(&input->slices[0], 0);
+  print_slice_config(&input->slices[1], 1);
+  printf("    Note: sum(min)=120%% > 100%% — invalid NS policy\n\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(validate_slice_config(input), false, "validate should reject sum(min)>100%");
+  ASSERT_EQ(calculate_slice_prb_ranges(input, result), -1, "calculate should fail");
+  printf("    ✓ sum(min) > 100%% rejected\n");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test 6: Max ratio enforcement */
+static void test_max_ratio_enforcement(void) {
+  printf("  Purpose: Test that max_prb_ratio is enforced as a hard limit\n");
+  printf("  Expected: Even with 90 PRBs remaining, slice cannot exceed 30%% (30 PRBs)\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(1, input, result);
+  
+  // Slice with 30% max, but plenty of remaining PRBs
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.10f;
+  input->slices[0].min_prb_ratio = 0.10f;
+  input->slices[0].max_prb_ratio = 0.30f;  // Hard limit at 30%
+  
+  input->num_slices = 1;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  print_slice_config(&input->slices[0], 0);
+  printf("    Note: After dedicated (10 PRBs), 90 PRBs remain, but max is 30%%\n");
+  printf("          Slice should get exactly 30 PRBs (max limit)\n\n");
+  
+  int ret = calculate_slice_prb_ranges(input, result);
+  
+  print_allocation_result_with_required(result, input, input->total_prbs);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 1, "Should allocate to 1 slice");
+  printf("    ✓ Slice 1: %d PRBs (expected: ≤30, hard limit)\n", result->ranges[0].num_prbs);
+  ASSERT_LE(result->ranges[0].num_prbs, 30, "Should not exceed max (30 PRBs)");
+  // Even though there are 90 PRBs remaining, slice should only get up to 30
+  printf("    ✓ Max ratio (30%%) is correctly enforced as hard limit\n");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test 7: Validation tests */
+static void test_validation(void) {
+  printf("  Purpose: Test input validation and error handling\n");
+  printf("  Expected: Invalid inputs return -1, valid inputs succeed\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(1, input, result);
+  
+  printf("  Testing NULL input...\n");
+  int ret = calculate_slice_prb_ranges(NULL, result);
+  ASSERT_EQ(ret, -1, "NULL input should return -1");
+  printf("    ✓ NULL input correctly rejected\n");
+  
+  printf("  Testing NULL result...\n");
+  ret = calculate_slice_prb_ranges(input, NULL);
+  ASSERT_EQ(ret, -1, "NULL result should return -1");
+  printf("    ✓ NULL result correctly rejected\n");
+  
+  printf("  Testing invalid ratio (> 1.0)...\n");
+  // Test invalid ratios
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 1.5f;  // Invalid: > 1.0
+  input->slices[0].min_prb_ratio = 0.5f;
+  input->slices[0].max_prb_ratio = 0.5f;
+  input->total_prbs = 100;
+  
+  ret = calculate_slice_prb_ranges(input, result);
+  ASSERT_EQ(ret, -1, "Invalid ratio should return -1");
+  printf("    ✓ Ratio > 1.0 correctly rejected\n");
+  
+  printf("  Testing invalid relationship (dedicated > min)...\n");
+  // Test invalid relationship (dedicated > min)
+  input->slices[0].dedicated_prb_ratio = 0.5f;
+  input->slices[0].min_prb_ratio = 0.3f;  // Invalid: min < dedicated
+  input->slices[0].max_prb_ratio = 0.5f;
+  
+  ret = calculate_slice_prb_ranges(input, result);
+  ASSERT_EQ(ret, -1, "Invalid ratio relationship should return -1");
+  printf("    ✓ Invalid ratio relationship (dedicated > min) correctly rejected\n");
+}
+
+/* Test 8: Edge case - zero total PRBs */
+static void test_zero_total_prbs(void) {
+  printf("  Purpose: Test edge case with zero total PRBs\n");
+  printf("  Expected: Zero total PRBs should be rejected (return -1)\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(1, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.5f;
+  input->slices[0].min_prb_ratio = 0.5f;
+  input->slices[0].max_prb_ratio = 0.5f;
+  input->num_slices = 1;
+  input->total_prbs = 0;  // Invalid
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d (INVALID)\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  print_slice_config(&input->slices[0], 0);
+  printf("\n");
+  
+  int ret = calculate_slice_prb_ranges(input, result);
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, -1, "Zero total PRBs should return -1");
+  printf("    ✓ Zero total PRBs correctly rejected\n");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test 9: Real-world scenario - 106 PRBs with 2 slices */
+static void test_real_world_106_prbs(void) {
+  printf("  Purpose: Test real-world 5G NR scenario with 106 PRBs\n");
+  printf("  Expected: eMBB and URLLC slices get appropriate allocations\n");
+  printf("            respecting their dedicated, min, and max ratios\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  // Slice 1: 33% dedicated, 33% min, 50% max (typical eMBB slice)
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.33f;
+  input->slices[0].min_prb_ratio = 0.33f;
+  input->slices[0].max_prb_ratio = 0.50f;
+  
+  // Slice 2: 20% dedicated, 20% min, 50% max (typical URLLC slice)
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.20f;
+  input->slices[1].min_prb_ratio = 0.20f;
+  input->slices[1].max_prb_ratio = 0.50f;
+  
+  input->num_slices = 2;
+  input->total_prbs = 106;  // Typical 5G NR bandwidth
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d (typical 5G NR bandwidth)\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  printf("    Slice 1 (eMBB - Enhanced Mobile Broadband):\n");
+  print_slice_config(&input->slices[0], 0);
+  printf("    Slice 2 (URLLC - Ultra-Reliable Low-Latency Communication):\n");
+  print_slice_config(&input->slices[1], 1);
+  printf("\n");
+  
+  int ret = calculate_slice_prb_ranges(input, result);
+  
+  print_allocation_result_with_required(result, input, input->total_prbs);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 2, "Should allocate to 2 slices");
+  ASSERT_EQ(result->total_allocated_prbs, 56, "Dedicated only without require (35+21)");
+  
+  printf("    ✓ Slice 1 (eMBB): %d PRBs (expected: 35 dedicated)\n", result->ranges[0].num_prbs);
+  ASSERT_EQ(result->ranges[0].num_prbs, 35, "Slice 1 dedicated");
+  
+  printf("    ✓ Slice 2 (URLLC): %d PRBs (expected: 21 dedicated)\n", result->ranges[1].num_prbs);
+  ASSERT_EQ(result->ranges[1].num_prbs, 21, "Slice 2 dedicated");
+  
+  // Check contiguous allocation
+  ASSERT_EQ(result->ranges[0].end_prb, result->ranges[1].start_prb,
+            "Slices should be contiguous");
+  ASSERT_EQ(result->ranges[1].end_prb, 56, "Last slice ends at dedicated total");
+  printf("    ✓ Ranges are contiguous: [%d, %d) and [%d, %d)\n",
+         result->ranges[0].start_prb, result->ranges[0].end_prb,
+         result->ranges[1].start_prb, result->ranges[1].end_prb);
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test Pass 1: Dedicated PRB Allocation */
+static void test_pass1_dedicated(void) {
+  printf("  Purpose: Test Pass 1 (dedicated allocation) in isolation\n");
+  printf("  Expected: Allocates dedicated PRBs, handles scaling when exceeds total\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  // Test case 1: Normal dedicated allocation
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.30f;
+  input->slices[0].min_prb_ratio = 0.30f;
+  input->slices[0].max_prb_ratio = 0.50f;
+  
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.20f;
+  input->slices[1].min_prb_ratio = 0.20f;
+  input->slices[1].max_prb_ratio = 0.50f;
+  
+  input->num_slices = 2;
+  input->total_prbs = 100;
+  
+  // Initialize result
+  // Result already zeroed by calloc
+  for (int s = 0; s < input->num_slices; ++s) {
+    result->ranges[s].slice_id = input->slices[s].slice_id;
+  }
+  
+  int allocated_prbs = 0;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  print_slice_config(&input->slices[0], 0);
+  print_slice_config(&input->slices[1], 1);
+  printf("\n");
+  
+  int ret = pass1_allocate_dedicated(input, result, &allocated_prbs);
+  
+  printf("  Pass 1 Result:\n");
+  printf("    Allocated PRBs: %d\n", allocated_prbs);
+  printf("    Slice 1: %d PRBs (expected: 30)\n", result->ranges[0].num_prbs);
+  printf("    Slice 2: %d PRBs (expected: 20)\n", result->ranges[1].num_prbs);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 0, "Pass 1 should succeed");
+  ASSERT_EQ(result->ranges[0].num_prbs, 30, "Slice 1 should get 30 PRBs");
+  ASSERT_EQ(result->ranges[1].num_prbs, 20, "Slice 2 should get 20 PRBs");
+  ASSERT_EQ(allocated_prbs, 50, "Total allocated should be 50 PRBs");
+  
+  // Test case 2: Dedicated exceeds total (scaling)
+  input->slices[0].dedicated_prb_ratio = 0.60f;
+  input->slices[1].dedicated_prb_ratio = 0.60f;
+  
+  // Result already zeroed by calloc
+  for (int s = 0; s < input->num_slices; ++s) {
+    result->ranges[s].slice_id = input->slices[s].slice_id;
+  }
+  allocated_prbs = 0;
+  
+  printf("  Test Case 2: Dedicated exceeds total (60%% + 60%% = 120%%)\n");
+  ret = pass1_allocate_dedicated(input, result, &allocated_prbs);
+  
+  printf("  Pass 1 Result (with scaling):\n");
+  printf("    Allocated PRBs: %d (expected: 100 after scaling)\n", allocated_prbs);
+  printf("    Slice 1: %d PRBs (expected: 50 after scaling)\n", result->ranges[0].num_prbs);
+  printf("    Slice 2: %d PRBs (expected: 50 after scaling)\n", result->ranges[1].num_prbs);
+  printf("\n");
+  
+  ASSERT_EQ(ret, 0, "Pass 1 should succeed");
+  ASSERT_EQ(allocated_prbs, 100, "After scaling, should allocate exactly 100 PRBs");
+  ASSERT_EQ(result->ranges[0].num_prbs, 50, "Slice 1 should get 50 PRBs after scaling");
+  ASSERT_EQ(result->ranges[1].num_prbs, 50, "Slice 2 should get 50 PRBs after scaling");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test Pass 2: Prioritized Resource Allocation */
+static void test_pass2_prioritized(void) {
+  printf("  Purpose: Test Pass 2 (prioritized allocation) in isolation\n");
+  printf("  Expected: Allocates prioritized resources based on required_prbs\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  // Setup: Pass 1 already allocated dedicated PRBs
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.20f;
+  input->slices[0].min_prb_ratio = 0.30f;
+  input->slices[0].max_prb_ratio = 0.50f;
+  input->slices[0].required_prbs = 35; // Needs more than dedicated
+  
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.10f;
+  input->slices[1].min_prb_ratio = 0.25f;
+  input->slices[1].max_prb_ratio = 0.50f;
+  input->slices[1].required_prbs = 30; // Needs more than dedicated
+  
+  input->num_slices = 2;
+  input->total_prbs = 100;
+  
+  // Initialize result with Pass 1 allocations
+  // Result already zeroed by calloc
+  for (int s = 0; s < input->num_slices; ++s) {
+    result->ranges[s].slice_id = input->slices[s].slice_id;
+  }
+  result->ranges[0].num_prbs = 20; // Dedicated from Pass 1
+  result->ranges[1].num_prbs = 10; // Dedicated from Pass 1
+  
+  int allocated_prbs = 30; // From Pass 1
+  int remaining_prbs = 70; // 100 - 30
+  
+  printf("  Input Configuration (after Pass 1):\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Already allocated: %d PRBs (dedicated)\n", allocated_prbs);
+  printf("    Remaining: %d PRBs\n", remaining_prbs);
+  print_slice_config(&input->slices[0], 0);
+  print_slice_config(&input->slices[1], 1);
+  printf("\n");
+  
+  int ret = pass2_allocate_prioritized(input, result, &allocated_prbs, &remaining_prbs);
+  
+  printf("  Pass 2 Result:\n");
+  printf("    Allocated PRBs: %d (was %d, added %d)\n", allocated_prbs, 30, allocated_prbs - 30);
+  printf("    Remaining PRBs: %d\n", remaining_prbs);
+  printf("    Slice 1: %d PRBs (was 20, added %d, prioritized=10)\n",
+         result->ranges[0].num_prbs, result->ranges[0].num_prbs - 20);
+  printf("    Slice 2: %d PRBs (was 10, added %d, prioritized=15)\n",
+         result->ranges[1].num_prbs, result->ranges[1].num_prbs - 10);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 0, "Pass 2 should succeed");
+  ASSERT_EQ(result->ranges[0].num_prbs, 30, "Slice 1 should get 30 PRBs (20 dedicated + 10 prioritized)");
+  ASSERT_EQ(result->ranges[1].num_prbs, 25, "Slice 2 should get 25 PRBs (10 dedicated + 15 prioritized)");
+  ASSERT_EQ(allocated_prbs, 55, "Total allocated should be 55 PRBs");
+  ASSERT_EQ(remaining_prbs, 45, "Remaining should be 45 PRBs");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test Pass 3: Shared Resource Allocation */
+static void test_pass3_shared(void) {
+  printf("  Purpose: Test Pass 3 (shared allocation) in isolation\n");
+  printf("  Expected: Distributes shared resources proportionally\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  // Setup: Pass 1 and 2 already allocated
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.20f;
+  input->slices[0].min_prb_ratio = 0.30f;
+  input->slices[0].max_prb_ratio = 0.50f;
+  input->slices[0].required_prbs = 45;
+  
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.10f;
+  input->slices[1].min_prb_ratio = 0.25f;
+  input->slices[1].max_prb_ratio = 0.50f;
+  input->slices[1].required_prbs = 35;
+  
+  input->num_slices = 2;
+  input->total_prbs = 100;
+  
+  // Initialize result with Pass 1+2 allocations
+  // Result already zeroed by calloc
+  for (int s = 0; s < input->num_slices; ++s) {
+    result->ranges[s].slice_id = input->slices[s].slice_id;
+  }
+  result->ranges[0].num_prbs = 30; // After Pass 1+2
+  result->ranges[1].num_prbs = 25; // After Pass 1+2
+  
+  int allocated_prbs = 55; // From Pass 1+2
+  int remaining_prbs = 45; // Shared resources
+  
+  printf("  Input Configuration (after Pass 1+2):\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Already allocated: %d PRBs\n", allocated_prbs);
+  printf("    Remaining (shared): %d PRBs\n", remaining_prbs);
+  printf("    Slice 1: %d PRBs, max=50, can_add=%d, required=%d\n",
+         result->ranges[0].num_prbs, 50 - result->ranges[0].num_prbs, input->slices[0].required_prbs);
+  printf("    Slice 2: %d PRBs, max=50, can_add=%d, required=%d\n",
+         result->ranges[1].num_prbs, 50 - result->ranges[1].num_prbs, input->slices[1].required_prbs);
+  printf("\n");
+  
+  int ret = pass3_allocate_shared(input, result, &allocated_prbs, &remaining_prbs);
+  
+  printf("  Pass 3 Result:\n");
+  printf("    Allocated PRBs: %d (was %d, added %d)\n", allocated_prbs, 55, allocated_prbs - 55);
+  printf("    Remaining PRBs: %d\n", remaining_prbs);
+  printf("    Slice 1: %d PRBs (was 30, added %d)\n",
+         result->ranges[0].num_prbs, result->ranges[0].num_prbs - 30);
+  printf("    Slice 2: %d PRBs (was 25, added %d)\n",
+         result->ranges[1].num_prbs, result->ranges[1].num_prbs - 25);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 0, "Pass 3 should succeed");
+  ASSERT_GE(result->ranges[0].num_prbs, 30, "Slice 1 should get at least 30 PRBs");
+  ASSERT_LE(result->ranges[0].num_prbs, 50, "Slice 1 should not exceed max (50)");
+  ASSERT_GE(result->ranges[1].num_prbs, 25, "Slice 2 should get at least 25 PRBs");
+  ASSERT_LE(result->ranges[1].num_prbs, 50, "Slice 2 should not exceed max (50)");
+  ASSERT_EQ(allocated_prbs + remaining_prbs, 100, "Allocated + remaining should equal total");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test Pass 4: Range Assignment */
+static void test_pass4_ranges(void) {
+  printf("  Purpose: Test Pass 4 (range assignment) in isolation\n");
+  printf("  Expected: Assigns contiguous, non-overlapping ranges\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(3, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[2].slice_id = slice_nssai_from_int(3);
+  input->num_slices = 3;
+  
+  // Setup: PRBs already allocated (from previous passes)
+  result->ranges[0].num_prbs = 30;
+  result->ranges[1].num_prbs = 20;
+  result->ranges[2].num_prbs = 50;
+  // Slice 0 has no PRBs (should be skipped)
+  
+  printf("  Input Configuration:\n");
+  printf("    Slice 1: %d PRBs\n", result->ranges[0].num_prbs);
+  printf("    Slice 2: %d PRBs\n", result->ranges[1].num_prbs);
+  printf("    Slice 3: %d PRBs\n", result->ranges[2].num_prbs);
+  printf("    Total: %d PRBs\n", 30 + 20 + 50);
+  printf("\n");
+  
+  int ret = pass4_assign_ranges(input, result);
+  
+  printf("  Pass 4 Result:\n");
+  printf("    Slice 1: [%d, %d) = %d PRBs\n",
+         result->ranges[0].start_prb, result->ranges[0].end_prb, result->ranges[0].num_prbs);
+  printf("    Slice 2: [%d, %d) = %d PRBs\n",
+         result->ranges[1].start_prb, result->ranges[1].end_prb, result->ranges[1].num_prbs);
+  printf("    Slice 3: [%d, %d) = %d PRBs\n",
+         result->ranges[2].start_prb, result->ranges[2].end_prb, result->ranges[2].num_prbs);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 0, "Pass 4 should succeed");
+  ASSERT_EQ(result->ranges[0].start_prb, 0, "Slice 1 should start at 0");
+  ASSERT_EQ(result->ranges[0].end_prb, 30, "Slice 1 should end at 30");
+  ASSERT_EQ(result->ranges[1].start_prb, 30, "Slice 2 should start at 30 (contiguous)");
+  ASSERT_EQ(result->ranges[1].end_prb, 50, "Slice 2 should end at 50");
+  ASSERT_EQ(result->ranges[2].start_prb, 50, "Slice 3 should start at 50 (contiguous)");
+  ASSERT_EQ(result->ranges[2].end_prb, 100, "Slice 3 should end at 100");
+  ASSERT_EQ(result->ranges[0].end_prb, result->ranges[1].start_prb,
+            "Slices should be contiguous");
+  ASSERT_EQ(result->ranges[1].end_prb, result->ranges[2].start_prb,
+            "Slices should be contiguous");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test Pass 1 Edge Cases */
+static void test_pass1_dedicated_static_allocation(void) {
+  printf("  Purpose: Test Pass 1 with dedicated = min = max (static allocation)\n");
+  printf("  Expected: All PRBs allocated in Pass 1, no scaling needed\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.50f;
+  input->slices[0].min_prb_ratio = 0.50f;
+  input->slices[0].max_prb_ratio = 0.50f;
+  
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.50f;
+  input->slices[1].min_prb_ratio = 0.50f;
+  input->slices[1].max_prb_ratio = 0.50f;
+  
+  input->num_slices = 2;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  print_slice_config(&input->slices[0], 0);
+  print_slice_config(&input->slices[1], 1);
+  printf("\n");
+  
+  // Result already zeroed by calloc
+  for (int s = 0; s < input->num_slices; ++s) {
+    result->ranges[s].slice_id = input->slices[s].slice_id;
+  }
+  
+  int allocated_prbs = 0;
+  
+  int ret = pass1_allocate_dedicated(input, result, &allocated_prbs);
+  
+  printf("  Pass 1 Result:\n");
+  printf("    Allocated PRBs: %d\n", allocated_prbs);
+  printf("    Slice 1: %d PRBs\n", result->ranges[0].num_prbs);
+  printf("    Slice 2: %d PRBs\n", result->ranges[1].num_prbs);
+  printf("\n");
+  
+  ASSERT_EQ(ret, 0, "Should succeed");
+  ASSERT_EQ(allocated_prbs, 100, "Should allocate all PRBs");
+  ASSERT_EQ(result->ranges[0].num_prbs, 50, "Slice 1 should get 50 PRBs");
+  ASSERT_EQ(result->ranges[1].num_prbs, 50, "Slice 2 should get 50 PRBs");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+static void test_pass1_max_less_than_dedicated(void) {
+  printf("  Purpose: Test Pass 1 when max < dedicated (should cap at max)\n");
+  printf("  Expected: Dedicated is capped at max_prb_ratio\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(1, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.50f;
+  input->slices[0].min_prb_ratio = 0.50f;
+  input->slices[0].max_prb_ratio = 0.30f; // Max < dedicated
+  
+  input->num_slices = 1;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  print_slice_config(&input->slices[0], 0);
+  printf("    Note: Max (30%%) < Dedicated (50%%), so dedicated will be capped at max\n\n");
+  
+  // Result already zeroed by calloc
+  result->ranges[0].slice_id = input->slices[0].slice_id;
+  
+  int allocated_prbs = 0;
+  
+  int ret = pass1_allocate_dedicated(input, result, &allocated_prbs);
+  
+  printf("  Pass 1 Result:\n");
+  printf("    Allocated PRBs: %d (capped at max=30)\n", allocated_prbs);
+  printf("    Slice 1: %d PRBs (capped at max, dedicated was 50)\n", result->ranges[0].num_prbs);
+  printf("\n");
+  
+  ASSERT_EQ(ret, 0, "Should succeed");
+  ASSERT_EQ(result->ranges[0].num_prbs, 30, "Should be capped at max (30)");
+  ASSERT_EQ(allocated_prbs, 30, "Total should be 30");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+static void test_pass1_zero_dedicated(void) {
+  printf("  Purpose: Test Pass 1 with zero dedicated (slice still active)\n");
+  printf("  Expected: Slice gets 0 PRBs but is counted as active\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(1, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.0f;
+  input->slices[0].min_prb_ratio = 0.30f;
+  input->slices[0].max_prb_ratio = 0.50f;
+  
+  input->num_slices = 1;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  print_slice_config(&input->slices[0], 0);
+  printf("    Note: Dedicated is 0%%, but slice has active UEs, so it's counted as active\n\n");
+  
+  // Result already zeroed by calloc
+  result->ranges[0].slice_id = input->slices[0].slice_id;
+  
+  int allocated_prbs = 0;
+  
+  int ret = pass1_allocate_dedicated(input, result, &allocated_prbs);
+  
+  printf("  Pass 1 Result:\n");
+  printf("    Allocated PRBs: %d\n", allocated_prbs);
+  printf("    Slice 1: %d PRBs (zero dedicated)\n", result->ranges[0].num_prbs);
+  printf("\n");
+  
+  ASSERT_EQ(ret, 0, "Should succeed");
+  ASSERT_EQ(result->ranges[0].num_prbs, 0, "Should get 0 PRBs (zero dedicated)");
+  ASSERT_EQ(allocated_prbs, 0, "Total should be 0");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test Pass 2 Edge Cases */
+static void test_pass2_slice_doesnt_need_prioritized(void) {
+  printf("  Purpose: Test Pass 2 when slice doesn't need prioritized resources\n");
+  printf("  Expected: Prioritized resources remain available for Pass 3\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.20f;
+  input->slices[0].min_prb_ratio = 0.30f;
+  input->slices[0].max_prb_ratio = 0.50f;
+  input->slices[0].required_prbs = 15; // Less than current (20)
+  
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.10f;
+  input->slices[1].min_prb_ratio = 0.25f;
+  input->slices[1].max_prb_ratio = 0.50f;
+  input->slices[1].required_prbs = 30; // Needs more
+  
+  input->num_slices = 2;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration (after Pass 1):\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Already allocated (dedicated): 30 PRBs\n");
+  printf("    Remaining: 70 PRBs\n");
+  print_slice_config(&input->slices[0], 0);
+  print_slice_config(&input->slices[1], 1);
+  printf("    Note: Slice 1 required=15 < current=20, so doesn't need prioritized\n");
+  printf("          Slice 2 required=30 > current=10, so needs prioritized\n\n");
+  
+  // Result already zeroed by calloc
+  for (int s = 0; s < input->num_slices; ++s) {
+    result->ranges[s].slice_id = input->slices[s].slice_id;
+  }
+  result->ranges[0].num_prbs = 20; // From Pass 1
+  result->ranges[1].num_prbs = 10; // From Pass 1
+  
+  int allocated_prbs = 30;
+  int remaining_prbs = 70;
+  
+  int ret = pass2_allocate_prioritized(input, result, &allocated_prbs, &remaining_prbs);
+  
+  printf("  Pass 2 Result:\n");
+  printf("    Allocated PRBs: %d (was 30, added %d)\n", allocated_prbs, allocated_prbs - 30);
+  printf("    Remaining PRBs: %d\n", remaining_prbs);
+  printf("    Slice 1: %d PRBs (no change, doesn't need prioritized)\n", result->ranges[0].num_prbs);
+  printf("    Slice 2: %d PRBs (was 10, added %d prioritized)\n",
+         result->ranges[1].num_prbs, result->ranges[1].num_prbs - 10);
+  printf("    Note: Slice 1's prioritized resources (10 PRBs) remain available for Pass 3\n");
+  printf("\n");
+  
+  ASSERT_EQ(ret, 0, "Should succeed");
+  ASSERT_EQ(result->ranges[0].num_prbs, 20, "Slice 1 should not get prioritized (doesn't need)");
+  ASSERT_EQ(result->ranges[1].num_prbs, 25, "Slice 2 should get prioritized (15 PRBs)");
+  // Slice 1's prioritized resources (10 PRBs) remain available, so remaining = 70 - 15 = 55
+  // But actually, Slice 1's prioritized (10) + remaining after Pass 2 = 10 + 45 = 55
+  // The prioritized resources that weren't claimed become available for Pass 3
+  ASSERT_GE(remaining_prbs, 55, "At least 55 PRBs should remain (Slice 1's prioritized not claimed)");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+static void test_pass2_insufficient_prioritized(void) {
+  printf("  Purpose: Test Pass 2 with insufficient prioritized resources\n");
+  printf("  Expected: Proportional scaling of prioritized allocations\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.20f;
+  input->slices[0].min_prb_ratio = 0.50f; // Needs 30 prioritized
+  input->slices[0].max_prb_ratio = 0.60f;
+  input->slices[0].required_prbs = 50;
+  
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.10f;
+  input->slices[1].min_prb_ratio = 0.40f; // Needs 30 prioritized
+  input->slices[1].max_prb_ratio = 0.60f;
+  input->slices[1].required_prbs = 40;
+  
+  input->num_slices = 2;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration (after Pass 1):\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Already allocated (dedicated): 30 PRBs\n");
+  printf("    Remaining: 40 PRBs (insufficient for both slices' prioritized needs)\n");
+  print_slice_config(&input->slices[0], 0);
+  print_slice_config(&input->slices[1], 1);
+  printf("    Note: Slice 1 needs 30 prioritized, Slice 2 needs 30 prioritized\n");
+  printf("          Total need: 60 PRBs, but only 40 available (proportional scaling)\n\n");
+  
+  // Result already zeroed by calloc
+  for (int s = 0; s < input->num_slices; ++s) {
+    result->ranges[s].slice_id = input->slices[s].slice_id;
+  }
+  result->ranges[0].num_prbs = 20; // From Pass 1
+  result->ranges[1].num_prbs = 10; // From Pass 1
+  
+  int allocated_prbs = 30;
+  int remaining_prbs = 40; // Not enough for both (need 60 total)
+  
+  int ret = pass2_allocate_prioritized(input, result, &allocated_prbs, &remaining_prbs);
+  
+  printf("  Pass 2 Result (with proportional scaling):\n");
+  printf("    Allocated PRBs: %d (was 30, added %d)\n", allocated_prbs, allocated_prbs - 30);
+  printf("    Remaining PRBs: %d\n", remaining_prbs);
+  printf("    Slice 1: %d PRBs (was 20, added %d)\n",
+         result->ranges[0].num_prbs, result->ranges[0].num_prbs - 20);
+  printf("    Slice 2: %d PRBs (was 10, added %d)\n",
+         result->ranges[1].num_prbs, result->ranges[1].num_prbs - 10);
+  printf("    Scale factor: 40/60 = 0.667\n");
+  printf("\n");
+  
+  ASSERT_EQ(ret, 0, "Should succeed");
+  ASSERT_EQ(allocated_prbs, 70, "Should allocate all remaining (40)");
+  ASSERT_EQ(remaining_prbs, 0, "No PRBs should remain");
+  // Proportional: 30/60 * 40 = 20 for slice 1, 30/60 * 40 = 20 for slice 2
+  ASSERT_EQ(result->ranges[0].num_prbs, 40, "Slice 1 should get 40 (20 + 20)");
+  ASSERT_EQ(result->ranges[1].num_prbs, 30, "Slice 2 should get 30 (10 + 20)");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+static void test_pass2_max_less_than_min(void) {
+  printf("  Purpose: Test Pass 2 when max < min (max takes precedence)\n");
+  printf("  Expected: Allocation capped at max, min not fully met\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(1, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.20f;
+  input->slices[0].min_prb_ratio = 0.50f; // Min = 50
+  input->slices[0].max_prb_ratio = 0.30f; // Max = 30 (< min!)
+  input->slices[0].required_prbs = 50;
+  
+  input->num_slices = 1;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration (after Pass 1):\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Already allocated (dedicated): 20 PRBs\n");
+  printf("    Remaining: 80 PRBs\n");
+  print_slice_config(&input->slices[0], 0);
+  printf("    Note: Max (30%%) < Min (50%%), so max takes precedence\n");
+  printf("          Slice needs prioritized to reach min=50, but max=30 caps allocation\n\n");
+  
+  // Result already zeroed by calloc
+  result->ranges[0].slice_id = input->slices[0].slice_id;
+  result->ranges[0].num_prbs = 20; // From Pass 1
+  
+  int allocated_prbs = 20;
+  int remaining_prbs = 80;
+  
+  int ret = pass2_allocate_prioritized(input, result, &allocated_prbs, &remaining_prbs);
+  
+  printf("  Pass 2 Result:\n");
+  printf("    Allocated PRBs: %d (was 20, added %d)\n", allocated_prbs, allocated_prbs - 20);
+  printf("    Remaining PRBs: %d\n", remaining_prbs);
+  printf("    Slice 1: %d PRBs (capped at max=30, min=50 not met)\n", result->ranges[0].num_prbs);
+  printf("\n");
+  
+  ASSERT_EQ(ret, 0, "Should succeed");
+  ASSERT_EQ(result->ranges[0].num_prbs, 30, "Should be capped at max (30)");
+  ASSERT_EQ(allocated_prbs, 30, "Total should be 30");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test Pass 3 Edge Cases */
+static void test_pass3_no_prb_requirements(void) {
+  printf("  Purpose: Test Pass 3 without PRB requirements\n");
+  printf("  Expected: No shared allocation (min alone does not activate Pass 3)\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.30f;
+  input->slices[0].min_prb_ratio = 0.30f;
+  input->slices[0].max_prb_ratio = 0.50f;
+  input->slices[0].required_prbs = 0; // No requirement
+  
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.20f;
+  input->slices[1].min_prb_ratio = 0.20f;
+  input->slices[1].max_prb_ratio = 0.50f;
+  input->slices[1].required_prbs = 0; // No requirement
+  
+  input->num_slices = 2;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration (after Pass 1+2):\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Already allocated: 50 PRBs\n");
+  printf("    Remaining (shared): 50 PRBs\n");
+  print_slice_config(&input->slices[0], 0);
+  print_slice_config(&input->slices[1], 1);
+  printf("    Note: required=0 for both slices — Pass 3 must not add PRBs\n\n");
+  
+  // Result already zeroed by calloc
+  for (int s = 0; s < input->num_slices; ++s) {
+    result->ranges[s].slice_id = input->slices[s].slice_id;
+  }
+  result->ranges[0].num_prbs = 30; // After Pass 1+2
+  result->ranges[1].num_prbs = 20; // After Pass 1+2
+  
+  int allocated_prbs = 50;
+  int remaining_prbs = 50; // Shared resources
+  
+  int ret = pass3_allocate_shared(input, result, &allocated_prbs, &remaining_prbs);
+  
+  printf("  Pass 3 Result (no demand):\n");
+  printf("    Allocated PRBs: %d (unchanged)\n", allocated_prbs);
+  printf("    Remaining PRBs: %d\n", remaining_prbs);
+  printf("    Slice 1: %d PRBs\n", result->ranges[0].num_prbs);
+  printf("    Slice 2: %d PRBs\n", result->ranges[1].num_prbs);
+  printf("\n");
+  
+  ASSERT_EQ(ret, 0, "Should succeed");
+  ASSERT_EQ(result->ranges[0].num_prbs, 30, "Slice 1 unchanged");
+  ASSERT_EQ(result->ranges[1].num_prbs, 20, "Slice 2 unchanged");
+  ASSERT_EQ(allocated_prbs, 50, "No Pass 3 allocation without require");
+  ASSERT_EQ(remaining_prbs, 50, "Shared pool left unallocated");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+static void test_pass3_all_slices_at_max(void) {
+  printf("  Purpose: Test Pass 3 when all slices are at max limit\n");
+  printf("  Expected: No allocation, remaining PRBs stay unallocated\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.50f;
+  input->slices[0].min_prb_ratio = 0.50f;
+  input->slices[0].max_prb_ratio = 0.50f;
+  
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.30f;
+  input->slices[1].min_prb_ratio = 0.30f;
+  input->slices[1].max_prb_ratio = 0.30f;
+  
+  input->num_slices = 2;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration (after Pass 1+2):\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Already allocated: 80 PRBs\n");
+  printf("    Remaining (shared): 20 PRBs\n");
+  print_slice_config(&input->slices[0], 0);
+  print_slice_config(&input->slices[1], 1);
+  printf("    Note: Both slices are already at their max limits\n");
+  printf("          Slice 1: 50 PRBs (at max=50%%)\n");
+  printf("          Slice 2: 30 PRBs (at max=30%%)\n\n");
+  
+  // Result already zeroed by calloc
+  for (int s = 0; s < input->num_slices; ++s) {
+    result->ranges[s].slice_id = input->slices[s].slice_id;
+  }
+  result->ranges[0].num_prbs = 50; // At max
+  result->ranges[1].num_prbs = 30; // At max
+  
+  int allocated_prbs = 80;
+  int remaining_prbs = 20; // But can't allocate (all at max)
+  
+  int ret = pass3_allocate_shared(input, result, &allocated_prbs, &remaining_prbs);
+  
+  printf("  Pass 3 Result:\n");
+  printf("    Allocated PRBs: %d (no change, all at max)\n", allocated_prbs);
+  printf("    Remaining PRBs: %d (cannot allocate, all slices at max)\n", remaining_prbs);
+  printf("    Slice 1: %d PRBs (at max, no change)\n", result->ranges[0].num_prbs);
+  printf("    Slice 2: %d PRBs (at max, no change)\n", result->ranges[1].num_prbs);
+  printf("\n");
+  
+  ASSERT_EQ(ret, 0, "Should succeed");
+  ASSERT_EQ(result->ranges[0].num_prbs, 50, "Slice 1 should stay at 50");
+  ASSERT_EQ(result->ranges[1].num_prbs, 30, "Slice 2 should stay at 30");
+  ASSERT_EQ(remaining_prbs, 20, "20 PRBs should remain (all slices at max)");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Test Pass 4 Edge Cases */
+static void test_pass4_empty_result(void) {
+  printf("  Purpose: Test Pass 4 with no PRBs allocated\n");
+  printf("  Expected: No ranges assigned, no errors\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(1, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->num_slices = 1;
+  
+  printf("  Input Configuration:\n");
+  printf("    Number of Slices: %d\n", input->num_slices);
+  printf("    Slice 1: 0 PRBs allocated\n");
+  printf("    Note: No PRBs allocated, so no ranges will be assigned\n\n");
+  
+  // No PRBs allocated (all slices have num_prbs = 0)
+  // Result already zeroed by calloc
+  result->ranges[0].slice_id = slice_nssai_from_int(1);
+  result->ranges[0].num_prbs = 0;
+  
+  int ret = pass4_assign_ranges(input, result);
+  
+  printf("  Pass 4 Result:\n");
+  printf("    Slice 1: [%d, %d) = %d PRBs (no range assigned, 0 PRBs)\n",
+         result->ranges[0].start_prb, result->ranges[0].end_prb, result->ranges[0].num_prbs);
+  printf("\n");
+  
+  ASSERT_EQ(ret, 0, "Should succeed");
+  ASSERT_EQ(result->ranges[0].start_prb, 0, "Start should be 0");
+  ASSERT_EQ(result->ranges[0].end_prb, 0, "End should be 0");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+static void test_pass4_single_slice(void) {
+  printf("  Purpose: Test Pass 4 with single slice\n");
+  printf("  Expected: Range [0, num_prbs)\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(1, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->num_slices = 1;
+  
+  printf("  Input Configuration:\n");
+  printf("    Number of Slices: %d\n", input->num_slices);
+  printf("    Slice 1: 100 PRBs allocated\n");
+  printf("    Note: Single slice gets all PRBs, range should be [0, 100)\n\n");
+  
+  result->ranges[0].slice_id = slice_nssai_from_int(1);
+  result->ranges[0].num_prbs = 100;
+  
+  int ret = pass4_assign_ranges(input, result);
+  
+  printf("  Pass 4 Result:\n");
+  printf("    Slice 1: [%d, %d) = %d PRBs\n",
+         result->ranges[0].start_prb, result->ranges[0].end_prb, result->ranges[0].num_prbs);
+  printf("\n");
+  
+  ASSERT_EQ(ret, 0, "Should succeed");
+  ASSERT_EQ(result->ranges[0].start_prb, 0, "Should start at 0");
+  ASSERT_EQ(result->ranges[0].end_prb, 100, "Should end at 100");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* Integration Edge Cases */
+static void test_integration_max_less_than_min(void) {
+  printf("  Purpose: Test full algorithm with max < min (edge case)\n");
+  printf("  Expected: Max takes precedence, min not fully met\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(1, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.20f;
+  input->slices[0].min_prb_ratio = 0.50f; // Min = 50
+  input->slices[0].max_prb_ratio = 0.30f; // Max = 30 (< min!)
+  input->slices[0].required_prbs = 50;
+  
+  input->num_slices = 1;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  print_slice_config(&input->slices[0], 0);
+  printf("    Note: Max (30%%) < Min (50%%), so max takes precedence\n\n");
+  
+  int ret = calculate_slice_prb_ranges(input, result);
+  
+  print_allocation_result_with_required(result, input, input->total_prbs);
+  printf("\n");
+  
+  ASSERT_EQ(ret, 1, "Should have 1 active slice");
+  ASSERT_EQ(result->ranges[0].num_prbs, 30, "Should be capped at max (30)");
+  ASSERT_EQ(result->total_allocated_prbs, 30, "Total should be 30");
+  ASSERT_EQ(result->ranges[0].start_prb, 0, "Should start at 0");
+  ASSERT_EQ(result->ranges[0].end_prb, 30, "Should end at 30");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+static void test_integration_all_slices_no_prioritized_need(void) {
+  printf("  Purpose: Test when all slices don't need prioritized resources\n");
+  printf("  Expected: Dedicated only; Pass 3 skipped when require < dedicated\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(2, input, result);
+  
+  input->slices[0].slice_id = slice_nssai_from_int(1);
+  input->slices[0].dedicated_prb_ratio = 0.20f;
+  input->slices[0].min_prb_ratio = 0.30f;
+  input->slices[0].max_prb_ratio = 0.50f;
+  input->slices[0].required_prbs = 15; // Less than dedicated (20)
+  
+  input->slices[1].slice_id = slice_nssai_from_int(2);
+  input->slices[1].dedicated_prb_ratio = 0.10f;
+  input->slices[1].min_prb_ratio = 0.25f;
+  input->slices[1].max_prb_ratio = 0.50f;
+  input->slices[1].required_prbs = 5; // Less than dedicated (10)
+  
+  input->num_slices = 2;
+  input->total_prbs = 100;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  print_slice_config(&input->slices[0], 0);
+  print_slice_config(&input->slices[1], 1);
+  printf("    Note: Both slices don't need prioritized resources\n");
+  printf("          Slice 1: required=15 < dedicated=20\n");
+  printf("          Slice 2: required=5 < dedicated=10\n");
+  printf("          Prioritized resources will go to Pass 3 as shared\n\n");
+  
+  int ret = calculate_slice_prb_ranges(input, result);
+  
+  print_allocation_result_with_required(result, input, input->total_prbs);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 2, "Should have 2 active slices");
+  // Pass 1: 20 + 10 = 30; Pass 2/3: require below dedicated → no extra PRBs
+  ASSERT_EQ(result->ranges[0].num_prbs, 20, "Slice 1 dedicated");
+  ASSERT_EQ(result->ranges[1].num_prbs, 10, "Slice 2 dedicated");
+  ASSERT_EQ(result->total_allocated_prbs, 30, "No idle Pass 3 allocation");
+free_slice_input(input);
+free_slice_result(result);
+
+}
+
+/* ============================================================================
+ * OOP Scheduler Interface Tests
+ * ============================================================================ */
+
+/* Test OOP: Basic two slices */
+static void test_oop_basic_two_slices(void) {
+  printf("  Purpose: Test OOP scheduler with basic two-slice allocation\n");
+  printf("  Expected: Dedicated PRBs only when require=0\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add slice 1: 30% dedicated, 30% min, 50% max
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.30f, 0.30f, 0.50f, 0), 0, "Should add slice 1");
+  
+  // Add slice 2: 20% dedicated, 20% min, 50% max
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.20f, 0.20f, 0.50f, 0), 0, "Should add slice 2");
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", sch->input->total_prbs);
+  printf("    Number of Slices: %d\n", sch->input->num_slices);
+  print_slice_config(&sch->input->slices[0], 0);
+  print_slice_config(&sch->input->slices[1], 1);
+  printf("\n");
+  
+  // Schedule
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  print_oop_allocation_result(sch, sch->input->total_prbs);
+  printf("\n");
+  
+  // Get allocation
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Allocation should be available");
+  
+  int num_active = 0;
+  int total_allocated = 0;
+  ASSERT_EQ(slice_sch_get_stats(sch, &num_active, &total_allocated), 0, "Get stats should succeed");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(num_active, 2, "Should have 2 active slices");
+  ASSERT_EQ(total_allocated, 50, "Only dedicated PRBs without require");
+  
+  // Find slices by ID
+  int slice1_idx = -1, slice2_idx = -1;
+  for (int i = 0; i < num_ranges; ++i) {
+    if (slice_nssai_eq_int(&ranges[i].slice_id, 1)) slice1_idx = i;
+    if (slice_nssai_eq_int(&ranges[i].slice_id, 2)) slice2_idx = i;
+  }
+  
+  ASSERT_TRUE(slice1_idx >= 0, "Slice 1 should be found");
+  ASSERT_TRUE(slice2_idx >= 0, "Slice 2 should be found");
+  
+  printf("    ✓ Slice 1: %d PRBs (expected: 30 dedicated)\n", ranges[slice1_idx].num_prbs);
+  ASSERT_EQ(ranges[slice1_idx].num_prbs, 30, "Slice 1 should get 30 dedicated PRBs");
+  
+  printf("    ✓ Slice 2: %d PRBs (expected: 20 dedicated)\n", ranges[slice2_idx].num_prbs);
+  ASSERT_EQ(ranges[slice2_idx].num_prbs, 20, "Slice 2 should get 20 dedicated PRBs");
+  
+  ASSERT_EQ(ranges[slice1_idx].num_prbs + ranges[slice2_idx].num_prbs, 50,
+            "Total PRBs should equal dedicated sum");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Add and delete slices */
+static void test_oop_add_delete_slices(void) {
+  printf("  Purpose: Test adding and deleting slices dynamically\n");
+  printf("  Expected: Slices can be added and removed, scheduling adapts\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add three slices
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.20f, 0.20f, 0.40f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.15f, 0.15f, 0.35f, 0), 0, "Should add slice 2");
+  ASSERT_EQ(slice_sch_add_slice(sch, 3, 0, 0.10f, 0.10f, 0.30f, 0), 0, "Should add slice 3");
+  
+  ASSERT_EQ(sch->input->num_slices, 3, "Should have 3 slices");
+  
+  // Schedule with 3 slices
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Allocation should be available");
+  
+  printf("  After adding 3 slices:\n");
+  print_oop_allocation_result(sch, sch->input->total_prbs);
+  printf("\n");
+  
+  // Delete slice 2
+  ASSERT_EQ(slice_sch_del_slice(sch, 2, 0), 0, "Should delete slice 2");
+  ASSERT_EQ(sch->input->num_slices, 2, "Should have 2 slices after deletion");
+  
+  // Schedule again
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed after deletion");
+  
+  ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Allocation should be available");
+  
+  printf("  After deleting slice 2:\n");
+  print_oop_allocation_result(sch, sch->input->total_prbs);
+  printf("\n");
+  
+  // Verify slice 2 is gone
+  int found_slice2 = 0;
+  for (int i = 0; i < num_ranges; ++i) {
+    if (slice_nssai_eq_int(&ranges[i].slice_id, 2)) {
+      found_slice2 = 1;
+      break;
+    }
+  }
+  ASSERT_EQ(found_slice2, 0, "Slice 2 should not be in allocation");
+  
+  // Verify slices 1 and 3 are still there
+  int found_slice1 = 0, found_slice3 = 0;
+  for (int i = 0; i < num_ranges; ++i) {
+    if (slice_nssai_eq_int(&ranges[i].slice_id, 1)) found_slice1 = 1;
+    if (slice_nssai_eq_int(&ranges[i].slice_id, 3)) found_slice3 = 1;
+  }
+  ASSERT_EQ(found_slice1, 1, "Slice 1 should still be present");
+  ASSERT_EQ(found_slice3, 1, "Slice 3 should still be present");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Slice 2 successfully removed\n");
+  printf("    ✓ Slices 1 and 3 still present\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Update requirements */
+static void test_oop_update_require(void) {
+  printf("  Purpose: Test updating PRB requirements for slices\n");
+  printf("  Expected: Updating requirements invalidates result, new schedule adapts\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add slice with no requirement
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.10f, 0.20f, 0.50f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.10f, 0.20f, 0.50f, 0), 0, "Should add slice 2");
+  
+  // Schedule
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  printf("  Initial allocation (no requirements):\n");
+  print_oop_allocation_result(sch, sch->input->total_prbs);
+  printf("\n");
+  
+  // Update requirement for slice 1
+  ASSERT_EQ(slice_sch_update_require(sch, 1, 0, 40), 0, "Should update requirement for slice 1");
+  
+  // Schedule again
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed after update");
+  
+  printf("  After updating slice 1 requirement to 40 PRBs:\n");
+  print_oop_allocation_result(sch, sch->input->total_prbs);
+  printf("\n");
+  
+  // Verify slice 1 gets more PRBs
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Allocation should be available");
+  
+  int slice1_idx = -1;
+  for (int i = 0; i < num_ranges; ++i) {
+    if (slice_nssai_eq_int(&ranges[i].slice_id, 1)) {
+      slice1_idx = i;
+      break;
+    }
+  }
+  
+  ASSERT_TRUE(slice1_idx >= 0, "Slice 1 should be found");
+  printf("  Verification:\n");
+  printf("    ✓ Slice 1 requirement updated to 40 PRBs\n");
+  printf("    ✓ Slice 1 allocated: %d PRBs\n", ranges[slice1_idx].num_prbs);
+  ASSERT_GE(ranges[slice1_idx].num_prbs, 20, "Slice 1 should get at least min (20 PRBs)");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Dynamic allocation (many slices) */
+static void test_oop_dynamic_allocation(void) {
+  printf("  Purpose: Test scheduler with many slices\n");
+  printf("  Expected: Scheduler can store and schedule any number of slices dynamically\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add many slices
+  int num_slices_to_add = 50;
+  for (int i = 0; i < num_slices_to_add; ++i) {
+    float ratio = 0.01f; // 1% each
+    ASSERT_EQ(slice_sch_add_slice(sch, i + 1, 0, ratio, ratio, ratio * 2, 0), 0,
+              "Should add slice");
+  }
+  
+  ASSERT_EQ(sch->input->num_slices, num_slices_to_add, "Should have all slices");
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", sch->input->total_prbs);
+  printf("    Number of Slices: %d\n", sch->input->num_slices);
+  printf("    (Showing first 5 slices)\n");
+  for (int i = 0; i < 5 && i < sch->input->num_slices; ++i) {
+    print_slice_config(&sch->input->slices[i], i);
+  }
+  printf("    ...\n\n");
+  
+  // Schedule
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Allocation should be available");
+  
+  int num_active = 0;
+  int total_allocated = 0;
+  slice_sch_get_stats(sch, &num_active, &total_allocated);
+  
+  printf("  Allocation Result:\n");
+  printf("    Active Slices: %d\n", num_active);
+  printf("    Total Allocated: %d / %d PRBs\n", total_allocated, sch->input->total_prbs);
+  printf("    (Showing first 5 allocations)\n");
+  for (int i = 0; i < 5 && i < num_ranges; ++i) {
+    if (ranges[i].num_prbs > 0) {
+      printf("      Slice (SST=%d, SD=%u): %d PRBs\n", ranges[i].slice_id.sst, ranges[i].slice_id.sd, ranges[i].num_prbs);
+    }
+  }
+  printf("    ...\n\n");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Successfully stored %d slices (dynamic allocation works)\n", num_slices_to_add);
+  printf("    ✓ Scheduling processed all %d slices (unlimited slices supported)\n", num_slices_to_add);
+  ASSERT_EQ(num_active, num_slices_to_add, "All slices should be active");
+  ASSERT_EQ(total_allocated, 50, "50 slices × 1%% dedicated without require");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Error handling */
+static void test_oop_error_handling(void) {
+  printf("  Purpose: Test error handling in OOP scheduler\n");
+  printf("  Expected: Proper error codes for invalid operations\n\n");
+  
+  // Test NULL scheduler
+  ASSERT_EQ(slice_sch_add_slice(NULL, 1, 0, 0.1f, 0.1f, 0.2f, 0), -1,
+            "Should fail with NULL scheduler");
+  ASSERT_EQ(slice_sch_del_slice(NULL, 1, 0), -1, "Should fail with NULL scheduler");
+  ASSERT_EQ(slice_sch_update_require(NULL, 1, 0, 10), -1, "Should fail with NULL scheduler");
+  ASSERT_EQ(slice_sch_schedule(NULL), -1, "Should fail with NULL scheduler");
+  ASSERT_TRUE(slice_sch_get_allocation(NULL, NULL) == NULL, "Should return NULL with NULL scheduler");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Test invalid total PRBs
+  slice_scheduler_t *sch_invalid = slice_sch_create(0);
+  ASSERT_TRUE(sch_invalid == NULL, "Should fail with invalid total PRBs");
+  sch_invalid = slice_sch_create(-1);
+  ASSERT_TRUE(sch_invalid == NULL, "Should fail with negative total PRBs");
+  
+  // Test duplicate slice ID (should update existing slice, not reject)
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.1f, 0.2f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(sch->input->num_slices, 1, "Should have 1 slice");
+  ASSERT_FLOAT_EQ(sch->input->slices[0].dedicated_prb_ratio, 0.1f, "Initial dedicated should be 0.1");
+  
+  // Add with same SST/SD - should update, not reject
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.2f, 0.2f, 0.3f, 10), 0,
+            "Should update existing slice with same SST/SD");
+  ASSERT_EQ(sch->input->num_slices, 1, "Should still have 1 slice (not duplicated)");
+  ASSERT_FLOAT_EQ(sch->input->slices[0].dedicated_prb_ratio, 0.2f, "Updated dedicated should be 0.2");
+  
+  // Test invalid ratios
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, -0.1f, 0.1f, 0.2f, 0), -1,
+            "Should fail with negative dedicated ratio");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.1f, 1.5f, 0.2f, 0), -1,
+            "Should fail with ratio > 1.0");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.3f, 0.1f, 0.2f, 0), -1,
+            "Should fail with dedicated > min");
+  
+  // Test invalid requirement
+  ASSERT_EQ(slice_sch_update_require(sch, 1, 0, -1), -1, "Should fail with negative requirement");
+  
+  // Test non-existent slice (delete is idempotent - returns success)
+  ASSERT_EQ(slice_sch_del_slice(sch, (uint8_t)999, 0), 0, "Should succeed with non-existent slice (idempotent)");
+  ASSERT_EQ(slice_sch_update_require(sch, (uint8_t)999, 0, 10), -1, "Should fail with non-existent slice");
+  
+  // Test get_allocation before schedule
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges == NULL, "Should return NULL before schedule");
+  
+  printf("  Verification:\n");
+  printf("    ✓ All error cases handled correctly\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Initial capacity */
+static void test_oop_initial_capacity(void) {
+  printf("  Purpose: Test that scheduler starts with MIN_CAPACITY (8)\n");
+  printf("  Expected: Initial capacity should be 8\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  printf("  Verification:\n");
+  printf("    Initial capacity: %d\n", sch->slices_capacity);
+  ASSERT_EQ(sch->slices_capacity, 8, "Initial capacity should be MIN_CAPACITY (8)");
+  ASSERT_EQ(sch->input->num_slices, 0, "Should start with 0 slices");
+  printf("    ✓ Initial capacity is correct\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Array growth */
+static void test_oop_array_growth(void) {
+  printf("  Purpose: Test that array grows when adding many slices\n");
+  printf("  Expected: Capacity doubles when full, starting from 8\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  printf("  Adding slices to trigger growth:\n");
+  printf("    Initial capacity: %d\n", sch->slices_capacity);
+  
+  // Add 8 slices (should fit in initial capacity)
+  for (int i = 0; i < 8; ++i) {
+    ASSERT_EQ(slice_sch_add_slice(sch, i + 1, 0, 0.05f, 0.05f, 0.10f, 0), 0,
+              "Should add slice");
+  }
+  printf("    After adding 8 slices: capacity=%d, num_slices=%d\n",
+         sch->slices_capacity, sch->input->num_slices);
+  ASSERT_EQ(sch->slices_capacity, 8, "Capacity should still be 8");
+  ASSERT_EQ(sch->input->num_slices, 8, "Should have 8 slices");
+  
+  // Add one more (should trigger growth to 16)
+  ASSERT_EQ(slice_sch_add_slice(sch, 9, 0, 0.05f, 0.05f, 0.10f, 0), 0,
+            "Should add 9th slice");
+  printf("    After adding 9th slice: capacity=%d, num_slices=%d\n",
+         sch->slices_capacity, sch->input->num_slices);
+  ASSERT_EQ(sch->slices_capacity, 16, "Capacity should double to 16");
+  ASSERT_EQ(sch->input->num_slices, 9, "Should have 9 slices");
+  
+  // Add more to trigger another growth (to 32)
+  for (int i = 9; i < 16; ++i) {
+    ASSERT_EQ(slice_sch_add_slice(sch, i + 1, 0, 0.05f, 0.05f, 0.10f, 0), 0,
+              "Should add slice");
+  }
+  printf("    After adding 16th slice: capacity=%d, num_slices=%d\n",
+         sch->slices_capacity, sch->input->num_slices);
+  ASSERT_EQ(sch->slices_capacity, 16, "Capacity should still be 16");
+  
+  // Add one more to trigger growth to 32
+  ASSERT_EQ(slice_sch_add_slice(sch, 17, 0, 0.05f, 0.05f, 0.10f, 0), 0,
+            "Should add 17th slice");
+  printf("    After adding 17th slice: capacity=%d, num_slices=%d\n",
+         sch->slices_capacity, sch->input->num_slices);
+  ASSERT_EQ(sch->slices_capacity, 32, "Capacity should double to 32");
+  ASSERT_EQ(sch->input->num_slices, 17, "Should have 17 slices");
+  
+  printf("\n  Verification:\n");
+  printf("    ✓ Array grows correctly: 8 -> 16 -> 32\n");
+  printf("    ✓ Growth happens when capacity is reached\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Array shrinking */
+static void test_oop_array_shrinking(void) {
+  printf("  Purpose: Test that array shrinks when capacity is much larger than needed\n");
+  printf("  Expected: Capacity halves when using <25%% of capacity, but not below MIN_CAPACITY\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Grow array to 32 by adding 17 slices
+  for (int i = 0; i < 17; ++i) {
+    ASSERT_EQ(slice_sch_add_slice(sch, i + 1, 0, 0.05f, 0.05f, 0.10f, 0), 0,
+              "Should add slice");
+  }
+  printf("  After adding 17 slices:\n");
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  ASSERT_EQ(sch->slices_capacity, 32, "Capacity should be 32");
+  ASSERT_EQ(sch->input->num_slices, 17, "Should have 17 slices");
+  
+  // Delete slices until we're using <25% of capacity (32 * 0.25 = 8)
+  // We need to delete down to 7 or fewer slices to trigger shrinking
+  printf("\n  Deleting slices to trigger shrinking:\n");
+  for (int i = 17; i > 7; --i) {
+    ASSERT_EQ(slice_sch_del_slice(sch, i, 0), 0, "Should delete slice");
+  }
+  printf("    After deleting down to 7 slices: capacity=%d, num_slices=%d\n",
+         sch->slices_capacity, sch->input->num_slices);
+  // Should shrink: 32 -> 16 (since 7 < 32/4 = 8)
+  ASSERT_EQ(sch->slices_capacity, 16, "Capacity should shrink to 16");
+  ASSERT_EQ(sch->input->num_slices, 7, "Should have 7 slices");
+  
+  // Delete more to trigger another shrink
+  for (int i = 7; i > 3; --i) {
+    ASSERT_EQ(slice_sch_del_slice(sch, i, 0), 0, "Should delete slice");
+  }
+  printf("    After deleting down to 3 slices: capacity=%d, num_slices=%d\n",
+         sch->slices_capacity, sch->input->num_slices);
+  // Should shrink: 16 -> 8 (since 3 < 16/4 = 4, and 8 >= MIN_CAPACITY)
+  ASSERT_EQ(sch->slices_capacity, 8, "Capacity should shrink to 8 (MIN_CAPACITY)");
+  ASSERT_EQ(sch->input->num_slices, 3, "Should have 3 slices");
+  
+  // Delete one more - should NOT shrink below MIN_CAPACITY
+  ASSERT_EQ(slice_sch_del_slice(sch, 2, 0), 0, "Should delete slice");
+  printf("    After deleting down to 2 slices: capacity=%d, num_slices=%d\n",
+         sch->slices_capacity, sch->input->num_slices);
+  // Should NOT shrink: 2 < 8/4 = 2, but capacity is already MIN_CAPACITY
+  ASSERT_EQ(sch->slices_capacity, 8, "Capacity should stay at MIN_CAPACITY (8)");
+  ASSERT_EQ(sch->input->num_slices, 2, "Should have 2 slices");
+  
+  printf("\n  Verification:\n");
+  printf("    ✓ Array shrinks correctly: 32 -> 16 -> 8\n");
+  printf("    ✓ Shrinking happens when using <25%% of capacity\n");
+  printf("    ✓ Does not shrink below MIN_CAPACITY (8)\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: No shrinking when num_slices would exceed new capacity */
+static void test_oop_no_shrink_below_num_slices(void) {
+  printf("  Purpose: Test that array doesn't shrink if new capacity would be < num_slices\n");
+  printf("  Expected: Capacity should not shrink below num_slices\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Grow to capacity 16 by adding 9 slices
+  for (int i = 0; i < 9; ++i) {
+    ASSERT_EQ(slice_sch_add_slice(sch, i + 1, 0, 0.05f, 0.05f, 0.10f, 0), 0,
+              "Should add slice");
+  }
+  printf("  After adding 9 slices:\n");
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  ASSERT_EQ(sch->slices_capacity, 16, "Capacity should be 16");
+  ASSERT_EQ(sch->input->num_slices, 9, "Should have 9 slices");
+  
+  // Delete down to 9 slices (no change)
+  // Now delete to 5 slices
+  // 5 < 16/4 = 4? No, 5 >= 4, so should NOT shrink
+  for (int i = 9; i > 5; --i) {
+    ASSERT_EQ(slice_sch_del_slice(sch, i, 0), 0, "Should delete slice");
+  }
+  printf("\n  After deleting down to 5 slices:\n");
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  // 5 >= 16/4 = 4, so should NOT shrink
+  ASSERT_EQ(sch->slices_capacity, 16, "Capacity should stay at 16 (5 >= 16/4)");
+  ASSERT_EQ(sch->input->num_slices, 5, "Should have 5 slices");
+  
+  // Delete one more to 4 slices
+  // 4 < 16/4 = 4? No, 4 == 4, so should NOT shrink (needs to be < 25%)
+  ASSERT_EQ(slice_sch_del_slice(sch, 5, 0), 0, "Should delete slice");
+  printf("  After deleting down to 4 slices:\n");
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  // 4 == 16/4 = 4, so should NOT shrink (needs to be strictly < 25%)
+  ASSERT_EQ(sch->slices_capacity, 16, "Capacity should stay at 16 (4 == 16/4, not <)");
+  ASSERT_EQ(sch->input->num_slices, 4, "Should have 4 slices");
+  
+  // Delete one more to 3 slices
+  // 3 < 16/4 = 4, so should shrink to 8
+  // But 8 >= 3, so it's valid
+  ASSERT_EQ(slice_sch_del_slice(sch, 4, 0), 0, "Should delete slice");
+  printf("  After deleting down to 3 slices:\n");
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  // 3 < 16/4 = 4, so should shrink to 8
+  ASSERT_EQ(sch->slices_capacity, 8, "Capacity should shrink to 8");
+  ASSERT_EQ(sch->input->num_slices, 3, "Should have 3 slices");
+  
+  printf("\n  Verification:\n");
+  printf("    ✓ Does not shrink when num_slices >= 25%% of capacity\n");
+  printf("    ✓ Shrinks only when num_slices < 25%% of capacity\n");
+  printf("    ✓ New capacity is always >= num_slices\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Add slice at exact capacity boundary */
+static void test_oop_add_at_capacity_boundary(void) {
+  printf("  Purpose: Test adding slice when exactly at capacity\n");
+  printf("  Expected: Capacity should double before adding\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Fill to exact capacity (initial capacity is 8)
+  int initial_capacity = sch->slices_capacity;
+  for (int i = 1; i <= initial_capacity; ++i) {
+    ASSERT_EQ(slice_sch_add_slice(sch, i, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice");
+  }
+  
+  printf("  After adding %d slices (at capacity):\n", initial_capacity);
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  ASSERT_EQ(sch->slices_capacity, initial_capacity, "Should be at initial capacity");
+  ASSERT_EQ(sch->input->num_slices, initial_capacity, "Should have 8 slices");
+  
+  // Add one more - should trigger growth
+  ASSERT_EQ(slice_sch_add_slice(sch, initial_capacity + 1, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice");
+  
+  printf("  After adding one more slice (should grow):\n");
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  ASSERT_EQ(sch->slices_capacity, initial_capacity * 2, "Capacity should double");
+  ASSERT_EQ(sch->input->num_slices, initial_capacity + 1, "Should have 9 slices");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Capacity doubles when adding at boundary\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Delete all slices */
+static void test_oop_delete_all_slices(void) {
+  printf("  Purpose: Test deleting all slices from scheduler\n");
+  printf("  Expected: Scheduler should handle empty state correctly\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add some slices
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice 2");
+  ASSERT_EQ(slice_sch_add_slice(sch, 3, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice 3");
+  
+  printf("  After adding 3 slices:\n");
+  printf("    Num slices: %d\n", sch->input->num_slices);
+  ASSERT_EQ(sch->input->num_slices, 3, "Should have 3 slices");
+  
+  // Delete all slices
+  ASSERT_EQ(slice_sch_del_slice(sch, 1, 0), 0, "Should delete slice 1");
+  ASSERT_EQ(slice_sch_del_slice(sch, 2, 0), 0, "Should delete slice 2");
+  ASSERT_EQ(slice_sch_del_slice(sch, 3, 0), 0, "Should delete slice 3");
+  
+  printf("  After deleting all slices:\n");
+  printf("    Num slices: %d\n", sch->input->num_slices);
+  ASSERT_EQ(sch->input->num_slices, 0, "Should have 0 slices");
+  
+  // Schedule should work with empty slices
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed with 0 slices");
+  
+  int num_active = 0;
+  int total_allocated = 0;
+  ASSERT_EQ(slice_sch_get_stats(sch, &num_active, &total_allocated), 0, "Should get stats");
+  ASSERT_EQ(num_active, 0, "Should have 0 active slices");
+  ASSERT_EQ(total_allocated, 0, "Should have 0 allocated PRBs");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Can delete all slices\n");
+  printf("    ✓ Scheduler handles empty state correctly\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Update existing slice */
+static void test_oop_update_existing_slice(void) {
+  printf("  Purpose: Test updating an existing slice with same SST/SD\n");
+  printf("  Expected: Should update parameters instead of adding duplicate\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add initial slice
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 10), 0, "Should add slice 1");
+  ASSERT_EQ(sch->input->num_slices, 1, "Should have 1 slice");
+  
+  // Verify initial parameters
+  ASSERT_FLOAT_EQ(sch->input->slices[0].dedicated_prb_ratio, 0.1f, "Initial dedicated should be 0.1");
+  ASSERT_FLOAT_EQ(sch->input->slices[0].min_prb_ratio, 0.2f, "Initial min should be 0.2");
+  ASSERT_FLOAT_EQ(sch->input->slices[0].max_prb_ratio, 0.5f, "Initial max should be 0.5");
+  ASSERT_EQ(sch->input->slices[0].required_prbs, 10, "Initial required_prbs should be 10");
+  
+  // Schedule multiple times to generate some statistics
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "First schedule should succeed");
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Second schedule should succeed");
+  
+  // Get statistics before update
+  slice_statistics_t stats_before;
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 1, 0, &stats_before), 0, "Should get stats for slice 1");
+  int sample_count_before = stats_before.sample_count;
+  float avg_num_prbs_before = stats_before.avg_num_prbs;
+  
+  // Verify we have some statistics
+  ASSERT_GT(sample_count_before, 0, "Should have some statistics before update");
+  
+  // Update the slice with new parameters (same SST/SD)
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.2f, 0.3f, 0.6f, 20), 0, "Should update slice 1");
+  ASSERT_EQ(sch->input->num_slices, 1, "Should still have only 1 slice (not duplicated)");
+  
+  // Verify updated parameters
+  ASSERT_FLOAT_EQ(sch->input->slices[0].dedicated_prb_ratio, 0.2f, "Updated dedicated should be 0.2");
+  ASSERT_FLOAT_EQ(sch->input->slices[0].min_prb_ratio, 0.3f, "Updated min should be 0.3");
+  ASSERT_FLOAT_EQ(sch->input->slices[0].max_prb_ratio, 0.6f, "Updated max should be 0.6");
+  ASSERT_EQ(sch->input->slices[0].required_prbs, 20, "Updated required_prbs should be 20");
+  
+  // Verify statistics are preserved (not reset)
+  slice_statistics_t stats_after;
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 1, 0, &stats_after), 0, "Should get stats for slice 1 after update");
+  ASSERT_EQ(stats_after.sample_count, sample_count_before, "Statistics sample count should be preserved");
+  ASSERT_FLOAT_EQ(stats_after.avg_num_prbs, avg_num_prbs_before, "Statistics average should be preserved");
+  
+  // Verify result is invalidated (need to reschedule)
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  // Result should still be valid from previous schedule, but let's reschedule to get new allocation
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Reschedule should succeed after update");
+  ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Allocation should be available after reschedule");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Slice parameters are updated when adding with same SST/SD\n");
+  printf("    ✓ Slice count remains the same (no duplicate added)\n");
+  printf("    ✓ Statistics are preserved during update\n");
+  printf("    ✓ Result is invalidated after update\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Update slice with different SD */
+static void test_oop_update_slice_with_different_sd(void) {
+  printf("  Purpose: Test that slices with same SST but different SD are treated separately\n");
+  printf("  Expected: Should add as new slice, not update\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add slice with SST=1, SD=0
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 10), 0, "Should add slice (SST=1, SD=0)");
+  ASSERT_EQ(sch->input->num_slices, 1, "Should have 1 slice");
+  
+  // Add slice with SST=1, SD=1 (different SD, should be new slice)
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 1, 0.2f, 0.3f, 0.6f, 20), 0, "Should add new slice (SST=1, SD=1)");
+  ASSERT_EQ(sch->input->num_slices, 2, "Should have 2 slices (different SD)");
+  
+  // Update slice with SST=1, SD=0 (should update first slice)
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.15f, 0.25f, 0.55f, 15), 0, "Should update slice (SST=1, SD=0)");
+  ASSERT_EQ(sch->input->num_slices, 2, "Should still have 2 slices");
+  
+  // Verify first slice was updated
+  ASSERT_FLOAT_EQ(sch->input->slices[0].dedicated_prb_ratio, 0.15f, "First slice dedicated should be updated");
+  ASSERT_FLOAT_EQ(sch->input->slices[0].min_prb_ratio, 0.25f, "First slice min should be updated");
+  
+  // Verify second slice was not affected
+  ASSERT_FLOAT_EQ(sch->input->slices[1].dedicated_prb_ratio, 0.2f, "Second slice dedicated should be unchanged");
+  ASSERT_FLOAT_EQ(sch->input->slices[1].min_prb_ratio, 0.3f, "Second slice min should be unchanged");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Slices with same SST but different SD are treated separately\n");
+  printf("    ✓ Update only affects the slice with matching SST and SD\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Invalid ratio values */
+static void test_oop_invalid_ratios(void) {
+  printf("  Purpose: Test adding slice with invalid ratio values\n");
+  printf("  Expected: Should reject invalid ratios\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Test negative dedicated
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, -0.1f, 0.2f, 0.5f, 0), -1, "Should reject negative dedicated");
+  
+  // Test > 1.0 dedicated
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 1.5f, 0.2f, 0.5f, 0), -1, "Should reject dedicated > 1.0");
+  
+  // Test negative min
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, -0.2f, 0.5f, 0), -1, "Should reject negative min");
+  
+  // Test > 1.0 max
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 1.5f, 0), -1, "Should reject max > 1.0");
+  
+  // Test dedicated > min (invalid relationship)
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.3f, 0.2f, 0.5f, 0), -1, "Should reject dedicated > min");
+  
+  // Test dedicated > max (when max < min, dedicated should be <= max)
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.3f, 0.5f, 0.2f, 0), -1, "Should reject dedicated > max when max < min");
+  
+  printf("  Verification:\n");
+  printf("    ✓ All invalid ratio values are rejected\n");
+  ASSERT_EQ(sch->input->num_slices, 0, "Should have 0 slices");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Invalid require value */
+static void test_oop_invalid_require(void) {
+  printf("  Purpose: Test adding/updating with invalid require value\n");
+  printf("  Expected: Should reject negative require\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Test negative require in add
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, -10), -1, "Should reject negative require");
+  
+  // Add valid slice first
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice");
+  
+  // Test negative require in update
+  ASSERT_EQ(slice_sch_update_require(sch, 1, 0, -5), -1, "Should reject negative require in update");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Negative require values are rejected\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Update require for non-existent slice */
+static void test_oop_update_nonexistent_slice(void) {
+  printf("  Purpose: Test updating require for non-existent slice\n");
+  printf("  Expected: Should return error\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_update_require(sch, (uint8_t)999, 0, 50), -1, "Should reject update for non-existent slice");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Update for non-existent slice is rejected\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Delete non-existent slice */
+static void test_oop_delete_nonexistent_slice(void) {
+  printf("  Purpose: Test deleting non-existent slice (idempotent behavior)\n");
+  printf("  Expected: Should return success (idempotent operation)\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Delete non-existent slice - should succeed (idempotent)
+  ASSERT_EQ(slice_sch_del_slice(sch, (uint8_t)999, 0), 0, "Should succeed for non-existent slice (idempotent)");
+  ASSERT_EQ(sch->input->num_slices, 0, "Should still have 0 slices");
+  
+  // Add a slice and verify it exists
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(sch->input->num_slices, 1, "Should have 1 slice");
+  
+  // Delete it
+  ASSERT_EQ(slice_sch_del_slice(sch, 1, 0), 0, "Should delete slice 1");
+  ASSERT_EQ(sch->input->num_slices, 0, "Should have 0 slices after deletion");
+  
+  // Delete again - should still succeed (idempotent)
+  ASSERT_EQ(slice_sch_del_slice(sch, 1, 0), 0, "Should succeed deleting already-deleted slice (idempotent)");
+  ASSERT_EQ(sch->input->num_slices, 0, "Should still have 0 slices");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Delete for non-existent slice returns success (idempotent)\n");
+  printf("    ✓ Multiple deletes of same slice are safe (idempotent)\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Get allocation before scheduling */
+static void test_oop_get_allocation_before_schedule(void) {
+  printf("  Purpose: Test getting allocation before calling schedule\n");
+  printf("  Expected: Should return NULL\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice");
+  
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges == NULL, "Should return NULL before schedule");
+  
+  int num_active = 0;
+  int total_allocated = 0;
+  ASSERT_EQ(slice_sch_get_stats(sch, &num_active, &total_allocated), -1, "Should return error before schedule");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Get allocation before schedule returns NULL\n");
+  printf("    ✓ Get stats before schedule returns error\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Boundary ratio values (0.0 and 1.0) */
+static void test_oop_boundary_ratios(void) {
+  printf("  Purpose: Test adding slices with boundary ratio values (0.0, 1.0)\n");
+  printf("  Expected: Should accept valid boundary values\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Test all zeros (valid)
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.0f, 0.0f, 1.0f, 0), 0, "Should accept all zeros");
+  
+  // Test all at 1.0 (valid)
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.0f, 1.0f, 1.0f, 0), 0, "Should accept max at 1.0");
+  
+  // Test exact 1.0 dedicated (valid if min >= 1.0)
+  ASSERT_EQ(slice_sch_add_slice(sch, 3, 0, 0.0f, 1.0f, 1.0f, 0), 0, "Should accept dedicated 0.0 with min 1.0");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Boundary ratio values (0.0, 1.0) are accepted\n");
+  ASSERT_EQ(sch->input->num_slices, 3, "Should have 3 slices");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - NULL scheduler operations */
+static void test_oop_null_scheduler_operations(void) {
+  printf("  Purpose: Test operations on NULL scheduler\n");
+  printf("  Expected: All should return error or handle gracefully\n\n");
+  
+  // Test all operations with NULL
+  ASSERT_EQ(slice_sch_add_slice(NULL, 1, 0, 0.1f, 0.2f, 0.5f, 0), -1, "Should reject NULL scheduler");
+  ASSERT_EQ(slice_sch_del_slice(NULL, 1, 0), -1, "Should reject NULL scheduler");
+  ASSERT_EQ(slice_sch_update_require(NULL, 1, 0, 50), -1, "Should reject NULL scheduler");
+  ASSERT_EQ(slice_sch_schedule(NULL), -1, "Should reject NULL scheduler");
+  
+  int num_ranges = 0;
+  ASSERT_TRUE(slice_sch_get_allocation(NULL, &num_ranges) == NULL, "Should return NULL for NULL scheduler");
+  
+  int num_active = 0;
+  int total_allocated = 0;
+  ASSERT_EQ(slice_sch_get_stats(NULL, &num_active, &total_allocated), -1, "Should reject NULL scheduler");
+  
+  // Destroy NULL should be safe (no-op)
+  slice_sch_destroy(NULL);
+  
+  printf("  Verification:\n");
+  printf("    ✓ All operations handle NULL scheduler gracefully\n");
+}
+
+/* Test OOP: Edge case - Invalid total_prbs in create */
+static void test_oop_invalid_total_prbs(void) {
+  printf("  Purpose: Test creating scheduler with invalid total_prbs\n");
+  printf("  Expected: Should return NULL\n\n");
+  
+  slice_scheduler_t *sch1 = slice_sch_create(0);
+  ASSERT_TRUE(sch1 == NULL, "Should reject total_prbs = 0");
+  
+  slice_scheduler_t *sch2 = slice_sch_create(-10);
+  ASSERT_TRUE(sch2 == NULL, "Should reject negative total_prbs");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Invalid total_prbs values are rejected\n");
+}
+
+/* Test OOP: Edge case - Capacity at exact shrink threshold */
+static void test_oop_capacity_at_shrink_threshold(void) {
+  printf("  Purpose: Test capacity behavior at exact 25%% threshold\n");
+  printf("  Expected: Should not shrink at exactly 25%%, only when < 25%%\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Grow to 16 capacity (add 9 slices to go from 8 to 16)
+  for (int i = 1; i <= 9; ++i) {
+    ASSERT_EQ(slice_sch_add_slice(sch, i, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice");
+  }
+  
+  printf("  After adding 9 slices:\n");
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  ASSERT_EQ(sch->slices_capacity, 16, "Capacity should be 16");
+  ASSERT_EQ(sch->input->num_slices, 9, "Should have 9 slices");
+  
+  // Delete down to exactly 4 (which is 16/4 = 25%)
+  for (int i = 9; i >= 5; --i) {
+    ASSERT_EQ(slice_sch_del_slice(sch, i, 0), 0, "Should delete slice");
+  }
+  
+  printf("  After deleting down to 4 slices (exactly 25%%):\n");
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  ASSERT_EQ(sch->slices_capacity, 16, "Should NOT shrink at exactly 25%");
+  ASSERT_EQ(sch->input->num_slices, 4, "Should have 4 slices");
+  
+  // Delete one more to 3 (< 25%)
+  ASSERT_EQ(slice_sch_del_slice(sch, 4, 0), 0, "Should delete slice");
+  
+  printf("  After deleting down to 3 slices (< 25%%):\n");
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  ASSERT_EQ(sch->slices_capacity, 8, "Should shrink to 8");
+  ASSERT_EQ(sch->input->num_slices, 3, "Should have 3 slices");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Does not shrink at exactly 25%% threshold\n");
+  printf("    ✓ Shrinks only when strictly < 25%%\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Multiple rapid add/delete operations */
+static void test_oop_rapid_add_delete(void) {
+  printf("  Purpose: Test rapid sequence of add/delete operations\n");
+  printf("  Expected: Should handle correctly without corruption\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Rapid add/delete sequence
+  for (int i = 1; i <= 20; ++i) {
+    ASSERT_EQ(slice_sch_add_slice(sch, i, 0, 0.05f, 0.05f, 0.10f, 0), 0, "Should add slice");
+    if (i % 3 == 0) {
+      ASSERT_EQ(slice_sch_del_slice(sch, i - 1, 0), 0, "Should delete slice");
+    }
+  }
+  
+  printf("  After rapid add/delete sequence:\n");
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  
+  // Schedule should still work
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  int num_active = 0;
+  int total_allocated = 0;
+  ASSERT_EQ(slice_sch_get_stats(sch, &num_active, &total_allocated), 0, "Should get stats");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Rapid add/delete operations handled correctly\n");
+  printf("    ✓ Scheduler remains functional after rapid operations\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Edge case - Schedule after delete without re-schedule */
+static void test_oop_schedule_after_delete(void) {
+  printf("  Purpose: Test scheduling after delete (result should be invalidated)\n");
+  printf("  Expected: Result should be invalidated, new schedule should work\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice 2");
+  
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  // Delete a slice - should invalidate result
+  ASSERT_EQ(slice_sch_del_slice(sch, 1, 0), 0, "Should delete slice 1");
+  
+  // Get allocation should fail (result invalidated)
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges == NULL, "Should return NULL after delete (result invalidated)");
+  
+  // Re-schedule should work
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Re-schedule should succeed");
+  
+  ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Should return valid allocation after re-schedule");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Result is invalidated after delete\n");
+  printf("    ✓ Re-schedule works correctly after delete\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Statistics - Initial state */
+static void test_oop_statistics_initial_state(void) {
+  printf("  Purpose: Test statistics initialization when adding slices\n");
+  printf("  Expected: Statistics should be initialized to zero\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice 2");
+  
+  slice_statistics_t stats1, stats2;
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 1, 0, &stats1), 0, "Should get stats for slice 1");
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 2, 0, &stats2), 0, "Should get stats for slice 2");
+  
+  printf("  Initial statistics:\n");
+  printf("    Slice (SST=%d, SD=%u): latest=(%d,%d,%d), avg=(%.1f,%.1f,%.1f), samples=%d\n",
+         stats1.slice_id.sst, stats1.slice_id.sd,
+         stats1.latest_start_prb, stats1.latest_end_prb, stats1.latest_num_prbs,
+         stats1.avg_start_prb, stats1.avg_end_prb, stats1.avg_num_prbs, stats1.sample_count);
+  
+  ASSERT_EQ(stats1.slice_id.sst, 1, "Slice ID SST should be 1");
+  ASSERT_EQ(stats1.slice_id.sd, 0, "Slice ID SD should be 0");
+  ASSERT_EQ(stats1.latest_start_prb, 0, "Latest start should be 0");
+  ASSERT_EQ(stats1.latest_end_prb, 0, "Latest end should be 0");
+  ASSERT_EQ(stats1.latest_num_prbs, 0, "Latest num_prbs should be 0");
+  ASSERT_FLOAT_EQ(stats1.avg_start_prb, 0.0f, "Avg start should be 0");
+  ASSERT_FLOAT_EQ(stats1.avg_end_prb, 0.0f, "Avg end should be 0");
+  ASSERT_FLOAT_EQ(stats1.avg_num_prbs, 0.0f, "Avg num_prbs should be 0");
+  ASSERT_EQ(stats1.sample_count, 0, "Sample count should be 0");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Statistics initialized to zero\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Statistics - Update after schedule */
+static void test_oop_statistics_after_schedule(void) {
+  printf("  Purpose: Test statistics update after scheduling\n");
+  printf("  Expected: Latest values should match allocation, averages should be initialized\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.0f, 0.2f, 0.5f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.0f, 0.3f, 0.5f, 0), 0, "Should add slice 2");
+  
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  slice_statistics_t stats1, stats2;
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 1, 0, &stats1), 0, "Should get stats for slice 1");
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 2, 0, &stats2), 0, "Should get stats for slice 2");
+  
+  printf("  Statistics after first schedule:\n");
+  printf("    Slice 1: latest=(%d,%d,%d), avg=(%.1f,%.1f,%.1f), samples=%d\n",
+         stats1.latest_start_prb, stats1.latest_end_prb, stats1.latest_num_prbs,
+         stats1.avg_start_prb, stats1.avg_end_prb, stats1.avg_num_prbs, stats1.sample_count);
+  printf("    Slice 2: latest=(%d,%d,%d), avg=(%.1f,%.1f,%.1f), samples=%d\n",
+         stats2.latest_start_prb, stats2.latest_end_prb, stats2.latest_num_prbs,
+         stats2.avg_start_prb, stats2.avg_end_prb, stats2.avg_num_prbs, stats2.sample_count);
+  
+  // Get allocation to compare
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Allocation should be available");
+  
+  // Find slice 1 in ranges
+  int slice1_start = -1, slice1_end = -1, slice1_num = -1;
+  for (int i = 0; i < num_ranges; ++i) {
+    if (slice_nssai_eq_int(&ranges[i].slice_id, 1)) {
+      slice1_start = ranges[i].start_prb;
+      slice1_end = ranges[i].end_prb;
+      slice1_num = ranges[i].num_prbs;
+      break;
+    }
+  }
+  
+  ASSERT_GE(slice1_start, 0, "Slice 1 should have allocation");
+  ASSERT_EQ(stats1.latest_start_prb, slice1_start, "Latest start should match allocation");
+  ASSERT_EQ(stats1.latest_end_prb, slice1_end, "Latest end should match allocation");
+  ASSERT_EQ(stats1.latest_num_prbs, slice1_num, "Latest num_prbs should match allocation");
+  
+  // After first sample, averages should equal latest values
+  ASSERT_FLOAT_EQ(stats1.avg_start_prb, (float)slice1_start, "Avg start should equal latest (first sample)");
+  ASSERT_FLOAT_EQ(stats1.avg_end_prb, (float)slice1_end, "Avg end should equal latest (first sample)");
+  ASSERT_FLOAT_EQ(stats1.avg_num_prbs, (float)slice1_num, "Avg num_prbs should equal latest (first sample)");
+  ASSERT_EQ(stats1.sample_count, 1, "Sample count should be 1");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Latest values match allocation\n");
+  printf("    ✓ Averages initialized to latest values (first sample)\n");
+  printf("    ✓ Sample count incremented\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Statistics - Moving average calculation */
+static void test_oop_statistics_moving_average(void) {
+  printf("  Purpose: Test moving average calculation across multiple schedules\n");
+  printf("  Expected: Averages should smooth out using EMA (alpha=0.1)\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.0f, 0.2f, 0.5f, 0), 0, "Should add slice 1");
+  
+  // First schedule
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  slice_statistics_t stats;
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 1, 0, &stats), 0, "Should get stats");
+  
+  int first_num = stats.latest_num_prbs;
+  float first_avg = stats.avg_num_prbs;
+  
+  printf("  After first schedule:\n");
+  printf("    Latest: %d PRBs, Avg: %.1f PRBs, Samples: %d\n", 
+         first_num, first_avg, stats.sample_count);
+  
+  // Update requirement to change allocation
+  ASSERT_EQ(slice_sch_update_require(sch, 1, 0, 30), 0, "Should update requirement");
+  
+  // Second schedule
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 1, 0, &stats), 0, "Should get stats");
+  
+  int second_num = stats.latest_num_prbs;
+  float second_avg = stats.avg_num_prbs;
+  
+  printf("  After second schedule:\n");
+  printf("    Latest: %d PRBs, Avg: %.1f PRBs, Samples: %d\n", 
+         second_num, second_avg, stats.sample_count);
+  
+  // Third schedule
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 1, 0, &stats), 0, "Should get stats");
+  
+  int third_num = stats.latest_num_prbs;
+  float third_avg = stats.avg_num_prbs;
+  
+  printf("  After third schedule:\n");
+  printf("    Latest: %d PRBs, Avg: %.1f PRBs, Samples: %d\n", 
+         third_num, third_avg, stats.sample_count);
+  
+  // Verify moving average calculation
+  // EMA: new_avg = 0.1 * new_value + 0.9 * old_avg
+  float expected_second_avg = 0.1f * (float)second_num + 0.9f * first_avg;
+  float expected_third_avg = 0.1f * (float)third_num + 0.9f * second_avg;
+  
+  printf("  Expected averages:\n");
+  printf("    After 2nd: %.1f (calculated), %.1f (actual)\n", expected_second_avg, second_avg);
+  printf("    After 3rd: %.1f (calculated), %.1f (actual)\n", expected_third_avg, third_avg);
+  
+  // Allow small floating point differences
+  ASSERT_TRUE(fabsf(second_avg - expected_second_avg) < 0.1f, "Second avg should match EMA calculation");
+  ASSERT_TRUE(fabsf(third_avg - expected_third_avg) < 0.1f, "Third avg should match EMA calculation");
+  ASSERT_EQ(stats.sample_count, 3, "Sample count should be 3");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Moving averages calculated correctly using EMA\n");
+  printf("    ✓ Sample count increments correctly\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Statistics - Slice without allocation */
+static void test_oop_statistics_no_allocation(void) {
+  printf("  Purpose: Test statistics for slice that doesn't get allocation\n");
+  printf("  Expected: Latest values should be 0, averages should not update\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add slice with no active UEs (won't get allocation)
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.0f, 0.0f, 1.0f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.2f, 0.2f, 0.5f, 0), 0, "Should add slice 2");
+  
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  slice_statistics_t stats1, stats2;
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 1, 0, &stats1), 0, "Should get stats for slice 1");
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 2, 0, &stats2), 0, "Should get stats for slice 2");
+  
+  printf("  Statistics:\n");
+  printf("    Slice 1 (no allocation): latest=(%d,%d,%d), avg=(%.1f,%.1f,%.1f), samples=%d\n",
+         stats1.latest_start_prb, stats1.latest_end_prb, stats1.latest_num_prbs,
+         stats1.avg_start_prb, stats1.avg_end_prb, stats1.avg_num_prbs, stats1.sample_count);
+  printf("    Slice 2 (with allocation): latest=(%d,%d,%d), avg=(%.1f,%.1f,%.1f), samples=%d\n",
+         stats2.latest_start_prb, stats2.latest_end_prb, stats2.latest_num_prbs,
+         stats2.avg_start_prb, stats2.avg_end_prb, stats2.avg_num_prbs, stats2.sample_count);
+  
+  ASSERT_EQ(stats1.latest_start_prb, 0, "Slice 1 latest start should be 0");
+  ASSERT_EQ(stats1.latest_end_prb, 0, "Slice 1 latest end should be 0");
+  ASSERT_EQ(stats1.latest_num_prbs, 0, "Slice 1 latest num_prbs should be 0");
+  ASSERT_FLOAT_EQ(stats1.avg_start_prb, 0.0f, "Slice 1 avg start should be 0");
+  ASSERT_FLOAT_EQ(stats1.avg_end_prb, 0.0f, "Slice 1 avg end should be 0");
+  ASSERT_FLOAT_EQ(stats1.avg_num_prbs, 0.0f, "Slice 1 avg num_prbs should be 0");
+  ASSERT_EQ(stats1.sample_count, 1, "Slice 1 sample count tracks scheduling slot (0 PRBs)");
+  
+  ASSERT_EQ(stats2.latest_num_prbs, 20, "Slice 2 dedicated 20%");
+  ASSERT_EQ(stats2.sample_count, 1, "Slice 2 sample count should be 1");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Slices without PRBs still record a scheduling sample (latest=0)\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Statistics - Get all statistics */
+static void test_oop_statistics_get_all(void) {
+  printf("  Purpose: Test getting all statistics at once\n");
+  printf("  Expected: Should return array of all slice statistics\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.0f, 0.2f, 0.5f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.0f, 0.3f, 0.5f, 0), 0, "Should add slice 2");
+  ASSERT_EQ(slice_sch_add_slice(sch, 3, 0, 0.0f, 0.1f, 0.5f, 0), 0, "Should add slice 3");
+  
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  int num_stats = 0;
+  const slice_statistics_t *all_stats = slice_sch_get_all_statistics(sch, &num_stats);
+  
+  ASSERT_TRUE(all_stats != NULL, "Should get all statistics");
+  ASSERT_EQ(num_stats, 3, "Should have 3 statistics entries");
+  
+  printf("  All statistics:\n");
+  for (int i = 0; i < num_stats; ++i) {
+    printf("    Slice (SST=%d, SD=%u): latest=(%d,%d,%d), avg=(%.1f,%.1f,%.1f), samples=%d\n",
+           all_stats[i].slice_id.sst, all_stats[i].slice_id.sd,
+           all_stats[i].latest_start_prb, all_stats[i].latest_end_prb, all_stats[i].latest_num_prbs,
+           all_stats[i].avg_start_prb, all_stats[i].avg_end_prb, all_stats[i].avg_num_prbs,
+           all_stats[i].sample_count);
+  }
+  
+  // Verify each slice
+  ASSERT_EQ(all_stats[0].slice_id.sst, 1, "First entry should be slice 1 (SST=1)");
+  ASSERT_EQ(all_stats[0].slice_id.sd, 0, "First entry should have SD=0");
+  ASSERT_EQ(all_stats[1].slice_id.sst, 2, "Second entry should be slice 2 (SST=2)");
+  ASSERT_EQ(all_stats[1].slice_id.sd, 0, "Second entry should have SD=0");
+  ASSERT_EQ(all_stats[2].slice_id.sst, 3, "Third entry should be slice 3 (SST=3)");
+  ASSERT_EQ(all_stats[2].slice_id.sd, 0, "Third entry should have SD=0");
+  
+  printf("  Verification:\n");
+  printf("    ✓ All statistics returned correctly\n");
+  printf("    ✓ Statistics match individual slice queries\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Statistics - Statistics persist after delete */
+static void test_oop_statistics_after_delete(void) {
+  printf("  Purpose: Test statistics behavior after deleting slices\n");
+  printf("  Expected: Remaining slices should keep their statistics\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.0f, 0.2f, 0.5f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.0f, 0.3f, 0.5f, 0), 0, "Should add slice 2");
+  ASSERT_EQ(slice_sch_add_slice(sch, 3, 0, 0.0f, 0.1f, 0.5f, 0), 0, "Should add slice 3");
+  
+  // Schedule multiple times to build up statistics
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  }
+  
+  slice_statistics_t stats2_before;
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 2, 0, &stats2_before), 0, "Should get stats for slice 2");
+  
+  printf("  Before delete:\n");
+  printf("    Slice 2: latest=%d PRBs, avg=%.1f PRBs, samples=%d\n",
+         stats2_before.latest_num_prbs, stats2_before.avg_num_prbs, stats2_before.sample_count);
+  
+  // Delete slice 1
+  ASSERT_EQ(slice_sch_del_slice(sch, 1, 0), 0, "Should delete slice 1");
+  
+  // Slice 2 should still have its statistics (now at index 0, shifted in array)
+  // Note: result_valid is set to false after delete, so statistics are preserved
+  // but won't be updated until next schedule
+  slice_statistics_t stats2_after;
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 2, 0, &stats2_after), 0, "Should get stats for slice 2");
+  
+  printf("  After delete (before re-schedule):\n");
+  printf("    Slice 2: latest=%d PRBs, avg=%.1f PRBs, samples=%d\n",
+         stats2_after.latest_num_prbs, stats2_after.avg_num_prbs, stats2_after.sample_count);
+  
+  // Statistics should be preserved (shifted in array) before re-schedule
+  ASSERT_EQ(stats2_after.latest_num_prbs, stats2_before.latest_num_prbs, "Latest should be preserved before re-schedule");
+  ASSERT_FLOAT_EQ(stats2_after.avg_num_prbs, stats2_before.avg_num_prbs, "Average should be preserved before re-schedule");
+  ASSERT_EQ(stats2_after.sample_count, stats2_before.sample_count, "Sample count should be preserved");
+  
+  // Now schedule again - statistics will update with new allocation
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Re-schedule should succeed");
+  
+  slice_statistics_t stats2_after_schedule;
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 2, 0, &stats2_after_schedule), 0, "Should get stats for slice 2");
+  
+  printf("  After re-schedule:\n");
+  printf("    Slice 2: latest=%d PRBs, avg=%.1f PRBs, samples=%d\n",
+         stats2_after_schedule.latest_num_prbs, stats2_after_schedule.avg_num_prbs, stats2_after_schedule.sample_count);
+  
+  // After re-schedule, statistics should update but sample_count should increment
+  ASSERT_GT(stats2_after_schedule.sample_count, stats2_before.sample_count, "Sample count should increment after re-schedule");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Statistics preserved after slice deletion\n");
+  printf("    ✓ Statistics correctly shifted in array\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Statistics - Error handling */
+static void test_oop_statistics_error_handling(void) {
+  printf("  Purpose: Test error handling for statistics functions\n");
+  printf("  Expected: Should handle NULL and invalid inputs gracefully\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Test NULL scheduler
+  slice_statistics_t stats;
+  ASSERT_EQ(slice_sch_get_slice_statistics(NULL, 1, 0, &stats), -1, "Should reject NULL scheduler");
+  
+  int num_stats = 0;
+  ASSERT_TRUE(slice_sch_get_all_statistics(NULL, &num_stats) == NULL, "Should return NULL for NULL scheduler");
+  
+  // Test non-existent slice
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, (uint8_t)999, 0, &stats), -1, "Should reject non-existent slice");
+  
+  // Test NULL stats pointer
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 1, 0, NULL), -1, "Should reject NULL stats pointer");
+  
+  printf("  Verification:\n");
+  printf("    ✓ NULL scheduler handled correctly\n");
+  printf("    ✓ Non-existent slice handled correctly\n");
+  printf("    ✓ NULL pointer handled correctly\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Crash prevention - Very large number of slices */
+static void test_oop_crash_prevention_large_slices(void) {
+  printf("  Purpose: Test scheduler with very large number of slices\n");
+  printf("  Expected: Should handle gracefully without crashing\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add many slices (but not so many that we run out of memory)
+  int num_slices = 1000;
+  int success_count = 0;
+  for (int i = 1; i <= num_slices; ++i) {
+    if (slice_sch_add_slice(sch, i, 0, 0.01f, 0.01f, 0.02f, 0) == 0) {
+      success_count++;
+    } else {
+      break; // Stop if allocation fails
+    }
+  }
+  
+  printf("  Added %d slices successfully\n", success_count);
+  ASSERT_GT(success_count, 0, "Should add at least some slices");
+  
+  // Schedule should not crash
+  int ret = slice_sch_schedule(sch);
+  ASSERT_GE(ret, -1, "Schedule should return valid code (0 or -1)");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Scheduler handles large number of slices without crashing\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Crash prevention - Very large total_prbs */
+static void test_oop_crash_prevention_large_total_prbs(void) {
+  printf("  Purpose: Test scheduler with very large total_prbs\n");
+  printf("  Expected: Should handle gracefully without crashing\n\n");
+  
+  // Test with large but reasonable total_prbs (e.g., 10000)
+  slice_scheduler_t *sch = slice_sch_create(10000);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice");
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Should get allocation");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Scheduler handles large total_prbs without crashing\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Crash prevention - Operations on destroyed scheduler */
+static void test_oop_crash_prevention_use_after_destroy(void) {
+  printf("  Purpose: Test that destroy handles NULL and multiple destroys safely\n");
+  printf("  Expected: Should handle gracefully without crashing\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice");
+  
+  // Test destroying NULL (should be safe)
+  slice_sch_destroy(NULL);
+  printf("    ✓ Destroying NULL scheduler is safe\n");
+  
+  // Destroy scheduler
+  slice_sch_destroy(sch);
+  printf("    ✓ Destroying scheduler succeeds\n");
+  
+  // Test double destroy (should be safe - destroy should handle this)
+  // Note: After destroy, sch points to freed memory, so we can't safely use it
+  // But we can test that destroy(NULL) is safe
+  slice_sch_destroy(NULL);
+  printf("    ✓ Multiple destroy calls are handled safely\n");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Destroy function handles edge cases safely\n");
+  printf("    ✓ Note: Using scheduler after destroy is undefined behavior\n");
+}
+
+/* Test OOP: Crash prevention - Integer overflow in calculations */
+static void test_oop_crash_prevention_overflow(void) {
+  printf("  Purpose: Test scheduler with values that could cause overflow\n");
+  printf("  Expected: Should handle gracefully without crashing\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add slice with very large requirement (but within int range)
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.0f, 0.0f, 1.0f, INT_MAX / 2), 0, "Should add slice with large requirement");
+  
+  // Schedule should handle large requirement gracefully
+  int ret = slice_sch_schedule(sch);
+  ASSERT_GE(ret, -1, "Schedule should return valid code");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Scheduler handles large requirement values without crashing\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Crash prevention - Rapid add/delete causing reallocation issues */
+static void test_oop_crash_prevention_rapid_reallocation(void) {
+  printf("  Purpose: Test rapid add/delete causing frequent reallocations\n");
+  printf("  Expected: Should handle gracefully without memory corruption\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Rapidly add and delete slices to trigger many reallocations
+  for (int cycle = 0; cycle < 10; ++cycle) {
+    // Add slices to trigger growth
+    for (int i = 1; i <= 20; ++i) {
+      slice_sch_add_slice(sch, cycle * 100 + i, 0, 0.01f, 0.01f, 0.02f, 0);
+    }
+    
+    // Delete slices to trigger shrink
+    for (int i = 1; i <= 15; ++i) {
+      slice_sch_del_slice(sch, cycle * 100 + i, 0);
+    }
+    
+    // Schedule to ensure consistency
+    slice_sch_schedule(sch);
+  }
+  
+  printf("  After rapid add/delete cycles:\n");
+  printf("    Capacity: %d, Num slices: %d\n", sch->slices_capacity, sch->input->num_slices);
+  
+  // Final schedule should work
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Final schedule should succeed");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Scheduler handles rapid reallocations without memory corruption\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Crash prevention - Zero-sized allocations */
+static void test_oop_crash_prevention_zero_sized(void) {
+  printf("  Purpose: Test edge cases with zero-sized or minimal allocations\n");
+  printf("  Expected: Should handle gracefully without crashing\n\n");
+  
+  // Test with total_prbs = 1 (minimum)
+  slice_scheduler_t *sch = slice_sch_create(1);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.0f, 1.0f, 1.0f, 0), 0, "Should add slice");
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Should get allocation");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Scheduler handles minimal total_prbs without crashing\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Crash prevention - Invalid state transitions */
+static void test_oop_crash_prevention_invalid_state(void) {
+  printf("  Purpose: Test invalid state transitions and operations\n");
+  printf("  Expected: Should handle gracefully without crashing\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add slice but don't schedule
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice");
+  
+  // Try to get allocation before scheduling (should return NULL)
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges == NULL, "Should return NULL before schedule");
+  
+  // Try to get stats before scheduling (should return error)
+  int num_active = 0;
+  int total_allocated = 0;
+  ASSERT_EQ(slice_sch_get_stats(sch, &num_active, &total_allocated), -1, "Should return error before schedule");
+  
+  // Schedule
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  // Now operations should work
+  ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Should get allocation after schedule");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Scheduler handles invalid state transitions gracefully\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Crash prevention - Boundary ratio values causing division issues */
+static void test_oop_crash_prevention_boundary_ratios(void) {
+  printf("  Purpose: Test boundary ratio values that could cause division issues\n");
+  printf("  Expected: Should handle gracefully without crashing\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Test with ratios that sum to exactly 1.0
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.0f, 0.5f, 0.5f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.0f, 0.5f, 0.5f, 0), 0, "Should add slice 2");
+  
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  // Test with all slices at max (1.0)
+  slice_scheduler_t *sch2 = slice_sch_create(100);
+  ASSERT_TRUE(sch2 != NULL, "Scheduler should be created");
+  
+  ASSERT_EQ(slice_sch_add_slice(sch2, 1, 0, 0.0f, 1.0f, 1.0f, 0), 0, "Should add slice");
+  ASSERT_EQ(slice_sch_schedule(sch2), 0, "Schedule should succeed");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Scheduler handles boundary ratio values without crashing\n");
+  
+  slice_sch_destroy(sch);
+  slice_sch_destroy(sch2);
+}
+
+/* Test OOP: Crash prevention - Memory exhaustion simulation */
+static void test_oop_crash_prevention_memory_pressure(void) {
+  printf("  Purpose: Test scheduler behavior under memory pressure\n");
+  printf("  Expected: Should handle allocation failures gracefully\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add many slices to potentially trigger memory issues
+  // (In practice, this would require actual memory exhaustion, which is hard to simulate)
+  // But we can test that the scheduler handles many slices correctly
+  int added = 0;
+  for (int i = 1; i <= 10000; ++i) {
+    if (slice_sch_add_slice(sch, i, 0, 0.001f, 0.001f, 0.002f, 0) == 0) {
+      added++;
+    } else {
+      // Allocation failed - this is acceptable
+      break;
+    }
+  }
+  
+  printf("  Added %d slices\n", added);
+  
+  if (added > 0) {
+    // If we added slices, try to schedule
+    int ret = slice_sch_schedule(sch);
+    ASSERT_GE(ret, -1, "Schedule should return valid code");
+  }
+  
+  printf("  Verification:\n");
+  printf("    ✓ Scheduler handles memory pressure gracefully\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Crash prevention - Concurrent-like operations (invalid sequences) */
+static void test_oop_crash_prevention_invalid_sequences(void) {
+  printf("  Purpose: Test invalid operation sequences that could cause crashes\n");
+  printf("  Expected: Should handle gracefully without crashing\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Sequence 1: Delete before add (idempotent - should succeed)
+  ASSERT_EQ(slice_sch_del_slice(sch, (uint8_t)999, 0), 0, "Should succeed deleting non-existent slice (idempotent)");
+  
+  // Sequence 2: Update require before add
+  ASSERT_EQ(slice_sch_update_require(sch, (uint8_t)999, 0, 50), -1, "Should fail to update non-existent slice");
+  
+  // Sequence 3: Add, delete, then try to use deleted slice
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.1f, 0.2f, 0.5f, 0), 0, "Should add slice");
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  ASSERT_EQ(slice_sch_del_slice(sch, 1, 0), 0, "Should delete slice");
+  
+  // Try to get stats for deleted slice
+  slice_statistics_t stats;
+  ASSERT_EQ(slice_sch_get_slice_statistics(sch, 1, 0, &stats), -1, "Should fail to get stats for deleted slice");
+  
+  // Sequence 4: Multiple deletes of same slice (idempotent - should succeed)
+  ASSERT_EQ(slice_sch_del_slice(sch, 1, 0), 0, "Should succeed deleting already deleted slice (idempotent)");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Scheduler handles invalid operation sequences gracefully\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Crash prevention - Array bounds and indexing */
+static void test_oop_crash_prevention_array_bounds(void) {
+  printf("  Purpose: Test array bounds and indexing edge cases\n");
+  printf("  Expected: Should handle gracefully without buffer overflows\n\n");
+  
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Fill to capacity boundary
+  int initial_capacity = sch->slices_capacity;
+  for (int i = 1; i <= initial_capacity; ++i) {
+    ASSERT_EQ(slice_sch_add_slice(sch, i, 0, 0.01f, 0.01f, 0.02f, 0), 0, "Should add slice");
+  }
+  
+  // Add one more to trigger growth (tests array bounds during reallocation)
+  ASSERT_EQ(slice_sch_add_slice(sch, initial_capacity + 1, 0, 0.01f, 0.01f, 0.02f, 0), 0, "Should add slice at boundary");
+  
+  // Schedule to ensure all indices are valid
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  // Get statistics for all slices (tests array bounds)
+  int num_stats = 0;
+  const slice_statistics_t *all_stats = slice_sch_get_all_statistics(sch, &num_stats);
+  ASSERT_TRUE(all_stats != NULL, "Should get all statistics");
+  ASSERT_EQ(num_stats, initial_capacity + 1, "Should have correct number of statistics");
+  
+  printf("  Verification:\n");
+  printf("    ✓ Scheduler handles array bounds correctly\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test OOP: Runtime total_prbs change */
+static void test_oop_runtime_total_prbs_change(void) {
+  printf("  Purpose: Test that total_prbs can be changed at runtime\n");
+  printf("  Expected: Allocations should correctly reflect the new total_prbs value\n\n");
+  
+  // Create scheduler with initial total_prbs
+  slice_scheduler_t *sch = slice_sch_create(100);
+  ASSERT_TRUE(sch != NULL, "Scheduler should be created");
+  
+  // Add slices with max ratios that allow full allocation (0.6 + 0.4 = 1.0)
+  ASSERT_EQ(slice_sch_add_slice(sch, 1, 0, 0.2f, 0.3f, 0.6f, 0), 0, "Should add slice 1");
+  ASSERT_EQ(slice_sch_add_slice(sch, 2, 0, 0.1f, 0.2f, 0.4f, 0), 0, "Should add slice 2");
+  
+  // Schedule with initial total_prbs = 100
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed");
+  
+  int num_ranges = 0;
+  const slice_prb_range_t *ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Should get allocation");
+  
+  int num_active = 0;
+  int total_allocated = 0;
+  ASSERT_EQ(slice_sch_get_stats(sch, &num_active, &total_allocated), 0, "Should get stats");
+  
+  printf("  Initial state (total_prbs = 100):\n");
+  printf("    Total Allocated: %d / 100 PRBs\n", total_allocated);
+  ASSERT_EQ(total_allocated, 30, "Dedicated only without require (20+10)");
+  
+  // Find slice allocations
+  int slice1_prbs = 0, slice2_prbs = 0;
+  for (int i = 0; i < num_ranges; ++i) {
+    if (ranges[i].slice_id.sst == 1 && ranges[i].slice_id.sd == 0) {
+      slice1_prbs = ranges[i].num_prbs;
+    } else if (ranges[i].slice_id.sst == 2 && ranges[i].slice_id.sd == 0) {
+      slice2_prbs = ranges[i].num_prbs;
+    }
+  }
+  printf("    Slice 1: %d PRBs, Slice 2: %d PRBs\n", slice1_prbs, slice2_prbs);
+  ASSERT_EQ(slice1_prbs, 20, "Slice 1 dedicated");
+  ASSERT_EQ(slice2_prbs, 10, "Slice 2 dedicated");
+  
+  // Change total_prbs to 200 at runtime using update function
+  ASSERT_EQ(slice_sch_update_total_prbs(sch, 200), 0, "Should update total_prbs to 200");
+  printf("  Changed total_prbs to 200 at runtime\n");
+  
+  // Schedule again with new total_prbs
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed with new total_prbs");
+  
+  ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Should get allocation after total_prbs change");
+  
+  ASSERT_EQ(slice_sch_get_stats(sch, &num_active, &total_allocated), 0, "Should get stats");
+  
+  printf("  After change (total_prbs = 200):\n");
+  printf("    Total Allocated: %d / 200 PRBs\n", total_allocated);
+  ASSERT_EQ(total_allocated, 60, "Dedicated scales with total_prbs (40+20)");
+  
+  // Verify allocations scale proportionally
+  int slice1_prbs_new = 0, slice2_prbs_new = 0;
+  for (int i = 0; i < num_ranges; ++i) {
+    if (ranges[i].slice_id.sst == 1 && ranges[i].slice_id.sd == 0) {
+      slice1_prbs_new = ranges[i].num_prbs;
+    } else if (ranges[i].slice_id.sst == 2 && ranges[i].slice_id.sd == 0) {
+      slice2_prbs_new = ranges[i].num_prbs;
+    }
+  }
+  printf("    Slice 1: %d PRBs, Slice 2: %d PRBs\n", slice1_prbs_new, slice2_prbs_new);
+  ASSERT_EQ(slice1_prbs_new, 40, "Slice 1 dedicated at 200 PRBs");
+  ASSERT_EQ(slice2_prbs_new, 20, "Slice 2 dedicated at 200 PRBs");
+  
+  // Change total_prbs to 50 at runtime using update function
+  ASSERT_EQ(slice_sch_update_total_prbs(sch, 50), 0, "Should update total_prbs to 50");
+  printf("  Changed total_prbs to 50 at runtime\n");
+  
+  // Schedule again with new total_prbs
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed with new total_prbs");
+  
+  ranges = slice_sch_get_allocation(sch, &num_ranges);
+  ASSERT_TRUE(ranges != NULL, "Should get allocation after second total_prbs change");
+  
+  ASSERT_EQ(slice_sch_get_stats(sch, &num_active, &total_allocated), 0, "Should get stats");
+  
+  printf("  After second change (total_prbs = 50):\n");
+  printf("    Total Allocated: %d / 50 PRBs\n", total_allocated);
+  ASSERT_EQ(total_allocated, 15, "Dedicated at 50 PRBs (10+5)");
+  
+  // Verify allocations scale down proportionally
+  int slice1_prbs_50 = 0, slice2_prbs_50 = 0;
+  for (int i = 0; i < num_ranges; ++i) {
+    if (ranges[i].slice_id.sst == 1 && ranges[i].slice_id.sd == 0) {
+      slice1_prbs_50 = ranges[i].num_prbs;
+    } else if (ranges[i].slice_id.sst == 2 && ranges[i].slice_id.sd == 0) {
+      slice2_prbs_50 = ranges[i].num_prbs;
+    }
+  }
+  printf("    Slice 1: %d PRBs, Slice 2: %d PRBs\n", slice1_prbs_50, slice2_prbs_50);
+  ASSERT_EQ(slice1_prbs_50, 10, "Slice 1 dedicated at 50 PRBs");
+  ASSERT_EQ(slice2_prbs_50, 5, "Slice 2 dedicated at 50 PRBs");
+  
+  // Change total_prbs to a larger value (300) using update function
+  ASSERT_EQ(slice_sch_update_total_prbs(sch, 300), 0, "Should update total_prbs to 300");
+  printf("  Changed total_prbs to 300 at runtime\n");
+  
+  ASSERT_EQ(slice_sch_schedule(sch), 0, "Schedule should succeed with total_prbs = 300");
+  
+  ASSERT_EQ(slice_sch_get_stats(sch, &num_active, &total_allocated), 0, "Should get stats");
+  ASSERT_EQ(total_allocated, 90, "Dedicated at 300 PRBs (60+30)");
+  
+  printf("  After third change (total_prbs = 300):\n");
+  printf("    Total Allocated: %d / 300 PRBs\n", total_allocated);
+  
+  // Test error handling: invalid total_prbs values
+  ASSERT_EQ(slice_sch_update_total_prbs(sch, 0), -1, "Should reject total_prbs = 0");
+  ASSERT_EQ(slice_sch_update_total_prbs(sch, -1), -1, "Should reject negative total_prbs");
+  ASSERT_EQ(slice_sch_update_total_prbs(NULL, 100), -1, "Should reject NULL scheduler");
+  
+  // Verify scheduler still has valid total_prbs after failed updates
+  ASSERT_EQ(slice_sch_get_stats(sch, &num_active, &total_allocated), 0, "Should get stats");
+  ASSERT_EQ(total_allocated, 90, "Allocation unchanged after failed total_prbs update");
+  
+  printf("  Verification:\n");
+  printf("    ✓ total_prbs can be changed at runtime using slice_sch_update_total_prbs()\n");
+  printf("    ✓ Allocations correctly reflect new total_prbs value\n");
+  printf("    ✓ Allocations reflect dedicated (+ require) only, not idle min\n");
+  printf("    ✓ Invalid total_prbs values are rejected\n");
+  
+  slice_sch_destroy(sch);
+}
+
+/* Test: Real-world scenario from Frame 257 slot 0 */
+static void test_frame_756_slot_5_scenario(void) {
+  printf("  Purpose: Test real-world scenario from Frame 257 slot 0\n");
+  printf("  Expected: 6 slices with specific SST/SD values get allocations\n");
+  printf("            Slice SST 0x01 SD 0xffffff requires 4 PRBs, gets PRBs in Pass 3\n");
+  printf("            Other slices get PRBs based on their ratios\n\n");
+  
+  ALLOCATE_TEST_STRUCTURES(6, input, result);
+  
+  // Slice 0: SST 0x01 SD 0xffffff - Required 4 PRBs but gets 0
+  // Configuration: Dedicated: 0.000, Min: 0.000, Max: 1.000
+  input->slices[0].slice_id = slice_nssai_create(0x01, 0xffffff);
+  input->slices[0].dedicated_prb_ratio = 0.000f;
+  input->slices[0].min_prb_ratio = 0.000f;
+  input->slices[0].max_prb_ratio = 1.000f;
+  input->slices[0].required_prbs = 4;
+  
+  // Slice 1: SST 0x01 SD 0x000001 - Gets 11 PRBs
+  // Configuration: Dedicated: 0.100, Min: 0.100, Max: 1.000
+  input->slices[1].slice_id = slice_nssai_create(0x01, 0x000001);
+  input->slices[1].dedicated_prb_ratio = 0.100f;
+  input->slices[1].min_prb_ratio = 0.100f;
+  input->slices[1].max_prb_ratio = 1.000f;
+  input->slices[1].required_prbs = 0;
+  
+  // Slice 2: SST 0x01 SD 0x000002 — dedicated 30%, min 50% (sum(min) across slices <= 100%)
+  // Configuration: Dedicated: 0.300, Min: 0.500, Max: 1.000
+  input->slices[2].slice_id = slice_nssai_create(0x01, 0x000002);
+  input->slices[2].dedicated_prb_ratio = 0.300f;
+  input->slices[2].min_prb_ratio = 0.500f;
+  input->slices[2].max_prb_ratio = 1.000f;
+  input->slices[2].required_prbs = 0;
+  
+  // Slice 3: SST 0x01 SD 0x000003 - Gets 11 PRBs
+  // Configuration: Dedicated: 0.100, Min: 0.100, Max: 0.300
+  input->slices[3].slice_id = slice_nssai_create(0x01, 0x000003);
+  input->slices[3].dedicated_prb_ratio = 0.100f;
+  input->slices[3].min_prb_ratio = 0.100f;
+  input->slices[3].max_prb_ratio = 0.300f;
+  input->slices[3].required_prbs = 0;
+  
+  // Slice 4: SST 0x01 SD 0x000004 - Gets 11 PRBs
+  // Configuration: Dedicated: 0.100, Min: 0.100, Max: 0.300
+  input->slices[4].slice_id = slice_nssai_create(0x01, 0x000004);
+  input->slices[4].dedicated_prb_ratio = 0.100f;
+  input->slices[4].min_prb_ratio = 0.100f;
+  input->slices[4].max_prb_ratio = 0.300f;
+  input->slices[4].required_prbs = 0;
+  
+  // Slice 5: SST 0x01 SD 0x000005 - Gets 0 PRBs (not shown in ranges)
+  // Configuration: Dedicated: 0.100, Min: 0.100, Max: 0.300
+  input->slices[5].slice_id = slice_nssai_create(0x01, 0x000005);
+  input->slices[5].dedicated_prb_ratio = 0.100f;
+  input->slices[5].min_prb_ratio = 0.100f;
+  input->slices[5].max_prb_ratio = 0.300f;
+  input->slices[5].required_prbs = 0;
+  
+  input->num_slices = 6;
+  input->total_prbs = 95;
+  
+  printf("  Input Configuration:\n");
+  printf("    Total PRBs: %d\n", input->total_prbs);
+  printf("    Number of Slices: %d\n", input->num_slices);
+  for (int i = 0; i < input->num_slices; ++i) {
+    printf("    Slice %d (SST=0x%02x, SD=0x%06x):\n", i, 
+           input->slices[i].slice_id.sst, input->slices[i].slice_id.sd);
+    print_slice_config(&input->slices[i], i);
+  }
+  printf("\n");
+  
+  int ret = calculate_slice_prb_ranges(input, result);
+  
+  print_allocation_result_with_required(result, input, input->total_prbs);
+  printf("\n");
+  
+  printf("  Verification:\n");
+  ASSERT_EQ(ret, 6, "Should return 6 slices");
+  ASSERT_EQ(result->total_allocated_prbs, 73, "Dedicated + require-only (69+4)");
+  
+  // Find each slice in the result
+  int slice_ffffff_prbs = 0;
+  int slice_000001_prbs = 0;
+  int slice_000002_prbs = 0;
+  int slice_000003_prbs = 0;
+  int slice_000004_prbs = 0;
+  
+  int slice_ffffff_start = -1, slice_ffffff_end = -1;
+  int slice_000001_start = -1, slice_000001_end = -1;
+  int slice_000002_start = -1, slice_000002_end = -1;
+  int slice_000003_start = -1, slice_000003_end = -1;
+  int slice_000004_start = -1, slice_000004_end = -1;
+  
+  // Check all slices in result (may include slices with 0 PRBs)
+  for (int s = 0; s < input->num_slices; ++s) {
+    if (result->ranges[s].slice_id.sst == 0x01 && result->ranges[s].slice_id.sd == 0xffffff) {
+      slice_ffffff_prbs = result->ranges[s].num_prbs;
+      slice_ffffff_start = result->ranges[s].start_prb;
+      slice_ffffff_end = result->ranges[s].end_prb;
+    } else if (result->ranges[s].slice_id.sst == 0x01 && result->ranges[s].slice_id.sd == 0x000001) {
+      slice_000001_prbs = result->ranges[s].num_prbs;
+      slice_000001_start = result->ranges[s].start_prb;
+      slice_000001_end = result->ranges[s].end_prb;
+    } else if (result->ranges[s].slice_id.sst == 0x01 && result->ranges[s].slice_id.sd == 0x000002) {
+      slice_000002_prbs = result->ranges[s].num_prbs;
+      slice_000002_start = result->ranges[s].start_prb;
+      slice_000002_end = result->ranges[s].end_prb;
+    } else if (result->ranges[s].slice_id.sst == 0x01 && result->ranges[s].slice_id.sd == 0x000003) {
+      slice_000003_prbs = result->ranges[s].num_prbs;
+      slice_000003_start = result->ranges[s].start_prb;
+      slice_000003_end = result->ranges[s].end_prb;
+    } else if (result->ranges[s].slice_id.sst == 0x01 && result->ranges[s].slice_id.sd == 0x000004) {
+      slice_000004_prbs = result->ranges[s].num_prbs;
+      slice_000004_start = result->ranges[s].start_prb;
+      slice_000004_end = result->ranges[s].end_prb;
+    }
+  }
+  
+  // Verify slice 0xffffff gets PRBs in Pass 3 (required_prbs=4, min_prb_ratio=0.0)
+  // Since it has required_prbs=4 and max_prb_ratio=1.0, it should get at least 4 PRBs in Pass 3
+  printf("    ✓ Slice SST 0x01 SD 0xffffff: PRBs [%d, %d) (num_prbs=%d) - Required: 4, Got: %d\n",
+         slice_ffffff_start, slice_ffffff_end, slice_ffffff_prbs, slice_ffffff_prbs);
+  if (slice_ffffff_start >= 0) {
+    ASSERT_GE(slice_ffffff_prbs, 4, "Slice 0xffffff should get at least 4 PRBs (required_prbs)");
+    ASSERT_GE(slice_ffffff_start, 0, "Slice 0xffffff should have valid start_prb");
+    ASSERT_GT(slice_ffffff_end, slice_ffffff_start, "Slice 0xffffff should have valid range");
+  }
+  
+  // Verify slice 0x000001 gets dedicated only (require=0)
+  printf("    ✓ Slice SST 0x01 SD 0x000001: PRBs [%d, %d) (num_prbs=%d)\n",
+         slice_000001_start, slice_000001_end, slice_000001_prbs);
+  ASSERT_EQ(slice_000001_prbs, 10, "Slice 0x000001 dedicated 10%");
+  
+  // Verify slice 0x000002 gets dedicated only
+  printf("    ✓ Slice SST 0x01 SD 0x000002: PRBs [%d, %d) (num_prbs=%d)\n",
+         slice_000002_start, slice_000002_end, slice_000002_prbs);
+  ASSERT_EQ(slice_000002_prbs, 29, "Slice 0x000002 dedicated 30%");
+  
+  // Verify slice 0x000003 gets dedicated only
+  printf("    ✓ Slice SST 0x01 SD 0x000003: PRBs [%d, %d) (num_prbs=%d)\n",
+         slice_000003_start, slice_000003_end, slice_000003_prbs);
+  ASSERT_EQ(slice_000003_prbs, 10, "Slice 0x000003 dedicated 10%");
+  
+  // Verify slice 0x000004 gets dedicated only
+  printf("    ✓ Slice SST 0x01 SD 0x000004: PRBs [%d, %d) (num_prbs=%d)\n",
+         slice_000004_start, slice_000004_end, slice_000004_prbs);
+  ASSERT_EQ(slice_000004_prbs, 10, "Slice 0x000004 dedicated 10%");
+  
+  // Verify ranges are contiguous (all slices should have contiguous ranges)
+  printf("    ✓ All slices have contiguous ranges\n");
+  
+  free_slice_input(input);
+  free_slice_result(result);
+}
+
+int main(void) {
+  printf("╔════════════════════════════════════════════════════════════════════════════════╗\n");
+  printf("║     Network Slice PRB Allocation Algorithm - Unit Tests                     ║\n");
+  printf("╚════════════════════════════════════════════════════════════════════════════════╝\n\n");
+  printf("This test suite validates the four-pass PRB allocation algorithm:\n");
+  printf("  1. Pass 1: Dedicated PRB allocation (non-shareable)\n");
+  printf("  2. Pass 2: Prioritized resource distribution (min - dedicated)\n");
+  printf("  3. Pass 3: Shared resource distribution (max - min)\n");
+  printf("  4. Pass 4: Contiguous range assignment\n\n");
+  
+  printf("=== Individual Pass Tests ===\n\n");
+  TEST(pass1_dedicated);
+  TEST(pass2_prioritized);
+  TEST(pass3_shared);
+  TEST(pass4_ranges);
+  
+  printf("\n=== Pass 1 Edge Case Tests ===\n\n");
+  TEST(pass1_dedicated_static_allocation);
+  TEST(pass1_max_less_than_dedicated);
+  TEST(pass1_zero_dedicated);
+  
+  printf("\n=== Pass 2 Edge Case Tests ===\n\n");
+  TEST(pass2_slice_doesnt_need_prioritized);
+  TEST(pass2_insufficient_prioritized);
+  TEST(pass2_max_less_than_min);
+  
+  printf("\n=== Pass 3 Edge Case Tests ===\n\n");
+  TEST(pass3_no_prb_requirements);
+  TEST(pass3_all_slices_at_max);
+  
+  printf("\n=== Pass 4 Edge Case Tests ===\n\n");
+  TEST(pass4_empty_result);
+  TEST(pass4_single_slice);
+  
+  printf("\n=== Integrated Tests (Full Algorithm) ===\n\n");
+  TEST(basic_two_slices);
+  TEST(single_slice_all_prbs);
+  TEST(no_active_ues);
+  TEST(multiple_slices_different_ratios);
+  TEST(dedicated_exceeds_total);
+  TEST(max_ratio_enforcement);
+  TEST(validation);
+  TEST(zero_total_prbs);
+  TEST(real_world_106_prbs);
+  TEST(frame_756_slot_5_scenario);
+  
+  printf("\n=== Integration Edge Case Tests ===\n\n");
+  TEST(integration_max_less_than_min);
+  TEST(integration_all_slices_no_prioritized_need);
+  
+  printf("\n=== OOP Scheduler Interface Tests ===\n\n");
+  TEST(oop_basic_two_slices);
+  TEST(oop_add_delete_slices);
+  TEST(oop_update_require);
+  TEST(oop_dynamic_allocation);
+  TEST(oop_error_handling);
+  
+  printf("\n=== OOP Memory Management Tests ===\n\n");
+  TEST(oop_initial_capacity);
+  TEST(oop_array_growth);
+  TEST(oop_array_shrinking);
+  TEST(oop_no_shrink_below_num_slices);
+  
+  printf("\n=== OOP Edge Case Tests ===\n\n");
+  TEST(oop_add_at_capacity_boundary);
+  TEST(oop_delete_all_slices);
+  TEST(oop_update_existing_slice);
+  TEST(oop_update_slice_with_different_sd);
+  TEST(oop_invalid_ratios);
+  TEST(oop_invalid_require);
+  TEST(oop_update_nonexistent_slice);
+  TEST(oop_delete_nonexistent_slice);
+  TEST(oop_get_allocation_before_schedule);
+  TEST(oop_boundary_ratios);
+  TEST(oop_null_scheduler_operations);
+  TEST(oop_invalid_total_prbs);
+  TEST(oop_capacity_at_shrink_threshold);
+  TEST(oop_rapid_add_delete);
+  TEST(oop_schedule_after_delete);
+  
+  printf("\n=== OOP Statistics Tests ===\n\n");
+  TEST(oop_statistics_initial_state);
+  TEST(oop_statistics_after_schedule);
+  TEST(oop_statistics_moving_average);
+  TEST(oop_statistics_no_allocation);
+  TEST(oop_statistics_get_all);
+  TEST(oop_statistics_after_delete);
+  TEST(oop_statistics_error_handling);
+  
+  printf("\n=== OOP Crash Prevention Tests ===\n\n");
+  TEST(oop_crash_prevention_large_slices);
+  TEST(oop_crash_prevention_large_total_prbs);
+  TEST(oop_crash_prevention_use_after_destroy);
+  TEST(oop_crash_prevention_overflow);
+  TEST(oop_crash_prevention_rapid_reallocation);
+  TEST(oop_crash_prevention_zero_sized);
+  TEST(oop_crash_prevention_invalid_state);
+  TEST(oop_crash_prevention_boundary_ratios);
+  TEST(oop_crash_prevention_memory_pressure);
+  TEST(oop_crash_prevention_invalid_sequences);
+  TEST(oop_crash_prevention_array_bounds);
+  
+  printf("\n=== OOP Runtime Configuration Tests ===\n\n");
+  TEST(oop_runtime_total_prbs_change);
+  
+  printf("╔════════════════════════════════════════════════════════════════════════════════╗\n");
+  printf("║                            Test Summary                                       ║\n");
+  printf("╚════════════════════════════════════════════════════════════════════════════════╝\n");
+  printf("  Tests run:    %d\n", tests_run);
+  printf("  Tests passed: %d\n", tests_passed);
+  printf("  Tests failed: %d\n", tests_run - tests_passed);
+  
+  if (tests_passed == tests_run) {
+    printf("\n  ✓ All tests passed! The algorithm is working correctly.\n\n");
+    return 0;
+  } else {
+    printf("\n  ✗ Some tests failed! Please review the output above.\n\n");
+    return 1;
+  }
+}

--- a/openair2/LAYER2/nr_rlc/nr_rlc_oai_api.c
+++ b/openair2/LAYER2/nr_rlc/nr_rlc_oai_api.c
@@ -10,6 +10,7 @@
 #include "nr_rlc_asn1_utils.h"
 #include "nr_rlc_ue_manager.h"
 #include "nr_rlc_entity.h"
+#include "nr_rlc_entity_am.h"
 #include "nr_rlc_oai_api.h"
 #include "NR_RLC-BearerConfig.h"
 #include "NR_DRB-ToAddMod.h"
@@ -289,6 +290,23 @@ void nr_mac_rlc_status_ind(uint16_t ue_id, frame_t frame, int n_ch, const logica
     ret[i] = _nr_rlc_status_ind(ue, frame, ch[i]);
   }
   nr_rlc_manager_unlock(nr_rlc_ue_manager);
+}
+
+bool nr_rlc_am_status_triggered(const uint16_t ue_id, const logical_chan_id_t channel_idP)
+{
+  bool triggered = false;
+
+  nr_rlc_manager_lock(nr_rlc_ue_manager);
+  nr_rlc_ue_t *ue = nr_rlc_manager_get_ue(nr_rlc_ue_manager, ue_id);
+  nr_rlc_entity_t *rb = get_rlc_entity_from_lcid(ue, channel_idP);
+  /* SRB AM entities are nr_rlc_entity_am_t with common as first member. */
+  if (rb != NULL && rb->stats.mode == NR_RLC_AM) {
+    const nr_rlc_entity_am_t *am = (const nr_rlc_entity_am_t *)rb;
+    triggered = am->status_triggered != 0;
+  }
+  nr_rlc_manager_unlock(nr_rlc_ue_manager);
+
+  return triggered;
 }
 
 rlc_op_status_t nr_rlc_data_req(const protocol_ctxt_t *const ctxt_pP,

--- a/openair2/LAYER2/nr_rlc/nr_rlc_oai_api.h
+++ b/openair2/LAYER2/nr_rlc/nr_rlc_oai_api.h
@@ -58,6 +58,11 @@ rlc_op_status_t nr_rlc_data_req(const protocol_ctxt_t *const ctxt_pP,
                                 uint8_t *sdu_pP);
 void nr_mac_rlc_status_ind(uint16_t ue_id, frame_t frame, int n_ch, const logical_chan_id_t *ch, mac_rlc_status_resp_t *ret);
 
+/* True if AM entity has STATUS triggered (owed ACK/NACK), even while
+ * t-StatusProhibit blocks emission. Used by DL NS require so CP demand is
+ * not lost under min_prb_ratio=0. */
+bool nr_rlc_am_status_triggered(const uint16_t ue_id, const logical_chan_id_t channel_idP);
+
 void nr_rlc_add_srb(int ue_id, int srb_id, const NR_RLC_BearerConfig_t *rlc_BearerConfig);
 void nr_rlc_add_drb(int ue_id, int drb_id, const NR_RLC_BearerConfig_t *rlc_BearerConfig);
 


### PR DESCRIPTION
<!--
PR metadata (not shown on GitHub)
  Title:  Add frequency-domain network slicing (SCHE_NS)
  Repo:    duranta-project/openairinterface5g
  Base:    develop
  Head:    FCCLab:nws-3gpp-impl-no-flexric
  Label:   5G-NR, gNB (see pr/label.list)
  Compare: https://github.com/duranta-project/openairinterface5g/compare/develop...FCCLab:openairinterface5g-duranta:nws-3gpp-impl-no-flexric

  gh pr create \
    --repo duranta-project/openairinterface5g \
    --base develop \
    --head FCCLab:nws-3gpp-impl-no-flexric \
    --title "Add frequency-domain network slicing (SCHE_NS)" \
    --label "5G-NR" \
    --label "gNB" \
    --body-file pr/pr-nws-frequency-domain-slicing.md
-->

## Summary

This PR adds **frequency-domain network slicing** to the NR gNB MAC scheduler,
aligned with 3GPP S-NSSAI concepts and the existing modular proportional-fair
scheduler pipeline.

### What it does

- Introduces scheduler type `SCHE_NS` (independent DL/UL configuration via
  `dl_scheduler_type` / `ul_scheduler_type` in gNB YAML)
- Allocates per-slice PRB windows using a four-pass **dedicated / min / max**
  ratio policy (`slice_prb_allocator/`)
- Maps UEs to slices via S-NSSAI (SST + SD) from DRB/RRC configuration
- Reuses the modular PF pipeline **inside each slice** for intra-slice UE
  scheduling
- Extends the E2 Slice RAN function for runtime policy read/write
- Adds telnet slice statistics and a 5-slice rfsim CI config
- Documents the feature in `doc/network_slice_3gpp_impl.md`

### Architecture

Two-layer design:

1. **Slice layer** — PRB allocator assigns a contiguous frequency window per
   slice each slot (`nr_*_schedule_ns`)
2. **UE layer** — standard modular PF scheduler runs once per slice inside that
   window (`nr_*_schedule` with slice RB bounds)

```
Slot
 └─ nr_*sch_preprocessor
     ├─ SCHE_PF → nr_*_schedule()           (unchanged default path)
     └─ SCHE_NS → nr_*_schedule_ns()
                    ├─ slice_prb_allocator  (Pass 1–4: ded/min/max)
                    └─ per-slice nr_*_schedule(slice_prb, remainUEs)
```

### Scheduler modes

| Mode | DL | UL | Notes |
|------|----|----|-------|
| `NSUL` | PF | NS | Common NWS lab default |
| `NSDL` | NS | PF | DL NS shares `remainUEs` across slices |
| `NSBOTH` | NS | NS | Both directions sliced |
| `PF` | PF | PF | Default; slice YAML ignored for scheduler |

### Scope

| In scope | Out of scope |
|----------|--------------|
| Per-slice PRB range allocation (DL/UL) | Per-slice CORESET / PDCCH search spaces |
| S-NSSAI UE-to-slice mapping | CN slice selection (NSSF) |
| `dedicated` / `min` / `max` PRB ratios | L1 beam / cell-level slicing |
| E2 Slice SM policy read/write | End-to-end orchestration (separate repo) |

### Example YAML

```yaml
MACRLCs:
  - dl_scheduler_type: 0   # 0 = SCHE_PF, 1 = SCHE_NS
    ul_scheduler_type: 1

Slices:
  - slice_id: 1
    sst: 1
    sd: 0x000001
    dedicated_prb_ratio: 0.15
    min_prb_ratio: 0.15
    max_prb_ratio: 0.30
```

## Demo (5 UEs, 5 slices, rfsim)

### Lab setup

| Parameter | Value |
|-----------|-------|
| gNB | OAI rfsim, 133 PRB, band 78 |
| Scheduler | `NSBOTH` (`dl_scheduler_type: 1`, `ul_scheduler_type: 1`) |
| UEs | 5 UEs, one per slice (SST=1, SD=0x01 … 0x05) |
| Core | Open5GS with matching S-NSSAI per subscriber |
| Traffic | Full-traffic runs: simultaneous `iperf3` DL on all 5 UEs |

Each screenshot shows gNB MAC scheduler output with:

1. **NS UL/DL PRB allocation** — per-slice PRB window (`latest` / `avg`), PRB range
   `[start,end]`, utilization %, and configured `dedicated/min/max` ratios
2. **Per-UE stats** — RNTI, S-NSSAI, DL/UL MCS, BLER, and **goodput** (Mbps)

The five ratios in each heading are the per-slice policy values for slices
SD=0x01 … 0x05 (left to right). For example, `15 / 15 / 15 / 15 / 7 %` means
slice 1–4 each get 15% and slice 5 gets 7% of the configured ratio type.

### Dedicated policy

`dedicated_prb_ratio` is set per slice; `min` and `max` equal `dedicated` (no
shareable pool). PRBs are **always reserved** in Pass 1, even when a slice has
no traffic.

**What to look for**

- **Idle:** each active slice shows a fixed PRB window and non-zero `avg` allocation
  despite ~0% utilization — bandwidth is held, not released to other slices.
- **Full traffic:** each UE's goodput stays within its slice window; slices do not
  borrow from neighbours because dedicated resources are non-shareable.

#### 15 / 15 / 15 / 15 / 15 %

Equal 15% dedicated per slice (≈20 PRBs each on 133 PRB). Under load all five
UEs receive similar DL goodput (~20–24 Mbps).

| Idle (no traffic) | Full traffic (iperf) |
|---|---|
| ![dedicated 15-15 idle](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-dedicated-15-15-15-15-15-no-traffic.png) | ![dedicated 15-15 full](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-dedicated-15-15-15-15-15-full-traffic.png) |

#### 15 / 15 / 15 / 15 / 7 %

Asymmetric dedicated split: slice 5 gets a smaller guaranteed window (7% ≈ 9 PRBs).
Under load, UE on slice 5 achieves lower goodput than the other four.

| Idle (no traffic) | Full traffic (iperf) |
|---|---|
| ![dedicated 15-7 idle](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-dedicated-15-15-15-15-7-no-traffic.png) | ![dedicated 15-7 full](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-dedicated-15-15-15-15-7-full-traffic.png) |

### Min policy

`min_prb_ratio` is set per slice; `dedicated = 0`, `max = 100%`. The shareable
part above dedicated is allocated in Pass 2 only when the slice needs PRBs.

**What to look for**

- **Idle:** reserved min windows are visible but utilization stays near 0%; unused
  shareable PRBs can be used by other slices.
- **Full traffic:** each active slice receives at least its min share; slices with
  higher min ratios get proportionally more PRBs when all UEs are backlogged.

#### 20 / 20 / 20 / 20 / 20 %

Equal 20% minimum per slice (≈27 PRBs each). Under full load all five UEs achieve
similar goodput (~26–29 Mbps DL).

| Idle (no traffic) | Full traffic (iperf) |
|---|---|
| ![min 20-20 idle](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-min-20-20-20-20-20-no-traffic.png) | ![min 20-20 full](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-min-20-20-20-20-20-full-traffic.png) |

#### 20 / 20 / 20 / 20 / 10 %

Slice 5 has a lower min (10% ≈ 13 PRBs). Under load, UE on slice 5 gets roughly
half the goodput of the other four (~13 vs ~27 Mbps DL).

| Idle (no traffic) | Full traffic (iperf) |
|---|---|
| ![min 20-10 idle](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-min-20-20-20-20-10-no-traffic.png) | ![min 20-10 full](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-min-20-20-20-20-10-full-traffic.png) |

### Max policy

`max_prb_ratio` is set per slice; `dedicated = 0`, `min = 0`. Slices compete for
the full PRB pool in Pass 3, but no slice can exceed its max cap.

**What to look for**

- **Idle:** no PRBs are reserved; all slices show 0% utilization.
- **Full traffic:** slices grow up to their max cap; when caps differ, lower-cap
  slices are throttled while higher-cap slices consume more of the cell bandwidth.

#### 100 / 100 / 100 / 100 / 100 %

No cap — all slices can use the full 133 PRBs. Under contention each UE gets
similar goodput (~27–29 Mbps DL) as the PF scheduler shares the cell fairly.

| Idle (no traffic) | Full traffic (iperf) |
|---|---|
| ![max 100-100 idle](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-max-100-100-100-100-100-no-traffic.png) | ![max 100-100 full](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-max-100-100-100-100-100-full-traffic.png) |

#### 100 / 100 / 100 / 50 / 50 %

Slices 1–3 uncapped; slices 4–5 capped at 50%. Under load, UEs on slices 4–5
achieve ~13 Mbps DL while slices 1–3 reach ~27–29 Mbps — the max cap is enforced.

| Idle (no traffic) | Full traffic (iperf) |
|---|---|
| ![max 50-50 idle](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-max-100-100-100-50-50-no-traffic.png) | ![max 50-50 full](https://raw.githubusercontent.com/FCCLab/INA-Infra-oai-slice-implementation/main/imgs/nws-5ues-max-100-100-100-50-50-full-traffic.png) |

## Changes (37 files, +8855 / −108)

| Area | Key files |
|------|-----------|
| PRB allocator (new) | `openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/` |
| MAC scheduler | `gNB_scheduler_dlsch.c`, `gNB_scheduler_ulsch.c`, `main.c` |
| gNB config | `gnb_config.c`, `gnb_paramdef.h`, `MACRLC_nr_paramdef.h` |
| E2 control | `ran_func_slice.c`, `oai_ns_slice_ie.h` |
| RLC NSSAI API | `nr_rlc_oai_api.c`, `nr_rlc_oai_api.h` |
| Observability | `telnetsrv_proccmd.c` |
| CI | `ci-scripts/yaml_files/5g_sa_nws/gnb.sa.band78.133prb.rfsim5slices.nsboth.yaml` |
| Docs | `doc/network_slice_3gpp_impl.md`, `slice_prb_allocator/README.md` |

## Test plan

- [ ] Unit tests:
      `cd openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator && make test`
- [ ] Build gNB with default config (`SCHE_PF`) — no regression
- [ ] rfsim 5-slice config:
      `ci-scripts/yaml_files/5g_sa_nws/gnb.sa.band78.133prb.rfsim5slices.nsboth.yaml`
- [ ] E2 Slice SM read/write via `ran_func_slice.c`
- [ ] Confirm `dedicated ≤ min ≤ max` and sum of dedicated ratios ≤ 1.0 enforced at config time

## Documentation

- Feature overview: `doc/network_slice_3gpp_impl.md`
- Allocator algorithm: `openair2/LAYER2/NR_MAC_gNB/slice_prb_allocator/README.md`
- Scheduler pipeline: `doc/MAC/scheduler-architecture.md` (updated)

## Notes for reviewers

- End-to-end lab assets (Open5GS compose, xApp, e2e scripts) live in a separate
  INA-Infra workspace and are **not** part of this PR.
- CORESET / PDCCH remain cell-wide; multi-slice experiments require adequate
  `coreset_duration` and `uess_agg_levels` (documented in feature doc).
- Default scheduler path (`SCHE_PF`) is unchanged when `dl/ul_scheduler_type: 0`.
