### PR TITLE
gtpu: add per-instance packet and drop counters

### DIFF
--- a/openair3/ocp-gtpu/gtp_itf.cpp
+++ b/openair3/ocp-gtpu/gtp_itf.cpp
@@ -148,6 +148,7 @@ class gtpEndPoint {
   int ipVersion;
   gtpThread_t thrData;
   map<uint64_t, teidData_t> ue2te_mapping;
+  gtpu_stats_t stats = {};
   // we use the same port number for source and destination address
   // this allow using non standard gtp port number (different from 2152)
   // and so, for example tu run 4G and 5G cores on one system
@@ -182,6 +183,26 @@ class gtpEndPoints {
 };
 
 static gtpEndPoints globGtp;
+
+static void gtpu_stat_drop(int h, uint64_t gtpu_stats_t::*counter)
+{
+  pthread_mutex_lock(&globGtp.gtp_lock);
+  auto it = globGtp.instances.find(h);
+  if (it != globGtp.instances.end())
+    it->second.stats.*counter += 1;
+  pthread_mutex_unlock(&globGtp.gtp_lock);
+}
+
+static void gtpu_stat_rx_ok(int h, uint64_t bytes)
+{
+  pthread_mutex_lock(&globGtp.gtp_lock);
+  auto it = globGtp.instances.find(h);
+  if (it != globGtp.instances.end()) {
+    it->second.stats.rx_pkts++;
+    it->second.stats.rx_bytes += bytes;
+  }
+  pthread_mutex_unlock(&globGtp.gtp_lock);
+}
 
 // note TEid 0 is reserved for specific usage: echo req/resp, error and supported extensions
 static teid_t gtpv1uNewTeid(void)
@@ -329,6 +350,7 @@ static void _gtpv1uSendDirect(instance_t instance,
 
   if (ptr2 == ptrUe->second.bearers.end()) {
     LOG_E(GTPU, "[%ld] GTP-U instance: sending a packet to a non existant UE:RAB: %lx/%x\n", instance, ue_id, bearer_id);
+    inst->stats.tx_drop_no_tunnel++;
     pthread_mutex_unlock(&globGtp.gtp_lock);
     return;
   }
@@ -392,14 +414,19 @@ static void _gtpv1uSendDirect(instance_t instance,
   }
 
   DevAssert(compatInst(instance) == bearer.sock_fd);
-  gtpv1uCreateAndSendMsg(&bearer,
-                         GTP_GPDU,
-                         buf,
-                         len,
-                         seqNumFlag,
-                         npduNumFlag,
-                         ext,
-                         extension_count);
+  int send_ok = gtpv1uCreateAndSendMsg(&bearer, GTP_GPDU, buf, len, seqNumFlag, npduNumFlag, ext, extension_count);
+  int h = compatInst(instance);
+  if (send_ok != GTPNOK) {
+    pthread_mutex_lock(&globGtp.gtp_lock);
+    auto it = globGtp.instances.find(h);
+    if (it != globGtp.instances.end()) {
+      it->second.stats.tx_pkts++;
+      it->second.stats.tx_bytes += len;
+    }
+    pthread_mutex_unlock(&globGtp.gtp_lock);
+  } else {
+    gtpu_stat_drop(h, &gtpu_stats_t::tx_drop_send_fail);
+  }
 }
 
 /** Send GTP-U packet with QFI marking for N3-U tunnel
@@ -441,6 +468,7 @@ void gtpv1uSendDirectWithNRUSeqNum(instance_t instance,
 
   if (ptr2 == ptrUe->second.bearers.end()) {
     LOG_E(GTPU, "[%ld] GTP-U instance: sending a packet to a non existant UE:RAB: %lx/%x\n", instance, ue_id, bearer_id);
+    inst->stats.tx_drop_no_tunnel++;
     pthread_mutex_unlock(&globGtp.gtp_lock);
     return;
   }
@@ -1114,6 +1142,7 @@ static int Gtpv1uHandleGpdu(int h, uint8_t *msgBuf, uint32_t msgBufLen, const st
 
   if (msgHdr->version != 1 || msgHdr->PT != 1) {
     LOG_E(GTPU, "[%d] Received a packet that is not GTP header\n", h);
+    gtpu_stat_drop(h, &gtpu_stats_t::rx_drop_malformed);
     return GTPNOK;
   }
 
@@ -1123,6 +1152,7 @@ static int Gtpv1uHandleGpdu(int h, uint8_t *msgBuf, uint32_t msgBufLen, const st
   if (tunnel == globGtp.te2ue_mapping.end()) {
     LOG_E(GTPU, "[%d] Received a incoming packet on unknown TEID (0x%x) Dropping!\n", h, ntohl(msgHdr->teid));
     pthread_mutex_unlock(&globGtp.gtp_lock);
+    gtpu_stat_drop(h, &gtpu_stats_t::rx_drop_unknown_teid);
     return GTPNOK;
   }
   ueidData_t uedata = tunnel->second;
@@ -1259,8 +1289,12 @@ static int Gtpv1uHandleGpdu(int h, uint8_t *msgBuf, uint32_t msgBufLen, const st
                                        &destinationL2Id,
                                        qfi,
                                        rqi,
-                                       uedata.pdusession_id))
+                                       uedata.pdusession_id)) {
         LOG_E(GTPU, "[%d] down layer refused incoming SDAP packet\n", h);
+        gtpu_stat_drop(h, &gtpu_stats_t::rx_drop_refused);
+      } else {
+        gtpu_stat_rx_ok(h, sdu_buffer_size);
+      }
     } else {
       /* Non-SDAP callback path: direct TEID-to-incoming_rb_id delivery via callBack.
        * QFI must be absent on this path */
@@ -1270,8 +1304,12 @@ static int Gtpv1uHandleGpdu(int h, uint8_t *msgBuf, uint32_t msgBufLen, const st
                   qfi,
                   uedata.ue_id,
                   ntohl(msgHdr->teid));
-      if (!uedata.callBack(&ctxt, srb_flag, rb_id, mui, confirm, sdu_buffer_size, sdu_buffer, mode, &sourceL2Id, &destinationL2Id))
+      if (!uedata.callBack(&ctxt, srb_flag, rb_id, mui, confirm, sdu_buffer_size, sdu_buffer, mode, &sourceL2Id, &destinationL2Id)) {
         LOG_E(GTPU, "[%d] down layer refused incoming packet\n", h);
+        gtpu_stat_drop(h, &gtpu_stats_t::rx_drop_refused);
+      } else {
+        gtpu_stat_rx_ok(h, sdu_buffer_size);
+      }
     }
   }
 
@@ -1331,12 +1369,14 @@ static bool gtpv1uReceiveHandleMessage(int h, uint8_t buf[VLEN][BUFSIZE])
     uint8_t *udpData = buf[i];
     if (udpDataLen < (int)sizeof(Gtpv1uMsgHeaderT)) {
       LOG_W(GTPU, "[%d] received malformed gtp packet \n", h);
-      return true;
+      gtpu_stat_drop(h, &gtpu_stats_t::rx_drop_malformed);
+      continue;
     }
     Gtpv1uMsgHeaderT *msg = (Gtpv1uMsgHeaderT *)udpData;
     if ((int)(ntohs(msg->msgLength) + sizeof(Gtpv1uMsgHeaderT)) != udpDataLen) {
       LOG_W(GTPU, "[%d] received malformed gtp packet length\n", h);
-      return true;
+      gtpu_stat_drop(h, &gtpu_stats_t::rx_drop_malformed);
+      continue;
     }
     LOG_D(GTPU, "[%d] Received GTP data, msg type: %x\n", h, msg->msgType);
     switch (msg->msgType) {
@@ -1452,6 +1492,40 @@ void *gtpv1uTask(void *args)
   }
 
   return NULL;
+}
+
+bool gtpu_get_stats(instance_t instance, gtpu_stats_t *out)
+{
+  pthread_mutex_lock(&globGtp.gtp_lock);
+  auto it = globGtp.instances.find(compatInst(instance));
+  if (it == globGtp.instances.end()) {
+    pthread_mutex_unlock(&globGtp.gtp_lock);
+    return false;
+  }
+  *out = it->second.stats;
+  pthread_mutex_unlock(&globGtp.gtp_lock);
+  return true;
+}
+
+void gtpu_log_stats(instance_t instance)
+{
+  gtpu_stats_t s;
+  if (!gtpu_get_stats(instance, &s)) {
+    return;
+  }
+  LOG_I(GTPU,
+        "[%ld] GTP-U stats: TX pkts=%lu bytes=%lu drop_no_tunnel=%lu drop_send_fail=%lu | "
+        "RX pkts=%lu bytes=%lu drop_unknown_teid=%lu drop_malformed=%lu drop_refused=%lu\n",
+        instance,
+        s.tx_pkts,
+        s.tx_bytes,
+        s.tx_drop_no_tunnel,
+        s.tx_drop_send_fail,
+        s.rx_pkts,
+        s.rx_bytes,
+        s.rx_drop_unknown_teid,
+        s.rx_drop_malformed,
+        s.rx_drop_refused);
 }
 
 #ifdef __cplusplus

--- a/openair3/ocp-gtpu/gtp_itf.h
+++ b/openair3/ocp-gtpu/gtp_itf.h
@@ -14,6 +14,21 @@
 
 # define GTPU_HEADER_OVERHEAD_MAX 64
 
+typedef struct {
+  /* TX counters (outgoing GTP-U G-PDUs) */
+  uint64_t tx_pkts;           /* packets successfully sent */
+  uint64_t tx_bytes;          /* payload bytes successfully sent */
+  uint64_t tx_drop_no_tunnel; /* dropped: no matching UE/bearer found */
+  uint64_t tx_drop_send_fail; /* dropped: sendmsg() returned an error */
+
+  /* RX counters (incoming GTP-U G-PDUs from UDP socket) */
+  uint64_t rx_pkts;           /* G-PDUs delivered to lower layer */
+  uint64_t rx_bytes;          /* payload bytes delivered */
+  uint64_t rx_drop_malformed; /* dropped: bad GTP header or length */
+  uint64_t rx_drop_unknown_teid; /* dropped: TEID not in te2ue_mapping */
+  uint64_t rx_drop_refused;   /* dropped: lower-layer callback returned false */
+} gtpu_stats_t;
+
 #include "common/platform_types.h"
 #ifdef __cplusplus
 extern "C" {
@@ -137,6 +152,8 @@ typedef struct gtpv1u_gnb_delete_tunnel_req_s gtpv1u_gnb_delete_tunnel_req_t;
   instance_t gtpv1Init(openAddr_t context);
   int gtpv1Term(instance_t inst);
   void *gtpv1uTask(void *args);
+  bool gtpu_get_stats(instance_t instance, gtpu_stats_t *out);
+  void gtpu_log_stats(instance_t instance);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Closes #481.

Adds per-instance GTP-U packet counters, including categorised drop counters, so
losses on N3/F1-U can be attributed to a specific cause instead of being
invisible. This follows the pattern other interfaces already use.

### Counters

A `gtpu_stats_t` is kept per GTP-U instance:

| Counter | Meaning |
|---|---|
| `tx_pkts` / `tx_bytes` | G-PDUs successfully sent |
| `tx_drop_no_tunnel` | dropped: no matching UE/bearer |
| `tx_drop_send_fail` | dropped: `sendmsg()` failed |
| `rx_pkts` / `rx_bytes` | G-PDUs delivered to the lower layer |
| `rx_drop_malformed` | dropped: bad GTP header or length |
| `rx_drop_unknown_teid` | dropped: TEID not in `te2ue_mapping` |
| `rx_drop_refused` | dropped: lower-layer callback returned false |

Separating the RX drop reasons is the useful part: an unknown TEID points at
tunnel setup or a stale context, a malformed header points at the transport,
and a refused delivery points at the layer above.

### API

```c
bool gtpu_get_stats(instance_t instance, gtpu_stats_t *out);
void gtpu_log_stats(instance_t instance);
```

`gtpu_get_stats()` copies a snapshot under `globGtp.gtp_lock` and returns
`false` for an unknown instance.

### Notes

- Counter updates take the existing `globGtp.gtp_lock`; no new lock is
  introduced and no lock ordering changes.
- The TX success path updates counters inline while it already holds the lock,
  so the added cost is a couple of increments rather than an extra
  lock/unlock round trip.
- Purely additive: no existing struct layout, signature, or behaviour changes,
  so nothing outside `openair3/ocp-gtpu/` is affected.

### Testing

Built with the `default` preset and exercised over rfsimulator in an SA setup
(gNB + nrUE + OAI CN). TX/RX counters track the transferred G-PDUs, and the
drop counters stay at zero on a healthy tunnel.

I am happy to adjust naming, split the TX and RX counters into separate
commits, or expose these through an existing stats/telnet path if you would
prefer that over the standalone accessor.
