### PR TITLE
Wait for response in asynchronous telnet commands

### DIFF
--- a/ci-scripts/scripts/set-and-verify-distance-prs.sh
+++ b/ci-scripts/scripts/set-and-verify-distance-prs.sh
@@ -6,18 +6,12 @@ DISTANCES=("$@")
 
 IP=192.168.71.150
 PORT=8091
-NCAT_TIMEOUT=1 #s
 SLEEP_WAIT=4 #s
-MAX_RETRIES=3
-
 set_and_verify_distance() {
   local distance=$1
   echo "Testing PRS ToA estimation for distance: $distance m"
 
-  # it seems that grep returns immediately with this syntax, but not echo | ncat | grep
-  # so prefer this to receive new distance immediately. We use --idle to keep
-  # ncat open for some additional time
-  local setdist_resp="$(grep --max-count 1 new_offset <(echo rfsimu setdistance rfsimu_channel_enB0 $distance | ncat --idle ${NCAT_TIMEOUT} ${IP} ${PORT}))"
+  local setdist_resp="$(grep --max-count 1 new_offset <(echo rfsimu setdistance rfsimu_channel_enB0 $distance | ncat ${IP} ${PORT}))"
   echo "> response: ${setdist_resp}"
 
   local gettoa_resp="$(echo "ciUE get_max_dl_toa" | ncat ${IP} ${PORT} | grep "UE max PRS DL ToA")"
@@ -36,55 +30,31 @@ set_and_verify_distance() {
 }
 
 test_distance() {
-  local distance=$1 retries=0
-
-  # retry loop incase we didn't receive the response
-  while (( retries < MAX_RETRIES )); do
-    echo "  Attempt $((retries + 1))/$MAX_RETRIES"
+  local distance=$1
 
     # Always reset to 0 m before testing target distance
-    if ! set_and_verify_distance 0; then
-      echo " Set distance 0 m failed during attempt $((retries + 1))"
-    else
-      sleep "$SLEEP_WAIT"
-      # Now test the actual target distance
-      if set_and_verify_distance "$distance"; then
-        return 0
-      fi
-    fi
+  if ! set_and_verify_distance 0; then
+    return 1
+  fi
 
-    ((retries++))
-    if (( retries < MAX_RETRIES )); then
-      sleep "$SLEEP_WAIT"
-    else
-      echo " ERROR: No valid response after $MAX_RETRIES retries for distance: $distance m"
-      return 1
-    fi
-  done
+  sleep "$SLEEP_WAIT"
+
+  if set_and_verify_distance "$distance"; then
+    return 0
+  fi
 }
 
-num_success=0
 num_fail=0
 
 for d in "${DISTANCES[@]}"; do
-  if test_distance "$d"; then
-    ((num_success++))
-  else
+  if ! test_distance "$d"; then
     ((num_fail++))
   fi
   sleep "$SLEEP_WAIT"
 done
 
-# ---- Summary ----
-echo
-echo "==================== SUMMARY ===================="
-echo "Total tests run : ${#DISTANCES[@]}"
-echo "Successful tests: ${num_success}"
-echo "Failed tests    : ${num_fail}"
-echo "================================================="
-
-if [ $num_success -gt 0 ]; then
-  exit 0
-else
+if [ $num_fail -gt 0 ]; then
   exit 1
 fi
+
+exit 0

--- a/ci-scripts/xml_files/container_5g_rfsim_fr2_66prb.xml
+++ b/ci-scripts/xml_files/container_5g_rfsim_fr2_66prb.xml
@@ -63,7 +63,7 @@
     <class>Custom_Command</class>
     <desc>Move UE to beam 2 via the rfsimulator's telnet interface and verify the switch was acknowledged</desc>
     <node>localhost</node>
-    <command>echo rfsimulator setbeamids 2 | ncat 192.168.71.150 8091</command>
+    <command>echo rfsimulator setbeamids 2 | ncat 192.168.71.150 8091 | grep -q "Beam ids set"</command>
   </testCase>
 
   <testCase>

--- a/common/utils/telnetsrv/telnetsrv.c
+++ b/common/utils/telnetsrv/telnetsrv.c
@@ -45,6 +45,11 @@
 static char *telnet_defstatmod[] = {"softmodem","phy","loader","measur"};
 static telnetsrv_params_t telnetparams;
 
+#define TELNET_CMDQ_TIMEOUT_MS 200
+
+/* Response queue for telnet commands posted to queue. */
+static notifiedFIFO_t telnet_cmdrespq;
+
 #define TELNETSRV_OPTNAME_STATICMOD   "staticmod"
 #define TELNETSRV_OPTNAME_SHRMOD      "shrmod"
 
@@ -510,6 +515,48 @@ void telnet_pushcmd(telnetshell_cmddef_t *cmd, char *cmdbuff, telnet_printfunc_t
   telnet_pushcmd_key(cmd, cmdbuff, prnt, NULL, 0);
 }
 
+/* \brief Push a command into the queue, and wait for the
+ * module thread to execute it. Unrelated, late messages from previous jobs are
+ * discarded. */
+static void telnet_pushcmd_wait(telnetshell_cmddef_t *cmd, char *cmdbuff, telnet_printfunc_t prnt)
+{
+  static uint64_t cmdkey = 0;
+  uint64_t key = ++cmdkey;
+
+  struct timespec deadline;
+  int rc = clock_gettime(CLOCK_REALTIME, &deadline);
+  AssertFatal(rc == 0, "clock_gettime() failed: errno %d, %s\n", errno, strerror(errno));
+  deadline.tv_sec += TELNET_CMDQ_TIMEOUT_MS / 1000;
+  deadline.tv_nsec += (TELNET_CMDQ_TIMEOUT_MS % 1000) * 1000000L;
+  if (deadline.tv_nsec >= 1000000000L) {
+    deadline.tv_sec += 1;
+    deadline.tv_nsec -= 1000000000L;
+  }
+
+  telnet_pushcmd_key(cmd, cmdbuff, prnt, &telnet_cmdrespq, key);
+
+  while (true) {
+    notifiedFIFO_elt_t *resp = pullNotifiedFIFO_timeout(&telnet_cmdrespq, &deadline);
+
+    if (resp == NULL) {
+      /* There was no answer to message with "key" on time. Inform the user of
+       * missing answer. */
+      TELNET_LOG("command \"%s\" not completed within %d ms, answer might be lost\n", cmd->cmdname, TELNET_CMDQ_TIMEOUT_MS);
+      prnt("Error: command \"%s\" not completed within %d ms\n", cmd->cmdname, TELNET_CMDQ_TIMEOUT_MS);
+      return;
+    }
+
+    uint64_t respkey = resp->key;
+    delNotifiedFIFO_elt(resp);
+
+    /* response message was what we waited for */
+    if (respkey == key)
+      return;
+
+    /* received answer must be late, keep waiting for ours */
+  }
+}
+
 int process_command(char *buf)
 {
   int i,j,k;
@@ -567,7 +614,7 @@ int process_command(char *buf)
             if (telnetparams.CmdParsers[i].cmd[k].cmdflags & TELNETSRV_CMDFLAG_WEBSRVONLY)
               continue;
             if (telnetparams.CmdParsers[i].cmd[k].qptr != NULL) {
-              telnet_pushcmd(&(telnetparams.CmdParsers[i].cmd[k]), cmdb, client_printf);
+              telnet_pushcmd_wait(&telnetparams.CmdParsers[i].cmd[k], cmdb, client_printf);
             } else {
               telnetparams.CmdParsers[i].cmd[k].cmdfunc(cmdb, telnetparams.telnetdbg, client_printf);
             }
@@ -741,6 +788,10 @@ void run_telnetsrv(void) {
     write_history(telnetparams.histfile);
     clear_history();
     close(telnetparams.new_socket);
+    /* invalidate the socket: a command that timed out in telnet_pushcmd_wait()
+     * will print its answer later on. Then, client_printf() falls back to
+     * stdout. */
+    telnetparams.new_socket = -1;
     TELNET_LOG("Telnet server waiting for connection...\n");
   }
 
@@ -819,15 +870,23 @@ void run_telnetclt(void) {
   return;
 } /* run_telnetclt */
 
-void poll_telnetcmdq(void *qid, void *arg) {
-	notifiedFIFO_elt_t *msg = pollNotifiedFIFO((notifiedFIFO_t *)qid);
-	
-	if (msg != NULL) {
-	  telnetsrv_qmsg_t *msgdata=NotifiedFifoData(msg);
-	  msgdata->cmdfunc(msgdata->cmdbuff,msgdata->debug,msgdata->prnt,arg);
-	  free(msgdata->cmdbuff);
-	  delNotifiedFIFO_elt(msg);
-	}
+void poll_telnetcmdq(void *qid, void *arg)
+{
+  notifiedFIFO_elt_t *msg = pollNotifiedFIFO((notifiedFIFO_t *)qid);
+
+  if (msg == NULL)
+    return;
+
+  telnetsrv_qmsg_t *msgdata = NotifiedFifoData(msg);
+  msgdata->cmdfunc(msgdata->cmdbuff, msgdata->debug, msgdata->prnt, arg);
+  free(msgdata->cmdbuff);
+
+  if (msg->reponseFifo != NULL) {
+    /* post response so telnet_pushcmd_wait() can unblock */
+    pushNotifiedFIFO(msg->reponseFifo, msg);
+  } else {
+    delNotifiedFIFO_elt(msg);
+  }
 }
 /*------------------------------------------------------------------------------------------------*/
 /* load the commands delivered with the telnet server
@@ -895,6 +954,7 @@ int telnetsrv_autoinit(void) {
   char libname[64];
   sprintf(libname,"telnetsrv_%s",execfunc);
   load_module_shlib(libname,NULL,0,NULL);
+  initNotifiedFIFO(&telnet_cmdrespq);
   if(pthread_create(&telnetparams.telnet_pthread,NULL, (void *(*)(void *))run_telnetsrv, NULL) != 0) {
     fprintf(stderr,"[TELNETSRV] Error %s on pthread_create call\n",strerror(errno));
     return -1;

--- a/common/utils/telnetsrv/telnetsrv.c
+++ b/common/utils/telnetsrv/telnetsrv.c
@@ -494,16 +494,20 @@ char *get_time(char *buff,int bufflen) {
   strftime (buff, bufflen, "%Y-%m-%d %H:%M:%S.000", localtime_r(&now,&tmstruct));
   return buff;
 }
-void telnet_pushcmd(telnetshell_cmddef_t *cmd, char *cmdbuff, telnet_printfunc_t prnt)
+static void telnet_pushcmd_key(telnetshell_cmddef_t *cmd, char *cmdbuff, telnet_printfunc_t prnt, notifiedFIFO_t *respq, uint64_t key)
 {
-  notifiedFIFO_elt_t *msg = newNotifiedFIFO_elt(sizeof(telnetsrv_qmsg_t), 0, NULL, NULL);
+  notifiedFIFO_elt_t *msg = newNotifiedFIFO_elt(sizeof(telnetsrv_qmsg_t), key, respq, NULL);
   telnetsrv_qmsg_t *cmddata = NotifiedFifoData(msg);
   cmddata->cmdfunc = (qcmdfunc_t)cmd->cmdfunc;
   cmddata->prnt = prnt;
   cmddata->debug = telnetparams.telnetdbg;
-  if (cmdbuff != NULL)
-    cmddata->cmdbuff = strdup(cmdbuff);
+  cmddata->cmdbuff = cmdbuff != NULL ? strdup(cmdbuff) : NULL;
   pushNotifiedFIFO(cmd->qptr, msg);
+}
+
+void telnet_pushcmd(telnetshell_cmddef_t *cmd, char *cmdbuff, telnet_printfunc_t prnt)
+{
+  telnet_pushcmd_key(cmd, cmdbuff, prnt, NULL, 0);
 }
 
 int process_command(char *buf)
@@ -563,7 +567,7 @@ int process_command(char *buf)
             if (telnetparams.CmdParsers[i].cmd[k].cmdflags & TELNETSRV_CMDFLAG_WEBSRVONLY)
               continue;
             if (telnetparams.CmdParsers[i].cmd[k].qptr != NULL) {
-              telnet_pushcmd(&(telnetparams.CmdParsers[i].cmd[k]), (cmdb != NULL) ? strdup(cmdb) : NULL, client_printf);
+              telnet_pushcmd(&(telnetparams.CmdParsers[i].cmd[k]), cmdb, client_printf);
             } else {
               telnetparams.CmdParsers[i].cmd[k].cmdfunc(cmdb, telnetparams.telnetdbg, client_printf);
             }

--- a/common/utils/threadPool/notified_fifo.h
+++ b/common/utils/threadPool/notified_fifo.h
@@ -5,6 +5,7 @@
 #ifndef NOTIFIED_FIFO_H
 #define NOTIFIED_FIFO_H
 #include "pthread_utils.h"
+#include <errno.h>
 #include <stdint.h>
 #include <malloc.h>
 #include <pthread.h>
@@ -149,6 +150,27 @@ static inline notifiedFIFO_elt_t *pullNotifiedFIFO(notifiedFIFO_t *nf)
 
   while ((ret = pullNotifiedFIFO_nothreadSafe(nf)) == NULL && !nf->abortFIFO)
     condwait(nf->notifF, nf->lockF);
+
+  mutexunlock(nf->lockF);
+  return ret;
+}
+
+/// @brief Pull an element, blocking until one is available or timeout, or FIFO
+/// is aborted.
+/// @param nf the FIFO
+/// @param abstime absolute deadline
+/// @return the element, or NULL on timeout or abort
+static inline notifiedFIFO_elt_t *pullNotifiedFIFO_timeout(notifiedFIFO_t *nf, const struct timespec *abstime)
+{
+  mutexlock(nf->lockF);
+  notifiedFIFO_elt_t *ret = NULL;
+
+  while ((ret = pullNotifiedFIFO_nothreadSafe(nf)) == NULL && !nf->abortFIFO) {
+    int rc = pthread_cond_timedwait(&nf->notifF, &nf->lockF, abstime);
+    if (rc == ETIMEDOUT)
+      break;
+    AssertFatal(rc == 0, "pthread_cond_timedwait() failed: %d\n", rc);
+  }
 
   mutexunlock(nf->lockF);
   return ret;

--- a/radio/rfsimulator/simulator.cpp
+++ b/radio/rfsimulator/simulator.cpp
@@ -1219,26 +1219,28 @@ static void rfsimulator_read_internal(rfsimulator_state_t *t,
           rxAddInput(input, temp_array[aarx], aarx, ptr->channel_model, nsamps);
         }
       } else {
+        // Apply propagation delay
+        const int64_t read_timestamp = timestamp - t->chan_offset;
         // Assume received_packets is ordered by timestamp
         std::queue<rfsim_packet_t *> packets_copy = ptr->received_packets;
         while (!packets_copy.empty()) {
           rfsim_packet_t *pkt = packets_copy.front();
-          if (static_cast<int64_t>(pkt->header.timestamp + pkt->header.size) <= timestamp) {
+          if (static_cast<int64_t>(pkt->header.timestamp + pkt->header.size) <= read_timestamp) {
             // This packet is before the start timestamp, discard it
             packets_copy.pop();
             continue;
           }
-          if (static_cast<int64_t>(pkt->header.timestamp) > timestamp + nsamps) {
+          if (static_cast<int64_t>(pkt->header.timestamp) > read_timestamp + nsamps) {
             // This packet is after the end of the buffer, stop processing
             break;
           }
 
           // The beams transmitted in are ordered by beam index
           uint16_t *tx_beams = (uint16_t *)pkt->payload;
-          uint64_t overlap_start = std::max(timestamp, static_cast<int64_t>(pkt->header.timestamp));
-          uint64_t overlap_end = std::min(timestamp + nsamps, static_cast<int64_t>(pkt->header.timestamp + pkt->header.size));
-          int write_start_idx = overlap_start - timestamp;
-          int write_end_idx = overlap_end - timestamp;
+          uint64_t overlap_start = std::max(read_timestamp, static_cast<int64_t>(pkt->header.timestamp));
+          uint64_t overlap_end = std::min(read_timestamp + nsamps, static_cast<int64_t>(pkt->header.timestamp + pkt->header.size));
+          int write_start_idx = overlap_start - read_timestamp;
+          int write_end_idx = overlap_end - read_timestamp;
           int read_start_idx = overlap_start - pkt->header.timestamp;
           c16_t *buffer = (c16_t *)&pkt->payload[sizeof(uint16_t) * pkt->header.nbAnt];
 


### PR DESCRIPTION
Telnet commands registered with flag TELNETSRV_CMDFLAG_PUSHINTPOOLQ are executed asynchronously by having a the registering module poll on a queue. However, the telnet module did not wait for an answer. This PR adds a response queue such that telnetsrv now, by default, waits for up to 200ms (or until job completion), and logs if no response has been received.

This allows to simplify the PRS script in `ci-scripts/scripts/set-and-verify-distance-prs.sh`, and to immediately check for a beam check as introduced in #424.

Closes: #93