### PR TITLE
fix(config): honour CONFIG_NOABORTONCHKF; skip rfsim false-abort in nr-uesoftmodem

### DIFF
--- a/common/config/config_cmdline.c
+++ b/common/config/config_cmdline.c
@@ -183,8 +183,13 @@ int config_check_unknown_cmdlineopt(configmodule_interface_t *cfg, char *prefix)
   }
 
   if (unknowndetected > 0) {
-    CONFIG_PRINTF_ERROR("[CONFIG] %i unknown option(s) in command line starting with %s (section %s)\n",
-                        unknowndetected,testprefix,((prefix==NULL)?"":prefix));
+    if (CONFIG_ISFLAGSET(CONFIG_NOABORTONCHKF)) {
+      LOG_W(ENB_APP, "[CONFIG] %i unknown option(s) in command line starting with %s (section %s) — suppressed (NOABORTONCHKF)\n",
+            unknowndetected, testprefix, (prefix == NULL) ? "" : prefix);
+    } else {
+      CONFIG_PRINTF_ERROR("[CONFIG] %i unknown option(s) in command line starting with %s (section %s)\n",
+                          unknowndetected, testprefix, ((prefix == NULL) ? "" : prefix));
+    }
   }
 
   return unknowndetected;

--- a/executables/nr-uesoftmodem.c
+++ b/executables/nr-uesoftmodem.c
@@ -491,7 +491,9 @@ int main(int argc, char **argv)
   // Sleep a while before checking all parameters have been used
   // Some are used directly in external threads, asynchronously
   sleep(2);
-  config_check_unknown_cmdlineopt(uniqCfg, CONFIG_CHECKALLSECTIONS);
+  /* rfsimulator registers its options after the config check window; skip the check for rfsim to avoid a false abort */
+  if (!IS_SOFTMODEM_RFSIM)
+    config_check_unknown_cmdlineopt(uniqCfg, CONFIG_CHECKALLSECTIONS);
 
   // wait for end of program
   printf("Entering ITTI signals handler\n");


### PR DESCRIPTION
## Problem

`nr-uesoftmodem --rfsimulator` aborts with \"N unknown option(s) detected\" even
when all options are valid. The rfsimulator shared library registers its own
`paramdef_t` tables after `config_check_unknown_cmdlineopt()` has already run, so
rfsim options appear unrecognised and trigger a false abort.

A second, pre-existing bug: `CONFIG_NOABORTONCHKF` was documented to suppress the
abort but had no effect — the code always called `CONFIG_PRINTF_ERROR`.

## Fix

- `common/config/config_cmdline.c`: honour `CONFIG_NOABORTONCHKF` — demote abort
  to `LOG_W` when the flag is set.
- `executables/nr-uesoftmodem.c`: skip the check entirely when `IS_SOFTMODEM_RFSIM`
  is set, since rfsim options are legitimate but arrive after the check window.

## Testing

Verified with `nr-uesoftmodem --phy-test --rfsimulator` on the rfsimulator
integration test; without this fix the UE crashes ~10 s after launch.

Assisted-by: Claude:claude-sonnet-4-6