### PR TITLE
nrL1_stats: avoid overflow in total_bytes_tx

### DIFF
--- a/openair1/PHY/NR_TRANSPORT/nr_dlsch.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_dlsch.c
@@ -895,7 +895,7 @@ void dump_pdsch_stats(FILE *fd, PHY_VARS_gNB *gNB)
     if (stats->active && stats->frame != stats->dlsch_stats.dump_frame) {
       stats->dlsch_stats.dump_frame = stats->frame;
       fprintf(fd,
-              "DLSCH RNTI %x: current_Qm %d, current_RI %d, total_bytes TX %d\n",
+              "DLSCH RNTI %x: current_Qm %d, current_RI %d, total_bytes TX %lu\n",
               stats->rnti,
               stats->dlsch_stats.current_Qm,
               stats->dlsch_stats.current_RI,

--- a/openair1/PHY/NR_TRANSPORT/nr_ulsch.c
+++ b/openair1/PHY/NR_TRANSPORT/nr_ulsch.c
@@ -183,7 +183,7 @@ void dump_pusch_stats(FILE *fd, PHY_VARS_gNB *gNB)
       int *rt = stats->ulsch_stats.round_trials;
       fprintf(fd,
               "                 round_trials %d(%1.1e):%d(%1.1e):%d(%1.1e):%d, DTX %d, current_Qm %d, current_RI %d, total_bytes "
-              "RX/SCHED %d/%d\n",
+              "RX/SCHED %d/%lu\n",
               rt[0],
               (double)rt[1] / rt[0],
               rt[1],

--- a/openair1/PHY/defs_gNB.h
+++ b/openair1/PHY/defs_gNB.h
@@ -56,7 +56,7 @@ typedef struct {
 typedef struct {
   int dump_frame;
   int round_trials[8];
-  int total_bytes_tx;
+  uint64_t total_bytes_tx;
   int total_bytes_rx;
   int current_Qm;
   int current_RI;


### PR DESCRIPTION
I noticed from some `nrL1stats.log` that `total_bytes_tx` overflows, for instance:

`total_bytes TX -2129096305`

This PR uses `uint64_t` instead of `int` to avoid the overflow.