### PR TITLE
RRC/NR: release a DRB towards the DU when a session modification removes it

### DIFF
--- a/openair2/RRC/NR/rrc_gNB.c
+++ b/openair2/RRC/NR/rrc_gNB.c
@@ -3417,6 +3417,27 @@ void rrc_gNB_process_e1_bearer_context_modif_resp(const e1ap_bearer_modif_resp_t
         if (drb_mod->numQosFlowSetup > 0 || drb_mod->numUpParam > 0)
           do_reconfig = true;
       }
+
+      /* DRBs this modification released. The E1 request that produced this
+         response asked the CU-UP to remove them; the DU is told here, in the
+         same F1 UE Context Modification the setups above go in. They are still
+         in ue->drbs, which is what makes them findable: a DRB is erased when
+         the modification completes, not when the E1 request is built. */
+      FOR_EACH_SEQ_ARR(drb_t *, drb, &ue->drbs) {
+        if (drb->pdusession_id != pdu->id)
+          continue;
+        bool drb_still_used = false;
+        FOR_EACH_SEQ_ARR(nr_rrc_qos_t *, q, &pdu_session->param.qos) {
+          if (q->drb_id == drb->drb_id) {
+            drb_still_used = true;
+            break;
+          }
+        }
+        if (drb_still_used)
+          continue;
+        DevAssert(n_f1_drbs_rel < MAX_DRBS_PER_UE);
+        f1_drbs_rel[n_f1_drbs_rel++].id = drb->drb_id;
+      }
       // Collect DRBs to release for PDU sessions marked for release
     } else if (pdu_session->status == PDU_SESSION_STATUS_TORELEASE) {
       FOR_EACH_SEQ_ARR(drb_t *, drb, &ue->drbs) {


### PR DESCRIPTION
The gNB dies after roughly 32 voice calls:

```
Assertion (encoded > 0) failed! In encode_cellgroup_config()
mac_rrc_dl_handler.c:599 / Could not encode CellGroup / Exiting execution
```

`rrc_gNB.c` collects DRBs to release for F1 in exactly one place, guarded by the
PDU session being torn down. A voice call never releases its PDU session - the
IMS session stays up for the whole registration, and each call adds a dedicated
5QI 1 DRB and drops it again at the end. The status is therefore `TOMODIFY`, and
that arm handles DRBs set up and DRBs modified but has no arm at all for a DRB
the modification removed.

What survives is lopsided: E1 releases PDCP in the CU-UP, while the DU hears
nothing - repeated `DRB N already exists for UE X, do nothing` from RLC and
`cannot add LCID 6: already present` from MAC. Its `rlc_BearerToAddModList` grows
one LCID per call until it passes `maxLC-ID` and the DU dies encoding a
`CellGroupConfig` it cannot represent. `handle_ue_context_drbs_release()` does
all the right things (`nr_mac_remove_lcid`, `nr_rlc_release_entity`,
`asn_sequence_del`); it is simply never called.

## The fix

The `TOMODIFY` arm now finds those DRBs the same way the E1 request did - no QoS
flow of this session maps to them - reading them straight out of `ue->drbs`, and
puts them in the F1 UE Context Modification Request alongside the DRBs being set
up. That mirrors what the `TORELEASE` arm right below it already does for a
session release.

Releasing a DRB the DU has already dropped is harmless: it looks the LCID up in
its add-mod list and does nothing when it is not there.

## Notes

Addresses @GuidoCasati's review: the `drbs_owed_to_du` list is gone, and
`nr_rrc_defs.h` is no longer touched at all. The DRBs are found where they
already are.

**Depends on #500.** This reads the DRBs out of `ue->drbs` when the E1
modification response arrives, which requires them to still be there - #500 is
what stops them being erased while the E1 request is built. This compiles and is
harmless without it, but finds nothing to release.
