### PR TITLE
Fix  PDUsession crash with multiple UE HO 

### DIFF
--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
@@ -707,15 +707,20 @@ void ue_context_setup_request(const f1ap_ue_context_setup_req_t *req)
   NR_UE_info_t *UE = NULL;
   if (!ue_id_provided) {
     UE = create_new_UE(mac, req->gNB_CU_ue_id, cg_configinfo);
-    resp.gNB_DU_ue_id = UE->rnti;
-    resp.crnti = malloc_or_fail(sizeof(*resp.crnti));
-    *resp.crnti = UE->rnti;
   } else {
     DevAssert(is_SA);
     UE = find_nr_UE(&mac->UE_info, *req->gNB_DU_ue_id);
   }
+  /* create_new_UE() returns NULL if no RNTI is available or the RA list is full
+   * (e.g. many simultaneous handovers into this cell), find_nr_UE() if the CU
+   * sent an unknown gNB_DU_ue_id: check here, before any dereference below */
   AssertFatal(UE, "no UE found or could not be created, but UE Context Setup Failed not implemented\n");
   resp.gNB_DU_ue_id = UE->rnti;
+  if (!ue_id_provided) {
+    /* new UE: report the C-RNTI we allocated back to the CU */
+    resp.crnti = malloc_or_fail(sizeof(*resp.crnti));
+    *resp.crnti = UE->rnti;
+  }
 
   NR_CellGroupConfig_t *new_CellGroup = get_cellgroup_config(UE);
 

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -72,7 +72,7 @@
 #define MAX_NUM_BWP 5
 #define MAX_NUM_CORESET 12
 /*!\brief Maximum number of random access process */
-#define NR_NB_RA_PROC_MAX 4
+#define NR_NB_RA_PROC_MAX 16 // set to 16 for multiple CFRA at the same time
 #define MAX_NUM_OF_SSB 64
 #define MAX_NUM_NR_PRACH_PREAMBLES 64
 #define NR_MAX_SIB_LENGTH 2976 // 3GPP TS 38.331 section 5.2.1

--- a/openair2/RRC/NR/rrc_gNB_NGAP.c
+++ b/openair2/RRC/NR/rrc_gNB_NGAP.c
@@ -1559,7 +1559,7 @@ int rrc_gNB_process_Handover_Request(gNB_RRC_INST *rrc, ngap_handover_request_t 
 
   // Process all PDU Session Resource Setup items from handover request
   DevAssert(msg->nb_of_pdusessions <= NR_MAX_NB_PDU_SESSIONS);
-  pdusession_t to_setup[NR_MAX_NB_PDU_SESSIONS];
+  pdusession_t to_setup[NR_MAX_NB_PDU_SESSIONS] = {0};
   for (int i = 0; i < msg->nb_of_pdusessions; i++) {
     ho_request_pdusession_t *ho_pdu = &msg->pduSessionResourceSetupList[i];
     pdusession_t *pdu = &to_setup[i];


### PR DESCRIPTION
Closes: #459 

## Changes

- `rrc_gNB_NGAP.c`: Add zero-initialize to PDUsession array`to_setup[]` in handover request. This zero initialization also exists in function`void rrc_gNB_process_NGAP_PDUSESSION_SETUP_REQ()`

- `mac_rrc_dl_handler.c`: move the `AssertFatal(UE, ...)` NULL check ahead of any
  dereference; assign `resp.gNB_DU_ue_id` once for both branches.

- `nr_mac_gNB.h`: `NR_NB_RA_PROC_MAX` 4 → 16. The previous`#define NR_NB_RA_PROC_MAX 4` was commits many years ago. Given the max UE would increase to over 100 in the near future (discussed below), we increase the max number of RA process to 16 to avoid tight limit for RA.

## Tests

After rebuilding OAI gNB with the commits, our 8 UE HO test with 4 cells setup with KS RuSIM get rid of the crash mentioned in #459 