### PR TITLE
Clang format automation

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,22 @@
+name: Pre-Commit Checks
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Run pre-commit hooks
+      uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
+    hooks:
+      - id: clang-format
+
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+
+default_stages: [pre-commit, pre-push]
+files: ^radio/(zmq|vrtsim)/

--- a/radio/vrtsim/cirdb_provider.c
+++ b/radio/vrtsim/cirdb_provider.c
@@ -133,12 +133,7 @@ static void load_snapshot_and_publish(cirdb_g *G, uint32_t s)
   int next = (G->cur + 1) % NUM_TAPS_BUFFERS;
   cirdb_buffer_t *buf = &G->bufs[next];
 
-  compact_L_out((struct complexf *)buf->taps_blob,
-                (const struct complexf *)G->snapshot_tmp,
-                G->n_tx,
-                G->n_rx,
-                G->L_full,
-                G->L_out);
+  compact_L_out((struct complexf *)buf->taps_blob, (const struct complexf *)G->snapshot_tmp, G->n_tx, G->n_rx, G->L_full, G->L_out);
 
   point_channel_desc(buf->ch, (struct complexf *)buf->taps_blob, G->n_tx, G->n_rx, G->L_out);
 

--- a/radio/vrtsim/vrtsim.c
+++ b/radio/vrtsim/vrtsim.c
@@ -663,11 +663,10 @@ static int vrtsim_connect(openair0_device_t *device)
                       ue_sel.want_model_id,
                       u);
 
-          vrtsim_state->cirdb_providers[u] = cirdb_connect(
-                        device->openair0_cfg[0].tx_num_channels,
-                        vrtsim_state->ue_conf[u].rx_ant,
-                        &ue_sel,
-                        &vrtsim_state->channel_desc[u]);
+          vrtsim_state->cirdb_providers[u] = cirdb_connect(device->openair0_cfg[0].tx_num_channels,
+                                                           vrtsim_state->ue_conf[u].rx_ant,
+                                                           &ue_sel,
+                                                           &vrtsim_state->channel_desc[u]);
 
           channel_desc_t *cd = vrtsim_state->channel_desc[u];
           AssertFatal(cd != NULL, "CIRDB failed to create channel_desc for UE %d\n", u);
@@ -698,7 +697,8 @@ static int vrtsim_connect(openair0_device_t *device)
         }
         LOG_A(HW, "VRTSIM: Multi-UE channel taps via CIR DB\n");
       } else {
-        vrtsim_state->cirdb_providers[0] = cirdb_connect(device->openair0_cfg[0].tx_num_channels, vrtsim_state->peer_rx_ant, &sel, &vrtsim_state->channel_desc[0]);
+        vrtsim_state->cirdb_providers[0] =
+            cirdb_connect(device->openair0_cfg[0].tx_num_channels, vrtsim_state->peer_rx_ant, &sel, &vrtsim_state->channel_desc[0]);
         LOG_A(HW, "VRTSIM: channel taps via CIR DB\n");
       }
     } else {

--- a/radio/zmq/tests/test_ring_buffer.cpp
+++ b/radio/zmq/tests/test_ring_buffer.cpp
@@ -10,7 +10,7 @@ TEST(CircularBuffer, simplePushPop)
   ring_buffer cb(10);
   cf_t data[10];
   for (int i = 0; i < 10; i++) {
-    data[i] = { (float)i, (float)(i + 1)};
+    data[i] = {(float)i, (float)(i + 1)};
   }
   ASSERT_EQ(cb.push_samples(data, 10), 0);
 

--- a/radio/zmq/zmq_imported.h
+++ b/radio/zmq/zmq_imported.h
@@ -48,11 +48,11 @@ class zmq_tx_channel {
 
 class zmq_rx_channel {
  public:
-   void *socket_;
-   overflow_buffer<c16_t> buffer_;
-   bool request_sent_;
-   std::atomic<bool> stopped_;
-   zmq_rx_channel(void *s, uint64_t buffer_size) : socket_(s), buffer_(buffer_size), stopped_(false)
+  void *socket_;
+  overflow_buffer<c16_t> buffer_;
+  bool request_sent_;
+  std::atomic<bool> stopped_;
+  zmq_rx_channel(void *s, uint64_t buffer_size) : socket_(s), buffer_(buffer_size), stopped_(false)
   {
   }
   void receive(c16_t *samples, size_t nsamps);


### PR DESCRIPTION
This is an implementation of a proposal I made on the TSC: it runs a free (meaning no-cost), non-gating code formatting validation of areas of code I am maintaining.