### PR TITLE
Use SNR estimated from SRS for link adaptation

### DIFF
--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac.h
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac.h
@@ -508,6 +508,7 @@ typedef struct nr_srs_feedback {
   uint8_t sri;
   uint8_t ul_ri;
   uint8_t tpmi;
+  int snrx10;
 } nr_srs_feedback_t;
 
 typedef struct NR_UE_DL_BWP {

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -2729,6 +2729,7 @@ void reset_sched_ctrl(NR_UE_sched_ctrl_t *sched_ctrl)
   sched_ctrl->srs_feedback.ul_ri = 0;
   sched_ctrl->srs_feedback.tpmi = 0;
   sched_ctrl->srs_feedback.sri = 0;
+  sched_ctrl->srs_feedback.snrx10 = INT_MIN;
 }
 
 int get_dlbw_tbslbrm(int scc_bwpsize, const NR_ServingCellConfig_t *servingCellConfig)
@@ -3165,6 +3166,7 @@ NR_UE_info_t *get_new_nr_ue_inst(uid_allocator_t *uia, rnti_t rnti, NR_CellGroup
   UE->ra = calloc(1, sizeof(*UE->ra));
   NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
   sched_ctrl->ta_update = 31;
+  sched_ctrl->srs_feedback.snrx10 = INT_MIN;
 
   const nr_mac_config_t *config = &cell->radio_config;
   nr_mac_set_target_snrx10(&sched_ctrl->pucch_pc, config->pucch.target_snrx10);

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -1549,6 +1549,7 @@ void handle_nr_srs_measurements(const module_id_t module_id,
       }
 #endif
 
+      UE->UE_sched_ctrl.srs_feedback.snrx10 = wide_band_snr_dB * 10;
       sprintf(stats->srs_stats, "UL-SNR %i dB", wide_band_snr_dB);
 
       const int ul_prbblack_SNR_threshold = cell->radio_config.ul_prbblack_SNR_threshold;
@@ -2759,7 +2760,9 @@ static int collect_ul_candidates(gNB_MAC_INST *mac,
     cand.current_mcs = sched_ctrl->ul_bler_stats.mcs;
     cand.max_mcs = max_mcs;
     cand.last_num_sched = sched_ctrl->ul_bler_stats.last_num_sched;
-    cand.snrx10 = (int)(sched_ctrl->pusch_pc.avg_snr * 10);
+    const int srs_snrx10 = sched_ctrl->srs_feedback.snrx10;
+    const int pusch_snrx10 = (int)(sched_ctrl->pusch_pc.avg_snr * 10);
+    cand.snrx10 = srs_snrx10 != INT_MIN ? srs_snrx10 : pusch_snrx10;
 
     LOG_D(NR_MAC,
           "[UE %04x][%4d.%2d] b %d, ul_thr_ue %f, mcs %d, sched_inactive %d sched_srs %d\n",


### PR DESCRIPTION
This PR uses SNR estimated from SRS for link adaption when available

Note: This is currently used in SRS beam management usage. Should be extended to codebook based SRS usage as well.