### PR TITLE
test(oru): add CI testcase for O-RU with BFP compression enabled

### DIFF
--- a/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru-bfp.conf
+++ b/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru-bfp.conf
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+Active_gNBs = ( "gNB-OAI");
+# Asn1_verbosity, choice in: none, info, annoying
+Asn1_verbosity = "none";
+
+gNBs =
+(
+ {
+    ////////// Identification parameters:
+    gNB_ID    =  0xe00;
+    gNB_name  =  "gNB-OAI";
+
+    // Tracking area code, 0x0000 and 0xfffe are reserved values
+    tracking_area_code  =  1;
+    plmn_list = ({ mcc = 208; mnc = 99; mnc_length = 2; snssaiList = ({ sst = 1; }) });
+
+    nr_cellid = 12345678L;
+
+    ////////// Physical parameters:
+
+    pdsch_AntennaPorts_XP = 1;
+    pdsch_AntennaPorts_N1 = 1;
+    pusch_AntennaPorts    = 1;
+
+    servingCellConfigCommon = (
+    {
+ #spCellConfigCommon
+
+      physCellId                                                    = 0;
+#  downlinkConfigCommon
+    #frequencyInfoDL
+      # center frequency = 4049.76 MHz
+      # selected SSB frequency = 4049.76 MHz
+      absoluteFrequencySSB                                          = 669984;
+      dl_frequencyBand                                              = 77;
+      # frequency point A = 4030.68 MHz
+      dl_absoluteFrequencyPointA                                    = 668712;
+      #scs-SpecificCarrierList
+        dl_offstToCarrier                                           = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        dl_subcarrierSpacing                                        = 1;
+        dl_carrierBandwidth                                         = 106;
+     #initialDownlinkBWP
+      #genericParameters
+       initialDLBWPlocationAndBandwidth                             = 28875; #38.101-1 Table 5.3.2-1
+       #
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialDLBWPsubcarrierSpacing                               = 1;
+      #pdcch-ConfigCommon
+        initialDLBWPcontrolResourceSetZero                          = 11;
+        initialDLBWPsearchSpaceZero                                 = 0;
+
+  #uplinkConfigCommon
+     #frequencyInfoUL
+      ul_frequencyBand                                              = 77;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 106;
+      pMax                                                          = 23;
+     #initialUplinkBWP
+      #genericParameters
+        initialULBWPlocationAndBandwidth                            = 28875;
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+        initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+        #rach-ConfigGeneric
+          prach_ConfigurationIndex                                  = 152;
+#prach_msg1_FDM
+#0 = one, 1=two, 2=four, 3=eight
+          prach_msg1_FDM                                            = 0;
+          prach_msg1_FrequencyStart                                 = 0;
+          zeroCorrelationZoneConfig                                 = 0;
+          preambleReceivedTargetPower                               = -100;
+#preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+          preambleTransMax                                          = 7;
+#powerRampingStep
+# 0=dB0,1=dB2,2=dB4,3=dB6
+        powerRampingStep                                            = 2;
+#ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+#1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+#one (0..15) 4,8,12,16,...60,64
+        ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 15;
+#ra_ContentionResolutionTimer
+#(0..7) 8,16,24,32,40,48,56,64
+        ra_ContentionResolutionTimer                                = 7;
+        rsrp_ThresholdSSB                                           = 19;
+#prach-RootSequenceIndex_PR
+#1 = 839, 2 = 139
+        prach_RootSequenceIndex_PR                                  = 2;
+        prach_RootSequenceIndex                                     = 1;
+        # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precendence over the one derived from prach-ConfigIndex
+        #
+        msg1_SubcarrierSpacing                                      = 1,
+# restrictedSetConfig
+# 0=unrestricted, 1=restricted type A, 2=restricted type B
+        restrictedSetConfig                                         = 0,
+
+# this is the offset between the last PRACH preamble power and the Msg3 PUSCH, 2 times the field value in dB
+        msg3_DeltaPreamble                                          = 2;
+        p0_NominalWithGrant                                         = -100;
+
+# pucch-ConfigCommon setup :
+# pucchGroupHopping
+# 0 = neither, 1= group hopping, 2=sequence hopping
+        pucchGroupHopping                                           = 0;
+        hoppingId                                                   = 0;
+        p0_nominal                                                  = -96;
+
+      ssb_PositionsInBurst_Bitmap                                   = 0x1;
+
+# ssb_periodicityServingCell
+# 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+# dmrs_TypeA_position
+# 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+  #tdd-UL-DL-ConfigurationCommon
+# subcarrierSpacing
+# 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 5;
+      nrofDownlinkSlots                                             = 3;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 1;
+      nrofUplinkSymbols                                             = 4;
+
+  ssPBCH_BlockPower                                                 = 0;
+  }
+
+  );
+
+
+    # ------- SCTP definitions
+    SCTP :
+    {
+        # Number of streams to use in input/output
+        SCTP_INSTREAMS  = 2;
+        SCTP_OUTSTREAMS = 2;
+    };
+
+    ////////// AMF parameters:
+    amf_ip_address = ({ ipv4 = "192.168.101.132"; });
+
+    NETWORK_INTERFACES :
+    {
+        GNB_IPV4_ADDRESS_FOR_NG_AMF              = "192.168.101.140";
+        GNB_IPV4_ADDRESS_FOR_NGU                 = "192.168.101.140";
+        GNB_PORT_FOR_NGU                         = 2152; # Spec 2152
+    };
+  }
+);
+
+MACRLCs = (
+{
+  num_cc                      = 1;
+  tr_s_preference             = "local_L1";
+  tr_n_preference             = "local_RRC";
+  pusch_TargetSNRx10          = 200;
+  pucch_TargetSNRx10          = 200;
+  pusch_FailureThres          = 100;
+}
+);
+
+L1s = (
+{
+  num_cc = 1;
+  tr_n_preference = "local_mac";
+  prach_dtx_threshold = 200;
+  pucch0_dtx_threshold = 80;
+  pusch_dtx_threshold = -100;
+ # thread_pool_size = 8;
+  tx_amp_backoff_dB = 36;
+  L1_rx_thread_core = 10;
+  L1_tx_thread_core = 11;
+  phase_compensation = 0; # needs to match O-RU configuration
+}
+);
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 1;
+  nb_rx          = 1;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  ru_thread_core = 12;
+  sl_ahead       = 10;
+  tr_preference  = "raw_if4p5"; # important: activate FHI7.2
+  do_precoding   = 0; # needs to match O-RU configuration
+}
+);
+
+security = {
+  # preferred ciphering algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nea0, nea1, nea2, nea3
+  ciphering_algorithms = ( "nea0" );
+
+  # preferred integrity algorithms
+  # the first one of the list that an UE supports in chosen
+  # valid values: nia0, nia1, nia2, nia3
+  integrity_algorithms = ( "nia2", "nia0" );
+
+  # setting 'drb_ciphering' to "no" disables ciphering for DRBs, no matter
+  # what 'ciphering_algorithms' configures; same thing for 'drb_integrity'
+  drb_ciphering = "yes";
+  drb_integrity = "no";
+};
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};
+
+fhi_72 = {
+  dpdk_devices = ("0000:41:11.0"); # one VF can be used as well
+  dpdk_iova_mode = "VA";
+  system_core = 7;
+  io_core = 8;
+  worker_cores = (9);
+  ru_addr = ("00:11:22:33:aa:67");
+  mtu = 9600;
+  fh_config = ({
+    T1a_cp_dl = (285, 470);
+    T1a_cp_ul = (285, 429);
+    T1a_up = (300, 450);
+    Ta4 = (0, 440);
+    ru_config = {
+      comp_hdr_type = "dynamic"; # must be "dynamic" when iq_width < 16: O-RU sends per-section compression headers
+      iq_width = 9;
+      iq_width_prach = 9;
+    };
+  });
+};

--- a/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru.conf
+++ b/ci-scripts/conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru.conf
@@ -170,7 +170,6 @@ gNBs =
 
 MACRLCs = (
 {
-  num_cc                      = 1;
   tr_s_preference             = "local_L1";
   tr_n_preference             = "local_RRC";
   pusch_TargetSNRx10          = 200;
@@ -181,7 +180,6 @@ MACRLCs = (
 
 L1s = (
 {
-  num_cc = 1;
   tr_n_preference = "local_mac";
   prach_dtx_threshold = 200;
   pucch0_dtx_threshold = 80;

--- a/ci-scripts/conf_files/ru.band77.mu1.106prb.1x1-bfp.conf
+++ b/ci-scripts/conf_files/ru.band77.mu1.106prb.1x1-bfp.conf
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+
+ORUs = (
+{
+  tx_bw = [106];
+  rx_bw = [106];
+  carrier_tx = [4049760];
+  carrier_rx = [4049760];
+  prach_config_index = 152;
+  prach_msg1_start = 0;
+  tdd_period = 5;
+  num_dl_slots = 3;
+  num_dl_symbols = 6;
+  num_ul_slots = 1;
+  num_ul_symbols = 4;
+  numerology = 1;
+  fronthaul = {
+    dpdk_devices = ("0000:01:01.0"); # one VF can be used as well
+    rx_core = 2;
+    du_mac_addr = ("00:11:22:33:aa:66");
+    mtu = 9216;
+    T2a_up = (250, 5000);
+    T2a_cp = (250, 5000);
+    prach_eaxc_offset = 1;
+    extra_eal_args = ("--file-prefix", "ru");
+    comp_type = "bfp"; # options: "none", "bfp", "blkscale", "ulaw"; must match iq_width on the O-DU side
+  }
+});
+
+RUs = (
+{
+  local_rf       = "no";
+  nb_tx          = 1;
+  nb_rx          = 1;
+  att_tx         = 0;
+  att_rx         = 0;
+  bands          = [77];
+  max_pdschReferenceSignalPower = -27;
+  max_rxgain                    = 75;
+  sf_extension                  = 0;
+  eNB_instances  = [0];
+  sl_ahead       = 10;
+  tr_preference  = "raw_if4p5"; # important: activate FHI7.2
+  do_precoding   = 0; # needs to match O-RU configuration
+  # PRACH configuration
+  num_tp_cores = 4;
+  tp_cores = [-1,-1,-1,-1];
+});
+
+
+log_config :
+{
+  global_log_level = "info";
+  hw_log_level     = "info";
+  phy_log_level    = "info";
+  mac_log_level    = "info";
+  rlc_log_level    = "info";
+  pdcp_log_level   = "info";
+  rrc_log_level    = "info";
+  ngap_log_level   = "info";
+  f1ap_log_level   = "info";
+};

--- a/ci-scripts/conf_files/untested/benetel-5g.conf
+++ b/ci-scripts/conf_files/untested/benetel-5g.conf
@@ -187,7 +187,6 @@ gNBs =
 
 MACRLCs = (
 	{
-	    num_cc              = 1;
 	    tr_s_preference     = "local_L1";
 	    tr_n_preference     = "local_RRC";
 	    pusch_TargetSNRx10  = 200;
@@ -197,7 +196,6 @@ MACRLCs = (
 
 L1s = (
 {
-  num_cc = 1;
   tr_n_preference = "local_mac";
 }
 );

--- a/ci-scripts/conf_files/untested/episci/episci_nr-ue.nfapi.conf
+++ b/ci-scripts/conf_files/untested/episci/episci_nr-ue.nfapi.conf
@@ -19,7 +19,6 @@ pdu_sessions = ({ dnn = "oai"; nssai_sst = 222; nssai_sd = 123; });
 
 MACRLCs = (
         {
-        num_cc = 1;
         tr_n_preference = "nfapi";
         remote_n_address = "127.0.0.1"; //Proxy IP
         local_n_address  = "127.0.0.1";

--- a/ci-scripts/conf_files/untested/episci/gnb_band78.sa.fr1.106PRB.2x2.l2sim.conf
+++ b/ci-scripts/conf_files/untested/episci/gnb_band78.sa.fr1.106PRB.2x2.l2sim.conf
@@ -173,7 +173,6 @@ gNBs =
 
 MACRLCs = (
         {
-        num_cc = 1;
         remote_s_address = "127.0.0.1"; // pnf addr [!]
         local_s_address  = "127.0.0.2"; // vnf addr
         local_s_portc    = 50601; // vnf p5 port

--- a/ci-scripts/conf_files/untested/episci/proxy_nr-ue.nfapi.conf
+++ b/ci-scripts/conf_files/untested/episci/proxy_nr-ue.nfapi.conf
@@ -19,7 +19,6 @@ pdu_sessions = ({ dnn = "oai"; nssai_sst = 1; nssai_sd = 1; });
 
 MACRLCs = (
         {
-        num_cc = 1;
         tr_n_preference = "nfapi";
         remote_n_address = "127.0.0.1"; //Proxy IP
         local_n_address  = "127.0.0.1";

--- a/ci-scripts/conf_files/untested/proxy_gnb.band78.sa.fr1.106PRB.usrpn310.conf
+++ b/ci-scripts/conf_files/untested/proxy_gnb.band78.sa.fr1.106PRB.usrpn310.conf
@@ -170,7 +170,6 @@ gNBs =
 
 MACRLCs = (
         {
-        num_cc = 1;
         remote_s_address = "127.0.0.1"; // pnf addr [!]
         local_s_address  = "127.0.0.2"; // vnf addr
         local_s_portc    = 50601; // vnf p5 port

--- a/ci-scripts/xml_files/container_5g_oai_nr_oru_bfp.xml
+++ b/ci-scripts/xml_files/container_5g_oai_nr_oru_bfp.xml
@@ -1,0 +1,162 @@
+<!-- SPDX-License-Identifier: LicenseRef-CSSL-1.0 -->
+
+<testCaseList>
+  <htmlTabRef>oai-nr-oru-bfp</htmlTabRef>
+  <htmlTabName>O-RU vrtsim 1x1 BFP compression</htmlTabName>
+  <htmlTabIcon>wrench</htmlTabIcon>
+
+  <testCase>
+    <class>Pull_Local_Registry</class>
+    <desc>Pull Images from Local Registry</desc>
+    <node>stonechat</node>
+    <images>oai-gnb-fhi72</images>
+  </testCase>
+
+  <testCase>
+    <class>Pull_Local_Registry</class>
+    <desc>Pull Images from Local Registry</desc>
+    <node>matix</node>
+    <images>oai-nr-ue oai-nr-oru</images>
+  </testCase>
+
+  <testCase>
+    <class>Create_Workspace</class>
+    <desc>Create new Workspace</desc>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Create_Workspace</class>
+    <desc>Create new Workspace</desc>
+    <node>stonechat</node>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G CoreNetwork</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp</yaml_path>
+    <services>mysql oai-amf oai-smf oai-upf oai-ext-dn</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI O-RU</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp</yaml_path>
+    <services>oai-nr-oru</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G gNB 7.2</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp</yaml_path>
+    <services>oai-gnb</services>
+  </testCase>
+
+  <testCase>
+    <class>Deploy_Object</class>
+    <desc>Deploy OAI 5G NR-UE</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp/</yaml_path>
+    <services>oai-nr-ue</services>
+  </testCase>
+
+  <testCase>
+    <class>Attach_UE</class>
+    <desc>Attach OAI UE (Wait for IP)</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Ping</class>
+    <desc>Ping ext-dn from NR-UE</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <ping_args>-c 20 -i 0.25</ping_args>
+    <ping_packetloss_threshold>5</ping_packetloss_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Ping</class>
+    <desc>Ping NR-UE from ext-dn</desc>
+    <id>rfsim5g_ext_dn</id>
+    <node>stonechat</node>
+    <svr_id>rfsim5g_ue</svr_id>
+    <svr_node>matix</svr_node>
+    <ping_args>-c 20 -i 0.25</ping_args>
+    <ping_packetloss_threshold>5</ping_packetloss_threshold>
+  </testCase>
+
+  <testCase>
+    <class>Iperf</class>
+    <desc>Iperf (DL/TCP)(20 sec)</desc>
+    <iperf_args>-t 20 -R</iperf_args>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <iperf_tcp_rate_target>90</iperf_tcp_rate_target>
+  </testCase>
+
+    <testCase>
+    <class>Iperf</class>
+    <desc>Iperf (UL/TCP)(20 sec)</desc>
+    <iperf_args>-t 20</iperf_args>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+    <svr_id>rfsim5g_ext_dn</svr_id>
+    <svr_node>stonechat</svr_node>
+    <iperf_tcp_rate_target>25</iperf_tcp_rate_target>
+  </testCase>
+
+  <testCase>
+    <class>Detach_UE</class>
+    <desc>Detach OAI UE</desc>
+    <id>rfsim5g_ue</id>
+    <node>matix</node>
+  </testCase>
+
+  <testCase>
+    <class>Undeploy_Object</class>
+    <always_exec>true</always_exec>
+    <desc>Undeploy all OAI 5G stack</desc>
+    <node>stonechat</node>
+    <yaml_path>ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp/</yaml_path>
+    <analysis>
+      <services>oai-gnb=EndsWithBye</services>
+    </analysis>
+  </testCase>
+
+  <testCase>
+    <class>Undeploy_Object</class>
+    <always_exec>true</always_exec>
+    <desc>Undeploy all OAI 5G stack</desc>
+    <node>matix</node>
+    <yaml_path>ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp</yaml_path>
+    <analysis>
+      <services>oai-nr-ue oai-nr-oru</services>
+    </analysis>
+  </testCase>
+
+  <testCase>
+    <class>Clean_Test_Server_Images</class>
+    <always_exec>true</always_exec>
+    <desc>Clean Test Images on Test Server</desc>
+    <node>stonechat</node>
+    <images>oai-gnb-fhi72</images>
+  </testCase>
+
+  <testCase>
+    <class>Clean_Test_Server_Images</class>
+    <always_exec>true</always_exec>
+    <desc>Clean Test Images on Test Server</desc>
+    <node>matix</node>
+    <images>oai-nr-ue oai-nr-oru</images>
+  </testCase>
+
+</testCaseList>

--- a/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue/docker-compose.yml
+++ b/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         devices:
             - /dev/vfio:/dev/vfio/
         volumes:
-            - ../../conf_files/ru.band77.mu1.106prb.1x1.conf:/opt/nr-oru/etc/nr-oru.conf
+            - ../../conf_files/${RU_CONF:-ru.band77.mu1.106prb.1x1.conf}:/opt/nr-oru/etc/nr-oru.conf
             - /dev/hugepages:/dev/hugepages
             - tmp_data:/tmp/
         cpuset: "2,3,4,5,6"

--- a/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp/.env
+++ b/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp/.env
@@ -1,0 +1,1 @@
+RU_CONF="ru.band77.mu1.106prb.1x1-bfp.conf"

--- a/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp/docker-compose.yml
+++ b/ci-scripts/yaml_files/5g_vrtsim_fhi72_oaioru_1x1_ru_ue_bfp/docker-compose.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+
+# Variant of 5g_vrtsim_fhi72_oaioru_1x1_ru_ue that deploys the O-RU with BFP
+# compression: the conf file to mount is picked by RU_CONF in .env, so no
+# docker file is duplicated. The UE setup scripts and service definitions are
+# the base compose's.
+include:
+    - ../5g_vrtsim_fhi72_oaioru_1x1_ru_ue/docker-compose.yml

--- a/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb/docker-compose.yml
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb/docker-compose.yml
@@ -29,7 +29,7 @@ services:
         devices:
             - /dev/vfio:/dev/vfio/
         volumes:
-            - ../../conf_files/gnb.sa.band77.106prb.fhi72.1x1-oaioru.conf:/opt/oai-gnb/etc/gnb.conf
+            - ../../conf_files/${GNB_CONF:-gnb.sa.band77.106prb.fhi72.1x1-oaioru.conf}:/opt/oai-gnb/etc/gnb.conf
             - /dev/hugepages:/dev/hugepages
         cpuset: "7,8,9,10,11,12,13,14,15,16"
         networks:

--- a/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp/.env
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp/.env
@@ -1,0 +1,1 @@
+GNB_CONF="gnb.sa.band77.106prb.fhi72.1x1-oaioru-bfp.conf"

--- a/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp/docker-compose.yml
+++ b/ci-scripts/yaml_files/sa_fhi_7.2_oaioru_1x1_gnb_bfp/docker-compose.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+
+# Variant of sa_fhi_7.2_oaioru_1x1_gnb that deploys the gNB with BFP compression:
+# the conf file to mount is picked by GNB_CONF in .env, so no docker file is
+# duplicated. The core network, setup scripts and service definitions are the
+# base compose's.
+include:
+    - ../sa_fhi_7.2_oaioru_1x1_gnb/docker-compose.yml

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.band77.mu1.106rb.fhi.1x1.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.band77.mu1.106rb.fhi.1x1.conf
@@ -181,7 +181,6 @@ MACRLCs = (
 
 L1s = (
 {
-  num_cc = 1;
   tr_n_preference = "local_mac";
   prach_dtx_threshold = 110;
   pucch0_dtx_threshold = 80;

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band257.132prb.fhi72.2x2-microamp.conf
@@ -192,7 +192,6 @@ MACRLCs = (
 
 L1s = (
 {
-  num_cc = 1;
   tr_n_preference = "local_mac";
   prach_dtx_threshold = 120;
   pucch0_dtx_threshold = 50;

--- a/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.106prb.fhi72.1x1-oru.conf
+++ b/targets/PROJECTS/GENERIC-NR-5GC/CONF/gnb.sa.band77.106prb.fhi72.1x1-oru.conf
@@ -181,7 +181,6 @@ MACRLCs = (
 
 L1s = (
 {
-  num_cc = 1;
   tr_n_preference = "local_mac";
   prach_dtx_threshold = 110;
   pucch0_dtx_threshold = 80;


### PR DESCRIPTION
Mirrors the existing container_5g_oai_nr_oru.xml (O-RU vrtsim 1x1) test, with iq_width/iq_width_prach dropped to 9 and comp_hdr_type=dynamic on the DU side, and comp_type=bfp on the O-RU side.

Verified locally against real DPDK/SR-IOV hardware.

Assisted-by: deepseek-v4-flash