### PR TITLE
NAS/UE: fix EPS attach against a commercial MME (IE length bound, HashMME)

### DIFF
--- a/openair3/NAS/COMMON/EMM/MSG/SecurityModeCommand.c
+++ b/openair3/NAS/COMMON/EMM/MSG/SecurityModeCommand.c
@@ -84,6 +84,20 @@ int decode_security_mode_command(security_mode_command_msg *security_mode_comman
       security_mode_command->presencemask |= SECURITY_MODE_COMMAND_NONCEMME_PRESENT;
       break;
 
+    /* HashMME (LV, 3GPP TS 24.301 9.9.3.50) */
+    case 0x4f: {
+      if (len - decoded < 2)
+        return TLV_DECODE_BUFFER_TOO_SHORT;
+
+      uint32_t hashmme_length = *(buffer + decoded + 1);
+
+      if (len - decoded < 2 + hashmme_length)
+        return TLV_DECODE_BUFFER_TOO_SHORT;
+
+      decoded += 2 + hashmme_length; // skip IE
+      break;
+    }
+
     default:
       errorCodeDecoder = TLV_DECODE_UNEXPECTED_IEI;
       return TLV_DECODE_UNEXPECTED_IEI;

--- a/openair3/NAS/COMMON/IES/UeSecurityCapability.c
+++ b/openair3/NAS/COMMON/IES/UeSecurityCapability.c
@@ -31,14 +31,14 @@ int decode_ue_security_capability(UeSecurityCapability *uesecuritycapability, ui
   uesecuritycapability->eia = *(buffer + decoded);
   decoded++;
 
-  if (len >= decoded + 3) {
+  if (ielen >= 4) {
     uesecuritycapability->umts_present = 1;
     uesecuritycapability->uea = *(buffer + decoded);
     decoded++;
     uesecuritycapability->uia = *(buffer + decoded) & 0x7f;
     decoded++;
 
-    if (len == decoded + 4) {
+    if (ielen >= 5) {
       uesecuritycapability->gprs_present = 1;
       uesecuritycapability->gea = *(buffer + decoded) & 0x7f;
       decoded++;


### PR DESCRIPTION
Two faults that together make an EPS attach fail against a commercial MME
*after* authentication has already succeeded, presenting as a credential
problem when it is a parser gap. Fixing either alone changes nothing.

**1. `decode_ue_security_capability()` bounds optional fields by the wrong
length.** It decides whether the optional UMTS and GPRS algorithm octets are
present by testing `len` - the bytes left in the whole NAS message - instead
of `ielen`, the IE length it has just read. Those are only the same thing when
the IE is last in the message. TS 24.301 9.9.3.36 explicitly allows a
two-octet EPS-only replayed capability; when one is followed by more IEs the
decoder swallows two of them and rejects the message with
`TLV_DECODE_UNEXPECTED_IEI`.

**2. Security Mode Command is rejected outright if it carries `HashMME`.**
The decoder knows only IMEISV-request, replayed-NonceUE and NonceMME; its
`default:` arm returns `TLV_DECODE_UNEXPECTED_IEI` for anything else, so the
whole message fails to decode, the UE answers EMM Status (cause 111) and the
MME rejects the attach.

`HashMME` (TS 24.301 9.9.3.50) is a hash of the initial NAS message and
checking it is optional for the UE - 5.4.3.3 only requires the UE to act on it
if it chooses to - so the minimal correct behaviour is to skip the IE rather
than refuse the message.