### PR TITLE
work around simde missing mm512_reduce_add_ps in signal_energy_nodc()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,43 @@ else ()
   set(C_FLAGS_PROCESSOR "${C_FLAGS_PROCESSOR} -march=armv8.2-a")
 endif()
 
+# The AVX512 code paths use a few SIMDe intrinsics that no released SIMDe
+# provides, so OAI assumes an unreleased commit, installed system-wide by
+# build_oai -I. A system-wide install goes stale easily -- e.g. after a rebase
+# onto a develop that assumes a newer one -- and a missing simde_* function is
+# merely an implicit declaration in C: the file compiles with a warning and the
+# build only fails when linking, on an undefined reference that looks like a
+# bug in OAI rather than a stale dependency. Detect it here instead, and fall
+# back to the assumed version, as we do for the other CPM dependencies.
+# Keep in sync with install_simde_from_source() in cmake_targets/tools/build_helper.
+set(OAI_SIMDE_VERSION 1c68d9ad60bf63f3fb527c4ee3b2319d828ffcc6)
+if(AVX512 AND NOT CROSS_COMPILE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  include(CheckCSourceCompiles)
+  # -Werror=... so that a missing function fails here, and not only when linking
+  set(CMAKE_REQUIRED_FLAGS "${C_FLAGS_PROCESSOR} -Werror=implicit-function-declaration")
+  check_c_source_compiles("
+    #include <simde/x86/avx512.h>
+    int main(void) {
+      return (int) simde_mm512_reduce_add_ps(simde_mm512_setzero_ps())
+             + simde_mm512_reduce_add_epi32(simde_mm512_cvtepi8_epi32(simde_mm_setzero_si128()));
+    }" HAVE_SIMDE_AVX512_INTRINSICS)
+  unset(CMAKE_REQUIRED_FLAGS)
+  if(NOT HAVE_SIMDE_AVX512_INTRINSICS)
+    message(WARNING "the SIMDe installed on this system is too old for the AVX512 code paths; "
+                    "downloading ${OAI_SIMDE_VERSION} instead. "
+                    "Run ./build_oai -I to install that version system-wide.")
+    CPMAddPackage(NAME simde
+                  GITHUB_REPOSITORY simd-everywhere/simde-no-tests
+                  GIT_TAG ${OAI_SIMDE_VERSION}
+                  DOWNLOAD_ONLY YES)
+    # simde-no-tests holds the headers at the repository root, but they are
+    # included as <simde/...>, so expose the checkout under such a directory
+    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/simde-include)
+    file(CREATE_LINK ${simde_SOURCE_DIR} ${CMAKE_BINARY_DIR}/simde-include/simde SYMBOLIC)
+    include_directories(SYSTEM BEFORE ${CMAKE_BINARY_DIR}/simde-include)
+  endif()
+endif()
+
 # we need -rdynamic to incorporate all symbols in shared objects, see man page
 set(commonOpts "-pipe -fPIC -Wall -fno-strict-aliasing -rdynamic")
 # GNU C/C++ Compiler might throw many warnings without packed-bitfield-compat, see man page

--- a/cmake_targets/tools/build_helper
+++ b/cmake_targets/tools/build_helper
@@ -491,12 +491,16 @@ install_simde_from_source(){
     git clone https://github.com/simd-everywhere/simde-no-tests.git /tmp/simde
     cd /tmp/simde
     # we can specify a given version of SIMDE (sha-one or tag)
-    if [[ -v SIMDE_VERSION ]]; then
-      git checkout -f $SIMDE_VERSION
-    else
-      # At time of writing, last working commit for OAI: 1c68d9a
-      git checkout 1c68d9ad60bf63f3fb527c4ee3b2319d828ffcc6
+    if [[ ! -v SIMDE_VERSION ]]; then
+      # otherwise install the version CMake expects, so that the two cannot
+      # drift apart and send the build through the CPM fallback
+      SIMDE_VERSION=$(sed -n 's/^set(OAI_SIMDE_VERSION \(.*\))$/\1/p' $OPENAIR_DIR/CMakeLists.txt)
+      if [[ -z "$SIMDE_VERSION" ]]; then
+        echo_error "could not read OAI_SIMDE_VERSION from $OPENAIR_DIR/CMakeLists.txt"
+        exit 1
+      fi
     fi
+    git checkout -f $SIMDE_VERSION
     # Showing which version is used
     git log -n1
     # brute force copy into /usr/include

--- a/openair1/PHY/CODING/nrSmallBlock/decodeSmallBlock.c
+++ b/openair1/PHY/CODING/nrSmallBlock/decodeSmallBlock.c
@@ -7,9 +7,6 @@
 #include "PHY/sse_intrin.h"
 #if defined(__AVX512F__)
 #include <simde/x86/avx512.h>
-// simde current version missed this instruction
-#define simde_mm512_reduce_add_epi32 _mm512_reduce_add_epi32
-#define simde_mm512_cvtepi8_epi32 _mm512_cvtepi8_epi32
 #endif
 
 //#define DEBUG_DECODESMALLBLOCK

--- a/openair1/PHY/TOOLS/signal_energy.c
+++ b/openair1/PHY/TOOLS/signal_energy.c
@@ -10,8 +10,6 @@
 // input  : points to vector
 // length : length of vector in complex samples
 
-#define shift 4
-
 //-----------------------------------------------------------------
 // Average Power calculation with DC removing
 //-----------------------------------------------------------------


### PR DESCRIPTION
**Title:** `build: detect a stale system SIMDe instead of working around it`

---

## What this was, and what it turned out to be

This branch started as a fix for an undefined reference hit while testing on an
AMD AVX-512 box:

```
libPHY_NR.a(signal_energy.c.o): in function `signal_energy_nodc:
signal_energy.c:62: undefined reference to `simde_mm512_reduce_add_ps
```

That is **not** a bug in `develop`. `develop` assumes SIMDe
`1c68d9ad60bf63f3fb527c4ee3b2319d828ffcc6` (2026-04-22), which does provide
`simde_mm512_reduce_add_ps` — it landed upstream on 2026-03-13 in simde
`099e7116` ("add more reduction functions...", simde#1395). The SIMDe actually
installed in `/usr/include` on that machine was from **2023-11-07**: the branch
had been rebased onto `develop` without re-running `./build_oai -I`.

So the interesting defect is the *diagnosis*, not the intrinsic. A missing
`simde_*` function is only an implicit declaration in C, so the file compiles
with a warning and the build breaks much later, at link time, with an error that
reads like an OAI regression rather than a stale dependency.

## What this PR does instead

Detects the problem at configure time and fixes it, rather than papering over it
in the sources.

- **`CMakeLists.txt`** — the assumed SIMDe commit now lives here as
  `OAI_SIMDE_VERSION`. A `check_c_source_compiles` verifies the three intrinsics
  the AVX-512 paths actually use; if they are missing, CMake says so, names the
  remedy (`./build_oai -I`), and falls back to `CPMAddPackage` on the assumed
  commit — the same `find_package`-then-CPM pattern already used for yaml-cpp,
  googletest, benchmark and tracy. The check is gated to native x86_64 AVX-512
  builds, the only configurations that compile these call sites, so ARM/cross and
  non-AVX-512 builds are untouched.
- **`cmake_targets/tools/build_helper`** — `install_simde_from_source()` reads
  `OAI_SIMDE_VERSION` from `CMakeLists.txt` instead of carrying its own copy of
  the SHA, so what `-I` installs and what CMake expects can no longer drift
  apart. The `SIMDE_VERSION` environment override still wins.
- **`signal_energy.c`, `decodeSmallBlock.c`** — drop the
  `#define simde_mm512_* _mm512_*` workarounds, now unnecessary. Also drops the
  unused `shift` macro in `signal_energy.c`, which nothing referenced and which
  squatted on a very common identifier.

The check deliberately covers all three intrinsics rather than just the one that
broke: `simde_mm512_cvtepi8_epi32` landed upstream on 2026-04-21, *later* than
`simde_mm512_reduce_add_ps` (2026-03-13), so a SIMDe from between those dates
would pass a single-symbol check and still fail to link.

## Verification

Tested on an x86_64 AVX-512 host:

| Scenario | Result |
| --- | --- |
| Stale `/usr/include/simde` (the 2023 tree) | check fails, warning names the remedy, CPM supplies the pin, `nr_ulsim` links |
| SIMDe new enough | check succeeds, no download, no `simde` entry in `cpm-package-lock.cmake` |
| `-DAVX512=OFF` | check skipped entirely |
| `nm -u` on `signal_energy.c.o`, `decodeSmallBlock.c.o` | no undefined `simde_*` |

## Note for reviewers

`docker/Dockerfile.base.ubuntu.cross-arm64` still pins `SIMDE_VERSION=389f360a`
(2023-10-16), commented as "a working version of SIMDE for ARM". It is left
alone here: the new check skips cross builds and `build_helper` still honours the
explicit environment variable, so it is inert either way. It is now, however, the
only pin in the tree that disagrees with `OAI_SIMDE_VERSION` — worth revisiting
separately by someone who knows why ARM was held back.