### PR TITLE
NAS: bound the Protocol Configuration Options container loop

### DIFF
--- a/openair3/NAS/COMMON/IES/ProtocolConfigurationOptions.c
+++ b/openair3/NAS/COMMON/IES/ProtocolConfigurationOptions.c
@@ -9,12 +9,14 @@
 #include "TLVEncoder.h"
 #include "TLVDecoder.h"
 #include "ProtocolConfigurationOptions.h"
+#include "nas_log.h"
 
 int decode_protocol_configuration_options(ProtocolConfigurationOptions *protocolconfigurationoptions, uint8_t iei, uint8_t *buffer, uint32_t len)
 {
   uint32_t decoded = 0;
   uint8_t ielen = 0;
   int decode_result;
+  uint32_t skipped_containers = 0;
 
   if (iei > 0) {
     CHECK_IEI_DECODER(iei, *buffer);
@@ -42,6 +44,29 @@ int decode_protocol_configuration_options(ProtocolConfigurationOptions *protocol
   //IES_DECODE_U16(protocolconfigurationoptions->protocolid, *(buffer + decoded));
   protocolconfigurationoptions->num_protocol_id_or_container_id = 0;
   while ((len - decoded) > 0) {
+    /* The index below addresses arrays of
+       PROTOCOL_CONFIGURATION_OPTIONS_MAXIMUM_PROTOCOL_ID_OR_CONTAINER_ID
+       entries, while this loop is bounded only by the peer's length. */
+    if (protocolconfigurationoptions->num_protocol_id_or_container_id >=
+        PROTOCOL_CONFIGURATION_OPTIONS_MAXIMUM_PROTOCOL_ID_OR_CONTAINER_ID) {
+      uint8_t skipped_len;
+
+      if ((decoded + PROTOCOL_CONFIGURATION_OPTIONS_CONTAINER_HEADER_LENGTH) > len) {
+        break;
+      }
+
+      decoded += sizeof(uint16_t); // protocol/container identifier, nowhere left to store it
+      DECODE_U8(buffer + decoded, skipped_len, decoded);
+
+      if (skipped_len > (len - decoded)) {
+        break;
+      }
+
+      decoded += skipped_len; // skip contents
+      skipped_containers++;
+      continue;
+    }
+
     IES_DECODE_U16(buffer, decoded, protocolconfigurationoptions->protocolid[protocolconfigurationoptions->num_protocol_id_or_container_id]);
     DECODE_U8(buffer + decoded, protocolconfigurationoptions->lengthofprotocolid[protocolconfigurationoptions->num_protocol_id_or_container_id], decoded);
 
@@ -57,6 +82,13 @@ int decode_protocol_configuration_options(ProtocolConfigurationOptions *protocol
       protocolconfigurationoptions->protocolidcontents[protocolconfigurationoptions->num_protocol_id_or_container_id].value = NULL;
     }
     protocolconfigurationoptions->num_protocol_id_or_container_id += 1;
+  }
+
+  if (skipped_containers > 0) {
+    LOG_TRACE(WARNING,
+              "PCO: %u container(s) beyond the %d that fit were not decoded",
+              skipped_containers,
+              PROTOCOL_CONFIGURATION_OPTIONS_MAXIMUM_PROTOCOL_ID_OR_CONTAINER_ID);
   }
 
 #if defined (NAS_DEBUG)

--- a/openair3/NAS/COMMON/IES/ProtocolConfigurationOptions.h
+++ b/openair3/NAS/COMMON/IES/ProtocolConfigurationOptions.h
@@ -17,6 +17,9 @@
 // arbitrary value, theoricaly can be greater than defined (250/3)
 #define PROTOCOL_CONFIGURATION_OPTIONS_MAXIMUM_PROTOCOL_ID_OR_CONTAINER_ID 16
 
+/* Container header: 2 octet protocol/container identifier + 1 octet length */
+#define PROTOCOL_CONFIGURATION_OPTIONS_CONTAINER_HEADER_LENGTH 3
+
 
 /* 3GPP TS 24.008 Table 10.5.154
  * MS to network table


### PR DESCRIPTION
`decode_protocol_configuration_options()` (TS 24.008 10.5.6.3) loops while
bytes remain and uses `num_protocol_id_or_container_id` as an index into three
arrays without ever comparing it against their size:

```c
uint16_t    protocolid         [PROTOCOL_CONFIGURATION_OPTIONS_MAXIMUM_...];  /* 16 */
uint8_t     lengthofprotocolid [PROTOCOL_CONFIGURATION_OPTIONS_MAXIMUM_...];  /* 16 */
OctetString protocolidcontents [PROTOCOL_CONFIGURATION_OPTIONS_MAXIMUM_...];  /* 16 */
```

A container costs three octets at minimum and the PCO length is a single
octet, so a peer can present roughly eighty containers and overrun all three -
including `protocolidcontents`, whose pointer is then filled by
`decode_octet_string()`.

Fix: stop storing at the sixteenth container but keep skipping the rest, so
`decoded` still describes the whole IE. TS 24.008 gives no way to refuse a PCO
for being too long, so ignoring the tail is preferable to dropping the message.

The skip path tests `decoded + header > len` rather than subtracting: both are
`uint32_t`, so a `len - decoded` that had already overshot would wrap rather
than go negative. Containers that did not fit are counted and reported once per
message, not once per container.

Separately, and not addressed here: `IES_DECODE_U16` advances by two without
checking there are two, so a truncated container overshoots on the storing
path too.
