### PR TITLE
XNAP: Add encode/decode+unit tests for RETRIEVE UE CONTEXT (initiating, successful and unsuccessful outcome)

### DIFF
--- a/openair2/COMMON/xnap_messages_types.h
+++ b/openair2/COMMON/xnap_messages_types.h
@@ -450,4 +450,56 @@ typedef struct {
   xnap_ran_paging_area_t ran_paging_area;
 } xnap_ran_paging_t;
 
+/* 3GPP TS 38.423 9.2.3.40 – UE Context ID */
+typedef enum {
+  XNAP_UE_CONTEXT_ID_RRC_RESUME = 1,
+  XNAP_UE_CONTEXT_ID_RRC_REESTABLISHMENT,
+} xnap_ue_context_id_choice_t;
+
+/* I-RNTI variant (3GPP TS 38.423 9.2.3.55): full (40-bit) or short (24-bit) */
+typedef enum {
+  XNAP_I_RNTI_FULL = 0,
+  XNAP_I_RNTI_SHORT,
+} xnap_i_rnti_type_t;
+
+/* UE Context ID for RRC Resume */
+typedef struct {
+  /* I-RNTI type – full or short (M) */
+  xnap_i_rnti_type_t i_rnti_type;
+  /* I-RNTI value – 40-bit if full, 24-bit if short (M) */
+  uint64_t i_rnti;
+  /* Allocated C-RNTI – 16-bit (M) */
+  uint16_t allocated_c_rnti;
+  /* Access PCI – NR PCI, 0..1007 (M) */
+  uint16_t access_pci;
+} xnap_ue_context_id_rrc_resume_t;
+
+/* UE Context ID for RRC Reestablishment */
+typedef struct {
+  /* C-RNTI – 16-bit (M) */
+  uint16_t c_rnti;
+  /* Failure Cell PCI – NR PCI, 0..1007 (M) */
+  uint16_t failure_cell_pci;
+} xnap_ue_context_id_rrc_reest_t;
+
+typedef struct {
+  xnap_ue_context_id_choice_t choice;
+  union {
+    xnap_ue_context_id_rrc_resume_t rrc_resume;
+    xnap_ue_context_id_rrc_reest_t rrc_reest;
+  };
+} xnap_ue_context_id_t;
+
+/* 3GPP TS 38.423 9.1.1.8 – Retrieve UE Context Request */
+typedef struct {
+  /* New NG-RAN node UE XnAP ID (M) */
+  uint32_t new_ng_node_ue_xnap_id;
+  /* UE Context ID (M) */
+  xnap_ue_context_id_t ue_context_id;
+  /* MAC-I – 16-bit (M) */
+  uint16_t mac_i;
+  /* New NG-RAN Cell Identity – NR Cell Identity, 36-bit (M) */
+  uint64_t new_ng_ran_cell_id;
+} xnap_retrieve_ue_context_request_t;
+
 #endif /* XNAP_MESSAGES_TYPES_H_ */

--- a/openair2/COMMON/xnap_messages_types.h
+++ b/openair2/COMMON/xnap_messages_types.h
@@ -502,4 +502,18 @@ typedef struct {
   uint64_t new_ng_ran_cell_id;
 } xnap_retrieve_ue_context_request_t;
 
+/* 3GPP TS 38.423 9.1.1.9 – Retrieve UE Context Response */
+typedef struct {
+  /* New NG-RAN node UE XnAP ID (M) */
+  uint32_t new_ng_node_ue_xnap_id;
+  /* Old NG-RAN node UE XnAP ID (M) */
+  uint32_t old_ng_node_ue_xnap_id;
+  /* GUAMI (M) */
+  nr_guami_t guami;
+  /* UE Context Information – Retrieve UE Context Response (M)
+   * Reuses the Handover Request UE Context Information container (the
+   * mandatory sub-IEs are identical). */
+  xnap_ue_context_info_t ue_context;
+} xnap_retrieve_ue_context_response_t;
+
 #endif /* XNAP_MESSAGES_TYPES_H_ */

--- a/openair2/COMMON/xnap_messages_types.h
+++ b/openair2/COMMON/xnap_messages_types.h
@@ -516,4 +516,12 @@ typedef struct {
   xnap_ue_context_info_t ue_context;
 } xnap_retrieve_ue_context_response_t;
 
+/* 3GPP TS 38.423 9.1.1.10 – Retrieve UE Context Failure */
+typedef struct {
+  /* New NG-RAN node UE XnAP ID (M) */
+  uint32_t new_ng_node_ue_xnap_id;
+  /* Cause (M) */
+  xnap_cause_t cause;
+} xnap_retrieve_ue_context_failure_t;
+
 #endif /* XNAP_MESSAGES_TYPES_H_ */

--- a/openair2/XNAP/lib/xnap_gNB_mobility_management.c
+++ b/openair2/XNAP/lib/xnap_gNB_mobility_management.c
@@ -1958,3 +1958,265 @@ void free_xnap_retrieve_ue_context_request(xnap_retrieve_ue_context_request_t *m
   // Nothing to free
   UNUSED(msg);
 }
+
+/**
+ * @brief XnAP UE Context Information (Retrieve UE Context Response) encoding.
+ *        Only the mandatory sub-IEs are handled; the container shares its
+ *        layout with the Handover Request UE Context Information.
+ */
+static void xnap_encode_ue_ctx_info_retr(const xnap_ue_context_info_t *in, XNAP_UEContextInfoRetrUECtxtResp_t *out)
+{
+  DevAssert(in != NULL);
+  DevAssert(out != NULL);
+
+  /* NG-C UE associated Signalling reference (M) 9.2.3.26 */
+  asn_uint642INTEGER(&out->ng_c_UE_signalling_ref, in->ngc_ue_sig_ref);
+
+  /* Signalling TNL association address at source NG-C side (M) 9.2.3.31 */
+  out->signalling_TNL_at_source.present = XNAP_CPTransportLayerInformation_PR_endpointIPAddress;
+  TRANSPORT_LAYER_ADDRESS_IPv4_TO_BIT_STRING(*(long *)in->cp_tnl_ip_source.buffer,
+                                             &out->signalling_TNL_at_source.choice.endpointIPAddress);
+
+  /* UE Security Capabilities (M) 9.2.3.49 */
+  out->ueSecurityCapabilities = xnap_encode_security_capabilities(&in->security_capabilities);
+
+  /* AS Security Information (M) 9.2.3.50 */
+  AS_KEY_STAR_TO_BIT_STRING(in->as_security_key_ranstar, &out->securityInformation.key_NG_RAN_Star);
+  out->securityInformation.ncc = in->as_security_ncc;
+
+  /* UE Aggregate Maximum Bit Rate (M) 9.2.3.17 */
+  UEAGMAXBITRTD_TO_ASN_PRIMITIVES(in->ue_ambr.br_dl, &out->ue_AMBR.dl_UE_AMBR);
+  UEAGMAXBITRTU_TO_ASN_PRIMITIVES(in->ue_ambr.br_ul, &out->ue_AMBR.ul_UE_AMBR);
+
+  /* PDU Session Resources To Be Setup List (M) 9.2.1.1 */
+  for (int i = 0; i < in->num_pdu; i++) {
+    const xnap_pdusession_resources_tobe_setup_item_t *pdu = &in->pdusession_resources_tobe_setup_list[i];
+    asn1cSequenceAdd(out->pduSessionResourcesToBeSetup_List.list, XNAP_PDUSessionResourcesToBeSetup_Item_t, pduItem);
+
+    pduItem->pduSessionId = pdu->pdusession_id;
+    pduItem->s_NSSAI = xnap_encode_snssai(pdu->nssai);
+    pduItem->uL_NG_U_TNLatUPF = xnap_encode_ul_ngu_tnl_info(&pdu->n3_incoming);
+    pduItem->pduSessionType = pdu->pdu_session_type;
+
+    for (int j = 0; j < pdu->num_qos; j++) {
+      const xnap_qos_flow_tobe_setup_item_t *qos = &pdu->qos_list[j];
+      asn1cSequenceAdd(pduItem->qosFlowsToBeSetup_List.list, XNAP_QoSFlowsToBeSetup_Item_t, qosItem);
+
+      qosItem->qfi = qos->qfi;
+
+      XNAP_QoSCharacteristics_t *qosChar = &qosItem->qosFlowLevelQoSParameters.qos_characteristics;
+      if (qos->qos_params.qos_type == NON_DYNAMIC) {
+        qosChar->present = XNAP_QoSCharacteristics_PR_non_dynamic;
+        asn1cCalloc(qosChar->choice.non_dynamic, nonDyn);
+        nonDyn->fiveQI = qos->qos_params.nondyn.fiveQI;
+      } else {
+        qosChar->present = XNAP_QoSCharacteristics_PR_dynamic;
+        asn1cCalloc(qosChar->choice.dynamic, dyn);
+        dyn->priorityLevelQoS = qos->qos_params.dyn.prio;
+        dyn->packetDelayBudget = qos->qos_params.dyn.pdb;
+        dyn->packetErrorRate.pER_Scalar = qos->qos_params.dyn.per.scalar;
+        dyn->packetErrorRate.pER_Exponent = qos->qos_params.dyn.per.exponent;
+      }
+
+      XNAP_AllocationandRetentionPriority_t *arp = &qosItem->qosFlowLevelQoSParameters.allocationAndRetentionPrio;
+      arp->priorityLevel = qos->qos_params.arp.priority_level;
+      arp->pre_emption_capability = qos->qos_params.arp.pre_emp_capability;
+      arp->pre_emption_vulnerability = qos->qos_params.arp.pre_emp_vulnerability;
+    }
+  }
+
+  /* RRC Context (M) TS 38.331 11.2.2 if the old and new serving NG-RAN nodes are gNBs */
+  OCTET_STRING_fromBuf(&out->rrc_Context, (const char *)in->rrc_context.buf, in->rrc_context.len);
+}
+
+/**
+ * @brief XnAP UE Context Information (Retrieve UE Context Response) decoding.
+ */
+static bool decode_xnap_ue_ctx_info_retr(const XNAP_UEContextInfoRetrUECtxtResp_t *in, xnap_ue_context_info_t *out)
+{
+  DevAssert(in != NULL);
+  DevAssert(out != NULL);
+
+  asn_INTEGER2uint64(&in->ng_c_UE_signalling_ref, &out->ngc_ue_sig_ref);
+
+  if (in->signalling_TNL_at_source.present != XNAP_CPTransportLayerInformation_PR_endpointIPAddress) {
+    PRINT_ERROR("Unsupported CPTransportLayerInformation choice %d\n", in->signalling_TNL_at_source.present);
+    return false;
+  }
+  BIT_STRING_TO_TRANSPORT_LAYER_ADDRESS_IPv4(&in->signalling_TNL_at_source.choice.endpointIPAddress,
+                                             *(long *)out->cp_tnl_ip_source.buffer);
+  out->cp_tnl_ip_source.length = 4;
+
+  if (!decode_xnap_ue_security_capabilities(&in->ueSecurityCapabilities, &out->security_capabilities))
+    return false;
+
+  memcpy(out->as_security_key_ranstar, in->securityInformation.key_NG_RAN_Star.buf, 32);
+  out->as_security_ncc = in->securityInformation.ncc;
+
+  asn_INTEGER2ulong(&in->ue_AMBR.ul_UE_AMBR, &out->ue_ambr.br_ul);
+  asn_INTEGER2ulong(&in->ue_AMBR.dl_UE_AMBR, &out->ue_ambr.br_dl);
+
+  out->rrc_context = create_byte_array(in->rrc_Context.size, in->rrc_Context.buf);
+
+  out->num_pdu = in->pduSessionResourcesToBeSetup_List.list.count;
+  out->pdusession_resources_tobe_setup_list = calloc_or_fail(out->num_pdu, sizeof(*out->pdusession_resources_tobe_setup_list));
+
+  for (int p = 0; p < out->num_pdu; p++) {
+    XNAP_PDUSessionResourcesToBeSetup_Item_t *pdu = in->pduSessionResourcesToBeSetup_List.list.array[p];
+    xnap_pdusession_resources_tobe_setup_item_t *dst = &out->pdusession_resources_tobe_setup_list[p];
+
+    dst->pdusession_id = pdu->pduSessionId;
+
+    dst->nssai = calloc_or_fail(1, sizeof(*dst->nssai));
+    if (!decode_xnap_snssai(&pdu->s_NSSAI, dst->nssai))
+      return false;
+
+    if (!decode_xnap_ul_ngu_tnl_info(&pdu->uL_NG_U_TNLatUPF, &dst->n3_incoming))
+      return false;
+
+    dst->pdu_session_type = pdu->pduSessionType;
+
+    if (!decode_xnap_qos_flows_to_be_setup_list(&pdu->qosFlowsToBeSetup_List, dst))
+      return false;
+  }
+
+  return true;
+}
+
+/**
+ * @brief XnAP Retrieve UE Context Response (9.1.1.9) encoding
+ */
+XNAP_XnAP_PDU_t *encode_xnap_retrieve_ue_context_response(const xnap_retrieve_ue_context_response_t *msg)
+{
+  XNAP_XnAP_PDU_t *pdu = calloc_or_fail(1, sizeof(*pdu));
+
+  pdu->present = XNAP_XnAP_PDU_PR_successfulOutcome;
+  asn1cCalloc(pdu->choice.successfulOutcome, succMsg);
+  succMsg->procedureCode = XNAP_ProcedureCode_id_retrieveUEContext;
+  succMsg->criticality = XNAP_Criticality_reject;
+  succMsg->value.present = XNAP_SuccessfulOutcome__value_PR_RetrieveUEContextResponse;
+
+  XNAP_RetrieveUEContextResponse_t *out = &succMsg->value.choice.RetrieveUEContextResponse;
+
+  /* New NG-RAN node UE XnAP ID (M) 9.2.3.16 */
+  asn1cSequenceAdd(out->protocolIEs.list, XNAP_RetrieveUEContextResponse_IEs_t, ie1);
+  ie1->id = XNAP_ProtocolIE_ID_id_newNG_RANnodeUEXnAPID;
+  ie1->criticality = XNAP_Criticality_ignore;
+  ie1->value.present = XNAP_RetrieveUEContextResponse_IEs__value_PR_NG_RANnodeUEXnAPID;
+  ie1->value.choice.NG_RANnodeUEXnAPID = msg->new_ng_node_ue_xnap_id;
+
+  /* Old NG-RAN node UE XnAP ID (M) 9.2.3.16 */
+  asn1cSequenceAdd(out->protocolIEs.list, XNAP_RetrieveUEContextResponse_IEs_t, ie2);
+  ie2->id = XNAP_ProtocolIE_ID_id_oldNG_RANnodeUEXnAPID;
+  ie2->criticality = XNAP_Criticality_ignore;
+  ie2->value.present = XNAP_RetrieveUEContextResponse_IEs__value_PR_NG_RANnodeUEXnAPID_1;
+  ie2->value.choice.NG_RANnodeUEXnAPID_1 = msg->old_ng_node_ue_xnap_id;
+
+  /* GUAMI (M) 9.2.3.24 */
+  asn1cSequenceAdd(out->protocolIEs.list, XNAP_RetrieveUEContextResponse_IEs_t, ie3);
+  ie3->id = XNAP_ProtocolIE_ID_id_GUAMI;
+  ie3->criticality = XNAP_Criticality_reject;
+  ie3->value.present = XNAP_RetrieveUEContextResponse_IEs__value_PR_GUAMI;
+  MCC_MNC_TO_PLMNID(msg->guami.plmn.mcc, msg->guami.plmn.mnc, msg->guami.plmn.mnc_digit_length, &ie3->value.choice.GUAMI.plmn_ID);
+  AMF_REGION_TO_BIT_STRING(msg->guami.amf_region_id, &ie3->value.choice.GUAMI.amf_region_id);
+  AMF_SETID_TO_BIT_STRING(msg->guami.amf_set_id, &ie3->value.choice.GUAMI.amf_set_id);
+  AMF_POINTER_TO_BIT_STRING(msg->guami.amf_pointer, &ie3->value.choice.GUAMI.amf_pointer);
+
+  /* UE Context Information – Retrieve UE Context Response (M) 9.2.1.13 */
+  asn1cSequenceAdd(out->protocolIEs.list, XNAP_RetrieveUEContextResponse_IEs_t, ie4);
+  ie4->id = XNAP_ProtocolIE_ID_id_UEContextInfoRetrUECtxtResp;
+  ie4->criticality = XNAP_Criticality_reject;
+  ie4->value.present = XNAP_RetrieveUEContextResponse_IEs__value_PR_UEContextInfoRetrUECtxtResp;
+  xnap_encode_ue_ctx_info_retr(&msg->ue_context, &ie4->value.choice.UEContextInfoRetrUECtxtResp);
+
+  return pdu;
+}
+
+/**
+ * @brief XnAP Retrieve UE Context Response (9.1.1.9) decoding
+ */
+bool decode_xnap_retrieve_ue_context_response(xnap_retrieve_ue_context_response_t *out, const XNAP_XnAP_PDU_t *pdu)
+{
+  _EQ_CHECK_INT(pdu->present, XNAP_XnAP_PDU_PR_successfulOutcome);
+  AssertError(pdu->choice.successfulOutcome != NULL, return false, "successfulOutcome is NULL");
+  _EQ_CHECK_LONG(pdu->choice.successfulOutcome->procedureCode, XNAP_ProcedureCode_id_retrieveUEContext);
+  _EQ_CHECK_INT(pdu->choice.successfulOutcome->value.present, XNAP_SuccessfulOutcome__value_PR_RetrieveUEContextResponse);
+
+  XNAP_RetrieveUEContextResponse_t *in = &pdu->choice.successfulOutcome->value.choice.RetrieveUEContextResponse;
+  XNAP_RetrieveUEContextResponse_IEs_t *ie;
+
+  XNAP_LIB_FIND_IE(XNAP_RetrieveUEContextResponse_IEs_t, ie, &in->protocolIEs.list, XNAP_ProtocolIE_ID_id_newNG_RANnodeUEXnAPID, true);
+  XNAP_LIB_FIND_IE(XNAP_RetrieveUEContextResponse_IEs_t, ie, &in->protocolIEs.list, XNAP_ProtocolIE_ID_id_oldNG_RANnodeUEXnAPID, true);
+  XNAP_LIB_FIND_IE(XNAP_RetrieveUEContextResponse_IEs_t, ie, &in->protocolIEs.list, XNAP_ProtocolIE_ID_id_GUAMI, true);
+  XNAP_LIB_FIND_IE(XNAP_RetrieveUEContextResponse_IEs_t, ie, &in->protocolIEs.list, XNAP_ProtocolIE_ID_id_UEContextInfoRetrUECtxtResp, true);
+
+  for (int i = 0; i < in->protocolIEs.list.count; i++) {
+    DevAssert(in->protocolIEs.list.array[i]);
+    ie = in->protocolIEs.list.array[i];
+
+    switch (ie->id) {
+      case XNAP_ProtocolIE_ID_id_newNG_RANnodeUEXnAPID: {
+        _EQ_CHECK_INT(ie->value.present, XNAP_RetrieveUEContextResponse_IEs__value_PR_NG_RANnodeUEXnAPID);
+        out->new_ng_node_ue_xnap_id = ie->value.choice.NG_RANnodeUEXnAPID;
+      } break;
+
+      case XNAP_ProtocolIE_ID_id_oldNG_RANnodeUEXnAPID: {
+        _EQ_CHECK_INT(ie->value.present, XNAP_RetrieveUEContextResponse_IEs__value_PR_NG_RANnodeUEXnAPID_1);
+        out->old_ng_node_ue_xnap_id = ie->value.choice.NG_RANnodeUEXnAPID_1;
+      } break;
+
+      case XNAP_ProtocolIE_ID_id_GUAMI: {
+        _EQ_CHECK_INT(ie->value.present, XNAP_RetrieveUEContextResponse_IEs__value_PR_GUAMI);
+        const XNAP_GUAMI_t *guami = &ie->value.choice.GUAMI;
+        plmn_id_t *plmn = &out->guami.plmn;
+        PLMNID_TO_MCC_MNC(&guami->plmn_ID, plmn->mcc, plmn->mnc, plmn->mnc_digit_length);
+        out->guami.amf_region_id = BIT_STRING_to_uint8(&guami->amf_region_id);
+        out->guami.amf_set_id = BIT_STRING_to_uint16(&guami->amf_set_id);
+        out->guami.amf_pointer = BIT_STRING_to_uint8(&guami->amf_pointer);
+      } break;
+
+      case XNAP_ProtocolIE_ID_id_UEContextInfoRetrUECtxtResp: {
+        _EQ_CHECK_INT(ie->value.present, XNAP_RetrieveUEContextResponse_IEs__value_PR_UEContextInfoRetrUECtxtResp);
+        if (!decode_xnap_ue_ctx_info_retr(&ie->value.choice.UEContextInfoRetrUECtxtResp, &out->ue_context))
+          return false;
+      } break;
+
+      case XNAP_ProtocolIE_ID_id_TraceActivation:
+      case XNAP_ProtocolIE_ID_id_MaskedIMEISV:
+      case XNAP_ProtocolIE_ID_id_LocationReportingInformation:
+      case XNAP_ProtocolIE_ID_id_CriticalityDiagnostics:
+      case XNAP_ProtocolIE_ID_id_UEHistoryInformation:
+      case XNAP_ProtocolIE_ID_id_MDTPLMNList:
+        PRINT_ERROR("XNAP_ProtocolIE_ID_id %ld not handled, skipping\n", ie->id);
+        break;
+
+      default:
+        PRINT_ERROR("XNAP_ProtocolIE_ID_id %ld unknown, skipping\n", ie->id);
+        break;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief XnAP Retrieve UE Context Response (9.1.1.9) equality function
+ */
+bool eq_xnap_retrieve_ue_context_response(const xnap_retrieve_ue_context_response_t *a, const xnap_retrieve_ue_context_response_t *b)
+{
+  _EQ_CHECK_UINT32(a->new_ng_node_ue_xnap_id, b->new_ng_node_ue_xnap_id);
+  _EQ_CHECK_UINT32(a->old_ng_node_ue_xnap_id, b->old_ng_node_ue_xnap_id);
+  if (!eq_nr_guami(&a->guami, &b->guami))
+    return false;
+  if (!eq_xnap_ue_context_info(&a->ue_context, &b->ue_context))
+    return false;
+  return true;
+}
+
+/**
+ * @brief XnAP Retrieve UE Context Response (9.1.1.9) memory management
+ */
+void free_xnap_retrieve_ue_context_response(xnap_retrieve_ue_context_response_t *msg)
+{
+  free_xnap_ue_context_info(&msg->ue_context);
+}

--- a/openair2/XNAP/lib/xnap_gNB_mobility_management.c
+++ b/openair2/XNAP/lib/xnap_gNB_mobility_management.c
@@ -1710,3 +1710,251 @@ void free_xnap_ran_paging(xnap_ran_paging_t *msg)
   else
     free(msg->ran_paging_area.ran_area_ids);
 }
+
+/* ======================================================================
+ * 3GPP TS 38.423 – Retrieve UE Context procedure (id-retrieveUEContext)
+ *   9.1.1.8  RETRIEVE UE CONTEXT REQUEST  (initiating message)
+ *   9.1.1.9  RETRIEVE UE CONTEXT RESPONSE (successful outcome)
+ *   9.1.1.10 RETRIEVE UE CONTEXT FAILURE  (unsuccessful outcome)
+ * Only mandatory IEs are implemented.
+ * ====================================================================== */
+
+/**
+ * @brief XnAP UE Context ID (9.2.3.40) encoding
+ */
+static XNAP_UEContextID_t xnap_encode_ue_context_id(const xnap_ue_context_id_t *in)
+{
+  DevAssert(in != NULL);
+
+  XNAP_UEContextID_t out = {0};
+  if (in->choice == XNAP_UE_CONTEXT_ID_RRC_RESUME) {
+    out.present = XNAP_UEContextID_PR_rRCResume;
+    asn1cCalloc(out.choice.rRCResume, resume);
+    if (in->rrc_resume.i_rnti_type == XNAP_I_RNTI_SHORT) {
+      resume->i_rnti.present = XNAP_I_RNTI_PR_i_RNTI_short;
+      IRNTI_SHORT_TO_BIT_STRING(in->rrc_resume.i_rnti, &resume->i_rnti.choice.i_RNTI_short);
+    } else {
+      resume->i_rnti.present = XNAP_I_RNTI_PR_i_RNTI_full;
+      IRNTI_TO_BIT_STRING(in->rrc_resume.i_rnti, &resume->i_rnti.choice.i_RNTI_full);
+    }
+    C_RNTI_TO_BIT_STRING(in->rrc_resume.allocated_c_rnti, &resume->allocated_c_rnti);
+    /* Only the NR branch of NG-RAN-CellPCI is supported (E-UTRA is not). */
+    resume->accessPCI.present = XNAP_NG_RAN_CellPCI_PR_nr;
+    resume->accessPCI.choice.nr = in->rrc_resume.access_pci;
+  } else if (in->choice == XNAP_UE_CONTEXT_ID_RRC_REESTABLISHMENT) {
+    out.present = XNAP_UEContextID_PR_rRRCReestablishment;
+    asn1cCalloc(out.choice.rRRCReestablishment, reest);
+    C_RNTI_TO_BIT_STRING(in->rrc_reest.c_rnti, &reest->c_rnti);
+    /* Only the NR branch of NG-RAN-CellPCI is supported (E-UTRA is not). */
+    reest->failureCellPCI.present = XNAP_NG_RAN_CellPCI_PR_nr;
+    reest->failureCellPCI.choice.nr = in->rrc_reest.failure_cell_pci;
+  } else {
+    AssertError(0, return out, "Unknown UE context ID choice %d\n", in->choice);
+  }
+
+  return out;
+}
+
+/**
+ * @brief XnAP UE Context ID (9.2.3.40) decoding
+ */
+static bool decode_xnap_ue_context_id(const XNAP_UEContextID_t *in, xnap_ue_context_id_t *out)
+{
+  DevAssert(in != NULL);
+  DevAssert(out != NULL);
+
+  switch (in->present) {
+    case XNAP_UEContextID_PR_rRCResume: {
+      const XNAP_UEContextIDforRRCResume_t *resume = in->choice.rRCResume;
+      DevAssert(resume != NULL);
+      out->choice = XNAP_UE_CONTEXT_ID_RRC_RESUME;
+      switch (resume->i_rnti.present) {
+        case XNAP_I_RNTI_PR_i_RNTI_full:
+          out->rrc_resume.i_rnti_type = XNAP_I_RNTI_FULL;
+          out->rrc_resume.i_rnti = BIT_STRING_to_uint64(&resume->i_rnti.choice.i_RNTI_full);
+          break;
+        case XNAP_I_RNTI_PR_i_RNTI_short:
+          out->rrc_resume.i_rnti_type = XNAP_I_RNTI_SHORT;
+          out->rrc_resume.i_rnti = BIT_STRING_to_uint64(&resume->i_rnti.choice.i_RNTI_short);
+          break;
+        default:
+          PRINT_ERROR("Unsupported I-RNTI choice %d\n", resume->i_rnti.present);
+          return false;
+      }
+      out->rrc_resume.allocated_c_rnti = BIT_STRING_to_uint16(&resume->allocated_c_rnti);
+      if (resume->accessPCI.present != XNAP_NG_RAN_CellPCI_PR_nr) {
+        PRINT_ERROR("Unsupported NG-RAN-CellPCI choice %d (only NR is supported, E-UTRA is not)\n", resume->accessPCI.present);
+        return false;
+      }
+      out->rrc_resume.access_pci = resume->accessPCI.choice.nr;
+    } break;
+
+    case XNAP_UEContextID_PR_rRRCReestablishment: {
+      const XNAP_UEContextIDforRRCReestablishment_t *reest = in->choice.rRRCReestablishment;
+      DevAssert(reest != NULL);
+      out->choice = XNAP_UE_CONTEXT_ID_RRC_REESTABLISHMENT;
+      out->rrc_reest.c_rnti = BIT_STRING_to_uint16(&reest->c_rnti);
+      if (reest->failureCellPCI.present != XNAP_NG_RAN_CellPCI_PR_nr) {
+        PRINT_ERROR("Unsupported NG-RAN-CellPCI choice %d (only NR is supported, E-UTRA is not)\n",
+                    reest->failureCellPCI.present);
+        return false;
+      }
+      out->rrc_reest.failure_cell_pci = reest->failureCellPCI.choice.nr;
+    } break;
+
+    default:
+      PRINT_ERROR("Unknown UEContextID.present=%d\n", in->present);
+      return false;
+  }
+
+  return true;
+}
+
+static bool eq_xnap_ue_context_id(const xnap_ue_context_id_t *a, const xnap_ue_context_id_t *b)
+{
+  _EQ_CHECK_INT(a->choice, b->choice);
+  if (a->choice == XNAP_UE_CONTEXT_ID_RRC_RESUME) {
+    _EQ_CHECK_INT(a->rrc_resume.i_rnti_type, b->rrc_resume.i_rnti_type);
+    _EQ_CHECK_UINT64(a->rrc_resume.i_rnti, b->rrc_resume.i_rnti);
+    _EQ_CHECK_INT(a->rrc_resume.allocated_c_rnti, b->rrc_resume.allocated_c_rnti);
+    _EQ_CHECK_INT(a->rrc_resume.access_pci, b->rrc_resume.access_pci);
+  } else {
+    _EQ_CHECK_INT(a->rrc_reest.c_rnti, b->rrc_reest.c_rnti);
+    _EQ_CHECK_INT(a->rrc_reest.failure_cell_pci, b->rrc_reest.failure_cell_pci);
+  }
+  return true;
+}
+
+/**
+ * @brief XnAP Retrieve UE Context Request (9.1.1.8) encoding
+ */
+XNAP_XnAP_PDU_t *encode_xnap_retrieve_ue_context_request(const xnap_retrieve_ue_context_request_t *msg)
+{
+  XNAP_XnAP_PDU_t *pdu = calloc_or_fail(1, sizeof(*pdu));
+
+  pdu->present = XNAP_XnAP_PDU_PR_initiatingMessage;
+  asn1cCalloc(pdu->choice.initiatingMessage, initMsg);
+  initMsg->procedureCode = XNAP_ProcedureCode_id_retrieveUEContext;
+  initMsg->criticality = XNAP_Criticality_reject;
+  initMsg->value.present = XNAP_InitiatingMessage__value_PR_RetrieveUEContextRequest;
+
+  XNAP_RetrieveUEContextRequest_t *out = &initMsg->value.choice.RetrieveUEContextRequest;
+
+  /* New NG-RAN node UE XnAP ID (M) 9.2.3.16 */
+  asn1cSequenceAdd(out->protocolIEs.list, XNAP_RetrieveUEContextRequest_IEs_t, ie1);
+  ie1->id = XNAP_ProtocolIE_ID_id_newNG_RANnodeUEXnAPID;
+  ie1->criticality = XNAP_Criticality_reject;
+  ie1->value.present = XNAP_RetrieveUEContextRequest_IEs__value_PR_NG_RANnodeUEXnAPID;
+  ie1->value.choice.NG_RANnodeUEXnAPID = msg->new_ng_node_ue_xnap_id;
+
+  /* UE Context ID (M) 9.2.3.40 */
+  asn1cSequenceAdd(out->protocolIEs.list, XNAP_RetrieveUEContextRequest_IEs_t, ie2);
+  ie2->id = XNAP_ProtocolIE_ID_id_UEContextID;
+  ie2->criticality = XNAP_Criticality_reject;
+  ie2->value.present = XNAP_RetrieveUEContextRequest_IEs__value_PR_UEContextID;
+  ie2->value.choice.UEContextID = xnap_encode_ue_context_id(&msg->ue_context_id);
+
+  /* MAC-I (M) – single BIT STRING(16) IE, identical for the RRC Resume and
+   * RRC Reestablishment cases; only the value the UE computes differs. */
+  asn1cSequenceAdd(out->protocolIEs.list, XNAP_RetrieveUEContextRequest_IEs_t, ie3);
+  ie3->id = XNAP_ProtocolIE_ID_id_MAC_I;
+  ie3->criticality = XNAP_Criticality_reject;
+  ie3->value.present = XNAP_RetrieveUEContextRequest_IEs__value_PR_MAC_I;
+  C_RNTI_TO_BIT_STRING(msg->mac_i, &ie3->value.choice.MAC_I);
+
+  /* New NG-RAN Cell Identity (M) 9.2.2.9 – CHOICE { nr, e-utra, ... }; only the
+   * NR branch is supported (E-UTRA is not). */
+  asn1cSequenceAdd(out->protocolIEs.list, XNAP_RetrieveUEContextRequest_IEs_t, ie4);
+  ie4->id = XNAP_ProtocolIE_ID_id_new_NG_RAN_Cell_Identity;
+  ie4->criticality = XNAP_Criticality_reject;
+  ie4->value.present = XNAP_RetrieveUEContextRequest_IEs__value_PR_NG_RAN_Cell_Identity;
+  ie4->value.choice.NG_RAN_Cell_Identity.present = XNAP_NG_RAN_Cell_Identity_PR_nr;
+  NR_CELL_ID_TO_BIT_STRING(msg->new_ng_ran_cell_id, &ie4->value.choice.NG_RAN_Cell_Identity.choice.nr);
+
+  return pdu;
+}
+
+/**
+ * @brief XnAP Retrieve UE Context Request (9.1.1.8) decoding
+ */
+bool decode_xnap_retrieve_ue_context_request(xnap_retrieve_ue_context_request_t *out, const XNAP_XnAP_PDU_t *pdu)
+{
+  _EQ_CHECK_INT(pdu->present, XNAP_XnAP_PDU_PR_initiatingMessage);
+  AssertError(pdu->choice.initiatingMessage != NULL, return false, "initiatingMessage is NULL");
+  _EQ_CHECK_LONG(pdu->choice.initiatingMessage->procedureCode, XNAP_ProcedureCode_id_retrieveUEContext);
+  _EQ_CHECK_INT(pdu->choice.initiatingMessage->value.present, XNAP_InitiatingMessage__value_PR_RetrieveUEContextRequest);
+
+  XNAP_RetrieveUEContextRequest_t *in = &pdu->choice.initiatingMessage->value.choice.RetrieveUEContextRequest;
+  XNAP_RetrieveUEContextRequest_IEs_t *ie;
+
+  XNAP_LIB_FIND_IE(XNAP_RetrieveUEContextRequest_IEs_t, ie, &in->protocolIEs.list, XNAP_ProtocolIE_ID_id_newNG_RANnodeUEXnAPID, true);
+  XNAP_LIB_FIND_IE(XNAP_RetrieveUEContextRequest_IEs_t, ie, &in->protocolIEs.list, XNAP_ProtocolIE_ID_id_UEContextID, true);
+  XNAP_LIB_FIND_IE(XNAP_RetrieveUEContextRequest_IEs_t, ie, &in->protocolIEs.list, XNAP_ProtocolIE_ID_id_MAC_I, true);
+  XNAP_LIB_FIND_IE(XNAP_RetrieveUEContextRequest_IEs_t, ie, &in->protocolIEs.list, XNAP_ProtocolIE_ID_id_new_NG_RAN_Cell_Identity, true);
+
+  for (int i = 0; i < in->protocolIEs.list.count; i++) {
+    DevAssert(in->protocolIEs.list.array[i]);
+    ie = in->protocolIEs.list.array[i];
+
+    switch (ie->id) {
+      case XNAP_ProtocolIE_ID_id_newNG_RANnodeUEXnAPID: {
+        _EQ_CHECK_INT(ie->value.present, XNAP_RetrieveUEContextRequest_IEs__value_PR_NG_RANnodeUEXnAPID);
+        out->new_ng_node_ue_xnap_id = ie->value.choice.NG_RANnodeUEXnAPID;
+      } break;
+
+      case XNAP_ProtocolIE_ID_id_UEContextID: {
+        _EQ_CHECK_INT(ie->value.present, XNAP_RetrieveUEContextRequest_IEs__value_PR_UEContextID);
+        if (!decode_xnap_ue_context_id(&ie->value.choice.UEContextID, &out->ue_context_id))
+          return false;
+      } break;
+
+      case XNAP_ProtocolIE_ID_id_MAC_I: {
+        _EQ_CHECK_INT(ie->value.present, XNAP_RetrieveUEContextRequest_IEs__value_PR_MAC_I);
+        out->mac_i = BIT_STRING_to_uint16(&ie->value.choice.MAC_I);
+      } break;
+
+      case XNAP_ProtocolIE_ID_id_new_NG_RAN_Cell_Identity: {
+        _EQ_CHECK_INT(ie->value.present, XNAP_RetrieveUEContextRequest_IEs__value_PR_NG_RAN_Cell_Identity);
+        const XNAP_NG_RAN_Cell_Identity_t *cell = &ie->value.choice.NG_RAN_Cell_Identity;
+        /* CHOICE { nr, e-utra, choice-extension } – only the NR branch is supported. */
+        if (cell->present != XNAP_NG_RAN_Cell_Identity_PR_nr) {
+          PRINT_ERROR("Unsupported NG-RAN-Cell-Identity choice %d (only NR is supported, E-UTRA is not)\n", cell->present);
+          return false;
+        }
+        BIT_STRING_TO_NR_CELL_IDENTITY(&cell->choice.nr, out->new_ng_ran_cell_id);
+      } break;
+
+      case XNAP_ProtocolIE_ID_id_RRCResumeCause:
+        PRINT_ERROR("XNAP_ProtocolIE_ID_id %ld not handled, skipping\n", ie->id);
+        break;
+
+      default:
+        PRINT_ERROR("XNAP_ProtocolIE_ID_id %ld unknown, skipping\n", ie->id);
+        break;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief XnAP Retrieve UE Context Request (9.1.1.8) equality function
+ */
+bool eq_xnap_retrieve_ue_context_request(const xnap_retrieve_ue_context_request_t *a, const xnap_retrieve_ue_context_request_t *b)
+{
+  _EQ_CHECK_UINT32(a->new_ng_node_ue_xnap_id, b->new_ng_node_ue_xnap_id);
+  if (!eq_xnap_ue_context_id(&a->ue_context_id, &b->ue_context_id))
+    return false;
+  _EQ_CHECK_INT(a->mac_i, b->mac_i);
+  _EQ_CHECK_UINT64(a->new_ng_ran_cell_id, b->new_ng_ran_cell_id);
+  return true;
+}
+
+/**
+ * @brief XnAP Retrieve UE Context Request (9.1.1.8) memory management
+ */
+void free_xnap_retrieve_ue_context_request(xnap_retrieve_ue_context_request_t *msg)
+{
+  // Nothing to free
+  UNUSED(msg);
+}

--- a/openair2/XNAP/lib/xnap_gNB_mobility_management.c
+++ b/openair2/XNAP/lib/xnap_gNB_mobility_management.c
@@ -2220,3 +2220,100 @@ void free_xnap_retrieve_ue_context_response(xnap_retrieve_ue_context_response_t 
 {
   free_xnap_ue_context_info(&msg->ue_context);
 }
+
+/**
+ * @brief XnAP Retrieve UE Context Failure (9.1.1.10) encoding
+ */
+XNAP_XnAP_PDU_t *encode_xnap_retrieve_ue_context_failure(const xnap_retrieve_ue_context_failure_t *msg)
+{
+  XNAP_XnAP_PDU_t *pdu = calloc_or_fail(1, sizeof(*pdu));
+
+  pdu->present = XNAP_XnAP_PDU_PR_unsuccessfulOutcome;
+  asn1cCalloc(pdu->choice.unsuccessfulOutcome, unsuccMsg);
+  unsuccMsg->procedureCode = XNAP_ProcedureCode_id_retrieveUEContext;
+  unsuccMsg->criticality = XNAP_Criticality_reject;
+  unsuccMsg->value.present = XNAP_UnsuccessfulOutcome__value_PR_RetrieveUEContextFailure;
+
+  XNAP_RetrieveUEContextFailure_t *out = &unsuccMsg->value.choice.RetrieveUEContextFailure;
+
+  /* New NG-RAN node UE XnAP ID (M) 9.2.3.16 */
+  asn1cSequenceAdd(out->protocolIEs.list, XNAP_RetrieveUEContextFailure_IEs_t, ie1);
+  ie1->id = XNAP_ProtocolIE_ID_id_newNG_RANnodeUEXnAPID;
+  ie1->criticality = XNAP_Criticality_ignore;
+  ie1->value.present = XNAP_RetrieveUEContextFailure_IEs__value_PR_NG_RANnodeUEXnAPID;
+  ie1->value.choice.NG_RANnodeUEXnAPID = msg->new_ng_node_ue_xnap_id;
+
+  /* Cause (M) 9.2.3.2 */
+  asn1cSequenceAdd(out->protocolIEs.list, XNAP_RetrieveUEContextFailure_IEs_t, ie2);
+  ie2->id = XNAP_ProtocolIE_ID_id_Cause;
+  ie2->criticality = XNAP_Criticality_ignore;
+  ie2->value.present = XNAP_RetrieveUEContextFailure_IEs__value_PR_Cause;
+  xnap_gNB_set_cause(&ie2->value.choice.Cause, &msg->cause);
+
+  return pdu;
+}
+
+/**
+ * @brief XnAP Retrieve UE Context Failure (9.1.1.10) decoding
+ */
+bool decode_xnap_retrieve_ue_context_failure(xnap_retrieve_ue_context_failure_t *out, const XNAP_XnAP_PDU_t *pdu)
+{
+  _EQ_CHECK_INT(pdu->present, XNAP_XnAP_PDU_PR_unsuccessfulOutcome);
+  AssertError(pdu->choice.unsuccessfulOutcome != NULL, return false, "unsuccessfulOutcome is NULL");
+  _EQ_CHECK_LONG(pdu->choice.unsuccessfulOutcome->procedureCode, XNAP_ProcedureCode_id_retrieveUEContext);
+  _EQ_CHECK_INT(pdu->choice.unsuccessfulOutcome->value.present, XNAP_UnsuccessfulOutcome__value_PR_RetrieveUEContextFailure);
+
+  XNAP_RetrieveUEContextFailure_t *in = &pdu->choice.unsuccessfulOutcome->value.choice.RetrieveUEContextFailure;
+  XNAP_RetrieveUEContextFailure_IEs_t *ie;
+
+  XNAP_LIB_FIND_IE(XNAP_RetrieveUEContextFailure_IEs_t, ie, &in->protocolIEs.list, XNAP_ProtocolIE_ID_id_newNG_RANnodeUEXnAPID, true);
+  XNAP_LIB_FIND_IE(XNAP_RetrieveUEContextFailure_IEs_t, ie, &in->protocolIEs.list, XNAP_ProtocolIE_ID_id_Cause, true);
+
+  for (int i = 0; i < in->protocolIEs.list.count; i++) {
+    DevAssert(in->protocolIEs.list.array[i]);
+    ie = in->protocolIEs.list.array[i];
+
+    switch (ie->id) {
+      case XNAP_ProtocolIE_ID_id_newNG_RANnodeUEXnAPID: {
+        _EQ_CHECK_INT(ie->value.present, XNAP_RetrieveUEContextFailure_IEs__value_PR_NG_RANnodeUEXnAPID);
+        out->new_ng_node_ue_xnap_id = ie->value.choice.NG_RANnodeUEXnAPID;
+      } break;
+
+      case XNAP_ProtocolIE_ID_id_Cause: {
+        _EQ_CHECK_INT(ie->value.present, XNAP_RetrieveUEContextFailure_IEs__value_PR_Cause);
+        out->cause = decode_xnap_cause(&ie->value.choice.Cause);
+      } break;
+
+      case XNAP_ProtocolIE_ID_id_OldtoNewNG_RANnodeResumeContainer:
+      case XNAP_ProtocolIE_ID_id_CriticalityDiagnostics:
+        PRINT_ERROR("XNAP_ProtocolIE_ID_id %ld not handled, skipping\n", ie->id);
+        break;
+
+      default:
+        PRINT_ERROR("XNAP_ProtocolIE_ID_id %ld unknown, skipping\n", ie->id);
+        break;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief XnAP Retrieve UE Context Failure (9.1.1.10) equality function
+ */
+bool eq_xnap_retrieve_ue_context_failure(const xnap_retrieve_ue_context_failure_t *a, const xnap_retrieve_ue_context_failure_t *b)
+{
+  _EQ_CHECK_UINT32(a->new_ng_node_ue_xnap_id, b->new_ng_node_ue_xnap_id);
+  if (!eq_xnap_cause(&a->cause, &b->cause))
+    return false;
+  return true;
+}
+
+/**
+ * @brief XnAP Retrieve UE Context Failure (9.1.1.10) memory management
+ */
+void free_xnap_retrieve_ue_context_failure(xnap_retrieve_ue_context_failure_t *msg)
+{
+  // Nothing to free
+  UNUSED(msg);
+}

--- a/openair2/XNAP/lib/xnap_gNB_mobility_management.h
+++ b/openair2/XNAP/lib/xnap_gNB_mobility_management.h
@@ -18,6 +18,7 @@ XNAP_XnAP_PDU_t *encode_xnap_handover_success(const xnap_handover_success_t *msg
 XNAP_XnAP_PDU_t *encode_xnap_ran_paging(const xnap_ran_paging_t *msg);
 XNAP_XnAP_PDU_t *encode_xnap_retrieve_ue_context_request(const xnap_retrieve_ue_context_request_t *msg);
 XNAP_XnAP_PDU_t *encode_xnap_retrieve_ue_context_response(const xnap_retrieve_ue_context_response_t *msg);
+XNAP_XnAP_PDU_t *encode_xnap_retrieve_ue_context_failure(const xnap_retrieve_ue_context_failure_t *msg);
 
 bool decode_xnap_handover_request(xnap_handover_req_t *req, const XNAP_XnAP_PDU_t *pdu);
 bool decode_xnap_handover_request_acknowledge(xnap_handover_req_ack_t *out, const XNAP_XnAP_PDU_t *pdu);
@@ -29,6 +30,7 @@ bool decode_xnap_handover_success(xnap_handover_success_t *out, const XNAP_XnAP_
 bool decode_xnap_ran_paging(xnap_ran_paging_t *out, const XNAP_XnAP_PDU_t *pdu);
 bool decode_xnap_retrieve_ue_context_request(xnap_retrieve_ue_context_request_t *out, const XNAP_XnAP_PDU_t *pdu);
 bool decode_xnap_retrieve_ue_context_response(xnap_retrieve_ue_context_response_t *out, const XNAP_XnAP_PDU_t *pdu);
+bool decode_xnap_retrieve_ue_context_failure(xnap_retrieve_ue_context_failure_t *out, const XNAP_XnAP_PDU_t *pdu);
 
 bool eq_xnap_handover_request(const xnap_handover_req_t *a, const xnap_handover_req_t *b);
 bool eq_xnap_handover_request_acknowledge(const xnap_handover_req_ack_t *a, const xnap_handover_req_ack_t *b);
@@ -41,6 +43,7 @@ bool eq_xnap_handover_success(const xnap_handover_success_t *a, const xnap_hando
 bool eq_xnap_ran_paging(const xnap_ran_paging_t *a, const xnap_ran_paging_t *b);
 bool eq_xnap_retrieve_ue_context_request(const xnap_retrieve_ue_context_request_t *a, const xnap_retrieve_ue_context_request_t *b);
 bool eq_xnap_retrieve_ue_context_response(const xnap_retrieve_ue_context_response_t *a, const xnap_retrieve_ue_context_response_t *b);
+bool eq_xnap_retrieve_ue_context_failure(const xnap_retrieve_ue_context_failure_t *a, const xnap_retrieve_ue_context_failure_t *b);
 
 void free_xnap_handover_request(xnap_handover_req_t *msg);
 void free_xnap_handover_request_acknowledge(xnap_handover_req_ack_t *msg);
@@ -52,5 +55,6 @@ void free_xnap_handover_success(xnap_handover_success_t *msg);
 void free_xnap_ran_paging(xnap_ran_paging_t *msg);
 void free_xnap_retrieve_ue_context_request(xnap_retrieve_ue_context_request_t *msg);
 void free_xnap_retrieve_ue_context_response(xnap_retrieve_ue_context_response_t *msg);
+void free_xnap_retrieve_ue_context_failure(xnap_retrieve_ue_context_failure_t *msg);
 
 #endif // XNAP_GNB_MOBILITY_MANAGEMENT_H_

--- a/openair2/XNAP/lib/xnap_gNB_mobility_management.h
+++ b/openair2/XNAP/lib/xnap_gNB_mobility_management.h
@@ -16,6 +16,7 @@ XNAP_XnAP_PDU_t *encode_xnap_ue_context_release(const xnap_ue_context_release_t 
 XNAP_XnAP_PDU_t *encode_xnap_handover_cancel(const xnap_handover_cancel_t *msg);
 XNAP_XnAP_PDU_t *encode_xnap_handover_success(const xnap_handover_success_t *msg);
 XNAP_XnAP_PDU_t *encode_xnap_ran_paging(const xnap_ran_paging_t *msg);
+XNAP_XnAP_PDU_t *encode_xnap_retrieve_ue_context_request(const xnap_retrieve_ue_context_request_t *msg);
 
 bool decode_xnap_handover_request(xnap_handover_req_t *req, const XNAP_XnAP_PDU_t *pdu);
 bool decode_xnap_handover_request_acknowledge(xnap_handover_req_ack_t *out, const XNAP_XnAP_PDU_t *pdu);
@@ -25,6 +26,7 @@ bool decode_xnap_ue_context_release(xnap_ue_context_release_t *out, const XNAP_X
 bool decode_xnap_handover_cancel(xnap_handover_cancel_t *out, const XNAP_XnAP_PDU_t *pdu);
 bool decode_xnap_handover_success(xnap_handover_success_t *out, const XNAP_XnAP_PDU_t *pdu);
 bool decode_xnap_ran_paging(xnap_ran_paging_t *out, const XNAP_XnAP_PDU_t *pdu);
+bool decode_xnap_retrieve_ue_context_request(xnap_retrieve_ue_context_request_t *out, const XNAP_XnAP_PDU_t *pdu);
 
 bool eq_xnap_handover_request(const xnap_handover_req_t *a, const xnap_handover_req_t *b);
 bool eq_xnap_handover_request_acknowledge(const xnap_handover_req_ack_t *a, const xnap_handover_req_ack_t *b);
@@ -35,6 +37,7 @@ bool eq_xnap_ue_context_release(const xnap_ue_context_release_t *a, const xnap_u
 bool eq_xnap_handover_cancel(const xnap_handover_cancel_t *a, const xnap_handover_cancel_t *b);
 bool eq_xnap_handover_success(const xnap_handover_success_t *a, const xnap_handover_success_t *b);
 bool eq_xnap_ran_paging(const xnap_ran_paging_t *a, const xnap_ran_paging_t *b);
+bool eq_xnap_retrieve_ue_context_request(const xnap_retrieve_ue_context_request_t *a, const xnap_retrieve_ue_context_request_t *b);
 
 void free_xnap_handover_request(xnap_handover_req_t *msg);
 void free_xnap_handover_request_acknowledge(xnap_handover_req_ack_t *msg);
@@ -44,5 +47,6 @@ void free_xnap_ue_context_release(xnap_ue_context_release_t *msg);
 void free_xnap_handover_cancel(xnap_handover_cancel_t *msg);
 void free_xnap_handover_success(xnap_handover_success_t *msg);
 void free_xnap_ran_paging(xnap_ran_paging_t *msg);
+void free_xnap_retrieve_ue_context_request(xnap_retrieve_ue_context_request_t *msg);
 
 #endif // XNAP_GNB_MOBILITY_MANAGEMENT_H_

--- a/openair2/XNAP/lib/xnap_gNB_mobility_management.h
+++ b/openair2/XNAP/lib/xnap_gNB_mobility_management.h
@@ -17,6 +17,7 @@ XNAP_XnAP_PDU_t *encode_xnap_handover_cancel(const xnap_handover_cancel_t *msg);
 XNAP_XnAP_PDU_t *encode_xnap_handover_success(const xnap_handover_success_t *msg);
 XNAP_XnAP_PDU_t *encode_xnap_ran_paging(const xnap_ran_paging_t *msg);
 XNAP_XnAP_PDU_t *encode_xnap_retrieve_ue_context_request(const xnap_retrieve_ue_context_request_t *msg);
+XNAP_XnAP_PDU_t *encode_xnap_retrieve_ue_context_response(const xnap_retrieve_ue_context_response_t *msg);
 
 bool decode_xnap_handover_request(xnap_handover_req_t *req, const XNAP_XnAP_PDU_t *pdu);
 bool decode_xnap_handover_request_acknowledge(xnap_handover_req_ack_t *out, const XNAP_XnAP_PDU_t *pdu);
@@ -27,6 +28,7 @@ bool decode_xnap_handover_cancel(xnap_handover_cancel_t *out, const XNAP_XnAP_PD
 bool decode_xnap_handover_success(xnap_handover_success_t *out, const XNAP_XnAP_PDU_t *pdu);
 bool decode_xnap_ran_paging(xnap_ran_paging_t *out, const XNAP_XnAP_PDU_t *pdu);
 bool decode_xnap_retrieve_ue_context_request(xnap_retrieve_ue_context_request_t *out, const XNAP_XnAP_PDU_t *pdu);
+bool decode_xnap_retrieve_ue_context_response(xnap_retrieve_ue_context_response_t *out, const XNAP_XnAP_PDU_t *pdu);
 
 bool eq_xnap_handover_request(const xnap_handover_req_t *a, const xnap_handover_req_t *b);
 bool eq_xnap_handover_request_acknowledge(const xnap_handover_req_ack_t *a, const xnap_handover_req_ack_t *b);
@@ -38,6 +40,7 @@ bool eq_xnap_handover_cancel(const xnap_handover_cancel_t *a, const xnap_handove
 bool eq_xnap_handover_success(const xnap_handover_success_t *a, const xnap_handover_success_t *b);
 bool eq_xnap_ran_paging(const xnap_ran_paging_t *a, const xnap_ran_paging_t *b);
 bool eq_xnap_retrieve_ue_context_request(const xnap_retrieve_ue_context_request_t *a, const xnap_retrieve_ue_context_request_t *b);
+bool eq_xnap_retrieve_ue_context_response(const xnap_retrieve_ue_context_response_t *a, const xnap_retrieve_ue_context_response_t *b);
 
 void free_xnap_handover_request(xnap_handover_req_t *msg);
 void free_xnap_handover_request_acknowledge(xnap_handover_req_ack_t *msg);
@@ -48,5 +51,6 @@ void free_xnap_handover_cancel(xnap_handover_cancel_t *msg);
 void free_xnap_handover_success(xnap_handover_success_t *msg);
 void free_xnap_ran_paging(xnap_ran_paging_t *msg);
 void free_xnap_retrieve_ue_context_request(xnap_retrieve_ue_context_request_t *msg);
+void free_xnap_retrieve_ue_context_response(xnap_retrieve_ue_context_response_t *msg);
 
 #endif // XNAP_GNB_MOBILITY_MANAGEMENT_H_

--- a/openair2/XNAP/lib/xnap_lib_includes.h
+++ b/openair2/XNAP/lib/xnap_lib_includes.h
@@ -60,6 +60,7 @@
 #include "XNAP_UEContextInfoRetrUECtxtResp.h"
 #include "XNAP_AS-SecurityInformation.h"
 #include "XNAP_CPTransportLayerInformation.h"
+#include "XNAP_RetrieveUEContextFailure.h"
 
 #endif // XNAP_LIB_INCLUDES_H
 

--- a/openair2/XNAP/lib/xnap_lib_includes.h
+++ b/openair2/XNAP/lib/xnap_lib_includes.h
@@ -56,6 +56,10 @@
 #include "XNAP_I-RNTI.h"
 #include "XNAP_NG-RAN-CellPCI.h"
 #include "XNAP_MAC-I.h"
+#include "XNAP_RetrieveUEContextResponse.h"
+#include "XNAP_UEContextInfoRetrUECtxtResp.h"
+#include "XNAP_AS-SecurityInformation.h"
+#include "XNAP_CPTransportLayerInformation.h"
 
 #endif // XNAP_LIB_INCLUDES_H
 

--- a/openair2/XNAP/lib/xnap_lib_includes.h
+++ b/openair2/XNAP/lib/xnap_lib_includes.h
@@ -49,5 +49,13 @@
 #include "XNAP_RANAreaID-List.h"
 #include "XNAP_RANAreaID.h"
 
+#include "XNAP_RetrieveUEContextRequest.h"
+#include "XNAP_UEContextID.h"
+#include "XNAP_UEContextIDforRRCResume.h"
+#include "XNAP_UEContextIDforRRCReestablishment.h"
+#include "XNAP_I-RNTI.h"
+#include "XNAP_NG-RAN-CellPCI.h"
+#include "XNAP_MAC-I.h"
+
 #endif // XNAP_LIB_INCLUDES_H
 

--- a/openair2/XNAP/tests/xnap_lib_test.c
+++ b/openair2/XNAP/tests/xnap_lib_test.c
@@ -846,6 +846,95 @@ static void test_xn_retrieve_ue_context_request(void)
   printf("%s() successful\n", __func__);
 }
 
+/**
+ * 13. XnAP Retrieve UE Context Response (9.1.1.9)
+ */
+static void test_xn_retrieve_ue_context_response(void)
+{
+  plmn_id_t plmn0 = {.mcc = 208, .mnc = 95, .mnc_digit_length = 2};
+
+  transport_layer_addr_t tnl_addr_source = {.length = 4, .buffer = {192, 168, 1, 100}};
+  transport_layer_addr_t tnl_addr_n3 = {.length = 4, .buffer = {10, 0, 0, 1}};
+
+  nssai_t nssai0 = {.sst = 1, .sd = 0x000001};
+
+  xnap_qos_flow_param_t qos_params = {.qos_type = NON_DYNAMIC,
+                                      .nondyn = {.fiveQI = 9},
+                                      .arp = {.priority_level = 2,
+                                              .pre_emp_capability = PEC_SHALL_NOT_TRIGGER_PREEMPTION,
+                                              .pre_emp_vulnerability = PEV_NOT_PREEMPTABLE}};
+
+  xnap_qos_flow_tobe_setup_item_t *qos_list = calloc_or_fail(2, sizeof(*qos_list));
+  qos_list[0].qfi = 1;
+  qos_list[0].qos_params = qos_params;
+  qos_list[1].qfi = 2;
+  qos_list[1].qos_params = qos_params;
+  qos_list[1].qos_params.nondyn.fiveQI = 5;
+
+  xnap_pdusession_resources_tobe_setup_item_t *pdusession_list = calloc_or_fail(1, sizeof(*pdusession_list));
+  pdusession_list[0].pdusession_id = 1;
+  pdusession_list[0].nssai = calloc_or_fail(1, sizeof(nssai_t));
+  *pdusession_list[0].nssai = nssai0;
+  pdusession_list[0].n3_incoming = (gtpu_tunnel_t){.teid = 0x12345678, .addr = tnl_addr_n3};
+  pdusession_list[0].pdu_session_type = PDUSessionType_ipv4;
+  pdusession_list[0].num_qos = 2;
+  pdusession_list[0].qos_list = qos_list;
+
+  xnap_security_capabilities_t security_cap = {.nRencryption_algorithms = 0xC000,
+                                               .nRintegrity_algorithms = 0xC000,
+                                               .eUTRAencryption_algorithms = 0xC000,
+                                               .eUTRAintegrity_algorithms = 0xC000};
+
+  uint8_t as_key[32];
+  for (int i = 0; i < 32; i++)
+    as_key[i] = i;
+
+  uint8_t rrc_data[] = {1, 2, 3, 4, 5};
+  byte_array_t rrc_context = {.buf = calloc_or_fail(5, sizeof(uint8_t)), .len = 5};
+  memcpy(rrc_context.buf, rrc_data, 5);
+
+  xnap_ue_context_info_t ue_context = {.ngc_ue_sig_ref = 0x123456789,
+                                       .cp_tnl_ip_source = tnl_addr_source,
+                                       .security_capabilities = security_cap,
+                                       .as_security_ncc = 1,
+                                       .ue_ambr = {.br_ul = 100000000, .br_dl = 200000000},
+                                       .rrc_context = rrc_context,
+                                       .num_pdu = 1,
+                                       .pdusession_resources_tobe_setup_list = pdusession_list};
+  memcpy(ue_context.as_security_key_ranstar, as_key, 32);
+
+  nr_guami_t guami = {.plmn = plmn0, .amf_region_id = 0x01, .amf_set_id = 0x0001, .amf_pointer = 0x01};
+
+  xnap_retrieve_ue_context_response_t orig = {
+      .new_ng_node_ue_xnap_id = 0xABCD,
+      .old_ng_node_ue_xnap_id = 0x1234,
+      .guami = guami,
+      .ue_context = ue_context,
+  };
+
+  /* ---------- encode ---------- */
+  XNAP_XnAP_PDU_t *xnenc = encode_xnap_retrieve_ue_context_response(&orig);
+  AssertFatal(xnenc != NULL, "encode_xnap_retrieve_ue_context_response failed");
+  XNAP_XnAP_PDU_t *xndec = xnap_encode_decode(xnenc);
+  xnap_msg_free(xnenc);
+
+  /* ---------- decode ---------- */
+  xnap_retrieve_ue_context_response_t decoded = {0};
+  bool ret = decode_xnap_retrieve_ue_context_response(&decoded, xndec);
+  AssertFatal(ret, "decode_xnap_retrieve_ue_context_response failed");
+  xnap_msg_free(xndec);
+
+  /* ---------- equality ---------- */
+  ret = eq_xnap_retrieve_ue_context_response(&orig, &decoded);
+  AssertFatal(ret, "XnAP Retrieve UE Context Response mismatch\n");
+
+  /* ---------- cleanup ---------- */
+  free_xnap_retrieve_ue_context_response(&decoded);
+  free_xnap_retrieve_ue_context_response(&orig);
+
+  printf("%s() successful\n", __func__);
+}
+
 int main() {
   printf("Starting XnAP Library Unit Tests...\n");
 
@@ -866,6 +955,7 @@ int main() {
 
   /* Xn Retrieve UE Context Testing */
   test_xn_retrieve_ue_context_request();
+  test_xn_retrieve_ue_context_response();
 
   printf("All XnAP tests passed!\n");
   return 0;

--- a/openair2/XNAP/tests/xnap_lib_test.c
+++ b/openair2/XNAP/tests/xnap_lib_test.c
@@ -785,6 +785,67 @@ static void test_xn_ran_paging(void)
   printf("%s() successful\n", __func__);
 }
 
+/**
+ * 12. XnAP Retrieve UE Context Request (9.1.1.8) – RRC Resume (full/short I-RNTI)
+ *     and RRC Reestablishment variants
+ */
+static void test_xn_retrieve_ue_context_request(void)
+{
+  xnap_retrieve_ue_context_request_t cases[] = {
+      {
+          .new_ng_node_ue_xnap_id = 0x0001ABCD,
+          .ue_context_id = {.choice = XNAP_UE_CONTEXT_ID_RRC_RESUME,
+                            .rrc_resume = {.i_rnti_type = XNAP_I_RNTI_FULL,
+                                           .i_rnti = 0xAABBCCDDEEULL,
+                                           .allocated_c_rnti = 0x1234,
+                                           .access_pci = 511}},
+          .mac_i = 0xBEEF,
+          .new_ng_ran_cell_id = 0x123456789ULL,
+      },
+      {
+          .new_ng_node_ue_xnap_id = 0x00ABCDEF,
+          .ue_context_id = {.choice = XNAP_UE_CONTEXT_ID_RRC_RESUME,
+                            .rrc_resume = {.i_rnti_type = XNAP_I_RNTI_SHORT,
+                                           .i_rnti = 0xA5C3F0ULL,
+                                           .allocated_c_rnti = 0xFFFF,
+                                           .access_pci = 0}},
+          .mac_i = 0x4321,
+          .new_ng_ran_cell_id = 0x0ULL,
+      },
+      {
+          .new_ng_node_ue_xnap_id = 0xFFFFFFFF,
+          .ue_context_id = {.choice = XNAP_UE_CONTEXT_ID_RRC_REESTABLISHMENT,
+                            .rrc_reest = {.c_rnti = 0x9ABC, .failure_cell_pci = 1007}},
+          .mac_i = 0x0001,
+          .new_ng_ran_cell_id = 0xABCDEF012ULL,
+      },
+  };
+
+  for (size_t i = 0; i < sizeof(cases) / sizeof(*cases); i++) {
+    /* ---------- encode ---------- */
+    XNAP_XnAP_PDU_t *xnenc = encode_xnap_retrieve_ue_context_request(&cases[i]);
+    AssertFatal(xnenc != NULL, "encode_xnap_retrieve_ue_context_request failed");
+    XNAP_XnAP_PDU_t *xndec = xnap_encode_decode(xnenc);
+    xnap_msg_free(xnenc);
+
+    /* ---------- decode ---------- */
+    xnap_retrieve_ue_context_request_t decoded = {0};
+    bool ret = decode_xnap_retrieve_ue_context_request(&decoded, xndec);
+    AssertFatal(ret, "decode_xnap_retrieve_ue_context_request failed");
+    xnap_msg_free(xndec);
+
+    /* ---------- equality ---------- */
+    ret = eq_xnap_retrieve_ue_context_request(&cases[i], &decoded);
+    AssertFatal(ret, "XnAP Retrieve UE Context Request mismatch (case %zu)\n", i);
+
+    /* ---------- cleanup ---------- */
+    free_xnap_retrieve_ue_context_request(&decoded);
+    free_xnap_retrieve_ue_context_request(&cases[i]);
+  }
+
+  printf("%s() successful\n", __func__);
+}
+
 int main() {
   printf("Starting XnAP Library Unit Tests...\n");
 
@@ -802,6 +863,9 @@ int main() {
   test_xn_handover_cancel();
   test_xn_handover_success();
   test_xn_ran_paging();
+
+  /* Xn Retrieve UE Context Testing */
+  test_xn_retrieve_ue_context_request();
 
   printf("All XnAP tests passed!\n");
   return 0;

--- a/openair2/XNAP/tests/xnap_lib_test.c
+++ b/openair2/XNAP/tests/xnap_lib_test.c
@@ -935,6 +935,39 @@ static void test_xn_retrieve_ue_context_response(void)
   printf("%s() successful\n", __func__);
 }
 
+/**
+ * 14. XnAP Retrieve UE Context Failure (9.1.1.10)
+ */
+static void test_xn_retrieve_ue_context_failure(void)
+{
+  xnap_retrieve_ue_context_failure_t orig = {
+      .new_ng_node_ue_xnap_id = 0x00ABCDEF,
+      .cause = {.type = XNAP_CAUSE_RADIO_NETWORK, .value = XNAP_CAUSE_RADIO_NETWORK_LAYER_UNKNOWN_LOCAL_NG_RAN_NODE_UE_XNAP_ID},
+  };
+
+  /* ---------- encode ---------- */
+  XNAP_XnAP_PDU_t *xnenc = encode_xnap_retrieve_ue_context_failure(&orig);
+  AssertFatal(xnenc != NULL, "encode_xnap_retrieve_ue_context_failure failed");
+  XNAP_XnAP_PDU_t *xndec = xnap_encode_decode(xnenc);
+  xnap_msg_free(xnenc);
+
+  /* ---------- decode ---------- */
+  xnap_retrieve_ue_context_failure_t decoded = {0};
+  bool ret = decode_xnap_retrieve_ue_context_failure(&decoded, xndec);
+  AssertFatal(ret, "decode_xnap_retrieve_ue_context_failure failed");
+  xnap_msg_free(xndec);
+
+  /* ---------- equality ---------- */
+  ret = eq_xnap_retrieve_ue_context_failure(&orig, &decoded);
+  AssertFatal(ret, "XnAP Retrieve UE Context Failure mismatch\n");
+
+  /* ---------- cleanup ---------- */
+  free_xnap_retrieve_ue_context_failure(&decoded);
+  free_xnap_retrieve_ue_context_failure(&orig);
+
+  printf("%s() successful\n", __func__);
+}
+
 int main() {
   printf("Starting XnAP Library Unit Tests...\n");
 
@@ -956,6 +989,7 @@ int main() {
   /* Xn Retrieve UE Context Testing */
   test_xn_retrieve_ue_context_request();
   test_xn_retrieve_ue_context_response();
+  test_xn_retrieve_ue_context_failure();
 
   printf("All XnAP tests passed!\n");
   return 0;

--- a/openair3/UTILS/conversions.h
+++ b/openair3/UTILS/conversions.h
@@ -553,6 +553,17 @@ do {                                                     \
     (bITsTRING)->bits_unused = 0;                        \
 } while (0)
 
+/* I-RNTI short is a 24bit BIT STRING (TS 38.423 9.2.3.55) */
+#define IRNTI_SHORT_TO_BIT_STRING(mACRO, bITsTRING)      \
+do {                                                     \
+    (bITsTRING)->buf = calloc(3, sizeof(uint8_t));       \
+    (bITsTRING)->buf[0] = ((mACRO) >> 16) & 0xff;        \
+    (bITsTRING)->buf[1] = ((mACRO) >> 8) & 0xff;         \
+    (bITsTRING)->buf[2] = ((mACRO) & 0xff);              \
+    (bITsTRING)->size = 3;                               \
+    (bITsTRING)->bits_unused = 0;                        \
+} while (0)
+
 /* Used to format an uint32_t containing an ipv4 address */
 #define IPV4_ADDR    "%u.%u.%u.%u"
 #define IPV4_ADDR_FORMAT(aDDRESS)               \


### PR DESCRIPTION
Extends the XNAP encode/decode library with the Retrieve UE Context procedure from 3GPP TS 38.423 v16.2.0 (§9.1.1.8 to §9.1.1.10) - the Xn procedure a gNB uses to fetch a UE context from the last serving node on RRC Resume / RRC Reestablishment. Each message has full encode/decode/eq/free support and an APER round-trip unit test. Only mandatory IEs are implemented; optional IEs are logged and skipped on decode.

### Retrieve UE Context Request (§9.1.1.8)
Sent by the node that received the RRCResumeRequest / RRCReestablishmentRequest to the node holding the UE context.
- New NG-RAN node UE XnAP ID (M)
- UE Context ID (M) - CHOICE of RRC Resume {I-RNTI (full/short), C-RNTI, NR PCI} or RRC Reestablishment {C-RNTI, NR PCI}
- MAC-I (M) - 16-bit BIT STRING
- New NG-RAN Cell Identity (M) - NR variant, 36-bit

### Retrieve UE Context Response (§9.1.1.9)
Sent by the node holding the context to hand it over.
- New NG-RAN node UE XnAP ID (M)
- Old NG-RAN node UE XnAP ID (M)
- GUAMI (M)
- UE Context Information (M) - AMF UE NGAP ID, CP-TNL address, UE security capabilities, AS security information, UE AMBR, PDU Session Resources To Be Setup list, RRC context

### Retrieve UE Context Failure (§9.1.1.10)
Sent instead of the Response when the context cannot be provided.
- New NG-RAN node UE XnAP ID (M)
- Cause (M)

### Notes
- `NG-RAN Cell Identity` / `NG-RAN CellPCI` support the NR branch only; E-UTRA is rejected on decode with an explicit error.

## Changed files

| File | Change |
|---|---|
| `openair2/COMMON/xnap_messages_types.h` | New type defs for the three messages + UE Context ID / I-RNTI variant |
| `openair2/XNAP/lib/xnap_gNB_mobility_management.c` | encode/decode/eq/free im
| `openair2/XNAP/lib/xnap_gNB_mobility_management.h` | Function declarations |
| `openair2/XNAP/lib/xnap_lib_includes.h` | ASN.1 headers for Retrieve UE Context IEs |
| `openair2/XNAP/tests/xnap_lib_test.c` | Unit tests (tests 12, 13, 14) |
| `openair3/UTILS/conversions.h` | `IRNTI_SHORT_TO_BIT_STRING` macro (24-bit I-RNTI) |