### PR TITLE
NAS: size the TFT packet filter array to the count the encoding can express

### DIFF
--- a/openair3/NAS/COMMON/IES/TrafficFlowTemplate.h
+++ b/openair3/NAS/COMMON/IES/TrafficFlowTemplate.h
@@ -106,7 +106,9 @@ typedef PacketFilterIdentifiers DeletePacketFilter;
  * in existing TFT" shall contain a variable number of packet filters
  * ------------------------------------------------------------------
  */
-#define TRAFFIC_FLOW_TEMPLATE_NB_PACKET_FILTERS_MAX 4
+/* Number of packet filters is a 4 bit field (TS 24.008 10.5.6.12), so up to
+   15, and the decoder writes as many as it is told. */
+#define TRAFFIC_FLOW_TEMPLATE_NB_PACKET_FILTERS_MAX 16
 typedef struct {
   uint8_t identifier:4;
 #define TRAFFIC_FLOW_TEMPLATE_PRE_REL7_TFT_FILTER 0b00


### PR DESCRIPTION
The number of packet filters in a Traffic Flow Template is a 4-bit field
(TS 24.008 10.5.6.12), so a network may legally announce up to 15.
`decode_traffic_flow_template()` passes that count straight through and
`decode_traffic_flow_template_packet_filters()` writes that many elements,
bounded only by running out of buffer.

The destination array holds 4:

```c
#define TRAFFIC_FLOW_TEMPLATE_NB_PACKET_FILTERS_MAX 4
```

A peer announcing 15 filters writes 11 elements (several hundred bytes) past
the end.

The 4 is the odd one out among its own neighbours, which is what makes it look
like an oversight rather than a deliberate limit: the packet filter identifier
list two definitions above is 16, and `NET_PACKET_FILTER_MAX` in
`openair2/COMMON/networkDef.h`, which these are copied into, is also 16.

Fix: size the array to 16 so it matches both. No clamp is then needed and no
filter is silently dropped.

A dedicated voice bearer normally carries two to four filters, which is
probably why this has not been hit - luck rather than a bound.