### PR TITLE
RRC/NR: erase a released DRB when the modification completes, and release it towards the DU

### DIFF
--- a/doc/RRC/rrc-dev.md
+++ b/doc/RRC/rrc-dev.md
@@ -275,11 +275,11 @@ sequenceDiagram
 
     alt !all_failed
         Note over CUCP: Pre-RRC step: E1/F1 updates
-        Note over CUCP: Build E1AP DRB-To-Remove/To-Modify/To-Setup lists<br/>(populated during nr_rrc_update_pdusession)
+        Note over CUCP: Build E1AP DRB-To-Remove/To-Modify/To-Setup lists<br/>(populated during nr_rrc_update_pdusession)<br/>DRBs left with no QoS flow are put in DRB-To-Remove,<br/>but kept in UE->drbs until the procedure completes
         CUCP->>CUUP: E1 BEARER CONTEXT MOD REQUEST (DRB-To-Remove/To-Modify/To-Setup)
         Note over CUUP: e1_bearer_context_modif()<br/>Process DRB modifications, removals, and setups<br/>Update PDCP/SDAP entities, GTP tunnels
         CUUP->>CUCP: E1 BEARER CONTEXT MOD RESPONSE
-        Note over CUCP: rrc_gNB_process_e1_bearer_context_modif_resp<br/>Save F1-U tunnel info for new DRBs<br/>Mark PDU sessions with new DRBs as PDU_SESSION_STATUS_NEW
+        Note over CUCP: rrc_gNB_process_e1_bearer_context_modif_resp<br/>Save F1-U tunnel info for new DRBs<br/>Mark PDU sessions with new DRBs as PDU_SESSION_STATUS_NEW<br/>Add released DRBs to the F1 DRB release list
         Note over CUCP, DU: F1-U tunnel changes (new DRBs or DRB releases)
         CUCP->>DU: F1 UE Context Modification Request
         Note over DU: handle_ue_context_drbs_setup/release
@@ -293,12 +293,12 @@ sequenceDiagram
         UE->>DU: RRCReconfigurationComplete
         DU->>CUCP: F1AP_UL_RRC_MESSAGE
         Note over CUCP: rrc_gNB_decode_dcch
-        Note over CUCP: handle_rrcReconfigurationComplete<br/>Calls rrc_gNB_send_NGAP_PDUSESSION_MODIFY_RESP<br/>(DRBs already removed earlier in nr_rrc_update_pdusession)
+        Note over CUCP: handle_rrcReconfigurationComplete<br/>Calls rrc_gNB_send_NGAP_PDUSESSION_MODIFY_RESP
 
         CUCP->>CUCP: rrc_gNB_send_NGAP_PDUSESSION_MODIFY_RESP
         loop UE->pduSessions (matching transaction ID)
             alt ESTABLISHED
-                Note over CUCP: Update status to ESTABLISHED<br/>Fill NGAP message (modified)<br/>Include QoS flow list
+                Note over CUCP: Update status to ESTABLISHED<br/>Fill NGAP message (modified)<br/>Include QoS flow list<br/>Erase the DRBs this modification released from UE->drbs
             else PDU_SESSION_STATUS_FAILED
                 Note over CUCP: Fill NGAP message (failed to modify)<br/>Include cause
             end

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -3428,25 +3428,14 @@ void rrc_gNB_process_e1_bearer_context_modif_resp(const e1ap_bearer_modif_resp_t
           do_reconfig = true;
       }
 
-      /* DRBs this modification released. The E1 request that produced this
-         response asked the CU-UP to remove them; the DU is told here, in the
-         same F1 UE Context Modification the setups above go in. They are still
-         in ue->drbs, which is what makes them findable: a DRB is erased when
-         the modification completes, not when the E1 request is built. */
-      FOR_EACH_SEQ_ARR(drb_t *, drb, &ue->drbs) {
-        if (drb->pdusession_id != pdu->id)
-          continue;
-        bool drb_still_used = false;
-        FOR_EACH_SEQ_ARR(nr_rrc_qos_t *, q, &pdu_session->param.qos) {
-          if (q->drb_id == drb->drb_id) {
-            drb_still_used = true;
-            break;
-          }
-        }
-        if (drb_still_used)
-          continue;
+      /* DRBs this modification released: the E1 request asked the CU-UP to
+         remove them, the DU is told here, in the same F1 UE Context
+         Modification as the setups above. */
+      int released[MAX_DRBS_PER_UE];
+      int n_released = nr_rrc_collect_released_drbs(&ue->drbs, pdu_session, released);
+      for (int j = 0; j < n_released; j++) {
         DevAssert(n_f1_drbs_rel < MAX_DRBS_PER_UE);
-        f1_drbs_rel[n_f1_drbs_rel++].id = drb->drb_id;
+        f1_drbs_rel[n_f1_drbs_rel++].id = released[j];
       }
       // Collect DRBs to release for PDU sessions marked for release
     } else if (pdu_session->status == PDU_SESSION_STATUS_TORELEASE) {

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -499,14 +499,6 @@ NR_DRB_ToAddModList_t *createDRBlist(gNB_RRC_UE_t *ue, bool reestablish, bool do
       continue;
     }
     pdusession_t *session = &pduSession->param;
-    NR_DRB_ToAddMod_t *drb_ToAddMod = calloc_or_fail(1, sizeof(*drb_ToAddMod));
-    drb_ToAddMod->drb_Identity = drb->drb_id;
-    // PDCP config
-    drb_ToAddMod->pdcp_Config = nr_rrc_build_pdcp_config_ie(do_integrity, do_ciphering, &drb->pdcp_config);
-    if (reestablish) {
-      asn1cCallocOne(drb_ToAddMod->reestablishPDCP, NR_DRB_ToAddMod__reestablishPDCP_true);
-    }
-    // cn-association: SDAP config
     // Get all QoS flows mapped to this DRB
     pdusession_level_qos_parameter_t flows_to_add[MAX_QOS_FLOWS] = {0};
     uint8_t n_flows = 0;
@@ -517,6 +509,24 @@ NR_DRB_ToAddModList_t *createDRBlist(gNB_RRC_UE_t *ue, bool reestablish, bool do
         flows_to_add[n_flows++] = q->qos;
       }
     }
+    /* A DRB that no QoS flow maps to any more is on its way out: a session
+       modification took its last flow and it is erased once that modification
+       completes. It must not be announced here. TS 38.331 constrains
+       SDAP-Config's mappedQoS-FlowsToAdd to SIZE(1..maxNrofQFIs), so there is
+       no encoding for such a DRB, and asking the UE to add a bearer nothing
+       can be sent on has no meaning to begin with. */
+    if (n_flows == 0) {
+      LOG_D(NR_RRC, "DRB %d has no QoS flow mapped to it, skip\n", drb->drb_id);
+      continue;
+    }
+    NR_DRB_ToAddMod_t *drb_ToAddMod = calloc_or_fail(1, sizeof(*drb_ToAddMod));
+    drb_ToAddMod->drb_Identity = drb->drb_id;
+    // PDCP config
+    drb_ToAddMod->pdcp_Config = nr_rrc_build_pdcp_config_ie(do_integrity, do_ciphering, &drb->pdcp_config);
+    if (reestablish) {
+      asn1cCallocOne(drb_ToAddMod->reestablishPDCP, NR_DRB_ToAddMod__reestablishPDCP_true);
+    }
+    // cn-association: SDAP config
     asn1cCalloc(drb_ToAddMod->cnAssociation, cn_association);
     cn_association->present = NR_DRB_ToAddMod__cnAssociation_PR_sdap_Config;
     nr_sdap_configuration_t *sdap = &session->sdap_config;

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -3427,6 +3427,27 @@ void rrc_gNB_process_e1_bearer_context_modif_resp(const e1ap_bearer_modif_resp_t
         if (drb_mod->numQosFlowSetup > 0 || drb_mod->numUpParam > 0)
           do_reconfig = true;
       }
+
+      /* DRBs this modification released. The E1 request that produced this
+         response asked the CU-UP to remove them; the DU is told here, in the
+         same F1 UE Context Modification the setups above go in. They are still
+         in ue->drbs, which is what makes them findable: a DRB is erased when
+         the modification completes, not when the E1 request is built. */
+      FOR_EACH_SEQ_ARR(drb_t *, drb, &ue->drbs) {
+        if (drb->pdusession_id != pdu->id)
+          continue;
+        bool drb_still_used = false;
+        FOR_EACH_SEQ_ARR(nr_rrc_qos_t *, q, &pdu_session->param.qos) {
+          if (q->drb_id == drb->drb_id) {
+            drb_still_used = true;
+            break;
+          }
+        }
+        if (drb_still_used)
+          continue;
+        DevAssert(n_f1_drbs_rel < MAX_DRBS_PER_UE);
+        f1_drbs_rel[n_f1_drbs_rel++].id = drb->drb_id;
+      }
       // Collect DRBs to release for PDU sessions marked for release
     } else if (pdu_session->status == PDU_SESSION_STATUS_TORELEASE) {
       FOR_EACH_SEQ_ARR(drb_t *, drb, &ue->drbs) {

--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -942,6 +942,28 @@ nr_rrc_reconfig_param_t get_RRCReconfiguration_params(gNB_RRC_INST *rrc, gNB_RRC
         }
       }
     }
+    /* A modification that took the last QoS flow off a DRB releases it, so the
+       UE is told in the same drb-ToReleaseList a session release would use.
+       createDRBlist() leaves such a DRB out of drb-ToAddModList, so the two
+       lists stay disjoint as TS 38.331 requires. */
+    if (item->status == PDU_SESSION_STATUS_TOMODIFY) {
+      int released[MAX_DRBS_PER_UE];
+      int n = nr_rrc_collect_released_drbs(&UE->drbs, item, released);
+      for (int i = 0; i < n; i++) {
+        if (params.n_drb_rel >= MAX_DRBS_PER_UE) {
+          LOG_E(NR_RRC, "UE %d: Too many DRBs to release (max %d)\n", UE->rrc_ue_id, MAX_DRBS_PER_UE);
+          break;
+        }
+        if (!params.drb_rel)
+          params.drb_rel = calloc_or_fail(MAX_DRBS_PER_UE, sizeof(int));
+        params.drb_rel[params.n_drb_rel++] = released[i];
+        LOG_I(NR_RRC,
+              "UE %d: releasing DRB %d towards the UE, PDU session %d modification left it with no QoS flow\n",
+              UE->rrc_ue_id,
+              released[i],
+              session->pdusession_id);
+      }
+    }
   }
 
   if (UE->nas_pdu.len > 0) {

--- a/openair2/RRC/NR/rrc_gNB_NGAP.c
+++ b/openair2/RRC/NR/rrc_gNB_NGAP.c
@@ -997,8 +997,14 @@ static void nr_rrc_override_flow_mapping_info(DRB_nGRAN_to_mod_t *mod, long drb_
 }
 
 /** @brief Finalize E1 DRB actions after QoS update/release processing:
- *         - remove DRBs no longer referenced by any QoS flow
+ *         - request release of DRBs no longer referenced by any QoS flow
  *         - refresh DRB-To-Modify QoS list for changed DRBs that are still used
+ *
+ * DRBs to be released are only put in the E1 request here; they stay in
+ * UE->drbs until the modification completes, exactly as a PDU session release
+ * keeps them until the release completes. Erasing one here would erase it out
+ * from under the loop below.
+ *
  * @param UE UE context
  * @param pduSession PDU session to check
  * @param e1_req E1AP bearer modification request
@@ -1024,17 +1030,15 @@ static void nr_rrc_send_e1_after_qos_update(gNB_RRC_UE_t *UE,
       }
     }
     if (!drb_still_used) {
-      if (nr_rrc_remove_drb_by_id(&UE->drbs, drb->drb_id)) {
-        LOG_I(NR_RRC,
-              "UE %d: removed DRB ID %d for PDU session %d (no remaining QoS flows mapped)\n",
-              UE->rrc_ue_id,
-              drb->drb_id,
-              dst->pdusession_id);
-      }
       // Add DRB to remove directly to e1_req
       DevAssert(pdu_mod->n_drb_to_remove < E1AP_MAX_NUM_DRBS);
       drb_to_remove_t *rem = &pdu_mod->drbs_to_remove[pdu_mod->n_drb_to_remove++];
       rem->id = drb->drb_id;
+      LOG_I(NR_RRC,
+            "UE %d: releasing DRB ID %d of PDU session %d (no remaining QoS flows mapped)\n",
+            UE->rrc_ue_id,
+            drb->drb_id,
+            dst->pdusession_id);
       continue;
     }
 
@@ -1385,6 +1389,33 @@ int rrc_gNB_send_NGAP_PDUSESSION_MODIFY_RESP(gNB_RRC_INST *rrc, gNB_RRC_UE_t *UE
               UE->rrc_ue_id,
               session->param.pdusession_id);
       }
+
+      /* The DRBs this modification released. nr_rrc_send_e1_after_qos_update()
+         asked the CU-UP to remove them and deliberately left them in UE->drbs,
+         so that the F1 UE Context Modification and the RRC Reconfiguration in
+         between could still be built from them. The procedure is over now,
+         which is where a PDU session release erases its DRBs too. */
+      int drbs_released[MAX_DRBS_PER_UE];
+      int n_drbs_released = 0;
+      FOR_EACH_SEQ_ARR(drb_t *, drb, &UE->drbs) {
+        if (drb->pdusession_id != session->param.pdusession_id)
+          continue;
+        bool drb_still_used = false;
+        FOR_EACH_SEQ_ARR(nr_rrc_qos_t *, q, &session->param.qos) {
+          if (q->drb_id == drb->drb_id) {
+            drb_still_used = true;
+            break;
+          }
+        }
+        if (!drb_still_used) {
+          DevAssert(n_drbs_released < MAX_DRBS_PER_UE);
+          drbs_released[n_drbs_released++] = drb->drb_id;
+        }
+      }
+      /* Only now: nr_rrc_remove_drb_by_id() erases from UE->drbs, which the
+         loop above is iterating. */
+      for (int i = 0; i < n_drbs_released; i++)
+        nr_rrc_remove_drb_by_id(&UE->drbs, drbs_released[i]);
     } else if (session->status == PDU_SESSION_STATUS_FAILED) {
       DevAssert(resp->nb_of_pdusessions_failed <= NR_MAX_NB_PDU_SESSIONS);
       pdusession_failed_t *failed = &resp->pdusessions_failed[resp->nb_of_pdusessions_failed++];

--- a/openair2/RRC/NR/rrc_gNB_NGAP.c
+++ b/openair2/RRC/NR/rrc_gNB_NGAP.c
@@ -1001,9 +1001,8 @@ static void nr_rrc_override_flow_mapping_info(DRB_nGRAN_to_mod_t *mod, long drb_
  *         - refresh DRB-To-Modify QoS list for changed DRBs that are still used
  *
  * DRBs to be released are only put in the E1 request here; they stay in
- * UE->drbs until the modification completes, exactly as a PDU session release
- * keeps them until the release completes. Erasing one here would erase it out
- * from under the loop below.
+ * UE->drbs until the modification completes. Erasing one here would erase it
+ * out from under the loop below.
  *
  * @param UE UE context
  * @param pduSession PDU session to check
@@ -1022,14 +1021,7 @@ static void nr_rrc_send_e1_after_qos_update(gNB_RRC_UE_t *UE,
   FOR_EACH_SEQ_ARR (drb_t *, drb, &UE->drbs) {
     if (drb->pdusession_id != dst->pdusession_id)
       continue;
-    bool drb_still_used = false;
-    FOR_EACH_SEQ_ARR (nr_rrc_qos_t *, qos, &dst->qos) {
-      if (qos->drb_id == drb->drb_id) {
-        drb_still_used = true;
-        break;
-      }
-    }
-    if (!drb_still_used) {
+    if (!nr_rrc_drb_has_qos_flow(pduSession, drb->drb_id)) {
       // Add DRB to remove directly to e1_req
       DevAssert(pdu_mod->n_drb_to_remove < E1AP_MAX_NUM_DRBS);
       drb_to_remove_t *rem = &pdu_mod->drbs_to_remove[pdu_mod->n_drb_to_remove++];
@@ -1390,30 +1382,11 @@ int rrc_gNB_send_NGAP_PDUSESSION_MODIFY_RESP(gNB_RRC_INST *rrc, gNB_RRC_UE_t *UE
               session->param.pdusession_id);
       }
 
-      /* The DRBs this modification released. nr_rrc_send_e1_after_qos_update()
-         asked the CU-UP to remove them and deliberately left them in UE->drbs,
-         so that the F1 UE Context Modification and the RRC Reconfiguration in
-         between could still be built from them. The procedure is over now,
-         which is where a PDU session release erases its DRBs too. */
+      /* The DRBs this modification released: asked of the CU-UP over E1, kept
+         in UE->drbs so F1 and RRC could still be built from them. */
       int drbs_released[MAX_DRBS_PER_UE];
-      int n_drbs_released = 0;
-      FOR_EACH_SEQ_ARR(drb_t *, drb, &UE->drbs) {
-        if (drb->pdusession_id != session->param.pdusession_id)
-          continue;
-        bool drb_still_used = false;
-        FOR_EACH_SEQ_ARR(nr_rrc_qos_t *, q, &session->param.qos) {
-          if (q->drb_id == drb->drb_id) {
-            drb_still_used = true;
-            break;
-          }
-        }
-        if (!drb_still_used) {
-          DevAssert(n_drbs_released < MAX_DRBS_PER_UE);
-          drbs_released[n_drbs_released++] = drb->drb_id;
-        }
-      }
-      /* Only now: nr_rrc_remove_drb_by_id() erases from UE->drbs, which the
-         loop above is iterating. */
+      int n_drbs_released = nr_rrc_collect_released_drbs(&UE->drbs, session, drbs_released);
+      // Only after the collection: removing erases from UE->drbs, which it iterates
       for (int i = 0; i < n_drbs_released; i++)
         nr_rrc_remove_drb_by_id(&UE->drbs, drbs_released[i]);
     } else if (session->status == PDU_SESSION_STATUS_FAILED) {

--- a/openair2/RRC/NR/rrc_gNB_radio_bearers.c
+++ b/openair2/RRC/NR/rrc_gNB_radio_bearers.c
@@ -154,6 +154,42 @@ bool rm_qos(seq_arr_t *flows, int qfi)
   return true;
 }
 
+/** @brief Whether any QoS flow of @param session is mapped to DRB @param drb_id */
+bool nr_rrc_drb_has_qos_flow(const rrc_pdu_session_param_t *session, int drb_id)
+{
+  DevAssert(session);
+  FOR_EACH_SEQ_ARR(const nr_rrc_qos_t *, q, &session->param.qos) {
+    if (q->drb_id == drb_id)
+      return true;
+  }
+  return false;
+}
+
+/** @brief Collect the DRBs of @param session that no QoS flow maps to any more
+ *
+ *  @param drbs the UE's DRB list
+ *  @param out  filled with the DRB IDs, at most MAX_DRBS_PER_UE
+ *  @return the number of DRB IDs written to @param out */
+int nr_rrc_collect_released_drbs(const seq_arr_t *drbs, const rrc_pdu_session_param_t *session, int out[MAX_DRBS_PER_UE])
+{
+  DevAssert(drbs);
+  DevAssert(session);
+  DevAssert(out);
+  int n = 0;
+  FOR_EACH_SEQ_ARR(const drb_t *, drb, drbs) {
+    if (drb->pdusession_id != session->param.pdusession_id)
+      continue;
+    if (nr_rrc_drb_has_qos_flow(session, drb->drb_id))
+      continue;
+    if (n == MAX_DRBS_PER_UE) {
+      LOG_E(NR_RRC, "PDU Session %d: more than %d released DRBs\n", session->param.pdusession_id, MAX_DRBS_PER_UE);
+      break;
+    }
+    out[n++] = drb->drb_id;
+  }
+  return n;
+}
+
 static bool eq_pdu_session_id(const void *vval, const void *vit)
 {
   const int id = *(const int *)vval;

--- a/openair2/RRC/NR/rrc_gNB_radio_bearers.h
+++ b/openair2/RRC/NR/rrc_gNB_radio_bearers.h
@@ -48,6 +48,14 @@ nr_rrc_qos_t *add_qos(seq_arr_t *qos, const pdusession_level_qos_parameter_t *in
 /// @brief Remove a single QoS flow identified by @param qfi from the list
 bool rm_qos(seq_arr_t *qos, int qfi);
 
+/// @brief Whether any QoS flow of @param session is mapped to DRB @param drb_id
+bool nr_rrc_drb_has_qos_flow(const rrc_pdu_session_param_t *session, int drb_id);
+
+/// @brief Collect into @param out the DRBs of @param session that no QoS flow maps to
+/// any more, i.e. the ones a session modification released
+/// @return the number of DRB IDs written to @param out
+int nr_rrc_collect_released_drbs(const seq_arr_t *drbs, const rrc_pdu_session_param_t *session, int out[MAX_DRBS_PER_UE]);
+
 /// @brief Find the first DRB for a given PDU session ID
 drb_t *find_drb_by_pdusession_id(seq_arr_t *seq, int pdusession_id);
 


### PR DESCRIPTION
A DRB dropped by a PDU session modification is mishandled in three places, two of
which kill the gNB. Dropping one is what the end of every voice call does - the
IMS PDU session stays up for the whole registration and each call adds a
dedicated 5QI 1 DRB and takes it away again - so none of this is a corner case
for VoNR.

The three are one story: such a DRB is erased too early, which crashes the gNB
outright; moving the erase to where it belongs then exposes that the DU is never
told about the release at all, and that the UE is told to add a bearer that is on
its way out.

## The DRB is erased while the loop is still reading it

```
[NR_RRC] UE 1: removed QoS flow with QFI=1
[NR_RRC] Removing DRB ID 3 (PDU Session ID=2)
[NR_RRC] UE 1: removed DRB ID 0 for PDU session 2 (no remaining QoS flows mapped)
Assertion (id > 0 && id <= (32)) failed! In get_drb() rrc_gNB_radio_bearers.c
```

The DRB is erased as 3 and reported as 0 one line later.
`nr_rrc_send_e1_after_qos_update()` erases DRBs from `UE->drbs` while iterating
it with `FOR_EACH_SEQ_ARR`, then keeps reading the element it just erased.
`seq_arr_erase_deep()` memmoves the tail down, decrements the size and memsets
the vacated slot to zero, so a DRB that was last in the array reads back as
`drb_id 0` - the 0 in the log and the 0 that reaches `get_drb()`. It may also
`maybe_shrink()`, leaving `drb` dangling rather than merely stale.

The iteration is broken too: `seq_arr_end()` has moved down one element, so
`seq_arr_next()` steps past the new end, `var != end` stays true and the loop
walks off the array.

The erase does not belong in that function at all. A PDU session *release* does
not erase its DRBs when it builds the E1 request. They stay in `UE->drbs`
through the E1 response, the F1 UE Context Modification and the RRC
Reconfiguration - all of which are built from them - and are erased in
`rrc_gNB_send_NGAP_PDUSESSION_RELEASE_RESPONSE()`, once the procedure is over. A
DRB dropped by a session *modification* has exactly the same lifetime, so it is
now erased in the same place: the modify counterpart,
`rrc_gNB_send_NGAP_PDUSESSION_MODIFY_RESP()`, which already erases the DRBs of a
session that failed to modify.

`nr_rrc_send_e1_after_qos_update()` therefore only records the DRB in the E1
request, and nothing is erased while its loop runs.

The assertion in `get_drb()` is deliberately left alone rather than softened to
tolerate the 0 - it was right, the caller was wrong.

## The DU is never told, and dies after ~32 calls

```
Assertion (encoded > 0) failed! In encode_cellgroup_config()
mac_rrc_dl_handler.c:599 / Could not encode CellGroup / Exiting execution
```

`rrc_gNB.c` collects DRBs to release for F1 in exactly one place, guarded by the
PDU session being torn down. A voice call never releases its PDU session, so the
status is `TOMODIFY`, and that arm handles DRBs set up and DRBs modified but has
no arm at all for a DRB the modification removed.

What survives is lopsided: E1 releases PDCP in the CU-UP, while the DU hears
nothing - repeated `DRB N already exists for UE X, do nothing` from RLC and
`cannot add LCID 6: already present` from MAC. Its `rlc_BearerToAddModList` grows
one LCID per call until it passes `maxLC-ID` and the DU dies encoding a
`CellGroupConfig` it cannot represent. `handle_ue_context_drbs_release()` does
all the right things (`nr_mac_remove_lcid`, `nr_rlc_release_entity`,
`asn_sequence_del`); it is simply never called.

The `TOMODIFY` arm now finds those DRBs the same way the E1 request did - no QoS
flow of this session maps to them - reading them straight out of `ue->drbs`, and
puts them in the F1 UE Context Modification Request alongside the DRBs being set
up. That mirrors what the `TORELEASE` arm right below it already does for a
session release. It is only possible because of the change above: the DRBs are
still in `ue->drbs` when the E1 modification response arrives, and the E1
response itself carries no list of what was removed, so they could not be
recovered from it.

Releasing a DRB the DU has already dropped is harmless: it looks the LCID up in
its add-mod list and does nothing when it is not there.

## A DRB nothing maps to is not announced to the UE

`createDRBlist()` builds `drb-ToAddModList` from `UE->drbs` and never asks
whether any QoS flow maps to the DRB. Before this PR a flowless DRB was erased
before any reconfiguration was built, so the list never saw one; now it can, and
it does not encode:

```
mappedQoS-FlowsToAdd  SEQUENCE (SIZE (1..maxNrofQFIs)) OF QFI  OPTIONAL
```

`nr_rrc_build_sdap_config_ie()` allocates `mappedQoS_FlowsToAdd` unconditionally
and then adds `n_flows` entries, so `n_flows == 0` produces a present but empty
SEQUENCE, one below the lower bound TS 38.331 puts on it. Beyond the encoding, a
DRB no flow maps to is one the network is taking away - telling the UE to add it
is the opposite of what the procedure means. So the flows are collected first and
the DRB is skipped when there are none.

This commit is ordered first, so that deferring the erase never opens the window
even briefly.

## Notes

Addresses @GuidoCasati's review: the DRBs stay in `UE->drbs` through E1 resp /
F1 mod / RRC reconfig and are erased at the end, as `TORELEASE` does, and the
`drbs_owed_to_du` list is gone - the DRBs are found where they already are, and
`nr_rrc_defs.h` is not touched at all.

Also on @GuidoCasati's suggestion, #501 is folded in here rather than kept as a
dependent PR, and is closed.
