### PR TITLE
RFSimulator parameter deprecation

### DIFF
--- a/common/config/config_cmdline.c
+++ b/common/config/config_cmdline.c
@@ -251,6 +251,9 @@ int config_process_cmdline(configmodule_interface_t *cfg, paramdef_t *cfgoptions
           int ret;
           cfg->argv_info[i] |= CONFIG_CMDLINEOPT_PROCESSED;
 
+          if ((cfgoptions[n].paramflags & PARAMFLAG_DEPRECATED) != 0)
+            fprintf(stderr, "[CONFIG] option %s is deprecated and will be removed in a future release\n", cfg->argv[i]);
+
           if (c > 0) {
             pp = cfg->argv[i + 1];
 

--- a/common/config/config_paramdesc.h
+++ b/common/config/config_paramdesc.h
@@ -24,6 +24,7 @@
 #define PARAMFLAG_CMDLINE_NOPREFIXENABLED (1 << 5)         // on the command line, allow a parameter to be specified without the prefix
 #define PARAMFLAG_CMDLINEONLY             (1 << 6)         // this parameter cannot be specified in config file
 #define PARAMFLAG_VALUE_OPTIONAL          (1 << 7)         // integer param is 1 if no value provided
+#define PARAMFLAG_DEPRECATED              (1 << 8)         // parameter is deprecated, a warning is printed when it is set
 
 /*   Flags used by config modules to return info to calling modules and/or to  for internal usage*/
 #define PARAMFLAG_MALLOCINCONFIG          (1 << 15)        // parameter allocated in config module

--- a/common/config/config_userapi.c
+++ b/common/config/config_userapi.c
@@ -51,9 +51,10 @@ void config_printhelp(paramdef_t *params,int numparams, const char *prefix) {
   printf("\n-----Help for section %-26s: %03i entries------\n",(prefix==NULL)?"(root section)":prefix,numparams);
 
   for (int i=0 ; i<numparams ; i++) {
-    printf("    %s%s: %s",
+    printf("    %s%s%s: %s",
            (strlen(params[i].optname) <= 1) ? "-" : "--",
            params[i].optname,
+           (params[i].paramflags & PARAMFLAG_DEPRECATED) ? " (deprecated)" : "",
            (params[i].helpstr != NULL)?params[i].helpstr:"Help string not specified\n");
   }   /* for on params entries */
 

--- a/common/config/libconfig/config_libconfig.c
+++ b/common/config/libconfig/config_libconfig.c
@@ -347,6 +347,10 @@ int config_libconfig_get(configmodule_interface_t *cfg, paramdef_t *cfgoptions, 
       continue;
     }
 
+    if ((cfgoptions[i].paramflags & PARAMFLAG_DEPRECATED) != 0 &&
+        config_lookup(&(libconfig_privdata.cfg), cfgpath) != NULL)
+      fprintf(stderr, "[CONFIG] option %s is deprecated and will be removed in a future release\n", cfgpath);
+
     int notfound = 0;
     int defval = 0;
 

--- a/common/config/tests/test_config.conf
+++ b/common/config/tests/test_config.conf
@@ -1,5 +1,6 @@
 prefix = (
   {
     test = 42;
+    oldtest = 7;
   }
 );

--- a/common/config/tests/test_config_cmdline.cpp
+++ b/common/config/tests/test_config_cmdline.cpp
@@ -35,6 +35,88 @@ void run_config_test(int argc, char **argv, int expected_numelt, int expected_re
   uniqCfg = nullptr;
 }
 
+TEST(cmdline, cmdline_deprecated_option_warns)
+{
+  char *array[] = {strdup("test_program"), strdup("--prefix.[0].test"), strdup("1")};
+
+  configmodule_interface_t *cfg = load_configmodule(sizeofArray(array), array, CONFIG_ENABLECMDLINEONLY);
+  ASSERT_NE(cfg, nullptr);
+  uniqCfg = cfg;
+
+  paramdef_t params[] = {UINT16PARAM("test", "", PARAMFLAG_DEPRECATED, NULL, 0)};
+  paramlist_def_t list = {"prefix", NULL, 0};
+
+  testing::internal::CaptureStderr();
+  int ret = config_getlist(cfg, &list, params, sizeofArray(params), NULL);
+  std::string captured = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(list.numelt, 1);
+  ASSERT_NE(list.paramarray[0], nullptr);
+  ASSERT_NE(list.paramarray[0][0].u16ptr, nullptr);
+  EXPECT_EQ(*(list.paramarray[0][0].u16ptr), 1);
+  EXPECT_NE(captured.find("deprecated"), std::string::npos);
+  EXPECT_NE(captured.find("--prefix.[0].test"), std::string::npos);
+
+  end_configmodule(cfg);
+  uniqCfg = nullptr;
+
+  for (auto i = 0U; i < sizeofArray(array); i++) {
+    free(array[i]);
+  }
+}
+
+TEST(cmdline, config_file_deprecated_option_warns)
+{
+  const char *conf_path = "test_config.conf";
+
+  char opt_string[256];
+  snprintf(opt_string, sizeof(opt_string), "%s", conf_path);
+
+  char *array[] = {strdup("test_program"), strdup("-O"), strdup(opt_string)};
+
+  configmodule_interface_t *cfg = load_configmodule(sizeofArray(array), array, 0);
+  ASSERT_NE(cfg, nullptr);
+  uniqCfg = cfg;
+
+  paramdef_t params[] = {UINT16PARAM("test", "", 0, NULL, 0),
+                         UINT16PARAM("oldtest", "", PARAMFLAG_DEPRECATED, NULL, 0)};
+  paramlist_def_t list = {"prefix", NULL, 0};
+
+  testing::internal::CaptureStderr();
+  int ret = config_getlist(cfg, &list, params, sizeofArray(params), NULL);
+  std::string captured = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(ret, 1);
+  EXPECT_EQ(list.numelt, 1);
+  ASSERT_NE(list.paramarray[0], nullptr);
+  ASSERT_NE(list.paramarray[0][0].u16ptr, nullptr);
+  EXPECT_EQ(*(list.paramarray[0][0].u16ptr), 42);
+  ASSERT_NE(list.paramarray[0][1].u16ptr, nullptr);
+  EXPECT_EQ(*(list.paramarray[0][1].u16ptr), 7);
+  EXPECT_NE(captured.find("deprecated"), std::string::npos);
+  EXPECT_NE(captured.find("oldtest"), std::string::npos);
+
+  end_configmodule(cfg);
+  uniqCfg = nullptr;
+
+  for (auto i = 0U; i < sizeofArray(array); i++) {
+    free(array[i]);
+  }
+}
+
+TEST(cmdline, deprecated_option_annotated_in_help)
+{
+  paramdef_t params[] = {UINT16PARAM("oldtest", "old help\n", PARAMFLAG_DEPRECATED, NULL, 0)};
+
+  testing::internal::CaptureStdout();
+  config_printhelp(params, sizeofArray(params), NULL);
+  std::string captured = testing::internal::GetCapturedStdout();
+
+  EXPECT_NE(captured.find("(deprecated)"), std::string::npos);
+  EXPECT_NE(captured.find("--oldtest"), std::string::npos);
+}
+
 TEST(cmdline, cmdline_new_array)
 {
   char *array[] = {strdup("test_program"), strdup("--prefix.[0].test"), strdup("1")};

--- a/common/config/yaml/config_yaml.cpp
+++ b/common/config/yaml/config_yaml.cpp
@@ -127,6 +127,8 @@ void SetNonDefault(configmodule_interface_t *cfg, const YAML::Node &node, paramd
 void GetParam(configmodule_interface_t *cfg, const YAML::Node &node, paramdef_t *param)
 {
   if (node && node[std::string(param->optname)]) {
+    if (param->paramflags & PARAMFLAG_DEPRECATED)
+      fprintf(stderr, "[CONFIG] option %s is deprecated and will be removed in a future release\n", param->optname);
     SetNonDefault(cfg, node, param);
   } else {
     config_common_getdefault(cfg, param, nullptr);

--- a/radio/rfsimulator/simulator.cpp
+++ b/radio/rfsimulator/simulator.cpp
@@ -93,7 +93,7 @@ typedef enum { SIMU_ROLE_SERVER = 1, SIMU_ROLE_CLIENT } simuRole;
   UINT16PARAM(RFSIMU_SERVER_PORT,       "<port to connect to>\n",                   simOpt, NULL,                             PORT),                  \
   STRLISTPARAM(RFSIMU_OPTIONS_PARAMNAME, RFSIM_CONFIG_HELP_OPTIONS,                 simOpt, NULL,                             NULL),                  \
   STRINGPARAM(RFSIMU_IQFILE,            "<file path to use when saving IQs>\n",     simOpt, NULL,                             "/tmp/rfsimulator.iqs"),\
-  STRINGPARAM(RFSIMU_MODELNAME,         "<channel model name>\n",                   simOpt, NULL,                             "AWGN"),                \
+  STRINGPARAM(RFSIMU_MODELNAME,         "<channel model name>\n",                   simOpt | PARAMFLAG_DEPRECATED, NULL,       "AWGN"),                \
   DOUBLEPARAM(RFSIMU_PLOSS,             "<channel path loss in dB>\n",              simOpt, NULL,                             0),                     \
   DOUBLEPARAM(RFSIMU_FORGETFACT,        "<channel forget factor ((0 to 1)>\n",      simOpt, NULL,                             0),                     \
   UINT64PARAM(RFSIMU_OFFSET,            "<channel offset in samps>\n",              simOpt, NULL,                             0L),                    \


### PR DESCRIPTION
Introduces deprecation of CLI/config parameters with a warning to users plus deprecates one RFsim parameter.

Closes #475