### PR TITLE
fix(fronthaul): stop pcap unit tests racing on shared download files

### DIFF
--- a/fronthaul/oru/tests/run_oru_pcap_test.sh
+++ b/fronthaul/oru/tests/run_oru_pcap_test.sh
@@ -20,12 +20,20 @@ while [[ $# -gt 0 ]]; do
 	shift
 done
 
-ARCHIVE_NAME="compressed_pcap.xz"
-EXTRACTED_FILENAME="uncompressed.pcap"
-curl -L $DOWNLOAD_URL --output $ARCHIVE_NAME
-unxz -c $ARCHIVE_NAME > $EXTRACTED_FILENAME
-
-
+#give each invocation its own scratch dir
+WORKDIR="$(mktemp -d "/tmp/oru_pcap.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+ARCHIVE_NAME="$WORKDIR/compressed_pcap.xz"
+EXTRACTED_FILENAME="$WORKDIR/uncompressed.pcap"
+if ! curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 -o "$ARCHIVE_NAME" "$DOWNLOAD_URL"; then
+	echo "ERROR: cannot download test PCAP ${DOWNLOAD_URL} (network/GitHub access?)" >&2
+	exit 2
+fi
+if ! xz --test "$ARCHIVE_NAME"; then
+	echo "ERROR: downloaded PCAP archive is corrupt or truncated: ${ARCHIVE_NAME}" >&2
+	exit 2
+fi
+xz --decompress -c "$ARCHIVE_NAME" > "$EXTRACTED_FILENAME"
 
 echo "Running test ${TEST_EXECUTABLE} with PCAP ${DOWNLOAD_URL} and arguments: ${EXTRA_ARGS[*]}"
-exec "${TEST_EXECUTABLE}" "${EXTRACTED_FILENAME}" "${EXTRA_ARGS[@]}"
+"${TEST_EXECUTABLE}" "${EXTRACTED_FILENAME}" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
test_oru_pcap_1 and test_oru_pcap_frag run concurrently in the same CTest working directory, and each run_oru_pcap_test.sh invocation downloaded and decompressed the same GitHub release asset to the same compressed_pcap.xz / uncompressed.pcap filenames. One test's unxz then reads a file the other test's curl is still truncating/writing, failing intermittently with "unxz: compressed_pcap.xz: Unexpected end of input" after ~0.5 s and reddening unrelated PRs on the RAN-Ubuntu-Image-Builder CI job.

Give each invocation its own mktemp scratch dir (removed on exit), make the download fail explicitly with retries, and verify the .xz archive before decompressing so a network/GitHub access problem is reported as such instead of as a corrupt-archive error.

Assisted-by: deepseek-v4-flash