### PR TITLE
fix(mac, nr_ue): don't overwrite target cell's k_SSB with source cell's during handover

### DIFF
--- a/openair2/LAYER2/NR_MAC_UE/config_ue.c
+++ b/openair2/LAYER2/NR_MAC_UE/config_ue.c
@@ -521,9 +521,10 @@ static void config_common_ue(NR_UE_MAC_INST_t *mac, NR_ServingCellConfigCommon_t
                                                                  mac->frequency_range);
     cfg->ssb_table.ssb_period = *scc->ssb_periodicityServingCell;
     // NSA -> take ssb offset from SCS
-    cfg->ssb_table.ssb_subcarrier_offset = get_ssb_subcarrier_offset(*frequencyInfoDL->absoluteFrequencySSB,
-                                                                     frequencyInfoDL->absoluteFrequencyPointA,
-                                                                     cfg->ssb_config.scs_common);
+    mac->ssb_subcarrier_offset = get_ssb_subcarrier_offset(*frequencyInfoDL->absoluteFrequencySSB,
+                                                           frequencyInfoDL->absoluteFrequencyPointA,
+                                                           cfg->ssb_config.scs_common);
+    cfg->ssb_table.ssb_subcarrier_offset = mac->ssb_subcarrier_offset;
     cfg->ssb_table.ssb_case = set_ssb_case(*scc->ssbSubcarrierSpacing, mac->nr_band);
   }
 


### PR DESCRIPTION
Found this issue when testing inter-frequency handover with OCUDU gNB over ZMQ.

`config_common_ue_sa()` falls back to `mac->ssb_subcarrier_offset` (the last MIB-decoded k_SSB) since SIB1 carries no k_SSB of its own. But a `dedicatedSIB1-Delivery` for a handover target cell can arrive bundled with the same `reconfigurationWithSync` that already derived the target cell's correct k_SSB from `absoluteFrequencySSB`, at that point `mac->ssb_subcarrier_offset` is still the source cell's, so this overwrote the correct value and broke PBCH sync on the target cell whenever the two cells' k_SSB differed.

Fix: update `mac->ssb_subcarrier_offset` directly in `config_common_ue()`, at the point where `reconfigurationWithSync` derives it from `absoluteFrequencySSB`, so the MAC-wide state is correct as soon as the reconfiguration is applied instead of only after a later MIB decode.