### PR TITLE
SCTP: optional userspace backend (usrsctp) for F1-C and N2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1390,13 +1390,50 @@ target_link_libraries(MME_APP PRIVATE asn1_nr_rrc_hdrs asn1_lte_rrc_hdrs)
 target_link_libraries(MME_APP PRIVATE nfapi_vnf_lib nfapi_user_lib)
 
 find_package(sctp REQUIRED)
+# Optional userspace SCTP stack for F1-C and N2, used when the kernel has no
+# CONFIG_IP_SCTP. This switch only decides whether the backend is COMPILED IN --
+# which backend is USED is decided at runtime in oai_sctp.c, by trying to open a
+# kernel SCTP socket. It has to be that way round: OAI is cross-compiled, so a
+# configure-time probe would test the build host's kernel rather than the
+# target's, and one image may be booted against kernels that differ in SCTP
+# support. See the header comment in openair3/SCTP/oai_sctp.h.
+option(ENABLE_USRSCTP "Build the usrsctp fallback backend for F1-C/N2" OFF)
 set(SCTP_SRC
   ${OPENAIR3_DIR}/SCTP/sctp_common.c
   ${OPENAIR3_DIR}/SCTP/sctp_eNB_task.c
   ${OPENAIR3_DIR}/SCTP/sctp_eNB_itti_messaging.c
+  ${OPENAIR3_DIR}/SCTP/oai_sctp.c
 )
 add_library(SCTP_CLIENT ${SCTP_SRC})
 target_link_libraries(SCTP_CLIENT PRIVATE sctp::sctp)
+if(ENABLE_USRSCTP)
+  # sctp_werror defaults ON upstream and turns any new-compiler warning into a
+  # build failure in third-party code; sctp_build_programs pulls in example
+  # binaries we do not want.
+  CPMAddPackage(
+    NAME usrsctp
+    GITHUB_REPOSITORY sctplab/usrsctp
+    GIT_TAG 0.9.5.0
+    OPTIONS
+      "sctp_build_programs OFF"
+      "sctp_build_shared_lib OFF"
+      "sctp_werror OFF"
+  )
+  # The backend MUST live in its own target. usrsctp does
+  # target_include_directories(usrsctp PUBLIC .) and ships its own
+  # usrsctplib/netinet/sctp.h, so anything that links it directly gets FreeBSD's
+  # netinet/sctp.h instead of the system one -- which breaks sctp_eNB_task.c,
+  # a file that does not use usrsctp at all (MSG_NOTIFICATION goes undeclared).
+  # Linking usrsctp PRIVATE into this small library confines that include path
+  # to the one source file that wants it, while still carrying the archive
+  # through to the final link.
+  add_library(oai_sctp_usrsctp STATIC ${OPENAIR3_DIR}/SCTP/oai_sctp_usrsctp.c)
+  target_compile_definitions(oai_sctp_usrsctp PRIVATE ENABLE_USRSCTP)
+  target_link_libraries(oai_sctp_usrsctp PRIVATE usrsctp)
+  target_include_directories(oai_sctp_usrsctp PRIVATE ${OPENAIR_DIR} ${OPENAIR3_DIR}/SCTP)
+  target_compile_definitions(SCTP_CLIENT PRIVATE ENABLE_USRSCTP)
+  target_link_libraries(SCTP_CLIENT PRIVATE oai_sctp_usrsctp)
+endif()
 target_link_libraries(SCTP_CLIENT PRIVATE asn1_nr_rrc_hdrs asn1_lte_rrc_hdrs)
 
 set(NAS_SRC ${OPENAIR3_DIR}/NAS/)

--- a/doc/sctp-usrsctp-backend.md
+++ b/doc/sctp-usrsctp-backend.md
@@ -1,0 +1,171 @@
+# Userspace SCTP backend (usrsctp) for F1-C and N2
+
+## What this is
+
+OAI's SCTP task can now run on either of two backends:
+
+| backend   | transport                                                    |
+|-----------|--------------------------------------------------------------|
+| `kernel`  | libsctp and kernel sockets. The default, unchanged behaviour. |
+| `usrsctp` | the FreeBSD SCTP stack in userspace, over a raw `IPPROTO_SCTP` socket. |
+
+The userspace backend exists for platforms whose kernel is built without
+`CONFIG_IP_SCTP` and cannot practically be rebuilt with it. It needs
+`CAP_NET_RAW`, but **not** kernel SCTP: a raw socket only has to carry the
+packets, not implement the protocol.
+
+Traffic is ordinary SCTP over IP — **not** UDP-encapsulated — so the CU or AMF
+sees a normal association and needs no configuration change.
+
+### Why it was needed
+
+On the Qualcomm SA8775P the vendor kernel ships with `CONFIG_IP_SCTP` unset, and
+a rebuild that enables it breaks the compute-DSP glink endpoints. Kernel SCTP and
+the DSP offloads were therefore mutually exclusive, and F1-C could not be brought
+up at all while the offloads were in use. That is a concrete case, but the
+constraint is general: any target with a fixed kernel lacking SCTP.
+
+## Building
+
+```
+cmake -DENABLE_USRSCTP=ON ...
+```
+
+Default is `OFF`, so existing builds are unaffected. When enabled, usrsctp is
+fetched with CPM (`sctplab/usrsctp`, tag `0.9.5.0`) like OAI's other third-party
+dependencies.
+
+### Licensing
+
+usrsctp is **BSD-3-Clause** — permissive, and compatible with OAI's own licence.
+Audited at tag `0.9.5.0`:
+
+| | |
+|---|---|
+| Top-level `LICENSE.md` | BSD-3-Clause (Randall Stewart, Michael Tuexen) |
+| SPDX tags in the tree | 42 x `BSD-3-Clause`, 1 x `BSD-2-Clause-FreeBSD` |
+| `usrsctplib` sources | 61 of 61 carry a BSD notice; none missing one |
+| GPL / LGPL | none anywhere in the tree |
+| External link dependencies | none on Linux (`ws2_32`/`iphlpapi` are Windows-only) |
+
+The single BSD-2-Clause-FreeBSD file is `usrsctplib/netinet/sctp_ss_functions.c`;
+still permissive, just the two-clause variant, which is ordinary for
+FreeBSD-derived code.
+
+Two consequences worth being explicit about:
+
+- **Nothing is vendored.** CPM fetches the sources at configure time, so this
+  repository redistributes no BSD-licensed code. The attribution obligations
+  (retain the copyright notice; do not use the authors' names to endorse) attach
+  to *binaries* built with `ENABLE_USRSCTP=ON`, and so to whoever ships them.
+- **A default build has no new licence surface at all.** With the flag `OFF` the
+  binary contains zero `usrsctp_*` symbols, which is checkable directly:
+
+  ```
+  nm nr-softmodem | grep -c ' usrsctp_'    # 0 with OFF, ~180 with ON
+  ```
+
+## Selecting the backend
+
+The choice is made **at runtime**, on first use, by trying to open a kernel SCTP
+socket and falling back if that fails:
+
+```
+[SCTP] kernel has no SCTP support (Protocol not supported), falling back to usrsctp
+[SCTP] SCTP backend: usrsctp (userspace stack on a raw IPPROTO_SCTP socket)
+```
+
+`OAI_SCTP_BACKEND=kernel|usrsctp` forces either, which is how the userspace path
+is exercised on a machine that has kernel SCTP.
+
+`ENABLE_USRSCTP` decides only whether the backend is *compiled in*. It is
+deliberately not a configure-time probe of the running kernel, because OAI is
+routinely cross-compiled — a probe would test the build host rather than the
+target — and because `<netinet/sctp.h>` being present in a sysroot says nothing
+about `CONFIG_IP_SCTP` in the kernel that will run the binary. One image may also
+be booted against kernels that differ in SCTP support.
+
+## Design
+
+`openair3/SCTP/oai_sctp.h` defines a backend-neutral API; all SCTP calls in
+`sctp_common.c` and `sctp_eNB_task.c` go through it. The kernel arm is a straight
+passthrough, so behaviour with `CONFIG_IP_SCTP` present is unchanged.
+
+**Handles stay `int`.** usrsctp sockets are `struct socket *`, are not file
+descriptors, and cannot be given to `epoll` — but the SCTP task is built around
+`epoll` and dispatches on `events[i].data.fd`. Each usrsctp socket is therefore
+paired with an `eventfd`, and it is the eventfd that is returned as the handle
+and registered with ITTI. usrsctp's upcall drains the message into a per-handle
+queue and posts one token; the task wakes exactly as before.
+
+The eventfd is `EFD_SEMAPHORE` deliberately: one token per queued message keeps
+the counter and the queue in step. A counter drained in a single read would lose
+wakeups whenever two messages arrived before the task was scheduled.
+
+## Maintenance note: translate constants, never forward them
+
+The two stacks share names but not values. Six distinct classes were found during
+bring-up, and **none produced a compile error** — each silently did the wrong
+thing. Anything crossing the backend boundary is expressed in neutral types and
+re-encoded on each side, in the translation unit where that stack's headers are
+in scope.
+
+| what | Linux | usrsctp |
+|------|-------|---------|
+| `MSG_NOTIFICATION` | 0x8000 | 0x2000 |
+| `SCTP_INITMSG` | 2 | 3 |
+| `SCTP_NODELAY` | 3 | 4 |
+| `SCTP_STATUS` | 14 | 0x100 |
+| `SCTP_EVENTS` | 11 | does not exist (uses per-type `SCTP_EVENT`) |
+| `struct sctp_event_subscribe` | 14 fields | 11 fields |
+| `SCTP_BINDX_ADD_ADDR` | 0x01 | 0x8001 |
+| `SCTP_ASSOC_CHANGE` | 0x8001 | 0x0001 |
+| `SCTP_REMOTE_ERROR` | 0x8004 | 0x0003 |
+| `SCTP_PARTIAL_DELIVERY_EVENT` | 0x8006 | 0x0007 |
+| `SCTP_COMM_UP` (`sac_state`) | 0 | 1 |
+
+Two of these deserve emphasis:
+
+* Notification types are **not** a constant offset. Linux numbers from
+  `SCTP_SN_TYPE_BASE` (`1<<15`) but orders `SEND_FAILED` before `REMOTE_ERROR`,
+  so a blanket `+0x8000` mis-maps `REMOTE_ERROR` and `PARTIAL_DELIVERY`. The
+  symptom of getting this wrong is subtle: the association establishes,
+  heartbeats flow normally, and F1 Setup is simply never sent.
+* usrsctp passes the `bindx` flag **straight to `setsockopt()` as the option
+  number**, so a wrong value does not merely differ — it names an option that
+  does not exist.
+
+An option with no translation is refused loudly rather than forwarded, because
+forwarding is precisely what failed.
+
+## Lifecycle difference from the kernel backend
+
+A userspace stack dies with its process. With kernel SCTP the kernel owns the
+socket and sends `SHUTDOWN`/`ABORT` when the process goes away, so the peer drops
+the association at once. usrsctp runs inside the gNB, so exiting without closing
+sends nothing and the peer is left heartbeating an association that will never
+answer. On F1-C the CU then keeps the DU registered and refuses reconnects:
+
+```
+[NR_RRC] E gNB-DU ID: existing DU gNB-DU-OAI on assoc_id 891 already has ID 3584,
+           rejecting requesting gNB-DU
+```
+
+Open associations are therefore closed from an `atexit()` handler, which covers
+normal shutdown. **`SIGKILL` cannot be covered** — there is no kernel left to
+clean up — and the peer falls back to its heartbeat timeout. If F1 Setup Failure
+appears unexpectedly, check the CU log for that duplicate-ID line before
+suspecting a configuration mismatch: it means a previous DU was hard-killed.
+
+## Status
+
+Verified against a live OAI CU on a kernel with `CONFIG_IP_SCTP` unset:
+
+```
+[MAC]     received F1 Setup Response from CU gNB-CU
+[MAC]     received gNB-DU configuration update acknowledge
+[NR_RRC]  Accepting DU 3584 (gNB-DU-OAI) ... cell PLMN 208.99 Cell ID 1 is in service
+```
+
+Consecutive DU restarts register, serve and tear down cleanly. N2 uses the same
+task and backend but has not been exercised separately.

--- a/openair3/SCTP/oai_sctp.c
+++ b/openair3/SCTP/oai_sctp.c
@@ -1,0 +1,363 @@
+/*! \file oai_sctp.c
+ * \brief Backend selection and the kernel passthrough. See oai_sctp.h.
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "oai_sctp.h"
+#include "oai_sctp_internal.h"
+#include "sctp_common.h"
+
+typedef enum { OAI_SCTP_KERNEL = 0, OAI_SCTP_USRSCTP } oai_sctp_backend_t;
+
+static oai_sctp_backend_t g_backend = OAI_SCTP_KERNEL;
+static pthread_once_t g_once = PTHREAD_ONCE_INIT;
+
+/* Ask the kernel, rather than the build system, whether it speaks SCTP.
+ *
+ * A configure-time probe cannot answer this: OAI is cross-compiled, so it would
+ * test the build host; and <netinet/sctp.h> being present in a sysroot says
+ * nothing about CONFIG_IP_SCTP in the kernel that ends up running the binary.
+ * Opening a socket is the only honest test, it costs one syscall once per run,
+ * and it lets the same image follow a reboot into a different kernel.
+ *
+ * OAI_SCTP_BACKEND=kernel|usrsctp overrides, for testing the userspace path on
+ * a kernel that has SCTP. */
+static void oai_sctp_select(void)
+{
+  const char *force = getenv("OAI_SCTP_BACKEND");
+
+  if (force && strcmp(force, "usrsctp") == 0) {
+#ifdef ENABLE_USRSCTP
+    if (oai_sctp_usr_init() == 0) {
+      g_backend = OAI_SCTP_USRSCTP;
+      SCTP_WARN("SCTP backend: usrsctp (forced by OAI_SCTP_BACKEND)\n");
+      return;
+    }
+    SCTP_ERROR("OAI_SCTP_BACKEND=usrsctp but the userspace stack failed to start\n");
+#else
+    SCTP_ERROR("OAI_SCTP_BACKEND=usrsctp but this build has no usrsctp support"
+               " (configure with -DENABLE_USRSCTP=ON)\n");
+#endif
+  }
+
+  if (!force || strcmp(force, "kernel") == 0) {
+    const int sd = socket(AF_INET, SOCK_STREAM, IPPROTO_SCTP);
+    if (sd >= 0) {
+      close(sd);
+      g_backend = OAI_SCTP_KERNEL;
+      SCTP_DEBUG("SCTP backend: kernel\n");
+      return;
+    }
+    if (force) { /* explicitly asked for kernel; do not silently substitute */
+      SCTP_ERROR("OAI_SCTP_BACKEND=kernel but the kernel has no SCTP: %s\n", strerror(errno));
+      g_backend = OAI_SCTP_KERNEL;
+      return;
+    }
+    SCTP_WARN("kernel has no SCTP support (%s), falling back to usrsctp\n", strerror(errno));
+  }
+
+#ifdef ENABLE_USRSCTP
+  if (oai_sctp_usr_init() == 0) {
+    g_backend = OAI_SCTP_USRSCTP;
+    SCTP_WARN("SCTP backend: usrsctp (userspace stack on a raw IPPROTO_SCTP socket)\n");
+    return;
+  }
+  SCTP_ERROR("usrsctp failed to start; F1-C/N2 will not come up\n");
+#else
+  SCTP_ERROR("no kernel SCTP and this build has no usrsctp support:"
+             " rebuild with -DENABLE_USRSCTP=ON or use a kernel with CONFIG_IP_SCTP\n");
+#endif
+  g_backend = OAI_SCTP_KERNEL;
+}
+
+static inline bool use_usr(void)
+{
+  pthread_once(&g_once, oai_sctp_select);
+  return g_backend == OAI_SCTP_USRSCTP;
+}
+
+const char *oai_sctp_backend_name(void)
+{
+  return use_usr() ? "usrsctp" : "kernel";
+}
+
+bool oai_sctp_is_usrsctp(void)
+{
+  return use_usr();
+}
+
+/* From here down: dispatch. The kernel arm is a straight passthrough, so the
+ * behaviour with CONFIG_IP_SCTP present is byte-for-byte what it always was. */
+
+#ifdef ENABLE_USRSCTP
+#define OAI_SCTP_DISPATCH(fn, ...) \
+  do {                             \
+    if (use_usr())                 \
+      return oai_sctp_usr_##fn(__VA_ARGS__); \
+  } while (0)
+#else
+#define OAI_SCTP_DISPATCH(fn, ...) \
+  do {                             \
+    (void)use_usr();               \
+  } while (0)
+#endif
+
+int oai_sctp_socket(int domain, int type, int protocol)
+{
+  OAI_SCTP_DISPATCH(socket, domain, type, protocol);
+  return socket(domain, type, protocol);
+}
+
+int oai_sctp_bind(int sd, const struct sockaddr *addr, socklen_t addrlen)
+{
+  OAI_SCTP_DISPATCH(bind, sd, addr, addrlen);
+  return bind(sd, addr, addrlen);
+}
+
+int oai_sctp_bindx(int sd, struct sockaddr *addrs, int addrcnt, int flags)
+{
+#ifdef ENABLE_USRSCTP
+  if (use_usr()) {
+    int neutral;
+    if (flags == SCTP_BINDX_ADD_ADDR)
+      neutral = OAI_SCTP_BINDX_ADD;
+    else if (flags == SCTP_BINDX_REM_ADDR)
+      neutral = OAI_SCTP_BINDX_REM;
+    else {
+      SCTP_ERROR("bindx: unknown flag %d\n", flags);
+      errno = EINVAL;
+      return -1;
+    }
+    return oai_sctp_usr_bindx(sd, addrs, addrcnt, neutral);
+  }
+#endif
+  return sctp_bindx(sd, addrs, addrcnt, flags);
+}
+
+int oai_sctp_connectx(int sd, struct sockaddr *addrs, int addrcnt, sctp_assoc_t *assoc_id)
+{
+#ifdef ENABLE_USRSCTP
+  if (use_usr()) {
+    uint32_t id = 0;
+    const int rc = oai_sctp_usr_connectx(sd, addrs, addrcnt, &id);
+    if (assoc_id)
+      *assoc_id = (sctp_assoc_t)id;
+    return rc;
+  }
+#endif
+  return sctp_connectx(sd, addrs, addrcnt, assoc_id);
+}
+
+int oai_sctp_listen(int sd, int backlog)
+{
+  OAI_SCTP_DISPATCH(listen, sd, backlog);
+  return listen(sd, backlog);
+}
+
+int oai_sctp_accept(int sd, struct sockaddr *addr, socklen_t *addrlen)
+{
+  OAI_SCTP_DISPATCH(accept, sd, addr, addrlen);
+  return accept(sd, addr, addrlen);
+}
+
+int oai_sctp_peeloff(int sd, sctp_assoc_t assoc_id)
+{
+  OAI_SCTP_DISPATCH(peeloff, sd, (uint32_t)assoc_id);
+  return sctp_peeloff(sd, assoc_id);
+}
+
+int oai_sctp_close(int sd)
+{
+  OAI_SCTP_DISPATCH(close, sd);
+  return close(sd);
+}
+
+int oai_sctp_setsockopt(int sd, int level, int optname, const void *optval, socklen_t optlen)
+{
+#ifdef ENABLE_USRSCTP
+  if (use_usr()) {
+    /* Translate rather than forward: the option numbers and the payload structs
+     * both differ between the stacks. Forwarding the Linux ones is what made
+     * sctp_set_init_opt() fail with the userspace backend selected. */
+    if (level == IPPROTO_SCTP && optname == SCTP_INITMSG) {
+      const struct sctp_initmsg *im = (const struct sctp_initmsg *)optval;
+      const oai_sctp_initmsg_t m = {.num_ostreams = im->sinit_num_ostreams,
+                                    .max_instreams = im->sinit_max_instreams,
+                                    .max_attempts = im->sinit_max_attempts,
+                                    .max_init_timeo = im->sinit_max_init_timeo};
+      return oai_sctp_usr_setopt(sd, OAI_SCTP_OPT_INITMSG, &m);
+    }
+    if (level == IPPROTO_SCTP && optname == SCTP_NODELAY)
+      return oai_sctp_usr_setopt(sd, OAI_SCTP_OPT_NODELAY, optval);
+    if (level == SOL_SOCKET && optname == SO_REUSEADDR)
+      return oai_sctp_usr_setopt(sd, OAI_SCTP_OPT_REUSEADDR, optval);
+    if (level == IPPROTO_SCTP && optname == SCTP_EVENTS) {
+      const struct sctp_event_subscribe *e = (const struct sctp_event_subscribe *)optval;
+      const oai_sctp_events_t ev = {.data_io = e->sctp_data_io_event != 0,
+                                    .association = e->sctp_association_event != 0,
+                                    .address = e->sctp_address_event != 0,
+                                    .send_failure = e->sctp_send_failure_event != 0,
+                                    .peer_error = e->sctp_peer_error_event != 0,
+                                    .shutdown = e->sctp_shutdown_event != 0,
+                                    .partial_delivery = e->sctp_partial_delivery_event != 0};
+      return oai_sctp_usr_setopt(sd, OAI_SCTP_OPT_EVENTS, &ev);
+    }
+    SCTP_ERROR("usrsctp backend: no translation for setsockopt(level=%d, optname=%d);"
+               " add one in oai_sctp.c rather than forwarding it\n", level, optname);
+    errno = ENOPROTOOPT;
+    return -1;
+  }
+  (void)optlen;
+#endif
+  return setsockopt(sd, level, optname, optval, optlen);
+}
+
+int oai_sctp_getsockopt(int sd, int level, int optname, void *optval, socklen_t *optlen)
+{
+#ifdef ENABLE_USRSCTP
+  if (use_usr()) {
+    if (level == IPPROTO_SCTP && optname == SCTP_STATUS) {
+      struct sctp_status *st = (struct sctp_status *)optval;
+      oai_sctp_status_t o;
+      memset(&o, 0, sizeof o);
+      o.assoc_id = (uint32_t)st->sstat_assoc_id;
+      if (oai_sctp_usr_getopt(sd, OAI_SCTP_OPT_STATUS, &o) < 0)
+        return -1;
+      memset(st, 0, sizeof *st);
+      st->sstat_assoc_id = (sctp_assoc_t)o.assoc_id;
+      st->sstat_state = o.state;
+      st->sstat_instrms = o.instrms;
+      st->sstat_outstrms = o.outstrms;
+      st->sstat_fragmentation_point = o.fragmentation_point;
+      st->sstat_penddata = o.penddata;
+      if (optlen)
+        *optlen = sizeof *st;
+      return 0;
+    }
+    SCTP_ERROR("usrsctp backend: no translation for getsockopt(level=%d, optname=%d)\n",
+               level, optname);
+    errno = ENOPROTOOPT;
+    return -1;
+  }
+#endif
+  return getsockopt(sd, level, optname, optval, optlen);
+}
+
+ssize_t oai_sctp_recvmsg(int sd, void *buf, size_t len, struct sockaddr *from,
+                         socklen_t *fromlen, struct sctp_sndrcvinfo *sinfo, int *msg_flags)
+{
+#ifdef ENABLE_USRSCTP
+  if (use_usr()) {
+    /* The backend reports our own POD struct rather than either stack's, so no
+     * layout is assumed to be shared between netinet and usrsctp. Convert here. */
+    oai_sctp_rcvinfo_t rcv;
+    memset(&rcv, 0, sizeof rcv);
+    int backend_flags = 0;
+    const ssize_t n = oai_sctp_usr_recvmsg(sd, buf, len, from, fromlen, &rcv, &backend_flags);
+    if (n > 0 && msg_flags != NULL) {
+      /* Re-encode with the system values; see oai_sctp_rcvinfo_t. */
+      *msg_flags = backend_flags;
+      if (rcv.notification)
+        *msg_flags |= MSG_NOTIFICATION;
+      if (rcv.eor)
+        *msg_flags |= MSG_EOR;
+    }
+    /* Rewrite the notification in place with the SYSTEM constants. The task
+     * compares snp->sn_header.sn_type against Linux's SCTP_ASSOC_CHANGE
+     * (0x8001) and reads sac_state against Linux's enum, neither of which
+     * matches what usrsctp puts on the wire. Without this the association comes
+     * up, heartbeats flow, and F1 Setup is never sent. */
+    if (n > 0 && rcv.notification && buf != NULL) {
+      uint16_t linux_type = 0;
+      switch (rcv.notif_type) {
+        case OAI_SCTP_NOTIF_ASSOC_CHANGE: linux_type = SCTP_ASSOC_CHANGE; break;
+        case OAI_SCTP_NOTIF_PEER_ADDR_CHANGE: linux_type = SCTP_PEER_ADDR_CHANGE; break;
+        case OAI_SCTP_NOTIF_SEND_FAILED: linux_type = SCTP_SEND_FAILED; break;
+        case OAI_SCTP_NOTIF_REMOTE_ERROR: linux_type = SCTP_REMOTE_ERROR; break;
+        case OAI_SCTP_NOTIF_SHUTDOWN: linux_type = SCTP_SHUTDOWN_EVENT; break;
+        case OAI_SCTP_NOTIF_PARTIAL_DELIVERY: linux_type = SCTP_PARTIAL_DELIVERY_EVENT; break;
+        case OAI_SCTP_NOTIF_ADAPTATION: linux_type = SCTP_ADAPTATION_INDICATION; break;
+        default: break;
+      }
+      if (linux_type != 0 && (size_t)n >= sizeof(uint16_t))
+        memcpy(buf, &linux_type, sizeof linux_type);
+
+      if (rcv.notif_type == OAI_SCTP_NOTIF_ASSOC_CHANGE
+          && (size_t)n >= sizeof(struct sctp_assoc_change)) {
+        struct sctp_assoc_change *ac = (struct sctp_assoc_change *)buf;
+        switch (rcv.sac_state) {
+          case OAI_SCTP_SAC_COMM_UP: ac->sac_state = SCTP_COMM_UP; break;
+          case OAI_SCTP_SAC_COMM_LOST: ac->sac_state = SCTP_COMM_LOST; break;
+          case OAI_SCTP_SAC_RESTART: ac->sac_state = SCTP_RESTART; break;
+          case OAI_SCTP_SAC_SHUTDOWN_COMP: ac->sac_state = SCTP_SHUTDOWN_COMP; break;
+          case OAI_SCTP_SAC_CANT_STR_ASSOC: ac->sac_state = SCTP_CANT_STR_ASSOC; break;
+          default: break;
+        }
+      }
+    }
+    if (n > 0 && sinfo != NULL) {
+      memset(sinfo, 0, sizeof *sinfo);
+      sinfo->sinfo_stream = rcv.stream;
+      sinfo->sinfo_ssn = rcv.ssn;
+      sinfo->sinfo_flags = rcv.flags;
+      sinfo->sinfo_ppid = rcv.ppid;
+      sinfo->sinfo_context = rcv.context;
+      sinfo->sinfo_timetolive = rcv.timetolive;
+      sinfo->sinfo_tsn = rcv.tsn;
+      sinfo->sinfo_cumtsn = rcv.cumtsn;
+      sinfo->sinfo_assoc_id = (sctp_assoc_t)rcv.assoc_id;
+    }
+    return n;
+  }
+#endif
+  return sctp_recvmsg(sd, buf, len, from, fromlen, sinfo, msg_flags);
+}
+
+ssize_t oai_sctp_sendmsg(int sd, const void *buf, size_t len, const struct sockaddr *to,
+                         socklen_t tolen, uint32_t ppid, uint32_t flags,
+                         uint16_t stream_no, uint32_t timetolive, uint32_t context)
+{
+  OAI_SCTP_DISPATCH(sendmsg, sd, buf, len, to, tolen, ppid, flags, stream_no, timetolive, context);
+  return sctp_sendmsg(sd, buf, len, (struct sockaddr *)to, tolen, ppid, flags, stream_no,
+                      timetolive, context);
+}
+
+int oai_sctp_getpaddrs(int sd, sctp_assoc_t id, struct sockaddr **addrs)
+{
+  OAI_SCTP_DISPATCH(getpaddrs, sd, (uint32_t)id, addrs);
+  return sctp_getpaddrs(sd, id, addrs);
+}
+
+void oai_sctp_freepaddrs(struct sockaddr *addrs)
+{
+#ifdef ENABLE_USRSCTP
+  if (use_usr()) {
+    oai_sctp_usr_freepaddrs(addrs);
+    return;
+  }
+#endif
+  sctp_freepaddrs(addrs);
+}
+
+int oai_sctp_getladdrs(int sd, sctp_assoc_t id, struct sockaddr **addrs)
+{
+  OAI_SCTP_DISPATCH(getladdrs, sd, (uint32_t)id, addrs);
+  return sctp_getladdrs(sd, id, addrs);
+}
+
+void oai_sctp_freeladdrs(struct sockaddr *addrs)
+{
+#ifdef ENABLE_USRSCTP
+  if (use_usr()) {
+    oai_sctp_usr_freeladdrs(addrs);
+    return;
+  }
+#endif
+  sctp_freeladdrs(addrs);
+}

--- a/openair3/SCTP/oai_sctp.h
+++ b/openair3/SCTP/oai_sctp.h
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the OAI Public License, Version 1.1  (the "License"); you may not use this
+ * file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *      http://www.openairinterface.org/?page_id=698
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+
+/*! \file oai_sctp.h
+ * \brief Backend-neutral SCTP calls for F1-C and N2.
+ *
+ * Two backends sit behind this interface:
+ *
+ *   kernel   thin passthrough to libsctp and kernel sockets. What OAI has
+ *            always used, and what runs when the kernel has CONFIG_IP_SCTP.
+ *   usrsctp  the FreeBSD SCTP stack in userspace, sending real SCTP over IP
+ *            through a raw IPPROTO_SCTP socket. Needs CAP_NET_RAW but NOT
+ *            kernel SCTP, because a raw socket only has to carry the packets,
+ *            not implement the protocol.
+ *
+ * WHY THIS EXISTS. Some kernels ship with CONFIG_IP_SCTP unset and cannot be
+ * rebuilt with it -- on the Qualcomm SA8775P the SCTP-enabled rebuild is what
+ * breaks the compute-DSP glink endpoints, so SCTP and the DSP offloads are
+ * mutually exclusive there. usrsctp lifts that constraint without touching the
+ * kernel and without any change at the peer: it is wire-compatible SCTP over
+ * IP, not UDP-encapsulated, so the CU or AMF sees an ordinary association.
+ *
+ * WHY THE CHOICE IS MADE AT RUNTIME, NOT IN CMAKE. The obvious thing is to
+ * probe for kernel SCTP at configure time, but that is wrong twice over: OAI is
+ * routinely cross-compiled, so a configure-time probe tests the BUILD host's
+ * kernel rather than the target's, and the presence of <netinet/sctp.h> in a
+ * sysroot says nothing about CONFIG_IP_SCTP in the kernel that will run the
+ * binary. A single image also has to work across a reboot into a different
+ * kernel. So CMake decides only whether the usrsctp backend is COMPILED IN
+ * (ENABLE_USRSCTP); which backend is USED is decided on first use by actually
+ * trying to open a kernel SCTP socket. See oai_sctp_backend_name().
+ *
+ * HANDLES. Every call takes and returns an int, exactly like a file
+ * descriptor, and that int stays usable with epoll. For the kernel backend it
+ * IS the descriptor. For usrsctp -- whose sockets are `struct socket *` and
+ * have no descriptor at all -- it is an eventfd that the backend signals when
+ * the association has a message ready. That keeps itti_subscribe_event_fd(),
+ * the epoll loop and the sctp_get_cnx() lookup working unchanged.
+ */
+
+#ifndef OAI_SCTP_H_
+#define OAI_SCTP_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netinet/sctp.h>
+
+/* Which backend is in use. Safe to call at any time; forces selection on the
+ * first call. Returns "kernel" or "usrsctp". */
+const char *oai_sctp_backend_name(void);
+
+/* True once the usrsctp backend has been selected. Only for logging and for
+ * the few places that must know; prefer adding a call here over branching on
+ * this at a call site. */
+bool oai_sctp_is_usrsctp(void);
+
+int oai_sctp_socket(int domain, int type, int protocol);
+int oai_sctp_bind(int sd, const struct sockaddr *addr, socklen_t addrlen);
+int oai_sctp_bindx(int sd, struct sockaddr *addrs, int addrcnt, int flags);
+int oai_sctp_connectx(int sd, struct sockaddr *addrs, int addrcnt, sctp_assoc_t *assoc_id);
+int oai_sctp_listen(int sd, int backlog);
+int oai_sctp_accept(int sd, struct sockaddr *addr, socklen_t *addrlen);
+int oai_sctp_peeloff(int sd, sctp_assoc_t assoc_id);
+int oai_sctp_close(int sd);
+
+int oai_sctp_setsockopt(int sd, int level, int optname, const void *optval, socklen_t optlen);
+int oai_sctp_getsockopt(int sd, int level, int optname, void *optval, socklen_t *optlen);
+
+ssize_t oai_sctp_recvmsg(int sd,
+                         void *buf,
+                         size_t len,
+                         struct sockaddr *from,
+                         socklen_t *fromlen,
+                         struct sctp_sndrcvinfo *sinfo,
+                         int *msg_flags);
+
+ssize_t oai_sctp_sendmsg(int sd,
+                         const void *buf,
+                         size_t len,
+                         const struct sockaddr *to,
+                         socklen_t tolen,
+                         uint32_t ppid,
+                         uint32_t flags,
+                         uint16_t stream_no,
+                         uint32_t timetolive,
+                         uint32_t context);
+
+int oai_sctp_getpaddrs(int sd, sctp_assoc_t id, struct sockaddr **addrs);
+void oai_sctp_freepaddrs(struct sockaddr *addrs);
+int oai_sctp_getladdrs(int sd, sctp_assoc_t id, struct sockaddr **addrs);
+void oai_sctp_freeladdrs(struct sockaddr *addrs);
+
+#endif /* OAI_SCTP_H_ */

--- a/openair3/SCTP/oai_sctp_internal.h
+++ b/openair3/SCTP/oai_sctp_internal.h
@@ -1,0 +1,150 @@
+/*! \file oai_sctp_internal.h
+ * \brief Backend entry points behind oai_sctp.h. Not a public interface --
+ *        include oai_sctp.h instead. Only oai_sctp.c and the backends use this.
+ *
+ * DELIBERATELY FREE OF BOTH <netinet/sctp.h> AND <usrsctp.h>. Those two headers
+ * declare the same struct and constant names and cannot be included in one
+ * translation unit. Worse, usrsctp ships its own netinet/sctp.h and exports its
+ * directory as a PUBLIC include, so anything linking the usrsctp target gets
+ * FreeBSD's netinet/sctp.h in place of the system one -- which is how a file
+ * that never mentions usrsctp ends up failing on a missing MSG_NOTIFICATION.
+ *
+ * So this header describes the backend boundary in plain integers and one POD
+ * struct of our own. The kernel side converts to struct sctp_sndrcvinfo; the
+ * usrsctp side converts from struct sctp_rcvinfo. Neither header crosses the
+ * boundary, and no struct layout is assumed to be shared between them.
+ */
+
+#ifndef OAI_SCTP_INTERNAL_H_
+#define OAI_SCTP_INTERNAL_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+/* The receive metadata OAI actually consumes, in a layout we own.
+ *
+ * The two message flags are booleans rather than a flags word ON PURPOSE. The
+ * two stacks number them differently -- MSG_NOTIFICATION is 0x8000 on Linux and
+ * 0x2000 in usrsctp, MSG_EOR is 0x80 on Linux and 0x8 -- so passing a raw flags
+ * word across this boundary silently means the wrong thing. sctp_eNB_task.c
+ * tests both: it would have missed every SCTP_ASSOC_CHANGE and rejected every
+ * message as truncated. The backend reports what happened; oai_sctp.c re-encodes
+ * it using the system constants. */
+/* Notification identity, neutral.
+ *
+ * The wire-visible sn_type inside a notification differs between the stacks and
+ * NOT by a constant offset: usrsctp numbers REMOTE_ERROR 3 and PARTIAL_DELIVERY
+ * 7, while Linux (whose types start at SCTP_SN_TYPE_BASE = 1<<15) numbers them
+ * 0x8004 and 0x8006. sac_state differs too -- usrsctp's SCTP_COMM_UP is 1,
+ * Linux's is 0. The task compares against the Linux constants, so the backend
+ * classifies and oai_sctp.c rewrites the buffer with the real Linux values. */
+typedef enum {
+  OAI_SCTP_NOTIF_NONE = 0,
+  OAI_SCTP_NOTIF_ASSOC_CHANGE,
+  OAI_SCTP_NOTIF_PEER_ADDR_CHANGE,
+  OAI_SCTP_NOTIF_SEND_FAILED,
+  OAI_SCTP_NOTIF_REMOTE_ERROR,
+  OAI_SCTP_NOTIF_SHUTDOWN,
+  OAI_SCTP_NOTIF_PARTIAL_DELIVERY,
+  OAI_SCTP_NOTIF_ADAPTATION,
+  OAI_SCTP_NOTIF_OTHER,
+} oai_sctp_notif_t;
+
+typedef enum {
+  OAI_SCTP_SAC_COMM_UP = 0,
+  OAI_SCTP_SAC_COMM_LOST,
+  OAI_SCTP_SAC_RESTART,
+  OAI_SCTP_SAC_SHUTDOWN_COMP,
+  OAI_SCTP_SAC_CANT_STR_ASSOC,
+  OAI_SCTP_SAC_OTHER,
+} oai_sctp_sac_t;
+
+typedef struct {
+  uint16_t stream;
+  uint16_t ssn;
+  uint16_t flags;
+  uint32_t ppid;
+  uint32_t context;
+  uint32_t timetolive;
+  uint32_t tsn;
+  uint32_t cumtsn;
+  uint32_t assoc_id;
+  bool notification; /* this is an SCTP notification, not user data */
+  bool eor;          /* end of record: the message is complete */
+  oai_sctp_notif_t notif_type; /* classified by the backend, rewritten by oai_sctp.c */
+  oai_sctp_sac_t sac_state;    /* only for OAI_SCTP_NOTIF_ASSOC_CHANGE */
+} oai_sctp_rcvinfo_t;
+
+/* Socket options, translated rather than passed through.
+ *
+ * The two stacks number them differently -- SCTP_INITMSG is 2 on Linux and 3 in
+ * usrsctp, SCTP_NODELAY 3 vs 4, SCTP_STATUS 14 vs 0x100 -- and usrsctp has no
+ * SCTP_EVENTS at all (it uses per-event SCTP_EVENT). The payload structs differ
+ * too: Linux's sctp_event_subscribe has 14 fields, usrsctp's has 11. So the
+ * option and its payload are both described neutrally here and re-encoded on
+ * each side. Passing the Linux optname and struct straight through is what made
+ * sctp_set_init_opt() fail. */
+typedef enum {
+  OAI_SCTP_OPT_INITMSG = 1,
+  OAI_SCTP_OPT_NODELAY,
+  OAI_SCTP_OPT_REUSEADDR,
+  OAI_SCTP_OPT_EVENTS,
+  OAI_SCTP_OPT_STATUS,
+} oai_sctp_opt_t;
+
+typedef struct {
+  uint16_t num_ostreams, max_instreams, max_attempts, max_init_timeo;
+} oai_sctp_initmsg_t;
+
+/* bindx flags, neutral. Linux uses 0x01/0x02; usrsctp uses 0x8001/0x8002 AND
+ * feeds the value straight to setsockopt() as the option number, so passing
+ * Linux's value is not merely a different constant -- it names an option that
+ * does not exist. usrsctp validates the flag first and returns EFAULT, which is
+ * how this showed up: "sctp_bindx() SCTP_BINDX_ADD_ADDR failed: errno 14". */
+#define OAI_SCTP_BINDX_ADD 1
+#define OAI_SCTP_BINDX_REM 2
+
+typedef struct {
+  bool data_io, association, address, send_failure, peer_error, shutdown, partial_delivery;
+} oai_sctp_events_t;
+
+typedef struct {
+  uint32_t assoc_id;
+  int32_t state;
+  uint16_t instrms, outstrms;
+  uint32_t fragmentation_point, penddata;
+} oai_sctp_status_t;
+
+#ifdef ENABLE_USRSCTP
+/* Brings up the userspace stack. Must be called from a thread with DEFAULT
+ * scheduling and an unrestricted affinity mask: usrsctp's raw-socket mode
+ * creates receive threads, and pthreads inherit the creating thread's policy,
+ * priority and CPU mask. Starting it from a real-time thread would pin those
+ * receive threads onto that thread's core at its priority. Returns 0 on
+ * success. Idempotent. */
+int oai_sctp_usr_init(void);
+
+int oai_sctp_usr_socket(int domain, int type, int protocol);
+int oai_sctp_usr_bind(int sd, const struct sockaddr *addr, socklen_t addrlen);
+int oai_sctp_usr_bindx(int sd, struct sockaddr *addrs, int addrcnt, int flags);
+int oai_sctp_usr_connectx(int sd, struct sockaddr *addrs, int addrcnt, uint32_t *assoc_id);
+int oai_sctp_usr_listen(int sd, int backlog);
+int oai_sctp_usr_accept(int sd, struct sockaddr *addr, socklen_t *addrlen);
+int oai_sctp_usr_peeloff(int sd, uint32_t assoc_id);
+int oai_sctp_usr_close(int sd);
+int oai_sctp_usr_setopt(int sd, oai_sctp_opt_t opt, const void *val);
+int oai_sctp_usr_getopt(int sd, oai_sctp_opt_t opt, void *val);
+ssize_t oai_sctp_usr_recvmsg(int sd, void *buf, size_t len, struct sockaddr *from,
+                             socklen_t *fromlen, oai_sctp_rcvinfo_t *rcv, int *msg_flags);
+ssize_t oai_sctp_usr_sendmsg(int sd, const void *buf, size_t len, const struct sockaddr *to,
+                             socklen_t tolen, uint32_t ppid, uint32_t flags,
+                             uint16_t stream_no, uint32_t timetolive, uint32_t context);
+int oai_sctp_usr_getpaddrs(int sd, uint32_t id, struct sockaddr **addrs);
+void oai_sctp_usr_freepaddrs(struct sockaddr *addrs);
+int oai_sctp_usr_getladdrs(int sd, uint32_t id, struct sockaddr **addrs);
+void oai_sctp_usr_freeladdrs(struct sockaddr *addrs);
+#endif /* ENABLE_USRSCTP */
+
+#endif /* OAI_SCTP_INTERNAL_H_ */

--- a/openair3/SCTP/oai_sctp_usrsctp.c
+++ b/openair3/SCTP/oai_sctp_usrsctp.c
@@ -1,0 +1,617 @@
+/*! \file oai_sctp_usrsctp.c
+ * \brief usrsctp backend: the FreeBSD SCTP stack in userspace, speaking real
+ *        SCTP over IP through a raw IPPROTO_SCTP socket. See oai_sctp.h.
+ *
+ * THE ONE STRUCTURAL PROBLEM, AND HOW IT IS SOLVED. usrsctp sockets are
+ * `struct socket *`. They are not file descriptors and there is no call that
+ * turns one into a descriptor, so they cannot be handed to epoll -- and OAI's
+ * SCTP task is built around epoll (itti_subscribe_event_fd, and a dispatch that
+ * looks up the connection by events[i].data.fd).
+ *
+ * So every usrsctp socket here is paired with an eventfd, and it is the EVENTFD
+ * that is returned as the int handle and registered with epoll. usrsctp calls
+ * our upcall when a socket becomes readable; the upcall drains the message into
+ * a per-handle queue and posts one token to the eventfd. The task therefore
+ * wakes exactly as it always did, and oai_sctp_usr_recvmsg() consumes one token
+ * and pops one message. Nothing in sctp_eNB_task.c has to know.
+ *
+ * The eventfd is EFD_SEMAPHORE deliberately: one token per queued message means
+ * the counter and the queue stay in step, and a level-triggered epoll keeps
+ * firing while messages remain. Draining the counter in one read (the default
+ * eventfd behaviour) would lose wakeups whenever two messages arrived before
+ * the task got scheduled.
+ *
+ * Receiving inside the upcall is the documented usrsctp pattern; the upcall runs
+ * on usrsctp's own receive thread, which is why the queue is mutex-protected.
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+#include <usrsctp.h>
+
+#include "oai_sctp_internal.h"
+#include "common/utils/LOG/log.h"
+
+/* sctp_common.h cannot be used here: it reaches <netinet/sctp.h>, which clashes
+ * with <usrsctp.h>. Same macros, declared locally. */
+#define SCTP_ERROR(x, args...) LOG_E(SCTP, x, ##args)
+#define SCTP_WARN(x, args...) LOG_W(SCTP, x, ##args)
+#define SCTP_DEBUG(x, args...) LOG_D(SCTP, x, ##args)
+
+#define USR_MAX_SOCKETS 64
+#define USR_RECV_BUFSZ  (1 << 16)
+
+typedef struct usr_msg_s {
+  struct usr_msg_s *next;
+  struct sockaddr_storage from;
+  socklen_t fromlen;
+  oai_sctp_rcvinfo_t rcv;
+  int flags;
+  size_t len;
+  uint8_t data[];
+} usr_msg_t;
+
+typedef struct {
+  struct socket *so; /* NULL means the slot is free */
+  int evfd;
+  bool listening;
+  usr_msg_t *head, *tail;
+  pthread_mutex_t lock;
+} usr_sock_t;
+
+static usr_sock_t g_socks[USR_MAX_SOCKETS];
+static pthread_mutex_t g_tbl_lock = PTHREAD_MUTEX_INITIALIZER;
+static bool g_inited;
+
+static usr_sock_t *slot_by_fd(int fd)
+{
+  for (unsigned i = 0; i < USR_MAX_SOCKETS; i++)
+    if (g_socks[i].so != NULL && g_socks[i].evfd == fd)
+      return &g_socks[i];
+  return NULL;
+}
+
+/* ---------------------------------------------------------------- receive */
+
+static void usr_upcall(struct socket *so, void *arg, int flags)
+{
+  usr_sock_t *s = (usr_sock_t *)arg;
+  (void)flags;
+
+  if (s == NULL || s->so != so)
+    return;
+
+  /* A listening socket has no message to drain: just say "something happened"
+   * and let oai_sctp_usr_accept() do the work, mirroring the kernel path where
+   * epoll readability on a listener means an association is pending. */
+  if (s->listening) {
+    const uint64_t one = 1;
+    ssize_t unused __attribute__((unused)) = write(s->evfd, &one, sizeof one);
+    return;
+  }
+
+  for (;;) {
+    struct sockaddr_storage from;
+    socklen_t fromlen = sizeof from;
+    struct sctp_rcvinfo rcv;
+    socklen_t infolen = sizeof rcv;
+    unsigned int infotype = 0;
+    int msg_flags = 0;
+
+    uint8_t *buf = malloc(USR_RECV_BUFSZ);
+    if (buf == NULL) {
+      SCTP_ERROR("usrsctp: out of memory in upcall\n");
+      return;
+    }
+
+    const ssize_t n = usrsctp_recvv(so, buf, USR_RECV_BUFSZ, (struct sockaddr *)&from, &fromlen,
+                                    &rcv, &infolen, &infotype, &msg_flags);
+    if (n <= 0) {
+      free(buf);
+      return; /* EAGAIN, or the association is gone */
+    }
+
+    usr_msg_t *m = malloc(sizeof *m + (size_t)n);
+    if (m == NULL) {
+      free(buf);
+      SCTP_ERROR("usrsctp: out of memory queueing %zd bytes\n", n);
+      return;
+    }
+    m->next = NULL;
+    m->from = from;
+    m->fromlen = fromlen;
+    /* MSG_NOTIFICATION/MSG_EOR here are usrsctp's values (0x2000/0x8), which are
+     * NOT the system ones (0x8000/0x80). Decide their meaning in this file,
+     * where usrsctp's headers are the ones in scope, and hand up booleans. */
+    m->flags = 0;
+    m->len = (size_t)n;
+    memcpy(m->data, buf, (size_t)n);
+    free(buf);
+
+    /* usrsctp reports sctp_rcvinfo; OAI reads the older sctp_sndrcvinfo. Only
+     * the three fields the task actually looks at are meaningful. */
+    memset(&m->rcv, 0, sizeof m->rcv);
+    m->rcv.notification = (msg_flags & MSG_NOTIFICATION) != 0;
+    m->rcv.eor = (msg_flags & MSG_EOR) != 0;
+
+    /* Classify the notification here, where usrsctp's constants are the ones in
+     * scope. oai_sctp.c rewrites the buffer with the Linux values, because the
+     * two numberings do not differ by a constant offset: usrsctp has
+     * REMOTE_ERROR 3 / PARTIAL_DELIVERY 7 against Linux's 0x8004 / 0x8006. */
+    if (m->rcv.notification && (size_t)n >= sizeof(uint16_t)) {
+      uint16_t t;
+      memcpy(&t, m->data, sizeof t);
+      switch (t) {
+        case SCTP_ASSOC_CHANGE: m->rcv.notif_type = OAI_SCTP_NOTIF_ASSOC_CHANGE; break;
+        case SCTP_PEER_ADDR_CHANGE: m->rcv.notif_type = OAI_SCTP_NOTIF_PEER_ADDR_CHANGE; break;
+        case SCTP_REMOTE_ERROR: m->rcv.notif_type = OAI_SCTP_NOTIF_REMOTE_ERROR; break;
+        case SCTP_SEND_FAILED_EVENT: m->rcv.notif_type = OAI_SCTP_NOTIF_SEND_FAILED; break;
+        case SCTP_SHUTDOWN_EVENT: m->rcv.notif_type = OAI_SCTP_NOTIF_SHUTDOWN; break;
+        case SCTP_PARTIAL_DELIVERY_EVENT: m->rcv.notif_type = OAI_SCTP_NOTIF_PARTIAL_DELIVERY; break;
+        case SCTP_ADAPTATION_INDICATION: m->rcv.notif_type = OAI_SCTP_NOTIF_ADAPTATION; break;
+        default: m->rcv.notif_type = OAI_SCTP_NOTIF_OTHER; break;
+      }
+      if (m->rcv.notif_type == OAI_SCTP_NOTIF_ASSOC_CHANGE
+          && (size_t)n >= sizeof(struct sctp_assoc_change)) {
+        struct sctp_assoc_change ac;
+        memcpy(&ac, m->data, sizeof ac);
+        switch (ac.sac_state) {
+          case SCTP_COMM_UP: m->rcv.sac_state = OAI_SCTP_SAC_COMM_UP; break;
+          case SCTP_COMM_LOST: m->rcv.sac_state = OAI_SCTP_SAC_COMM_LOST; break;
+          case SCTP_RESTART: m->rcv.sac_state = OAI_SCTP_SAC_RESTART; break;
+          case SCTP_SHUTDOWN_COMP: m->rcv.sac_state = OAI_SCTP_SAC_SHUTDOWN_COMP; break;
+          case SCTP_CANT_STR_ASSOC: m->rcv.sac_state = OAI_SCTP_SAC_CANT_STR_ASSOC; break;
+          default: m->rcv.sac_state = OAI_SCTP_SAC_OTHER; break;
+        }
+      }
+    }
+    if (infotype == SCTP_RECVV_RCVINFO) {
+      m->rcv.stream = rcv.rcv_sid;
+      m->rcv.ssn = rcv.rcv_ssn;
+      m->rcv.flags = rcv.rcv_flags;
+      m->rcv.ppid = rcv.rcv_ppid;
+      m->rcv.context = rcv.rcv_context;
+      m->rcv.tsn = rcv.rcv_tsn;
+      m->rcv.cumtsn = rcv.rcv_cumtsn;
+      m->rcv.assoc_id = rcv.rcv_assoc_id;
+    }
+
+    pthread_mutex_lock(&s->lock);
+    if (s->tail)
+      s->tail->next = m;
+    else
+      s->head = m;
+    s->tail = m;
+    pthread_mutex_unlock(&s->lock);
+
+    const uint64_t one = 1;
+    ssize_t unused __attribute__((unused)) = write(s->evfd, &one, sizeof one);
+  }
+}
+
+/* Tear the associations down on the way out.
+ *
+ * This matters more than it looks. With kernel SCTP the kernel owns the socket,
+ * so when the process dies it sends SHUTDOWN or ABORT and the peer drops the
+ * association immediately. usrsctp runs INSIDE this process: if we exit without
+ * closing, nothing is ever sent and the peer is left heartbeating an
+ * association that will never answer. On F1-C that is not cosmetic -- the CU
+ * keeps gNB_DU_id registered and answers the next F1 Setup Request with a
+ * Setup Failure until its own timeout expires, so a DU restart appears to work
+ * once and then be rejected.
+ *
+ * Registered with atexit() so it covers OAI's normal shutdown path and any
+ * exit() elsewhere. It cannot cover SIGKILL, but nothing can: that is inherent
+ * to a userspace stack, and the peer falls back to its heartbeat timeout. */
+static void usr_shutdown_atexit(void)
+{
+  bool any = false;
+
+  pthread_mutex_lock(&g_tbl_lock);
+  for (unsigned i = 0; i < USR_MAX_SOCKETS; i++) {
+    if (g_socks[i].so != NULL) {
+      usrsctp_close(g_socks[i].so);
+      g_socks[i].so = NULL;
+      any = true;
+    }
+  }
+  pthread_mutex_unlock(&g_tbl_lock);
+
+  /* usrsctp_close() only queues the SHUTDOWN; give its thread a moment to put
+   * it on the wire before the process disappears underneath it. Deliberately
+   * not usrsctp_finish(), which waits for associations to close and can hang a
+   * shutdown path that must not hang. */
+  if (any)
+    usleep(200000);
+}
+
+/* ------------------------------------------------------------------- init */
+
+static void *usr_boot(void *arg)
+{
+  (void)arg;
+  /* port 0 = no UDP encapsulation. F1-C and N2 are SCTP directly over IP, so
+   * the peer sees an ordinary association and needs no configuration. */
+  usrsctp_init(0, NULL, NULL);
+  usrsctp_sysctl_set_sctp_blackhole(2);
+  usrsctp_sysctl_set_sctp_no_csum_on_loopback(0);
+  return NULL;
+}
+
+int oai_sctp_usr_init(void)
+{
+  pthread_mutex_lock(&g_tbl_lock);
+  if (g_inited) {
+    pthread_mutex_unlock(&g_tbl_lock);
+    return 0;
+  }
+
+  /* Start the stack from a thread with DEFAULT scheduling and a full affinity
+   * mask. usrsctp's raw-socket mode spawns receive threads, and pthreads
+   * inherit the creating thread's policy, priority and CPU mask -- initialising
+   * from a real-time thread would strand those receive threads on that thread's
+   * core at its priority. Same failure mode, and same fix, as the FastRPC
+   * helper threads in the Hexagon offload. */
+  pthread_attr_t attr;
+  pthread_t boot;
+  int rc = -1;
+
+  if (pthread_attr_init(&attr) == 0) {
+    pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+    pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
+    const struct sched_param sp = {.sched_priority = 0};
+    pthread_attr_setschedparam(&attr, &sp);
+
+    cpu_set_t all;
+    CPU_ZERO(&all);
+    const long ncpu = sysconf(_SC_NPROCESSORS_ONLN);
+    for (long i = 0; i < (ncpu > 0 ? ncpu : 1); i++)
+      CPU_SET((int)i, &all);
+    pthread_attr_setaffinity_np(&attr, sizeof all, &all);
+
+    if (pthread_create(&boot, &attr, usr_boot, NULL) == 0) {
+      pthread_join(boot, NULL);
+      rc = 0;
+    }
+    pthread_attr_destroy(&attr);
+  }
+
+  if (rc != 0) {
+    SCTP_ERROR("usrsctp: could not start the bootstrap thread\n");
+    pthread_mutex_unlock(&g_tbl_lock);
+    return -1;
+  }
+
+  for (unsigned i = 0; i < USR_MAX_SOCKETS; i++)
+    pthread_mutex_init(&g_socks[i].lock, NULL);
+
+  atexit(usr_shutdown_atexit);
+  g_inited = true;
+  pthread_mutex_unlock(&g_tbl_lock);
+  return 0;
+}
+
+/* -------------------------------------------------------- handle handling */
+
+static int slot_new(struct socket *so, bool listening)
+{
+  const int fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC | EFD_SEMAPHORE);
+  if (fd < 0) {
+    SCTP_ERROR("usrsctp: eventfd(): %s\n", strerror(errno));
+    usrsctp_close(so);
+    return -1;
+  }
+
+  pthread_mutex_lock(&g_tbl_lock);
+  usr_sock_t *s = NULL;
+  for (unsigned i = 0; i < USR_MAX_SOCKETS; i++) {
+    if (g_socks[i].so == NULL) {
+      s = &g_socks[i];
+      break;
+    }
+  }
+  if (s == NULL) {
+    pthread_mutex_unlock(&g_tbl_lock);
+    SCTP_ERROR("usrsctp: out of socket slots (max %d)\n", USR_MAX_SOCKETS);
+    close(fd);
+    usrsctp_close(so);
+    return -1;
+  }
+  s->so = so;
+  s->evfd = fd;
+  s->listening = listening;
+  s->head = s->tail = NULL;
+  pthread_mutex_unlock(&g_tbl_lock);
+
+  usrsctp_set_non_blocking(so, 1);
+  usrsctp_set_upcall(so, usr_upcall, s);
+  return fd;
+}
+
+int oai_sctp_usr_socket(int domain, int type, int protocol)
+{
+  struct socket *so = usrsctp_socket(domain, type, protocol, NULL, NULL, 0, NULL);
+  if (so == NULL) {
+    SCTP_ERROR("usrsctp_socket(): %s\n", strerror(errno));
+    return -1;
+  }
+  return slot_new(so, false);
+}
+
+int oai_sctp_usr_close(int sd)
+{
+  pthread_mutex_lock(&g_tbl_lock);
+  usr_sock_t *s = slot_by_fd(sd);
+  if (s == NULL) {
+    pthread_mutex_unlock(&g_tbl_lock);
+    return close(sd); /* not ours: a plain descriptor */
+  }
+  struct socket *so = s->so;
+  s->so = NULL;
+  pthread_mutex_unlock(&g_tbl_lock);
+
+  usrsctp_close(so);
+
+  pthread_mutex_lock(&s->lock);
+  for (usr_msg_t *m = s->head; m != NULL;) {
+    usr_msg_t *n = m->next;
+    free(m);
+    m = n;
+  }
+  s->head = s->tail = NULL;
+  pthread_mutex_unlock(&s->lock);
+
+  return close(s->evfd);
+}
+
+#define SLOT_OR_FAIL(sd, s)                                   \
+  usr_sock_t *s = slot_by_fd(sd);                             \
+  if ((s) == NULL) {                                          \
+    SCTP_ERROR("usrsctp: unknown handle %d\n", (sd));          \
+    errno = EBADF;                                            \
+    return -1;                                                \
+  }
+
+int oai_sctp_usr_bind(int sd, const struct sockaddr *addr, socklen_t addrlen)
+{
+  SLOT_OR_FAIL(sd, s);
+  return usrsctp_bind(s->so, (struct sockaddr *)addr, addrlen);
+}
+
+int oai_sctp_usr_bindx(int sd, struct sockaddr *addrs, int addrcnt, int flags)
+{
+  SLOT_OR_FAIL(sd, s);
+  int usr_flags;
+  switch (flags) {
+    case OAI_SCTP_BINDX_ADD: usr_flags = SCTP_BINDX_ADD_ADDR; break;
+    case OAI_SCTP_BINDX_REM: usr_flags = SCTP_BINDX_REM_ADDR; break;
+    default:
+      SCTP_ERROR("usrsctp: unknown bindx flag %d\n", flags);
+      errno = EINVAL;
+      return -1;
+  }
+  return usrsctp_bindx(s->so, addrs, addrcnt, usr_flags);
+}
+
+int oai_sctp_usr_connectx(int sd, struct sockaddr *addrs, int addrcnt, uint32_t *assoc_id)
+{
+  SLOT_OR_FAIL(sd, s);
+  return usrsctp_connectx(s->so, addrs, addrcnt, (sctp_assoc_t *)assoc_id);
+}
+
+int oai_sctp_usr_listen(int sd, int backlog)
+{
+  SLOT_OR_FAIL(sd, s);
+  s->listening = true;
+  return usrsctp_listen(s->so, backlog);
+}
+
+int oai_sctp_usr_accept(int sd, struct sockaddr *addr, socklen_t *addrlen)
+{
+  SLOT_OR_FAIL(sd, s);
+  uint64_t tok;
+  ssize_t unused __attribute__((unused)) = read(s->evfd, &tok, sizeof tok);
+
+  struct socket *ns = usrsctp_accept(s->so, addr, addrlen);
+  if (ns == NULL)
+    return -1;
+  return slot_new(ns, false);
+}
+
+int oai_sctp_usr_peeloff(int sd, uint32_t assoc_id)
+{
+  SLOT_OR_FAIL(sd, s);
+  struct socket *ns = usrsctp_peeloff(s->so, assoc_id);
+  if (ns == NULL)
+    return -1;
+  return slot_new(ns, false);
+}
+
+/* Socket options are TRANSLATED, never passed through: the constants and the
+ * payload structs both differ between the stacks (SCTP_INITMSG 2 vs 3,
+ * SCTP_NODELAY 3 vs 4, SCTP_STATUS 14 vs 0x100), and usrsctp has no SCTP_EVENTS
+ * at all. The names below resolve against usrsctp's headers, which are the ones
+ * in scope in this file. */
+int oai_sctp_usr_setopt(int sd, oai_sctp_opt_t opt, const void *val)
+{
+  SLOT_OR_FAIL(sd, s);
+
+  switch (opt) {
+    case OAI_SCTP_OPT_INITMSG: {
+      const oai_sctp_initmsg_t *m = (const oai_sctp_initmsg_t *)val;
+      struct sctp_initmsg im;
+      memset(&im, 0, sizeof im);
+      im.sinit_num_ostreams = m->num_ostreams;
+      im.sinit_max_instreams = m->max_instreams;
+      im.sinit_max_attempts = m->max_attempts;
+      im.sinit_max_init_timeo = m->max_init_timeo;
+      return usrsctp_setsockopt(s->so, IPPROTO_SCTP, SCTP_INITMSG, &im, sizeof im);
+    }
+
+    case OAI_SCTP_OPT_NODELAY: {
+      const int on = *(const int *)val;
+      return usrsctp_setsockopt(s->so, IPPROTO_SCTP, SCTP_NODELAY, &on, sizeof on);
+    }
+
+    case OAI_SCTP_OPT_REUSEADDR: {
+      /* Best effort. Address reuse is a convenience for restarts, not something
+       * F1-C needs to associate, so a stack that declines it must not abort the
+       * gNB the way a failed AssertFatal would. */
+      const int on = *(const int *)val;
+      if (usrsctp_setsockopt(s->so, SOL_SOCKET, SO_REUSEADDR, &on, sizeof on) < 0)
+        SCTP_DEBUG("usrsctp: SO_REUSEADDR declined (%s), continuing\n", strerror(errno));
+      return 0;
+    }
+
+    case OAI_SCTP_OPT_EVENTS: {
+      const oai_sctp_events_t *e = (const oai_sctp_events_t *)val;
+      /* No SCTP_EVENTS here: subscribe per notification type with SCTP_EVENT. */
+      const struct {
+        uint16_t type;
+        bool on;
+      } wanted[] = {
+          {SCTP_ASSOC_CHANGE, e->association},
+          {SCTP_PEER_ADDR_CHANGE, e->address},
+          {SCTP_REMOTE_ERROR, e->peer_error},
+          {SCTP_SEND_FAILED_EVENT, e->send_failure},
+          {SCTP_SHUTDOWN_EVENT, e->shutdown},
+          {SCTP_PARTIAL_DELIVERY_EVENT, e->partial_delivery},
+      };
+      for (unsigned i = 0; i < sizeof wanted / sizeof wanted[0]; i++) {
+        struct sctp_event ev;
+        memset(&ev, 0, sizeof ev);
+        ev.se_assoc_id = SCTP_FUTURE_ASSOC; /* applies to the association to come */
+        ev.se_type = wanted[i].type;
+        ev.se_on = wanted[i].on ? 1 : 0;
+        if (usrsctp_setsockopt(s->so, IPPROTO_SCTP, SCTP_EVENT, &ev, sizeof ev) < 0)
+          SCTP_WARN("usrsctp: SCTP_EVENT type 0x%x: %s\n", wanted[i].type, strerror(errno));
+      }
+      /* sctp_data_io_event asks for per-message metadata. usrsctp delivers that
+       * through recvv's rcvinfo, which SCTP_RECVRCVINFO enables -- without it
+       * usrsctp_recvv reports no infotype and sinfo_assoc_id/stream/ppid would
+       * all read back as zero. */
+      if (e->data_io) {
+        const int on = 1;
+        if (usrsctp_setsockopt(s->so, IPPROTO_SCTP, SCTP_RECVRCVINFO, &on, sizeof on) < 0)
+          SCTP_WARN("usrsctp: SCTP_RECVRCVINFO: %s\n", strerror(errno));
+      }
+      return 0;
+    }
+
+    default:
+      SCTP_ERROR("usrsctp: unsupported set option %d\n", (int)opt);
+      errno = ENOPROTOOPT;
+      return -1;
+  }
+}
+
+int oai_sctp_usr_getopt(int sd, oai_sctp_opt_t opt, void *val)
+{
+  SLOT_OR_FAIL(sd, s);
+
+  if (opt != OAI_SCTP_OPT_STATUS) {
+    SCTP_ERROR("usrsctp: unsupported get option %d\n", (int)opt);
+    errno = ENOPROTOOPT;
+    return -1;
+  }
+
+  oai_sctp_status_t *out = (oai_sctp_status_t *)val;
+  struct sctp_status st;
+  memset(&st, 0, sizeof st);
+  st.sstat_assoc_id = out->assoc_id;
+  socklen_t len = sizeof st;
+  if (usrsctp_getsockopt(s->so, IPPROTO_SCTP, SCTP_STATUS, &st, &len) < 0)
+    return -1;
+
+  out->assoc_id = st.sstat_assoc_id;
+  out->state = st.sstat_state;
+  out->instrms = st.sstat_instrms;
+  out->outstrms = st.sstat_outstrms;
+  out->fragmentation_point = st.sstat_fragmentation_point;
+  out->penddata = st.sstat_penddata;
+  return 0;
+}
+
+ssize_t oai_sctp_usr_recvmsg(int sd, void *buf, size_t len, struct sockaddr *from,
+                             socklen_t *fromlen, oai_sctp_rcvinfo_t *rcvout, int *msg_flags)
+{
+  SLOT_OR_FAIL(sd, s);
+
+  uint64_t tok;
+  ssize_t unused __attribute__((unused)) = read(s->evfd, &tok, sizeof tok);
+
+  pthread_mutex_lock(&s->lock);
+  usr_msg_t *m = s->head;
+  if (m != NULL) {
+    s->head = m->next;
+    if (s->head == NULL)
+      s->tail = NULL;
+  }
+  pthread_mutex_unlock(&s->lock);
+
+  if (m == NULL) {
+    errno = EAGAIN;
+    return -1;
+  }
+
+  const size_t n = m->len < len ? m->len : len;
+  memcpy(buf, m->data, n);
+  if (rcvout)
+    *rcvout = m->rcv;
+  if (msg_flags)
+    *msg_flags = m->flags; /* always 0: the real flags travel as booleans in rcv */
+  if (from && fromlen) {
+    const socklen_t fl = m->fromlen < *fromlen ? m->fromlen : *fromlen;
+    memcpy(from, &m->from, fl);
+    *fromlen = fl;
+  }
+  free(m);
+  return (ssize_t)n;
+}
+
+ssize_t oai_sctp_usr_sendmsg(int sd, const void *buf, size_t len, const struct sockaddr *to,
+                             socklen_t tolen, uint32_t ppid, uint32_t flags,
+                             uint16_t stream_no, uint32_t timetolive, uint32_t context)
+{
+  SLOT_OR_FAIL(sd, s);
+  (void)tolen;
+
+  struct sctp_sndinfo snd;
+  memset(&snd, 0, sizeof snd);
+  snd.snd_sid = stream_no;
+  snd.snd_flags = (uint16_t)flags;
+  snd.snd_ppid = ppid;
+  snd.snd_context = context;
+  (void)timetolive; /* PR-SCTP lifetime is unused by F1-C/N2 */
+
+  return usrsctp_sendv(s->so, buf, len, (struct sockaddr *)to, to ? 1 : 0, &snd, sizeof snd,
+                       SCTP_SENDV_SNDINFO, 0);
+}
+
+int oai_sctp_usr_getpaddrs(int sd, uint32_t id, struct sockaddr **addrs)
+{
+  SLOT_OR_FAIL(sd, s);
+  return usrsctp_getpaddrs(s->so, id, addrs);
+}
+
+void oai_sctp_usr_freepaddrs(struct sockaddr *addrs)
+{
+  usrsctp_freepaddrs(addrs);
+}
+
+int oai_sctp_usr_getladdrs(int sd, uint32_t id, struct sockaddr **addrs)
+{
+  SLOT_OR_FAIL(sd, s);
+  return usrsctp_getladdrs(s->so, id, addrs);
+}
+
+void oai_sctp_usr_freeladdrs(struct sockaddr *addrs)
+{
+  usrsctp_freeladdrs(addrs);
+}

--- a/openair3/SCTP/sctp_common.c
+++ b/openair3/SCTP/sctp_common.c
@@ -19,6 +19,7 @@
 #include <netinet/sctp.h>
 
 #include "sctp_common.h"
+#include "oai_sctp.h"
 
 /* Pre-bind socket options configuration.
  * See http://linux.die.net/man/7/sctp for more information on these options.
@@ -37,23 +38,23 @@ int sctp_set_init_opt(int sd, uint16_t instreams, uint16_t outstreams,
   init.sinit_max_attempts   = max_attempts;
   init.sinit_max_init_timeo = init_timeout;
 
-  if (setsockopt(sd, IPPROTO_SCTP, SCTP_INITMSG, &init, sizeof(struct sctp_initmsg)) < 0) {
+  if (oai_sctp_setsockopt(sd, IPPROTO_SCTP, SCTP_INITMSG, &init, sizeof(struct sctp_initmsg)) < 0) {
     SCTP_ERROR("setsockopt: %d:%s\n", errno, strerror(errno));
-    close(sd);
+    oai_sctp_close(sd);
     return -1;
   }
 
   int flag = 1;
-  if (setsockopt(sd, IPPROTO_SCTP, SCTP_NODELAY, &flag, sizeof(flag)) < 0) {
+  if (oai_sctp_setsockopt(sd, IPPROTO_SCTP, SCTP_NODELAY, &flag, sizeof(flag)) < 0) {
     SCTP_ERROR("setsockopt SCTP_NODELAY failed: %d:%s\n", errno, strerror(errno));
-    close(sd);
+    oai_sctp_close(sd);
     return -1;
   }
 
   /* Allow socket reuse */
-  if (setsockopt(sd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0) {
+  if (oai_sctp_setsockopt(sd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0) {
     SCTP_ERROR("setsockopt SO_REUSEADDR failed (%d:%s)\n", errno, strerror(errno));
-    close(sd);
+    oai_sctp_close(sd);
     return -1;
   }
 
@@ -79,7 +80,7 @@ int sctp_get_sockinfo(int sock, uint16_t *instream, uint16_t *outstream,
   if (assoc_id != NULL)
     status.sstat_assoc_id = *assoc_id;
 
-  if (getsockopt(sock, IPPROTO_SCTP, SCTP_STATUS, &status, &i) < 0) {
+  if (oai_sctp_getsockopt(sock, IPPROTO_SCTP, SCTP_STATUS, &status, &i) < 0) {
     SCTP_ERROR("Getsockopt SCTP_STATUS failed: %s\n", strerror(errno));
     return -1;
   }
@@ -122,7 +123,7 @@ int sctp_get_peeraddresses(int sock, struct sockaddr **remote_addr, int *nb_remo
   int nb, j;
   struct sockaddr *temp_addr_p;
 
-  if ((nb = sctp_getpaddrs(sock, -1, &temp_addr_p)) <= 0) {
+  if ((nb = oai_sctp_getpaddrs(sock, -1, &temp_addr_p)) <= 0) {
     SCTP_ERROR("Failed to retrieve peer addresses\n");
     return -1;
   }
@@ -163,7 +164,7 @@ int sctp_get_peeraddresses(int sock, struct sockaddr **remote_addr, int *nb_remo
     *remote_addr = temp_addr_p;
   } else {
     /* We can destroy buffer */
-    sctp_freepaddrs((struct sockaddr*)temp_addr_p);
+    oai_sctp_freepaddrs((struct sockaddr*)temp_addr_p);
   }
 
   return 0;
@@ -174,7 +175,7 @@ int sctp_get_localaddresses(int sock, struct sockaddr **local_addr, int *nb_loca
   int nb, j;
   struct sockaddr *temp_addr_p;
 
-  if ((nb = sctp_getladdrs(sock, -1, &temp_addr_p)) <= 0) {
+  if ((nb = oai_sctp_getladdrs(sock, -1, &temp_addr_p)) <= 0) {
     SCTP_ERROR("Failed to retrieve local addresses\n");
     return -1;
   }
@@ -215,7 +216,7 @@ int sctp_get_localaddresses(int sock, struct sockaddr **local_addr, int *nb_loca
     *local_addr = temp_addr_p;
   } else {
     /* We can destroy buffer */
-    sctp_freeladdrs((struct sockaddr*)temp_addr_p);
+    oai_sctp_freeladdrs((struct sockaddr*)temp_addr_p);
   }
 
   return 0;

--- a/openair3/SCTP/sctp_eNB_task.c
+++ b/openair3/SCTP/sctp_eNB_task.c
@@ -31,6 +31,7 @@
 #include "sctp_default_values.h"
 #include "sctp_common.h"
 #include "sctp_eNB_itti_messaging.h"
+#include "oai_sctp.h"
 
 /* Used to format an uint32_t containing an ipv4 address */
 #define IPV4_ADDR    "%u.%u.%u.%u"
@@ -116,14 +117,14 @@ sctp_eNB_accept_associations_multi(
     from_len = (socklen_t)sizeof(struct sockaddr_in);
     memset((void *)&sinfo, 0, sizeof(struct sctp_sndrcvinfo));
 
-    n = sctp_recvmsg(sctp_cnx->sd, (void *)buffer, SCTP_RECV_BUFFER_SIZE,
+    n = oai_sctp_recvmsg(sctp_cnx->sd, (void *)buffer, SCTP_RECV_BUFFER_SIZE,
                      (struct sockaddr *)&addr, &from_len,
                      &sinfo, &flags);
 
     if (n < 0) {
         if (errno == ENOTCONN) {
             SCTP_DEBUG("Received not connected for sd %d\n", sctp_cnx->sd);
-            close(sctp_cnx->sd);
+            oai_sctp_close(sctp_cnx->sd);
         } else {
             SCTP_DEBUG("An error occured during read\n");
             SCTP_ERROR("sctp_recvmsg (fd %d, len %d ): %s:%d\n", sctp_cnx->sd, n, strerror(errno), errno);
@@ -158,7 +159,7 @@ sctp_eNB_accept_associations_multi(
 
                 new_cnx->connection_type = SCTP_TYPE_CLIENT;
 
-                ns = sctp_peeloff(sctp_cnx->sd, sctp_assoc_changed->sac_assoc_id);
+                ns = oai_sctp_peeloff(sctp_cnx->sd, sctp_assoc_changed->sac_assoc_id);
 
                 new_cnx->sd         = ns;
                 new_cnx->task_id    = sctp_cnx->task_id;
@@ -171,7 +172,7 @@ sctp_eNB_accept_associations_multi(
                 if (sctp_get_sockinfo(ns, &new_cnx->in_streams, &new_cnx->out_streams,
                                       &new_cnx->assoc_id) != 0) {
                     SCTP_ERROR("sctp_get_sockinfo failed\n");
-                    close(ns);
+                    oai_sctp_close(ns);
                     free(new_cnx);
                     return;
                 }
@@ -227,7 +228,7 @@ sctp_handle_new_association_req_multi(
     //if (fcntl(sd, F_SETFL, O_NONBLOCK) < 0) {
     //SCTP_ERROR("fcntl F_SETFL O_NONBLOCK failed: %s\n",
     //         strerror(errno));
-    //close(sd);
+    //oai_sctp_close(sd);
     //return;
     //}
 
@@ -250,7 +251,7 @@ sctp_handle_new_association_req_multi(
                 SCTP_ERROR("Failed to convert ipv6 address %*s to network type\n",
                            (int)strlen(remote->ipv6_address),
                            remote->ipv6_address);
-                //close(sd);
+                //oai_sctp_close(sd);
                 //return;
                 exit_fun("sctp_handle_new_association_req_multi fatal: inet_pton error");
             }
@@ -271,7 +272,7 @@ sctp_handle_new_association_req_multi(
                 SCTP_ERROR("Failed to convert ipv4 address %*s to network type\n",
                            (int)strlen(remote->ipv4_address),
                            remote->ipv4_address);
-                //close(sd);
+                //oai_sctp_close(sd);
                 //return;
                 exit_fun("sctp_handle_new_association_req_multi fatal: inet_pton error");
             }
@@ -286,7 +287,7 @@ sctp_handle_new_association_req_multi(
         }
 
         /* Connect to remote host and port */
-        if (sctp_connectx(sd, (struct sockaddr *)addr, 1, &assoc_id) < 0) {
+        if (oai_sctp_connectx(sd, (struct sockaddr *)addr, 1, &assoc_id) < 0) {
             /* sctp_connectx on non-blocking socket return EINPROGRESS */
             if (errno != EINPROGRESS) {
                 SCTP_ERROR("Connect failed: %s\n", strerror(errno));
@@ -295,7 +296,7 @@ sctp_handle_new_association_req_multi(
                     SCTP_STATE_UNREACHABLE, 0, 0);
                 /* Add the socket to list of fd monitored by ITTI */
                 //itti_unsubscribe_event_fd(TASK_SCTP, sd);
-                //close(sd);
+                //oai_sctp_close(sd);
                 return;
             } else {
                 SCTP_DEBUG("connectx assoc_id  %d in progress..., used %d addresses\n",
@@ -309,7 +310,7 @@ sctp_handle_new_association_req_multi(
         }
     }
 
-    ns = sctp_peeloff(sd, assoc_id);
+    ns = oai_sctp_peeloff(sd, assoc_id);
     if (ns == -1) {
       perror("sctp_peeloff");
       printf("sctp_peeloff: sd=%d assoc_id=%d\n", sd, assoc_id);
@@ -387,7 +388,7 @@ static void sctp_handle_new_association_req(const instance_t instance,
     const char *ip = print_ip(p, buf, sizeof(buf));
     SCTP_DEBUG("Trying %s for client socket creation\n", ip);
 
-    if ((sd = socket(serv->ai_family, serv->ai_socktype, serv->ai_protocol)) == -1) {
+    if ((sd = oai_sctp_socket(serv->ai_family, serv->ai_socktype, serv->ai_protocol)) == -1) {
       SCTP_WARN("Socket creation failed: %s\n", strerror(errno));
       continue;
     }
@@ -408,14 +409,14 @@ static void sctp_handle_new_association_req(const instance_t instance,
     events.sctp_partial_delivery_event = 1;
 
     /* as above */
-    ret = setsockopt(sd, serv->ai_protocol, SCTP_EVENTS, &events, 8);
+    ret = oai_sctp_setsockopt(sd, serv->ai_protocol, SCTP_EVENTS, &events, 8);
     AssertFatal(ret == 0, "setsockopt() IPPROTO_SCTP_EVENTS failed: %s\n", strerror(errno));
 
     /* if that fails, we will try the next address */
-    ret = sctp_bindx(sd, p->ai_addr, 1, SCTP_BINDX_ADD_ADDR);
+    ret = oai_sctp_bindx(sd, p->ai_addr, 1, SCTP_BINDX_ADD_ADDR);
     if (ret != 0) {
       SCTP_WARN("sctp_bindx() SCTP_BINDX_ADD_ADDR failed: errno %d %s\n", errno, strerror(errno));
-      close(sd);
+      oai_sctp_close(sd);
       continue;
     }
 
@@ -456,13 +457,13 @@ static void sctp_handle_new_association_req(const instance_t instance,
       const char *ip = print_ip(p, buf, sizeof(buf));
       SCTP_DEBUG("Trying to connect to %s for remote end %s\n", ip, remote);
 
-      if (sctp_connectx(sd, p->ai_addr, 1, &assoc_id) < 0) {
+      if (oai_sctp_connectx(sd, p->ai_addr, 1, &assoc_id) < 0) {
         /* sctp_connectx on non-blocking socket return EINPROGRESS */
         if (errno != EINPROGRESS) {
           SCTP_ERROR("Connect failed: %s\n", strerror(errno));
           sctp_itti_send_association_resp(requestor, instance, -1, req->ulp_cnx_id, SCTP_STATE_UNREACHABLE, 0, 0);
           freeaddrinfo(serv);
-          close(sd);
+          oai_sctp_close(sd);
           return;
         } else {
           SCTP_DEBUG("sctp_connectx(): assoc_id %d in progress...\n", assoc_id);
@@ -475,7 +476,7 @@ static void sctp_handle_new_association_req(const instance_t instance,
 
     freeaddrinfo(serv);
   } else {
-    /* I am not sure that this is relevant; we already did sctp_bindx() above */
+    /* I am not sure that this is relevant; we already did oai_sctp_bindx() above */
     connection_type = SCTP_TYPE_SERVER;
 
     /* No remote address provided -> only bind the socket for now.
@@ -490,9 +491,9 @@ static void sctp_handle_new_association_req(const instance_t instance,
     addr6.sin6_port = htons(req->port);
     addr6.sin6_flowinfo = 0;
 
-    if (bind(sd, (struct sockaddr *)&addr6, sizeof(addr6)) < 0) {
+    if (oai_sctp_bind(sd, (struct sockaddr *)&addr6, sizeof(addr6)) < 0) {
       SCTP_ERROR("Failed to bind the socket to address any (v4/v6): %s\n", strerror(errno));
-      close(sd);
+      oai_sctp_close(sd);
       return;
     }
     */
@@ -546,7 +547,7 @@ static void sctp_send_data(sctp_data_req_t *sctp_data_req_p)
     /* Send message on specified stream of the sd association
      * NOTE: PPID should be defined in network order
      */
-    if (sctp_sendmsg(sctp_cnx->sd, sctp_data_req_p->buffer,
+    if (oai_sctp_sendmsg(sctp_cnx->sd, sctp_data_req_p->buffer,
                      sctp_data_req_p->buffer_length, NULL, 0,
                      htonl(sctp_cnx->ppid), 0, sctp_data_req_p->stream, 0, 0) < 0) {
         SCTP_ERROR("Sctp_sendmsg failed: %s\n", strerror(errno));
@@ -574,7 +575,7 @@ static int sctp_close_association(sctp_close_association_t *close_association_p)
         /* TODO: notify upper layer */
         return -1;
     } else {
-        close(sctp_cnx->sd);
+        oai_sctp_close(sctp_cnx->sd);
         STAILQ_REMOVE(&sctp_cnx_list, sctp_cnx, sctp_cnx_list_elm_s, entries);
         SCTP_DEBUG("Removed assoc_id %d (closed socket %u)\n",
                    sctp_cnx->assoc_id, (unsigned int)sctp_cnx->sd);
@@ -610,7 +611,7 @@ static int sctp_create_new_listener(const instance_t instance, const task_id_t r
 
     /* SOCK_SEQPACKET to be able to reuse(?) socket through SCTP_INIT_MSG_MULTI_REQ */
     int socktype = server_type ? SOCK_SEQPACKET : SOCK_STREAM;
-    if ((sd = socket(serv->ai_family, socktype, serv->ai_protocol)) == -1) {
+    if ((sd = oai_sctp_socket(serv->ai_family, socktype, serv->ai_protocol)) == -1) {
       SCTP_WARN("Socket creation failed: %s\n", strerror(errno));
       continue;
     }
@@ -630,20 +631,20 @@ static int sctp_create_new_listener(const instance_t instance, const task_id_t r
     event.sctp_partial_delivery_event = 1;
 
     /* as above */
-    ret = setsockopt(sd, serv->ai_protocol, SCTP_EVENTS, &event, 8);
+    ret = oai_sctp_setsockopt(sd, serv->ai_protocol, SCTP_EVENTS, &event, 8);
     AssertFatal(ret == 0, "setsockopt() IPPROTO_SCTP_EVENTS failed: %s\n", strerror(errno));
 
     /* if that fails, we will try the next address */
-    ret = sctp_bindx(sd, p->ai_addr, 1, SCTP_BINDX_ADD_ADDR);
+    ret = oai_sctp_bindx(sd, p->ai_addr, 1, SCTP_BINDX_ADD_ADDR);
     if (ret != 0) {
       SCTP_WARN("sctp_bindx() SCTP_BINDX_ADD_ADDR failed: errno %d %s\n", errno, strerror(errno));
-      close(sd);
+      oai_sctp_close(sd);
       continue;
     }
 
-    if (listen(sd, 5) < 0) {
+    if (oai_sctp_listen(sd, 5) < 0) {
       SCTP_WARN("listen() failed: %s:%d\n", strerror(errno), errno);
-      close(sd);
+      oai_sctp_close(sd);
       return -1;
     }
 
@@ -696,7 +697,7 @@ sctp_eNB_accept_associations(
 
     /* There is a new client connecting. Accept it...
      */
-    if ((client_sd = accept(sctp_cnx->sd, (struct sockaddr*)&saddr, &saddr_size)) < 0) {
+    if ((client_sd = oai_sctp_accept(sctp_cnx->sd, (struct sockaddr*)&saddr, &saddr_size)) < 0) {
         SCTP_ERROR("[%d] accept failed: %s:%d\n", sctp_cnx->sd, strerror(errno), errno);
     } else {
         struct sctp_cnx_list_elm_s *new_cnx;
@@ -709,7 +710,7 @@ sctp_eNB_accept_associations(
         if (fcntl(client_sd, F_SETFL, O_NONBLOCK) < 0) {
             SCTP_ERROR("fcntl F_SETFL O_NONBLOCK failed: %s\n",
                        strerror(errno));
-            close(client_sd);
+            oai_sctp_close(client_sd);
             return;
         }
 
@@ -729,7 +730,7 @@ sctp_eNB_accept_associations(
         if (sctp_get_sockinfo(client_sd, &new_cnx->in_streams, &new_cnx->out_streams,
                               &new_cnx->assoc_id) != 0) {
             SCTP_ERROR("sctp_get_sockinfo failed\n");
-            close(client_sd);
+            oai_sctp_close(client_sd);
             free(new_cnx);
             return;
         }
@@ -759,7 +760,7 @@ sctp_eNB_read_from_socket(
     struct sctp_sndrcvinfo sinfo={0};
     uint8_t buffer[SCTP_RECV_BUFFER_SIZE];
 
-    int n = sctp_recvmsg(sctp_cnx->sd, (void *)buffer, SCTP_RECV_BUFFER_SIZE,
+    int n = oai_sctp_recvmsg(sctp_cnx->sd, (void *)buffer, SCTP_RECV_BUFFER_SIZE,
                     NULL, NULL, 
                      &sinfo, &flags);
 
@@ -775,7 +776,7 @@ sctp_eNB_read_from_socket(
                 sctp_cnx->task_id, sctp_cnx->instance, sctp_cnx->assoc_id,
                 sctp_cnx->cnx_id, SCTP_STATE_UNREACHABLE, 0, 0);
 
-            close(sctp_cnx->sd);
+            oai_sctp_close(sctp_cnx->sd);
             STAILQ_REMOVE(&sctp_cnx_list, sctp_cnx, sctp_cnx_list_elm_s, entries);
             sctp_nb_cnx--;
             free(sctp_cnx);
@@ -807,7 +808,7 @@ sctp_eNB_read_from_socket(
             itti_unsubscribe_event_fd(TASK_SCTP, sctp_cnx->sd);
 
             SCTP_WARN("Received SCTP SHUTDOWN EVENT\n");
-            close(sctp_cnx->sd);
+            oai_sctp_close(sctp_cnx->sd);
 
             sctp_itti_send_association_resp(
                 sctp_cnx->task_id, sctp_cnx->instance, sctp_cnx->assoc_id,


### PR DESCRIPTION
## Optional userspace SCTP backend (usrsctp) for 3GPP/O-RAN RAN control-plane interfaces

OAI's SCTP task can now run on either backend, selected at build time and
overridable at runtime:

| backend | transport |
|---|---|
| `kernel` | libsctp and kernel sockets. **The default, unchanged.** |
| `usrsctp` | the FreeBSD SCTP stack in userspace, over a raw `IPPROTO_SCTP` socket |

Traffic is ordinary SCTP over IP — *not* UDP-encapsulated — so the CU or AMF sees
a normal association and needs no configuration change.

### Why

The general case is any target whose kernel cannot practically be rebuilt and lacks native SCTP support.

### Scope of the change

No protocol layer is touched. The socket calls inside `sctp_eNB_task.c` and
`sctp_common.c` are replaced with `oai_sctp_*` wrappers, so **every interface
that reaches the network through the common SCTP task inherits the backend**:
NGAP (N2), E1AP, F1AP (CU and DU), X2AP, S1AP, M2AP, M3AP.

Socket options are **translated, never forwarded**. The constants and payload
structs differ between the two stacks (`SCTP_INITMSG` 2 vs 3, `SCTP_NODELAY` 3
vs 4, `SCTP_STATUS` 14 vs 0x100, and usrsctp has no `SCTP_EVENTS` at all).
Forwarding an untranslated option is exactly what failed during bring-up, so an
option with no translation is now refused loudly rather than passed through. The
full table is in `doc/sctp-usrsctp-backend.md`.

### Build and selection

```
cmake -DENABLE_USRSCTP=ON ...        # default is OFF
OAI_SCTP_BACKEND=usrsctp ./nr-softmodem ...
```

With `ENABLE_USRSCTP=OFF` (the default) the binary contains **zero** usrsctp
symbols and behaviour is byte-for-byte the current kernel path. Setting the env
var in a build without the flag produces an explicit error naming the flag, not a
silent fallback.

### What has been verified

- **Live**, on a DragonWing IQ-9075 platform: F1-C to a real CU, association up, F1 Setup,
  UE attach, user-plane traffic in both directions using the vendor-supplied kernel which lacks SCTP support.
- **x86 and aarch64**, both `ENABLE_USRSCTP=OFF` and `=ON`: configure, all SCTP
  targets, CPM-fetched usrsctp 0.9.5.0, and a full `nr-softmodem` link. `nm`
  shows 180 `usrsctp_*` symbols with `ON` and 0 with `OFF`.

### What has NOT been verified — please read before merging

1. **Only the client path has been exercised.** Every live test had the board as
   the SCTP client (`socket` → `bindx` → `connectx` → `peeloff`) against a peer
   on kernel SCTP. **N2 uses that same client path**, so it is structurally the
   proven one with a different peer, but it has not itself been run.
   The **server** path (`listen`/`accept`) is implemented for real, not stubbed,
   and shares its socket→fd mapping with `peeloff`, which *is* proven — but it
   has never been run. That is what **E1 on the CU-CP side** would use, and the
   CU side of F1-C.
2. **Interfaces beyond F1-C are inheritance, not evidence.** They share the code
   path; none has been run on this backend.

### Testing requirements for CI

Testing this backend needs more than setting the env var, because **a userspace
SCTP stack conflicts with a kernel that has SCTP**: the kernel ABORTs an INIT
arriving for a port it has no listener on, killing the association before
usrsctp sees it. 

Two ways to get a valid environment, cheapest first:

- **Per-job, no special runner.** A normal container plus a rule dropping
  inbound SCTP from the kernel stack inside the container's own network
  namespace, e.g. `iptables -A INPUT -p 132 -j DROP` before starting the gNB.
  This is the standard usrsctp-on-Linux workaround, is scoped to the container,
  and needs `--cap-add=NET_ADMIN` in addition to `NET_RAW`.
- **A runner whose kernel lacks `CONFIG_IP_SCTP`.** Closest to the real target
  and also covers the automatic fallback path (kernel refuses `IPPROTO_SCTP`
  → backend switches itself). Note a container **shares the host kernel**, so
  this cannot be done in an image — it needs the runner itself, or the `sctp`
  module blacklisted on it, which affects every job on that host.

Either way the process needs **`CAP_NET_RAW`** for the raw socket.

The first option is enough to exercise the backend across all interfaces; only
the automatic-fallback detection specifically requires the second.

### Note for reviewers / CI

This branch is one commit on top of `develop`. As of opening, `develop` does not
link natively on its own — `undefined reference to simde_mm512_reduce_add_ps` in
`openair1/PHY/TOOLS/signal_energy.c:62` — which is fixed by PR #511 and is
unrelated to this change. Verified by building unmodified `develop`: identical
failure. If CI runs this before #511 lands it will fail on that symbol.

Assisted-by: Claude Opus 5