### PR TITLE
Multiplex several periodic SRS UEs per full UL slot

### DIFF
--- a/openair1/PHY/INIT/nr_init.c
+++ b/openair1/PHY/INIT/nr_init.c
@@ -438,7 +438,7 @@ void init_nr_transport(PHY_VARS_gNB *gNB)
   ret = spsc_q_alloc(&gNB->pusch_queue, gNB->max_nb_pusch, sizeof(NR_gNB_PUSCH_job_t));
   DevAssert(ret);
 
-  int max_nb_srs = buffer_ul_slots ? buffer_ul_slots << 1 : 1; // assuming at most 2 SRS per slot
+  int max_nb_srs = buffer_ul_slots ? MAX_MOBILES_PER_GNB * buffer_ul_slots : 1;
   ret = spsc_q_alloc(&gNB->srs_queue, max_nb_srs, sizeof(NR_gNB_SRS_job_t));
   DevAssert(ret);
 

--- a/openair2/GNB_APP/MACRLC_nr_paramdef.h
+++ b/openair2/GNB_APP/MACRLC_nr_paramdef.h
@@ -55,11 +55,6 @@
 #define MACRLC_PUCCH_RSSI_THRESHOLD          "pucch_RSSI_Threshold"
 #define MACRLC_STATS_MAX_UE                  "stats_max_ue"
 #define MACRLC_SPATIAL_STREAM_IDX            "spatial_stream_index"
-#define MACRLC_SRS_COMB                      "srs_comb"
-#define MACRLC_SRS_UE_PER_SYMBOL             "srs_ue_per_symbol"
-#define MACRLC_SRS_SYMBOLS_PER_SLOT          "srs_symbols_per_slot"
-#define MACRLC_SRS_LAST_SYMBOL               "srs_last_symbol"
-#define MACRLC_SRS_PERIODICITY               "srs_periodicity"
 
 #define HLP_MACRLC_UL_PRBBLACK "SNR threshold to decide whether a PRB will be blacklisted or not"
 #define HLP_MACRLC_DL_BLER_UP "Upper threshold of BLER to decrease DL MCS"
@@ -82,11 +77,6 @@
 #define HLP_MACRLC_PUCCH_RSSI_THRESHOLD "Limits PUCCH TPC commands based on RSSI to prevent ADC railing. Value range [-1280, 0], unit 0.1 dBm/dBFS"
 #define HLP_MACRLC_STATS_MAX_UE "Maximum number of UEs before disabling periodical output (0 to disable)"
 #define HLP_MACRLC_SPATIAL_STREAM_INDEX "Array of RU antenna ports / eAxCIDs to be used by L1. This may only be applicable for MU-MIMO. Value range [0, 15]"
-#define HLP_MACRLC_SRS_COMB "SRS transmission comb, 2 or 4"
-#define HLP_MACRLC_SRS_UE_PER_SYMBOL "Number of UEs sharing one periodic SRS symbol through comb offsets, at most srs_comb"
-#define HLP_MACRLC_SRS_SYMBOLS_PER_SLOT "Number of symbols reserved for periodic SRS at the end of a full UL slot"
-#define HLP_MACRLC_SRS_LAST_SYMBOL "Last symbol of a full UL slot usable by periodic SRS, lower it to keep the PUCCH tail clear"
-#define HLP_MACRLC_SRS_PERIODICITY "Periodic SRS period in slots, rounded up to a valid value fitting the TDD period, 0 to derive it from the cell capacity"
 
 /*-------------------------------------------------------------------------------------------------------------------------------------------------------*/
 /*                                            MacRLC  configuration parameters                                                                           */
@@ -137,16 +127,6 @@
   {MACRLC_STATS_MAX_UE,                HLP_MACRLC_STATS_MAX_UE,  0, .iptr=NULL,   .defintval=8,               TYPE_INT,     0}, \
   {MACRLC_SPATIAL_STREAM_IDX,          HLP_MACRLC_SPATIAL_STREAM_INDEX, \
                                                                                0, .uptr=NULL,   .defintarrayval=0,          TYPE_INTARRAY,0}, \
-  {MACRLC_SRS_COMB,                    HLP_MACRLC_SRS_COMB, \
-                                                                               0, .iptr=NULL,   .defintval=2,               TYPE_INT,     0}, \
-  {MACRLC_SRS_UE_PER_SYMBOL,           HLP_MACRLC_SRS_UE_PER_SYMBOL, \
-                                                                               0, .iptr=NULL,   .defintval=1,               TYPE_INT,     0}, \
-  {MACRLC_SRS_SYMBOLS_PER_SLOT,        HLP_MACRLC_SRS_SYMBOLS_PER_SLOT, \
-                                                                               0, .iptr=NULL,   .defintval=1,               TYPE_INT,     0}, \
-  {MACRLC_SRS_LAST_SYMBOL,             HLP_MACRLC_SRS_LAST_SYMBOL, \
-                                                                               0, .iptr=NULL,   .defintval=12,              TYPE_INT,     0}, \
-  {MACRLC_SRS_PERIODICITY,             HLP_MACRLC_SRS_PERIODICITY, \
-                                                                               0, .iptr=NULL,   .defintval=0,               TYPE_INT,     0}, \
 }
 // clang-format off
 
@@ -194,12 +174,44 @@
   { .s2 =  { config_check_intrange, {-1280, 0}} }, /* PUCCH RSSI threshold range */ \
   { .s5 = { NULL } }, \
   { .s2 = { NULL } }, /* Spatial stream index */ \
-  { .s2 = { config_check_intrange, {2, 4} } }, /* SRS comb */ \
-  { .s2 = { config_check_intrange, {1, 4} } }, /* SRS UEs per symbol */ \
-  { .s2 = { config_check_intrange, {1, 6} } }, /* SRS symbols per slot */ \
-  { .s2 = { config_check_intrange, {8, 13} } }, /* SRS last symbol */ \
-  { .s2 = { config_check_intrange, {0, 2560} } }, /* SRS periodicity */ \
 }
+
+/*---------------------------------------------------------------------------------------------------------------------------------------------------------*/
+/* SRS configuration parameters section name */
+#define MACRLC_CONFIG_STRING_SRS_CONFIG      "srs"
+
+/* SRS configuration parameters names   */
+#define MACRLC_SRS_COMB                      "comb"
+#define MACRLC_SRS_UE_PER_SYMBOL             "ue_per_symbol"
+#define MACRLC_SRS_SYMBOLS_PER_SLOT          "symbols_per_slot"
+#define MACRLC_SRS_LAST_SYMBOL               "last_symbol"
+#define MACRLC_SRS_PERIODICITY               "periodicity"
+
+/*-------------------------------------------------------------------------------------------------------------------------------------------------------*/
+/*                                            SRS configuration parameters                                                                               */
+/*   optname                            helpstr   paramflags    XXXptr        defXXXval           type           numelt                                   */
+/*-------------------------------------------------------------------------------------------------------------------------------------------------------*/
+// clang-format off
+#define MACRLC_SRSPARAMS_DESC { \
+  {MACRLC_SRS_COMB, \
+    "SRS transmission comb, 2 or 4", 0, .iptr=NULL, .defintval=2, TYPE_INT, 0, \
+    .chkPptr = &(checkedparam_t){.s1 = {config_check_intval, {2, 4}, 2}}}, \
+  {MACRLC_SRS_UE_PER_SYMBOL, \
+    "UEs sharing one periodic SRS symbol through comb offsets, at most comb", 0, .iptr=NULL, .defintval=1, TYPE_INT, 0, \
+    .chkPptr = &(checkedparam_t){.s2 = {config_check_intrange, {1, 4}}}}, \
+  {MACRLC_SRS_SYMBOLS_PER_SLOT, \
+    "Symbols reserved for periodic SRS at the end of a full UL slot", 0, .iptr=NULL, .defintval=1, TYPE_INT, 0, \
+    .chkPptr = &(checkedparam_t){.s2 = {config_check_intrange, {1, 6}}}}, \
+  {MACRLC_SRS_LAST_SYMBOL, \
+    "Last symbol of a full UL slot usable by periodic SRS, lower it to reserve the slot tail", 0, .iptr=NULL, \
+    .defintval=12, TYPE_INT, 0, \
+    .chkPptr = &(checkedparam_t){.s2 = {config_check_intrange, {8, 13}}}}, \
+  {MACRLC_SRS_PERIODICITY, \
+    "Periodic SRS period in slots, rounded up to a valid value fitting the TDD period, 0 to derive it from the cell " \
+    "capacity", 0, .iptr=NULL, .defintval=0, TYPE_INT, 0, \
+    .chkPptr = &(checkedparam_t){.s2 = {config_check_intrange, {0, 2560}}}}, \
+}
+// clang-format on
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------------*/
 #endif

--- a/openair2/GNB_APP/MACRLC_nr_paramdef.h
+++ b/openair2/GNB_APP/MACRLC_nr_paramdef.h
@@ -55,6 +55,11 @@
 #define MACRLC_PUCCH_RSSI_THRESHOLD          "pucch_RSSI_Threshold"
 #define MACRLC_STATS_MAX_UE                  "stats_max_ue"
 #define MACRLC_SPATIAL_STREAM_IDX            "spatial_stream_index"
+#define MACRLC_SRS_COMB                      "srs_comb"
+#define MACRLC_SRS_UE_PER_SYMBOL             "srs_ue_per_symbol"
+#define MACRLC_SRS_SYMBOLS_PER_SLOT          "srs_symbols_per_slot"
+#define MACRLC_SRS_LAST_SYMBOL               "srs_last_symbol"
+#define MACRLC_SRS_PERIODICITY               "srs_periodicity"
 
 #define HLP_MACRLC_UL_PRBBLACK "SNR threshold to decide whether a PRB will be blacklisted or not"
 #define HLP_MACRLC_DL_BLER_UP "Upper threshold of BLER to decrease DL MCS"
@@ -77,6 +82,11 @@
 #define HLP_MACRLC_PUCCH_RSSI_THRESHOLD "Limits PUCCH TPC commands based on RSSI to prevent ADC railing. Value range [-1280, 0], unit 0.1 dBm/dBFS"
 #define HLP_MACRLC_STATS_MAX_UE "Maximum number of UEs before disabling periodical output (0 to disable)"
 #define HLP_MACRLC_SPATIAL_STREAM_INDEX "Array of RU antenna ports / eAxCIDs to be used by L1. This may only be applicable for MU-MIMO. Value range [0, 15]"
+#define HLP_MACRLC_SRS_COMB "SRS transmission comb, 2 or 4"
+#define HLP_MACRLC_SRS_UE_PER_SYMBOL "Number of UEs sharing one periodic SRS symbol through comb offsets, at most srs_comb"
+#define HLP_MACRLC_SRS_SYMBOLS_PER_SLOT "Number of symbols reserved for periodic SRS at the end of a full UL slot"
+#define HLP_MACRLC_SRS_LAST_SYMBOL "Last symbol of a full UL slot usable by periodic SRS, lower it to keep the PUCCH tail clear"
+#define HLP_MACRLC_SRS_PERIODICITY "Periodic SRS period in slots, rounded up to a valid value fitting the TDD period, 0 to derive it from the cell capacity"
 
 /*-------------------------------------------------------------------------------------------------------------------------------------------------------*/
 /*                                            MacRLC  configuration parameters                                                                           */
@@ -127,6 +137,16 @@
   {MACRLC_STATS_MAX_UE,                HLP_MACRLC_STATS_MAX_UE,  0, .iptr=NULL,   .defintval=8,               TYPE_INT,     0}, \
   {MACRLC_SPATIAL_STREAM_IDX,          HLP_MACRLC_SPATIAL_STREAM_INDEX, \
                                                                                0, .uptr=NULL,   .defintarrayval=0,          TYPE_INTARRAY,0}, \
+  {MACRLC_SRS_COMB,                    HLP_MACRLC_SRS_COMB, \
+                                                                               0, .iptr=NULL,   .defintval=2,               TYPE_INT,     0}, \
+  {MACRLC_SRS_UE_PER_SYMBOL,           HLP_MACRLC_SRS_UE_PER_SYMBOL, \
+                                                                               0, .iptr=NULL,   .defintval=1,               TYPE_INT,     0}, \
+  {MACRLC_SRS_SYMBOLS_PER_SLOT,        HLP_MACRLC_SRS_SYMBOLS_PER_SLOT, \
+                                                                               0, .iptr=NULL,   .defintval=1,               TYPE_INT,     0}, \
+  {MACRLC_SRS_LAST_SYMBOL,             HLP_MACRLC_SRS_LAST_SYMBOL, \
+                                                                               0, .iptr=NULL,   .defintval=12,              TYPE_INT,     0}, \
+  {MACRLC_SRS_PERIODICITY,             HLP_MACRLC_SRS_PERIODICITY, \
+                                                                               0, .iptr=NULL,   .defintval=0,               TYPE_INT,     0}, \
 }
 // clang-format off
 
@@ -174,6 +194,11 @@
   { .s2 =  { config_check_intrange, {-1280, 0}} }, /* PUCCH RSSI threshold range */ \
   { .s5 = { NULL } }, \
   { .s2 = { NULL } }, /* Spatial stream index */ \
+  { .s2 = { config_check_intrange, {2, 4} } }, /* SRS comb */ \
+  { .s2 = { config_check_intrange, {1, 4} } }, /* SRS UEs per symbol */ \
+  { .s2 = { config_check_intrange, {1, 6} } }, /* SRS symbols per slot */ \
+  { .s2 = { config_check_intrange, {8, 13} } }, /* SRS last symbol */ \
+  { .s2 = { config_check_intrange, {0, 2560} } }, /* SRS periodicity */ \
 }
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------------*/

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -1671,23 +1671,25 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg, nr_cell_sched_t **out_cel
     config.pucch.rssi_threshold = *gpd(params, np, MACRLC_PUCCH_RSSI_THRESHOLD)->iptr;
     config.pucch.target_snrx10 = *gpd(params, np, MACRLC_PUCCHTARGETSNRX10)->iptr;
     config.ul_prbblack_SNR_threshold = *gpd(params, np, MACRLC_UL_PRBBLACK_SNR_THRESHOLD)->iptr;
-    config.srs_comb = *gpd(params, np, MACRLC_SRS_COMB)->iptr;
-    config.srs_ue_per_symbol = *gpd(params, np, MACRLC_SRS_UE_PER_SYMBOL)->iptr;
-    config.srs_symbols_per_slot = *gpd(params, np, MACRLC_SRS_SYMBOLS_PER_SLOT)->iptr;
-    config.srs_last_symbol = *gpd(params, np, MACRLC_SRS_LAST_SYMBOL)->iptr;
-    config.srs_periodicity = *gpd(params, np, MACRLC_SRS_PERIODICITY)->iptr;
-    AssertFatal(config.srs_comb == 2 || config.srs_comb == 4, "srs_comb %d must be 2 or 4\n", config.srs_comb);
+    snprintf(aprefix, sizeof(aprefix), "%s.[%d].%s", MACRLC_LIST, 0, MACRLC_CONFIG_STRING_SRS_CONFIG);
+    GET_PARAMS(SRS_Params, MACRLC_SRSPARAMS_DESC, aprefix);
+    const int n_srs = sizeofArray(SRS_Params);
+    config.srs.comb = *gpd(SRS_Params, n_srs, MACRLC_SRS_COMB)->iptr;
+    config.srs.ue_per_symbol = *gpd(SRS_Params, n_srs, MACRLC_SRS_UE_PER_SYMBOL)->iptr;
+    config.srs.symbols_per_slot = *gpd(SRS_Params, n_srs, MACRLC_SRS_SYMBOLS_PER_SLOT)->iptr;
+    config.srs.last_symbol = *gpd(SRS_Params, n_srs, MACRLC_SRS_LAST_SYMBOL)->iptr;
+    config.srs.periodicity = *gpd(SRS_Params, n_srs, MACRLC_SRS_PERIODICITY)->iptr;
     // startPosition is INTEGER (0..5), which bounds how far the SRS block can reach down
-    AssertFatal(config.srs_symbols_per_slot <= config.srs_last_symbol - 7,
-                "srs_last_symbol %d allows at most %d SRS symbols, not %d\n",
-                config.srs_last_symbol,
-                config.srs_last_symbol - 7,
-                config.srs_symbols_per_slot);
-    AssertFatal(config.srs_ue_per_symbol <= config.srs_comb,
-                "srs_ue_per_symbol %d exceeds the %d offsets of comb %d\n",
-                config.srs_ue_per_symbol,
-                config.srs_comb,
-                config.srs_comb);
+    AssertFatal(config.srs.symbols_per_slot <= config.srs.last_symbol - 7,
+                "SRS last_symbol %d allows at most %d SRS symbols, not %d\n",
+                config.srs.last_symbol,
+                config.srs.last_symbol - 7,
+                config.srs.symbols_per_slot);
+    AssertFatal(config.srs.ue_per_symbol <= config.srs.comb,
+                "SRS ue_per_symbol %d exceeds the %d offsets of comb %d\n",
+                config.srs.ue_per_symbol,
+                config.srs.comb,
+                config.srs.comb);
     config.pucch.failure_thres = *gpd(params, np, MACRLC_PUCCHFAILURETHRES)->iptr;
     config.pusch.failure_thres = *gpd(params, np, MACRLC_PUSCHFAILURETHRES)->iptr;
 

--- a/openair2/GNB_APP/gnb_config.c
+++ b/openair2/GNB_APP/gnb_config.c
@@ -1671,6 +1671,23 @@ void RCconfig_nr_macrlc(configmodule_interface_t *cfg, nr_cell_sched_t **out_cel
     config.pucch.rssi_threshold = *gpd(params, np, MACRLC_PUCCH_RSSI_THRESHOLD)->iptr;
     config.pucch.target_snrx10 = *gpd(params, np, MACRLC_PUCCHTARGETSNRX10)->iptr;
     config.ul_prbblack_SNR_threshold = *gpd(params, np, MACRLC_UL_PRBBLACK_SNR_THRESHOLD)->iptr;
+    config.srs_comb = *gpd(params, np, MACRLC_SRS_COMB)->iptr;
+    config.srs_ue_per_symbol = *gpd(params, np, MACRLC_SRS_UE_PER_SYMBOL)->iptr;
+    config.srs_symbols_per_slot = *gpd(params, np, MACRLC_SRS_SYMBOLS_PER_SLOT)->iptr;
+    config.srs_last_symbol = *gpd(params, np, MACRLC_SRS_LAST_SYMBOL)->iptr;
+    config.srs_periodicity = *gpd(params, np, MACRLC_SRS_PERIODICITY)->iptr;
+    AssertFatal(config.srs_comb == 2 || config.srs_comb == 4, "srs_comb %d must be 2 or 4\n", config.srs_comb);
+    // startPosition is INTEGER (0..5), which bounds how far the SRS block can reach down
+    AssertFatal(config.srs_symbols_per_slot <= config.srs_last_symbol - 7,
+                "srs_last_symbol %d allows at most %d SRS symbols, not %d\n",
+                config.srs_last_symbol,
+                config.srs_last_symbol - 7,
+                config.srs_symbols_per_slot);
+    AssertFatal(config.srs_ue_per_symbol <= config.srs_comb,
+                "srs_ue_per_symbol %d exceeds the %d offsets of comb %d\n",
+                config.srs_ue_per_symbol,
+                config.srs_comb,
+                config.srs_comb);
     config.pucch.failure_thres = *gpd(params, np, MACRLC_PUCCHFAILURETHRES)->iptr;
     config.pusch.failure_thres = *gpd(params, np, MACRLC_PUSCHFAILURETHRES)->iptr;
 

--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.c
@@ -2328,8 +2328,8 @@ uint8_t get_K_ptrs(uint32_t nrb0, uint32_t nrb1, uint32_t N_RB)
 *
 *********************************************************************/
 
-uint16_t get_nr_srs_offset(NR_SRS_PeriodicityAndOffset_t periodicityAndOffset) {
-
+int get_nr_srs_offset(NR_SRS_PeriodicityAndOffset_t periodicityAndOffset)
+{
   switch(periodicityAndOffset.present) {
     case NR_SRS_PeriodicityAndOffset_PR_sl1:
       return periodicityAndOffset.choice.sl1;
@@ -2366,10 +2366,11 @@ uint16_t get_nr_srs_offset(NR_SRS_PeriodicityAndOffset_t periodicityAndOffset) {
     case NR_SRS_PeriodicityAndOffset_PR_sl2560:
       return periodicityAndOffset.choice.sl2560;
     case NR_SRS_PeriodicityAndOffset_PR_NOTHING:
-      LOG_W(NR_MAC,"NR_SRS_PeriodicityAndOffset_PR_NOTHING\n");
-      return 0;
+      LOG_E(NR_MAC,"NR_SRS_PeriodicityAndOffset_PR_NOTHING\n");
+      return -1;
     default:
-      return 0;
+      LOG_E(NR_MAC, "Invalid SRS periodicityAndOffset\n");
+      return -1;
   }
 }
 

--- a/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.h
+++ b/openair2/LAYER2/NR_MAC_COMMON/nr_mac_common.h
@@ -281,7 +281,7 @@ uint32_t nr_get_code_rate_ul(uint8_t Imcs, uint8_t table_idx);
 int srs_binomial_sum(int count, int Lmax);
 int srs_codebook_nb_res(NR_SRS_Config_t *srs_config);
 int srs_non_codebook_nb_res(NR_SRS_Config_t *srs_config);
-uint16_t get_nr_srs_offset(NR_SRS_PeriodicityAndOffset_t periodicityAndOffset);
+int get_nr_srs_offset(NR_SRS_PeriodicityAndOffset_t periodicityAndOffset);
 void get_monitoring_period_offset(const NR_SearchSpace_t *ss, int *period, int *offset);
 
 uint32_t nr_compute_tbslbrm(uint16_t table,

--- a/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
+++ b/openair2/LAYER2/NR_MAC_UE/nr_ue_scheduler.c
@@ -1080,7 +1080,9 @@ static bool nr_ue_periodic_srs_scheduling(NR_UE_MAC_INST_t *mac, frame_t frame, 
     }
 
     uint16_t period = srs_period[srs_resource->resourceType.choice.periodic->periodicityAndOffset_p.present];
-    uint16_t offset = get_nr_srs_offset(srs_resource->resourceType.choice.periodic->periodicityAndOffset_p);
+    int offset = get_nr_srs_offset(srs_resource->resourceType.choice.periodic->periodicityAndOffset_p);
+    if (offset < 0)
+      continue;
     int n_slots_frame = mac->frame_structure.numb_slots_frame;
 
     // Check if UE should transmit the SRS

--- a/openair2/LAYER2/NR_MAC_gNB/config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/config.c
@@ -441,6 +441,37 @@ int get_ul_slot_offset(const frame_structure_t *fs, int idx, bool count_mixed)
   return ul_slot_idxs[ul_slot_idx_in_period] + period_idx * fs->numb_slots_period;
 }
 
+/**
+ * @brief Get the UL slot index for a slot in a TDD period using the frame structure bitmap
+ * @param fs frame structure
+ * @param slot slot
+ * @param count_mixed indicates whether counting mixed slot with UL symbols or only full UL slots
+ * @param max_period size of the vector to be indicized
+ * @return UL slot index in period
+ */
+int get_ul_period_idx_from_abs_slot(const frame_structure_t *fs, int abs_slot, bool count_mixed, int max_period)
+{
+  DevAssert(fs);
+  // FDD: every slot is UL, compacted index == raw offset
+  if (fs->frame_type == FDD)
+    return abs_slot % max_period;
+  // UL slot indexes in period (same construction as get_ul_slot_offset)
+  int ul_slot_idxs[fs->numb_slots_period];
+  int ul_slot_count = 0;
+  for (int i = 0; i < fs->numb_slots_period; i++) {
+    if ((count_mixed && is_ul_slot(i, fs)) || fs->period_cfg.tdd_slot_bitmap[i].slot_type == TDD_NR_UPLINK_SLOT)
+      ul_slot_idxs[ul_slot_count++] = i;
+  }
+  AssertFatal(fs->numb_slots_period <= max_period, "Invalid max period, smaller than TDD period\n");
+  int slot_period = abs_slot % fs->numb_slots_period;
+  int num_period = (abs_slot % max_period) / fs->numb_slots_period;
+  for (int i = 0; i < ul_slot_count; i++) {
+    if (ul_slot_idxs[i] == slot_period)
+      return i + ul_slot_count * num_period;
+  }
+  return -1; // slot_in_period is not a UL slot under this count_mixed setting
+}
+
 static void config_common(nr_cell_sched_t *cell, const nr_mac_config_t *config, NR_ServingCellConfigCommon_t *scc)
 {
   nfapi_nr_config_request_scf_t *cfg = &cell->config;
@@ -967,14 +998,18 @@ static void init_ul_tda_info(const NR_PUSCH_TimeDomainResourceAllocationList_t *
   }
 }
 
-static void config_period_structures(nr_cell_sched_t *cell)
+static periodic_ue_sched_t config_period_structure(nr_cell_sched_t *cell, nr_periodic_channel_t channel)
 {
-  // only SRS for now
-  if (cell->radio_config.do_SRS == PERIODIC_SRS) {
-    cell->srs_period = set_ideal_period(cell, SRS, 0);
-    AssertFatal(cell->srs_period > 0, "Invalid SRS periodicity\n");
-    cell->period_srs_sched = calloc_or_fail(cell->srs_period, sizeof(NR_UE_info_t *));
-  }
+  int max_period = set_ideal_period(cell, SRS, 0);
+  const frame_structure_t *fs = &cell->frame_structure;
+  AssertFatal(max_period > 0 && max_period % fs->numb_slots_period == 0, "Invalid SRS periodicity\n");
+
+  bool count_mixed = channel != SRS;
+  int valid_slots_per_period = count_mixed ? get_ul_slots_per_period(fs) : get_full_ul_slots_per_period(fs);
+  int nb_slots = (max_period / fs->numb_slots_period) * valid_slots_per_period;
+  periodic_ue_sched_t p = {.max_period = max_period, .max_ue_per_slot = 1}; // currently 1 SRS per slot
+  p.list = calloc_or_fail(nb_slots * p.max_ue_per_slot, sizeof(NR_UE_info_t *));
+  return p;
 }
 
 void nr_mac_config_scc(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, NR_ServingCellConfigCommon_t *scc, const nr_mac_config_t *config)
@@ -1010,7 +1045,8 @@ void nr_mac_config_scc(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, NR_ServingCel
   LOG_D(NR_MAC, "Configuring common parameters from NR ServingCellConfig\n");
 
   config_common(cell, config, scc);
-  config_period_structures(cell);
+  if (cell->radio_config.do_SRS == PERIODIC_SRS)
+    cell->periodic_srs_config = config_period_structure(cell, SRS);
   fill_beam_index_list(scc, config, cell);
 
   if (NFAPI_MODE == NFAPI_MONOLITHIC) {

--- a/openair2/LAYER2/NR_MAC_gNB/config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/config.c
@@ -36,6 +36,44 @@
 #include "nfapi_nr_interface_scf.h"
 #include "utils.h"
 
+static bool check_periodicity(int val, int ideal_period, const frame_structure_t *fs)
+{
+  bool valid_periodicity_for_tdd_period = fs->frame_type == FDD ? true : (val % fs->numb_slots_period == 0);
+  return (ideal_period < val + 1) && valid_periodicity_for_tdd_period;
+}
+
+int set_ideal_period(const nr_cell_sched_t *cell, nr_periodic_channel_t channel_type, int num_pucch_slot)
+{
+  const frame_structure_t *fs = &cell->frame_structure;
+  const int nb_slots_per_period = fs->numb_slots_period;
+  const int n_ul_slots_per_period = get_ul_slots_per_period(fs); // full UL + mixed with UL symbols
+  // 2 reports per UE (RSRP and RI-PMI-CQI)
+  switch (channel_type) {
+    case SRS: {
+      int srs_periodicities[17] = {1, 2, 4, 5, 8, 10, 16, 20, 32, 40, 64, 80, 160, 320, 640, 1280, 2560};
+      int srs_ideal_period = nb_slots_per_period * MAX_MOBILES_PER_GNB;
+      for (int i = 0; i < 17; i++) {
+        if (check_periodicity(srs_periodicities[i], srs_ideal_period, fs))
+          return srs_periodicities[i];
+      }
+      break;
+    }
+    case CSI_RS:
+    case CSI_MEASUREMENTS: {
+      int csi_periodicities[10] = {4, 5, 8, 10, 16, 20, 40, 80, 160, 320};
+      int csi_ideal_period = MAX_MOBILES_PER_GNB * 2 * nb_slots_per_period / (n_ul_slots_per_period * num_pucch_slot);
+      for (int i = 0; i < 10; i++) {
+        if (check_periodicity(csi_periodicities[i], csi_ideal_period, fs))
+          return csi_periodicities[i];
+      }
+      break;
+    }
+    default:
+      AssertFatal(false, "Invalid periodic channel type");
+  }
+  return 0;
+}
+
 c16_t convert_precoder_weight(double complex c_in)
 {
   return (c16_t) {.r = round(SHRT_MAX*creal(c_in)), .i = round(SHRT_MAX*cimag(c_in))};
@@ -929,6 +967,16 @@ static void init_ul_tda_info(const NR_PUSCH_TimeDomainResourceAllocationList_t *
   }
 }
 
+static void config_period_structures(nr_cell_sched_t *cell)
+{
+  // only SRS for now
+  if (cell->radio_config.do_SRS == PERIODIC_SRS) {
+    cell->srs_period = set_ideal_period(cell, SRS, 0);
+    AssertFatal(cell->srs_period > 0, "Invalid SRS periodicity\n");
+    cell->period_srs_sched = calloc_or_fail(cell->srs_period, sizeof(NR_UE_info_t *));
+  }
+}
+
 void nr_mac_config_scc(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, NR_ServingCellConfigCommon_t *scc, const nr_mac_config_t *config)
 {
   DevAssert(nrmac != NULL);
@@ -962,6 +1010,7 @@ void nr_mac_config_scc(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, NR_ServingCel
   LOG_D(NR_MAC, "Configuring common parameters from NR ServingCellConfig\n");
 
   config_common(cell, config, scc);
+  config_period_structures(cell);
   fill_beam_index_list(scc, config, cell);
 
   if (NFAPI_MODE == NFAPI_MONOLITHIC) {
@@ -1270,7 +1319,7 @@ bool nr_mac_add_test_ue(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, uint32_t rnt
   bool res = add_connected_nr_ue(nrmac, UE);
   if (!res) {
     LOG_E(NR_MAC, "Error adding UE %04x\n", rnti);
-    delete_nr_ue_data(UE, &nrmac->UE_info.uid_allocator);
+    delete_nr_ue_data(nrmac, UE);
     NR_SCHED_UNLOCK(&nrmac->sched_lock);
     return false;
   }

--- a/openair2/LAYER2/NR_MAC_gNB/config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/config.c
@@ -51,7 +51,7 @@ int set_ideal_period(const nr_cell_sched_t *cell, nr_periodic_channel_t channel_
   switch (channel_type) {
     case SRS: {
       int srs_periodicities[17] = {1, 2, 4, 5, 8, 10, 16, 20, 32, 40, 64, 80, 160, 320, 640, 1280, 2560};
-      const int srs_period = cell->radio_config.srs_periodicity;
+      const int srs_period = cell->radio_config.srs.periodicity;
       int srs_ideal_period = srs_period > 0 ? srs_period : nb_slots_per_period * MAX_MOBILES_PER_GNB;
       for (int i = 0; i < 17; i++) {
         if (check_periodicity(srs_periodicities[i], srs_ideal_period, fs))
@@ -363,7 +363,7 @@ int get_ul_slots_per_period(const frame_structure_t *fs)
  */
 int nr_srs_ue_per_slot(const nr_mac_config_t *rc)
 {
-  return rc->srs_ue_per_symbol * rc->srs_symbols_per_slot;
+  return rc->srs.ue_per_symbol * rc->srs.symbols_per_slot;
 }
 
 /**
@@ -1080,8 +1080,8 @@ void nr_mac_config_scc(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, NR_ServingCel
                        scc->tdd_UL_DL_ConfigurationCommon,
                        csi_symbols_in_slot(scc),
                        num_symb_cset);
-  // PUSCH ends where the SRS block starts, counting down from srs_last_symbol
-  nr_rrc_config_ul_tda(scc, rc->minRXTXTIME, rc->do_SRS, rc->srs_last_symbol - rc->srs_symbols_per_slot + 1);
+  // PUSCH ends where the SRS block starts, counting down from the last SRS symbol
+  nr_rrc_config_ul_tda(scc, rc->minRXTXTIME, rc->do_SRS, rc->srs.last_symbol - rc->srs.symbols_per_slot + 1);
   seq_arr_init(&cell->ul_tda, sizeof(NR_tda_info_t));
   init_ul_tda_info(scc->uplinkConfigCommon->initialUplinkBWP->pusch_ConfigCommon->choice.setup->pusch_TimeDomainAllocationList, &cell->ul_tda);
   seq_arr_init(&nrmac->pos_act_ue_arr, sizeof(positioning_activation_info_t));

--- a/openair2/LAYER2/NR_MAC_gNB/config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/config.c
@@ -51,7 +51,8 @@ int set_ideal_period(const nr_cell_sched_t *cell, nr_periodic_channel_t channel_
   switch (channel_type) {
     case SRS: {
       int srs_periodicities[17] = {1, 2, 4, 5, 8, 10, 16, 20, 32, 40, 64, 80, 160, 320, 640, 1280, 2560};
-      int srs_ideal_period = nb_slots_per_period * MAX_MOBILES_PER_GNB;
+      const int srs_period = cell->radio_config.srs_periodicity;
+      int srs_ideal_period = srs_period > 0 ? srs_period : nb_slots_per_period * MAX_MOBILES_PER_GNB;
       for (int i = 0; i < 17; i++) {
         if (check_periodicity(srs_periodicities[i], srs_ideal_period, fs))
           return srs_periodicities[i];
@@ -353,6 +354,16 @@ int get_dl_slots_per_period(const frame_structure_t *fs)
 int get_ul_slots_per_period(const frame_structure_t *fs)
 {
   return fs->frame_type == TDD ? fs->period_cfg.num_ul_slots : fs->numb_slots_frame;
+}
+
+/**
+ * @brief Get number of periodic SRS UEs that fit in one full UL slot
+ * @param rc Pointer to the MAC radio configuration
+ * @return Number of UEs, comb offsets times SRS symbols
+ */
+int nr_srs_ue_per_slot(const nr_mac_config_t *rc)
+{
+  return rc->srs_ue_per_symbol * rc->srs_symbols_per_slot;
 }
 
 /**
@@ -1007,7 +1018,7 @@ static periodic_ue_sched_t config_period_structure(nr_cell_sched_t *cell, nr_per
   bool count_mixed = channel != SRS;
   int valid_slots_per_period = count_mixed ? get_ul_slots_per_period(fs) : get_full_ul_slots_per_period(fs);
   int nb_slots = (max_period / fs->numb_slots_period) * valid_slots_per_period;
-  periodic_ue_sched_t p = {.max_period = max_period, .max_ue_per_slot = 1}; // currently 1 SRS per slot
+  periodic_ue_sched_t p = {.max_period = max_period, .max_ue_per_slot = nr_srs_ue_per_slot(&cell->radio_config)};
   p.list = calloc_or_fail(nb_slots * p.max_ue_per_slot, sizeof(NR_UE_info_t *));
   return p;
 }
@@ -1069,7 +1080,8 @@ void nr_mac_config_scc(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, NR_ServingCel
                        scc->tdd_UL_DL_ConfigurationCommon,
                        csi_symbols_in_slot(scc),
                        num_symb_cset);
-  nr_rrc_config_ul_tda(scc, rc->minRXTXTIME, rc->do_SRS);
+  // PUSCH ends where the SRS block starts, counting down from srs_last_symbol
+  nr_rrc_config_ul_tda(scc, rc->minRXTXTIME, rc->do_SRS, rc->srs_last_symbol - rc->srs_symbols_per_slot + 1);
   seq_arr_init(&cell->ul_tda, sizeof(NR_tda_info_t));
   init_ul_tda_info(scc->uplinkConfigCommon->initialUplinkBWP->pusch_ConfigCommon->choice.setup->pusch_TimeDomainAllocationList, &cell->ul_tda);
   seq_arr_init(&nrmac->pos_act_ue_arr, sizeof(positioning_activation_info_t));

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_RA.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_RA.c
@@ -701,7 +701,7 @@ void nr_initiate_ra_proc(module_id_t module_idP,
     UE = get_new_nr_ue_inst(&nr_mac->UE_info.uid_allocator, rnti, NULL, cell);
     if (!add_new_UE_RA(nr_mac, UE)) {
       LOG_E(NR_MAC, "FAILURE: %4d.%2d initiating RA procedure for preamble index %d: no free RA process\n", frame, slot, preamble_index);
-      delete_nr_ue_data(UE, &nr_mac->UE_info.uid_allocator);
+      delete_nr_ue_data(nr_mac, UE);
       NR_SCHED_UNLOCK(&nr_mac->sched_lock);
       return;
     }
@@ -2113,7 +2113,7 @@ void nr_release_ra_UE(gNB_MAC_INST *mac, rnti_t rnti)
   NR_UEs_t *UE_info = &mac->UE_info;
   NR_UE_info_t *UE = remove_UE_from_list(NR_NB_RA_PROC_MAX, UE_info->access_ue_list, rnti);
   if (UE) {
-    delete_nr_ue_data(UE, &UE_info->uid_allocator);
+    delete_nr_ue_data(mac, UE);
   } else {
     LOG_W(NR_MAC,"Call to release RA UE with rnti %04x, but not existing\n", rnti);
   }

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -2675,12 +2675,21 @@ NR_UE_info_t *find_ra_UE(NR_UEs_t *UEs, rnti_t rntiP)
   return NULL;
 }
 
-void delete_nr_ue_data(NR_UE_info_t *UE, uid_allocator_t *uia)
+static void reset_srs_periodic_info(nr_cell_sched_t *cell, NR_sched_srs_t *sched_srs)
+{
+  if (cell->period_srs_sched && sched_srs->periodic_sched.periodic_offset >= 0) {
+    cell->period_srs_sched[sched_srs->periodic_sched.periodic_offset] = NULL;
+    sched_srs->periodic_sched.periodic_offset = -1;
+  }
+}
+
+void delete_nr_ue_data(gNB_MAC_INST *mac, NR_UE_info_t *UE)
 {
   ASN_STRUCT_FREE(asn_DEF_NR_CellGroupConfig, UE->CellGroup);
   ASN_STRUCT_FREE(asn_DEF_NR_CellGroupConfig, UE->reconfigCellGroup);
   ASN_STRUCT_FREE(asn_DEF_NR_UE_NR_Capability, UE->capability);
   NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
+  reset_srs_periodic_info(UE->pcell, &sched_ctrl->sched_srs);
   seq_arr_free(&sched_ctrl->lc_config, NULL);
   destroy_nr_list(&sched_ctrl->available_dl_harq);
   destroy_nr_list(&sched_ctrl->feedback_dl_harq);
@@ -2691,6 +2700,7 @@ void delete_nr_ue_data(NR_UE_info_t *UE, uid_allocator_t *uia)
   for (int i = 0; i < NR_MAX_HARQ_PROCESSES; ++i)
     free_transportBlock_buffer(&sched_ctrl->harq_processes[i].transportBlock);
   free_sched_pucch_list(sched_ctrl);
+  uid_allocator_t *uia = &mac->UE_info.uid_allocator;
   uid_linear_allocator_free(uia, UE->uid);
   LOG_I(NR_MAC, "Remove NR rnti 0x%04x\n", UE->rnti);
   free_and_zero(UE->ra);
@@ -2879,6 +2889,12 @@ void reset_sc_info(NR_UE_ServingCell_Info_t *sc_info)
 static void configure_sched_srs(nr_cell_sched_t *cell, NR_SRS_Config_t *srs_config, NR_sched_srs_t *sched_srs, NR_UE_info_t *UE)
 {
   nr_srs_type_t srs_type = cell->radio_config.do_SRS;
+  if (!srs_config || srs_type == NO_SRS) {
+    sched_srs->srs_resource = NULL;
+    reset_srs_periodic_info(cell, sched_srs);
+    return;
+  }
+
   NR_SRS_ResourceSet__resourceType_PR set_type = srs_type == PERIODIC_SRS ?
                                                  NR_SRS_ResourceSet__resourceType_PR_periodic :
                                                  NR_SRS_ResourceSet__resourceType_PR_aperiodic;
@@ -2894,8 +2910,9 @@ static void configure_sched_srs(nr_cell_sched_t *cell, NR_SRS_Config_t *srs_conf
   AssertFatal(srs_resource_set, "Couldn't find %s SRS resource set\n", srs_type == PERIODIC_SRS ? "periodic" : "aperiodic");
   sched_srs->usage = srs_resource_set->usage;
   if (srs_type == APERIODIC_SRS) {
-    sched_srs->aperiodic_slotOffset = srs_resource_set->resourceType.choice.aperiodic->slotOffset;
-    sched_srs->aperiodic_ResourceTrigger = srs_resource_set->resourceType.choice.aperiodic->aperiodicSRS_ResourceTrigger;
+    struct NR_SRS_ResourceSet__resourceType__aperiodic *aperiodic = srs_resource_set->resourceType.choice.aperiodic;
+    sched_srs->aperiodic_sched.aperiodic_slotOffset = aperiodic->slotOffset;
+    sched_srs->aperiodic_sched.aperiodic_ResourceTrigger = aperiodic->aperiodicSRS_ResourceTrigger;
   }
 
   NR_SRS_Resource__resourceType_PR res_type = srs_type == PERIODIC_SRS ?
@@ -2913,6 +2930,11 @@ static void configure_sched_srs(nr_cell_sched_t *cell, NR_SRS_Config_t *srs_conf
   }
   AssertFatal(srs_resource, "Couldn't find %s SRS resource\n", srs_type == PERIODIC_SRS ? "periodic" : "aperiodic");
   sched_srs->srs_resource = srs_resource;
+  if (srs_type == PERIODIC_SRS) {
+    sched_srs->periodic_sched.periodic_offset = get_nr_srs_offset(srs_resource->resourceType.choice.periodic->periodicityAndOffset_p);
+    DevAssert(sched_srs->periodic_sched.periodic_offset >= 0);
+    cell->period_srs_sched[sched_srs->periodic_sched.periodic_offset] = UE;
+  }
 }
 
 // main function to configure parameters of current BWP
@@ -3290,7 +3312,7 @@ bool add_connected_nr_ue(gNB_MAC_INST *nr_mac, NR_UE_info_t *UE)
   bool success = add_UE_to_list(MAX_MOBILES_PER_GNB, UE_info->connected_ue_list, UE);
   if (!success) {
     LOG_E(NR_MAC,"Try to add UE %04x but the list is full\n", UE->rnti);
-    delete_nr_ue_data(UE, &UE_info->uid_allocator);
+    delete_nr_ue_data(nr_mac, UE);
     return false;
   }
 
@@ -3298,8 +3320,9 @@ bool add_connected_nr_ue(gNB_MAC_INST *nr_mac, NR_UE_info_t *UE)
   sched_ctrl->dl_max_mcs = 28; /* do not limit MCS for individual UEs */
   sched_ctrl->pdcch_cl_adjust = 0;
   if (UE->pcell->radio_config.do_SRS == APERIODIC_SRS) {
-    nr_timer_setup(&sched_ctrl->sched_srs.aperiodic_srs_timer, 160, 1); // for now aperiodic hardcoded every 160 slots
-    nr_timer_start(&sched_ctrl->sched_srs.aperiodic_srs_timer);
+    // for now aperiodic hardcoded every 160 slots
+    nr_timer_setup(&sched_ctrl->sched_srs.aperiodic_sched.aperiodic_srs_timer, 160, 1);
+    nr_timer_start(&sched_ctrl->sched_srs.aperiodic_sched.aperiodic_srs_timer);
   }
   reset_srs_stats(UE);
 
@@ -3359,7 +3382,7 @@ void mac_remove_nr_ue(gNB_MAC_INST *nr_mac, rnti_t rnti)
   NR_UEs_t *UE_info = &nr_mac->UE_info;
   NR_UE_info_t *UE = remove_UE_from_list(MAX_MOBILES_PER_GNB + 1, UE_info->connected_ue_list, rnti);
   if (UE)
-    delete_nr_ue_data(UE, &UE_info->uid_allocator);
+    delete_nr_ue_data(nr_mac, UE);
   else
     nr_release_ra_UE(nr_mac, rnti);
 }
@@ -3901,7 +3924,7 @@ void nr_mac_update_timers(gNB_MAC_INST *mac, nr_cell_sched_t *cell)
       nr_timer_stop(&sched_ctrl->tci_beam_switch);
       beam_switching_procedure(mac, cell, UE, sched_ctrl->UE_mac_ce_ctrl.tci_state_ind.tciStateId);
     }
-    nr_timer_tick(&sched_ctrl->sched_srs.aperiodic_srs_timer);
+    nr_timer_tick(&sched_ctrl->sched_srs.aperiodic_sched.aperiodic_srs_timer);
   }
 }
 

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -2675,12 +2675,51 @@ NR_UE_info_t *find_ra_UE(NR_UEs_t *UEs, rnti_t rntiP)
   return NULL;
 }
 
-static void reset_srs_periodic_info(nr_cell_sched_t *cell, NR_sched_srs_t *sched_srs)
+NR_UE_info_t **get_periodic_ue(periodic_ue_sched_t *p, int ul_idx, int index)
 {
-  if (cell->period_srs_sched && sched_srs->periodic_sched.periodic_offset >= 0) {
-    cell->period_srs_sched[sched_srs->periodic_sched.periodic_offset] = NULL;
-    sched_srs->periodic_sched.periodic_offset = -1;
+  return &p->list[ul_idx * p->max_ue_per_slot + index];
+}
+
+static void reset_periodic_info(nr_cell_sched_t *cell, NR_UE_info_t *UE, nr_periodic_channel_t channel)
+{
+  NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
+  switch (channel) {
+    case SRS:
+      if (cell->periodic_srs_config.list && sched_ctrl->sched_srs.periodic_sched.periodic_offset >= 0) {
+        for (int i = 0; i < cell->periodic_srs_config.max_ue_per_slot; i++) {
+          if (*get_periodic_ue(&cell->periodic_srs_config, sched_ctrl->sched_srs.periodic_sched.periodic_offset, i) != UE)
+            continue;
+          *get_periodic_ue(&cell->periodic_srs_config, sched_ctrl->sched_srs.periodic_sched.periodic_offset, i) = NULL;
+          sched_ctrl->sched_srs.periodic_sched.periodic_offset = -1;
+          return;
+        }
+      }
+      break;
+    default:
+      AssertFatal(false, "Periodic channel handling not implemented\n");
   }
+}
+
+static void set_periodic_info(nr_cell_sched_t *cell, NR_UE_info_t *UE, nr_periodic_channel_t channel, int offset)
+{
+  AssertFatal(offset >= 0, "Invalid slot offset for periodic information %d\n", offset);
+  const frame_structure_t *fs = &cell->frame_structure;
+  switch (channel) {
+    case SRS:
+      AssertFatal(offset < cell->periodic_srs_config.max_period, "SRS offset not compatible with periodicity\n");
+      int idx = get_ul_period_idx_from_abs_slot(fs, offset, false, cell->periodic_srs_config.max_period);
+      for (int i = 0; i < cell->periodic_srs_config.max_ue_per_slot; i++) {
+        if (*get_periodic_ue(&cell->periodic_srs_config, idx, i) != NULL)
+          continue;
+        *get_periodic_ue(&cell->periodic_srs_config, idx, i) = UE;
+        UE->UE_sched_ctrl.sched_srs.periodic_sched.periodic_offset = idx;
+        return;
+      }
+      break;
+    default:
+      AssertFatal(false, "Periodic channel handling not implemented\n");
+  }
+  AssertFatal(false, "no free SRS slot at offset %d\n", offset);
 }
 
 void delete_nr_ue_data(gNB_MAC_INST *mac, NR_UE_info_t *UE)
@@ -2689,7 +2728,7 @@ void delete_nr_ue_data(gNB_MAC_INST *mac, NR_UE_info_t *UE)
   ASN_STRUCT_FREE(asn_DEF_NR_CellGroupConfig, UE->reconfigCellGroup);
   ASN_STRUCT_FREE(asn_DEF_NR_UE_NR_Capability, UE->capability);
   NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
-  reset_srs_periodic_info(UE->pcell, &sched_ctrl->sched_srs);
+  reset_periodic_info(UE->pcell, UE, SRS);
   seq_arr_free(&sched_ctrl->lc_config, NULL);
   destroy_nr_list(&sched_ctrl->available_dl_harq);
   destroy_nr_list(&sched_ctrl->feedback_dl_harq);
@@ -2891,7 +2930,7 @@ static void configure_sched_srs(nr_cell_sched_t *cell, NR_SRS_Config_t *srs_conf
   nr_srs_type_t srs_type = cell->radio_config.do_SRS;
   if (!srs_config || srs_type == NO_SRS) {
     sched_srs->srs_resource = NULL;
-    reset_srs_periodic_info(cell, sched_srs);
+    reset_periodic_info(cell, UE, SRS);
     return;
   }
 
@@ -2931,9 +2970,8 @@ static void configure_sched_srs(nr_cell_sched_t *cell, NR_SRS_Config_t *srs_conf
   AssertFatal(srs_resource, "Couldn't find %s SRS resource\n", srs_type == PERIODIC_SRS ? "periodic" : "aperiodic");
   sched_srs->srs_resource = srs_resource;
   if (srs_type == PERIODIC_SRS) {
-    sched_srs->periodic_sched.periodic_offset = get_nr_srs_offset(srs_resource->resourceType.choice.periodic->periodicityAndOffset_p);
-    DevAssert(sched_srs->periodic_sched.periodic_offset >= 0);
-    cell->period_srs_sched[sched_srs->periodic_sched.periodic_offset] = UE;
+    int slot_offset = get_nr_srs_offset(srs_resource->resourceType.choice.periodic->periodicityAndOffset_p);
+    set_periodic_info(cell, UE, SRS, slot_offset);
   }
 }
 

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -2876,6 +2876,45 @@ void reset_sc_info(NR_UE_ServingCell_Info_t *sc_info)
   sc_info->nrofHARQ_ProcessesForPUSCH_r17 = NULL;
 }
 
+static void configure_sched_srs(nr_cell_sched_t *cell, NR_SRS_Config_t *srs_config, NR_sched_srs_t *sched_srs, NR_UE_info_t *UE)
+{
+  nr_srs_type_t srs_type = cell->radio_config.do_SRS;
+  NR_SRS_ResourceSet__resourceType_PR set_type = srs_type == PERIODIC_SRS ?
+                                                 NR_SRS_ResourceSet__resourceType_PR_periodic :
+                                                 NR_SRS_ResourceSet__resourceType_PR_aperiodic;
+
+  NR_SRS_ResourceSet_t *srs_resource_set = NULL;
+  for(int rs = 0; rs < srs_config->srs_ResourceSetToAddModList->list.count; rs++) {
+    // Find resource set
+    if (srs_config->srs_ResourceSetToAddModList->list.array[rs]->resourceType.present == set_type) {
+      srs_resource_set = srs_config->srs_ResourceSetToAddModList->list.array[rs];
+      break;
+    }
+  }
+  AssertFatal(srs_resource_set, "Couldn't find %s SRS resource set\n", srs_type == PERIODIC_SRS ? "periodic" : "aperiodic");
+  sched_srs->usage = srs_resource_set->usage;
+  if (srs_type == APERIODIC_SRS) {
+    sched_srs->aperiodic_slotOffset = srs_resource_set->resourceType.choice.aperiodic->slotOffset;
+    sched_srs->aperiodic_ResourceTrigger = srs_resource_set->resourceType.choice.aperiodic->aperiodicSRS_ResourceTrigger;
+  }
+
+  NR_SRS_Resource__resourceType_PR res_type = srs_type == PERIODIC_SRS ?
+                                              NR_SRS_Resource__resourceType_PR_periodic :
+                                              NR_SRS_Resource__resourceType_PR_aperiodic;
+
+  NR_SRS_Resource_t *srs_resource = NULL;
+  for (int r1 = 0; r1 < srs_resource_set->srs_ResourceIdList->list.count; r1++) {
+    for (int r2 = 0; r2 < srs_config->srs_ResourceToAddModList->list.count; r2++) {
+      if ((*srs_resource_set->srs_ResourceIdList->list.array[r1] ==
+          srs_config->srs_ResourceToAddModList->list.array[r2]->srs_ResourceId) &&
+          (srs_config->srs_ResourceToAddModList->list.array[r2]->resourceType.present == res_type))
+        srs_resource = srs_config->srs_ResourceToAddModList->list.array[r2];
+    }
+  }
+  AssertFatal(srs_resource, "Couldn't find %s SRS resource\n", srs_type == PERIODIC_SRS ? "periodic" : "aperiodic");
+  sched_srs->srs_resource = srs_resource;
+}
+
 // main function to configure parameters of current BWP
 void configure_UE_BWP(nr_cell_sched_t *cell,
                       NR_ServingCellConfigCommon_t *scc,
@@ -2956,6 +2995,9 @@ void configure_UE_BWP(nr_cell_sched_t *cell,
     UL_BWP->configuredGrantConfig = NULL;
   }
 
+  NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
+  configure_sched_srs(cell, UL_BWP->srs_Config, &sched_ctrl->sched_srs, UE);
+
   // TDA lists
   if (DL_BWP->bwp_id > 0)
     DL_BWP->tdaList_Common = dl_bwp->bwp_Common->pdsch_ConfigCommon->choice.setup->pdsch_TimeDomainAllocationList;
@@ -3018,7 +3060,6 @@ void configure_UE_BWP(nr_cell_sched_t *cell,
   if (old_ul_bwp_id != UL_BWP->bwp_id)
     LOG_I(NR_MAC, "Switching to UL-BWP %li\n", UL_BWP->bwp_id);
 
-  NR_UE_sched_ctrl_t *sched_ctrl = &UE->UE_sched_ctrl;
   // Reset required fields in sched_ctrl (e.g. ul_ri and tpmi)
   reset_sched_ctrl(sched_ctrl);
   if(!is_RA) {
@@ -3257,8 +3298,8 @@ bool add_connected_nr_ue(gNB_MAC_INST *nr_mac, NR_UE_info_t *UE)
   sched_ctrl->dl_max_mcs = 28; /* do not limit MCS for individual UEs */
   sched_ctrl->pdcch_cl_adjust = 0;
   if (UE->pcell->radio_config.do_SRS == APERIODIC_SRS) {
-    nr_timer_setup(&sched_ctrl->aperiodic_srs_trigger, 160, 1); // for now aperiodic hardcoded every 160 slots
-    nr_timer_start(&sched_ctrl->aperiodic_srs_trigger);
+    nr_timer_setup(&sched_ctrl->sched_srs.aperiodic_srs_timer, 160, 1); // for now aperiodic hardcoded every 160 slots
+    nr_timer_start(&sched_ctrl->sched_srs.aperiodic_srs_timer);
   }
   reset_srs_stats(UE);
 
@@ -3860,7 +3901,7 @@ void nr_mac_update_timers(gNB_MAC_INST *mac, nr_cell_sched_t *cell)
       nr_timer_stop(&sched_ctrl->tci_beam_switch);
       beam_switching_procedure(mac, cell, UE, sched_ctrl->UE_mac_ce_ctrl.tci_state_ind.tciStateId);
     }
-    nr_timer_tick(&sched_ctrl->aperiodic_srs_trigger);
+    nr_timer_tick(&sched_ctrl->sched_srs.aperiodic_srs_timer);
   }
 }
 

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_primitives.c
@@ -2971,6 +2971,8 @@ static void configure_sched_srs(nr_cell_sched_t *cell, NR_SRS_Config_t *srs_conf
   sched_srs->srs_resource = srs_resource;
   if (srs_type == PERIODIC_SRS) {
     int slot_offset = get_nr_srs_offset(srs_resource->resourceType.choice.periodic->periodicityAndOffset_p);
+    // a reconfiguration still holds an entry, and the offset may have changed
+    reset_periodic_info(cell, UE, SRS);
     set_periodic_info(cell, UE, SRS, slot_offset);
   }
 }

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
@@ -450,7 +450,7 @@ static void nr_configure_srs(gNB_MAC_INST *nrmac,
                              nr_cell_sched_t *cell,
                              nfapi_nr_srs_pdu_t *srs_pdu,
                              NR_UE_info_t *UE,
-                             NR_SRS_ResourceSet_t *srs_resource_set,
+                             long usage,
                              NR_SRS_Resource_t *srs_resource,
                              int beam_idx)
 {
@@ -496,7 +496,7 @@ static void nr_configure_srs(gNB_MAC_INST *nrmac,
 
   // TODO: This should be completed
   srs_pdu->srs_parameters_v4.srs_bandwidth_size = m_SRS[srs_pdu->config_index];
-  srs_pdu->srs_parameters_v4.usage = 1 << srs_resource_set->usage;
+  srs_pdu->srs_parameters_v4.usage = 1 << usage;
   positioning_activation_info_t *pos_ue_context = get_pos_act_ue_context(nrmac, UE->rnti);
   if (pos_ue_context != NULL) {
     srs_pdu->srs_parameters_v4.usage = 1 << NFAPI_NR_SRS_POSITIONING;
@@ -511,7 +511,7 @@ static void nr_configure_srs(gNB_MAC_INST *nrmac,
   *             1                     2                   3
   *             2                     4                  15 */
   srs_pdu->srs_parameters_v4.sampled_ue_antennas = (2 << srs_pdu->num_ant_ports) - 1;
-  if (srs_resource_set->usage == NR_SRS_ResourceSet__usage_beamManagement) {
+  if (usage == NR_SRS_ResourceSet__usage_beamManagement) {
     srs_pdu->beamforming.trp_scheme = 0;
     srs_pdu->beamforming.num_prgs = m_SRS[srs_pdu->config_index];
     srs_pdu->beamforming.prg_size = srs_pdu->srs_parameters_v4.srs_bandwidth_size;
@@ -534,8 +534,7 @@ static bool nr_fill_nfapi_srs(gNB_MAC_INST *nrmac,
                               NR_UE_info_t *UE,
                               int frame,
                               int slot,
-                              NR_SRS_ResourceSet_t *srs_resource_set,
-                              NR_SRS_Resource_t *srs_resource)
+                              NR_sched_srs_t *sched_srs)
 {
   int slots_frame = cell->frame_structure.numb_slots_frame;
   int index = ul_buffer_index(frame, slot, slots_frame, cell->UL_tti_req_ahead_size);
@@ -546,6 +545,7 @@ static bool nr_fill_nfapi_srs(gNB_MAC_INST *nrmac,
   }
 
   uint16_t *vrb_map_UL = &cell->common_channels.vrb_map_UL[beam.idx][index * MAX_BWP_SIZE];
+  NR_SRS_Resource_t *srs_resource = sched_srs->srs_resource;
   uint16_t num = 1 << srs_resource->resourceMapping.nrofSymbols;
   const uint8_t l0 = NR_SYMBOLS_PER_SLOT - 1 - srs_resource->resourceMapping.startPosition;
   uint16_t mask = SL_to_bitmap(l0, num);
@@ -575,7 +575,7 @@ static bool nr_fill_nfapi_srs(gNB_MAC_INST *nrmac,
   memset(srs_pdu, 0, sizeof(nfapi_nr_srs_pdu_t));
   future_ul_tti_req->n_pdus += 1;
   index = ul_buffer_index(frame, slot, slots_frame, cell->vrb_map_UL_size);
-  nr_configure_srs(nrmac, cell, srs_pdu, UE, srs_resource_set, srs_resource, beam.idx);
+  nr_configure_srs(nrmac, cell, srs_pdu, UE, sched_srs->usage, srs_resource, beam.idx);
   return true;
 }
 
@@ -608,48 +608,23 @@ void nr_schedule_periodic_srs(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, frame_
     if (!srs_config)
       continue;
 
-    for(int rs = 0; rs < srs_config->srs_ResourceSetToAddModList->list.count; rs++) {
+    NR_sched_srs_t *srs = &UE->UE_sched_ctrl.sched_srs;
 
-      // Find periodic resource set
-      NR_SRS_ResourceSet_t *srs_resource_set = srs_config->srs_ResourceSetToAddModList->list.array[rs];
-      if (srs_resource_set->resourceType.present != NR_SRS_ResourceSet__resourceType_PR_periodic) {
-        continue;
-      }
+    // we are sheduling SRS max_k2 slot in advance for the presence of SRS to be taken into account when scheduling PUSCH
+    const int n_slots_frame = cell->frame_structure.numb_slots_frame;
+    const int n_ahead = n_slots_frame - 1 + get_NTN_Koffset(cell->common_channels.ServingCellConfigCommon);
+    const int sched_slot = (slot + n_ahead) % n_slots_frame;
+    const int sched_frame = (frame + (slot + n_ahead) / n_slots_frame) % MAX_FRAME_NUMBER;
 
-      // Find the corresponding srs resource
-      NR_SRS_Resource_t *srs_resource = NULL;
-      for (int r1 = 0; r1 < srs_resource_set->srs_ResourceIdList->list.count; r1++) {
-        for (int r2 = 0; r2 < srs_config->srs_ResourceToAddModList->list.count; r2++) {
-          if ((*srs_resource_set->srs_ResourceIdList->list.array[r1] ==
-               srs_config->srs_ResourceToAddModList->list.array[r2]->srs_ResourceId) &&
-              (srs_config->srs_ResourceToAddModList->list.array[r2]->resourceType.present ==
-               NR_SRS_Resource__resourceType_PR_periodic)) {
-            srs_resource = srs_config->srs_ResourceToAddModList->list.array[r2];
-            break;
-          }
-        }
-      }
+    const uint16_t period = srs_period[srs->srs_resource->resourceType.choice.periodic->periodicityAndOffset_p.present];
+    const uint16_t offset = get_nr_srs_offset(srs->srs_resource->resourceType.choice.periodic->periodicityAndOffset_p);
 
-      if (srs_resource == NULL) {
-        continue;
-      }
-
-      // we are sheduling SRS max_k2 slot in advance for the presence of SRS to be taken into account when scheduling PUSCH
-      const int n_slots_frame = cell->frame_structure.numb_slots_frame;
-      const int n_ahead = n_slots_frame - 1 + get_NTN_Koffset(cell->common_channels.ServingCellConfigCommon);
-      const int sched_slot = (slot + n_ahead) % n_slots_frame;
-      const int sched_frame = (frame + (slot + n_ahead) / n_slots_frame) % MAX_FRAME_NUMBER;
-
-      const uint16_t period = srs_period[srs_resource->resourceType.choice.periodic->periodicityAndOffset_p.present];
-      const uint16_t offset = get_nr_srs_offset(srs_resource->resourceType.choice.periodic->periodicityAndOffset_p);
-
-      // Check if UE will transmit the SRS in this frame
-      if ((sched_frame * n_slots_frame + sched_slot - offset) % period != 0)
-        continue;
-      bool ret = nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, srs_resource_set, srs_resource);
-      AssertFatal(ret, "Cannot allocate periodic SRS\n");
-      LOG_D(NR_MAC," %d.%d Scheduling SRS reception for %d.%d\n", frame, slot, sched_frame, sched_slot);
-    }
+    // Check if UE will transmit the SRS in this frame
+    if ((sched_frame * n_slots_frame + sched_slot - offset) % period != 0)
+      continue;
+    bool ret = nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, srs);
+    AssertFatal(ret, "Cannot allocate periodic SRS\n");
+    LOG_D(NR_MAC," %d.%d Scheduling SRS reception for %d.%d\n", frame, slot, sched_frame, sched_slot);
   }
 }
 
@@ -659,38 +634,15 @@ bool nr_schedule_aperiodic_srs(gNB_MAC_INST *nrmac,nr_cell_sched_t *cell, NR_UE_
   NR_SRS_Config_t *srs_config = current_BWP->srs_Config;
   AssertFatal(srs_config, "Attempting to schedule aperiodic SRS without SRS configuration\n");
 
-  for(int rs = 0; rs < srs_config->srs_ResourceSetToAddModList->list.count; rs++) {
-    // Find periodic resource set
-    NR_SRS_ResourceSet_t *srs_resource_set = srs_config->srs_ResourceSetToAddModList->list.array[rs];
-    if (srs_resource_set->resourceType.present != NR_SRS_ResourceSet__resourceType_PR_aperiodic)
-      continue;
-
-    // We aim to schedule SRS in the same slot as PUSCH
-    struct NR_SRS_ResourceSet__resourceType__aperiodic *aperiodic = srs_resource_set->resourceType.choice.aperiodic;
-    if (aperiodic->aperiodicSRS_ResourceTrigger != sched_srs)
-      continue;
-    int offset = aperiodic->slotOffset ? *aperiodic->slotOffset : 0;
-    if (offset != k2) {
-      LOG_E(NR_MAC, "Aperiodic SRS offset %d for trigger state %d doesn't match with K2 %d\n", offset, sched_srs, k2);
-      return false;
-    }
-
-    // Find the corresponding srs resource
-    for (int r1 = 0; r1 < srs_resource_set->srs_ResourceIdList->list.count; r1++) {
-      for (int r2 = 0; r2 < srs_config->srs_ResourceToAddModList->list.count; r2++) {
-        if ((*srs_resource_set->srs_ResourceIdList->list.array[r1] ==
-             srs_config->srs_ResourceToAddModList->list.array[r2]->srs_ResourceId) &&
-            (srs_config->srs_ResourceToAddModList->list.array[r2]->resourceType.present ==
-             NR_SRS_Resource__resourceType_PR_aperiodic)) {
-          NR_SRS_Resource_t *srs_resource = srs_config->srs_ResourceToAddModList->list.array[r2];
-          if (!nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, srs_resource_set, srs_resource))
-            continue;
-          LOG_D(NR_MAC,"Scheduling aperiodic SRS reception for %d.%d\n", sched_frame, sched_slot);
-          nr_timer_start(&UE->UE_sched_ctrl.aperiodic_srs_trigger);  // restart the timer, we are scheduling aperiodic SRS
-          return true;
-        }
-      }
-    }
+  NR_sched_srs_t *srs = &UE->UE_sched_ctrl.sched_srs;
+  int offset = srs->aperiodic_slotOffset ? *srs->aperiodic_slotOffset : 0;
+  if (offset != k2) {
+    LOG_E(NR_MAC, "Aperiodic SRS offset %d for trigger state %d doesn't match with K2 %d\n", offset, sched_srs, k2);
+    return false;
   }
-  return false;
+  if (!nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, srs))
+    return false;
+  LOG_D(NR_MAC,"Scheduling aperiodic SRS reception for %d.%d\n", sched_frame, sched_slot);
+  nr_timer_start(&srs->aperiodic_srs_timer);  // restart the timer, we are scheduling aperiodic SRS
+  return true;
 }

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
@@ -591,38 +591,23 @@ static bool nr_fill_nfapi_srs(gNB_MAC_INST *nrmac,
 *
 *********************************************************************/
 void nr_schedule_periodic_srs(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, frame_t frame, int slot)
-{
+ {
+  if (!cell->period_srs_sched)
+    return;
 
-  NR_UEs_t *UE_info = &nrmac->UE_info;
+  // we are sheduling SRS max_k2 slot in advance for the presence of SRS to be taken into account when scheduling PUSCH
+  const int n_slots_frame = cell->frame_structure.numb_slots_frame;
+  const int n_ahead = n_slots_frame - 1 + get_NTN_Koffset(cell->common_channels.ServingCellConfigCommon);
+  const int sched_slot = (slot + n_ahead) % n_slots_frame;
+  const int sched_frame = (frame + (slot + n_ahead) / n_slots_frame) % MAX_FRAME_NUMBER;
+  int abs_slot = sched_frame * n_slots_frame + sched_slot;
+  int offset = abs_slot % cell->srs_period;
 
-  UE_iterator(UE_info->connected_ue_list, UE) {
-    if (UE->pcell != cell)
-      continue;
-    NR_UE_UL_BWP_t *current_BWP = &UE->current_UL_BWP;
-
-    if (!nr_mac_ue_is_active(UE) && !get_softmodem_params()->phy_test) {
-      continue;
-    }
-
-    NR_SRS_Config_t *srs_config = current_BWP->srs_Config;
-    if (!srs_config)
-      continue;
-
-    NR_sched_srs_t *srs = &UE->UE_sched_ctrl.sched_srs;
-
-    // we are sheduling SRS max_k2 slot in advance for the presence of SRS to be taken into account when scheduling PUSCH
-    const int n_slots_frame = cell->frame_structure.numb_slots_frame;
-    const int n_ahead = n_slots_frame - 1 + get_NTN_Koffset(cell->common_channels.ServingCellConfigCommon);
-    const int sched_slot = (slot + n_ahead) % n_slots_frame;
-    const int sched_frame = (frame + (slot + n_ahead) / n_slots_frame) % MAX_FRAME_NUMBER;
-
-    const uint16_t period = srs_period[srs->srs_resource->resourceType.choice.periodic->periodicityAndOffset_p.present];
-    const uint16_t offset = get_nr_srs_offset(srs->srs_resource->resourceType.choice.periodic->periodicityAndOffset_p);
-
-    // Check if UE will transmit the SRS in this frame
-    if ((sched_frame * n_slots_frame + sched_slot - offset) % period != 0)
-      continue;
-    bool ret = nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, srs);
+  NR_UE_info_t *UE = cell->period_srs_sched[offset];
+  if (UE) {
+    if (!nr_mac_ue_is_active(UE) && !get_softmodem_params()->phy_test)
+      return;
+    bool ret = nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, &UE->UE_sched_ctrl.sched_srs);
     AssertFatal(ret, "Cannot allocate periodic SRS\n");
     LOG_D(NR_MAC," %d.%d Scheduling SRS reception for %d.%d\n", frame, slot, sched_frame, sched_slot);
   }
@@ -635,7 +620,7 @@ bool nr_schedule_aperiodic_srs(gNB_MAC_INST *nrmac,nr_cell_sched_t *cell, NR_UE_
   AssertFatal(srs_config, "Attempting to schedule aperiodic SRS without SRS configuration\n");
 
   NR_sched_srs_t *srs = &UE->UE_sched_ctrl.sched_srs;
-  int offset = srs->aperiodic_slotOffset ? *srs->aperiodic_slotOffset : 0;
+  int offset = srs->aperiodic_sched.aperiodic_slotOffset ? *srs->aperiodic_sched.aperiodic_slotOffset : 0;
   if (offset != k2) {
     LOG_E(NR_MAC, "Aperiodic SRS offset %d for trigger state %d doesn't match with K2 %d\n", offset, sched_srs, k2);
     return false;
@@ -643,6 +628,6 @@ bool nr_schedule_aperiodic_srs(gNB_MAC_INST *nrmac,nr_cell_sched_t *cell, NR_UE_
   if (!nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, srs))
     return false;
   LOG_D(NR_MAC,"Scheduling aperiodic SRS reception for %d.%d\n", sched_frame, sched_slot);
-  nr_timer_start(&srs->aperiodic_srs_timer);  // restart the timer, we are scheduling aperiodic SRS
+  nr_timer_start(&srs->aperiodic_sched.aperiodic_srs_timer);  // restart the timer, we are scheduling aperiodic SRS
   return true;
 }

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
@@ -559,7 +559,7 @@ static bool nr_fill_nfapi_srs(gNB_MAC_INST *nrmac,
       // resetting the resources allocated for SRS
       reset_beam_status(&cell->beam_info, frame, slot, UE->UE_beam_index, slots_frame, beam.new_beam);
       for (int j = UE->current_UL_BWP.BWPStart; j < rb; ++j)
-        vrb_map_UL[rb] = 0;
+        vrb_map_UL[j] &= ~mask;
       return false;
     }
     vrb_map_UL[rb] |= mask;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
@@ -534,13 +534,14 @@ static bool nr_fill_nfapi_srs(gNB_MAC_INST *nrmac,
                               NR_UE_info_t *UE,
                               int frame,
                               int slot,
-                              NR_sched_srs_t *sched_srs)
+                              NR_sched_srs_t *sched_srs,
+                              uint16_t *srs_symbols)
 {
   int slots_frame = cell->frame_structure.numb_slots_frame;
   int index = ul_buffer_index(frame, slot, slots_frame, cell->UL_tti_req_ahead_size);
   NR_beam_alloc_t beam = beam_allocation_procedure(&cell->beam_info, frame, slot, UE->UE_beam_index, slots_frame);
   if (beam.idx < 0) {
-    LOG_W(NR_MAC, "Cannot allocate aperiodic SRS in any available beam\n");
+    LOG_W(NR_MAC, "Cannot allocate SRS in any available beam\n");
     return false;
   }
 
@@ -550,20 +551,23 @@ static bool nr_fill_nfapi_srs(gNB_MAC_INST *nrmac,
   const uint8_t l0 = NR_SYMBOLS_PER_SLOT - 1 - srs_resource->resourceMapping.startPosition;
   uint16_t mask = SL_to_bitmap(l0, num);
   DevAssert(mask != 0);
+  // comb-multiplexed UEs share a symbol without colliding, which the VRB map cannot express
+  const uint16_t claim = mask & ~*srs_symbols;
   for (int i = 0; i < UE->current_UL_BWP.BWPSize; ++i) {
     int rb = i + UE->current_UL_BWP.BWPStart;
-    uint16_t alloc = vrb_map_UL[rb] & mask;
+    uint16_t alloc = vrb_map_UL[rb] & claim;
     // we allocate SRS regardless of prohibited UL PRBs (already present in VRB map)
     if (alloc != 0 && cell->ulprbbl[rb] == 0) {
-      LOG_W(NR_MAC, "RB %d not free for SRS: alloc 0x%02x for mask 0x%02x\n", rb, alloc, mask);
+      LOG_W(NR_MAC, "RB %d not free for SRS: alloc 0x%02x for mask 0x%02x\n", rb, alloc, claim);
       // resetting the resources allocated for SRS
       reset_beam_status(&cell->beam_info, frame, slot, UE->UE_beam_index, slots_frame, beam.new_beam);
       for (int j = UE->current_UL_BWP.BWPStart; j < rb; ++j)
-        vrb_map_UL[j] &= ~mask;
+        vrb_map_UL[j] &= ~claim;
       return false;
     }
     vrb_map_UL[rb] |= mask;
   }
+  *srs_symbols |= mask;
 
   nfapi_nr_ul_tti_request_t *future_ul_tti_req = &cell->UL_tti_req_ahead[index];
   AssertFatal(future_ul_tti_req->n_pdus <
@@ -604,12 +608,14 @@ void nr_schedule_periodic_srs(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, frame_
   int idx = get_ul_period_idx_from_abs_slot(&cell->frame_structure, abs_slot, false, cell->periodic_srs_config.max_period);
   if (idx < 0) // Not an UL slot
     return;
+  uint16_t srs_symbols = 0;
   for (int i = 0; i < cell->periodic_srs_config.max_ue_per_slot; i++) {
     NR_UE_info_t *UE = *get_periodic_ue(&cell->periodic_srs_config, idx, i);
     if (!UE || (!nr_mac_ue_is_active(UE) && !get_softmodem_params()->phy_test))
       continue;
-    bool ret = nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, &UE->UE_sched_ctrl.sched_srs);
-    AssertFatal(ret, "Cannot allocate periodic SRS\n");
+    // PRACH and Msg3 can take the SRS symbols, nr_fill_nfapi_srs() reports it
+    if (!nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, &UE->UE_sched_ctrl.sched_srs, &srs_symbols))
+      continue;
     LOG_D(NR_MAC," %d.%d Scheduling SRS reception for %d.%d\n", frame, slot, sched_frame, sched_slot);
   }
 }
@@ -626,7 +632,8 @@ bool nr_schedule_aperiodic_srs(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, NR_UE
     LOG_E(NR_MAC, "Aperiodic SRS offset %d for trigger state %d doesn't match with K2 %d\n", offset, sched_srs, k2);
     return false;
   }
-  if (!nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, srs))
+  uint16_t srs_symbols = 0;
+  if (!nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, srs, &srs_symbols))
     return false;
   LOG_D(NR_MAC,"Scheduling aperiodic SRS reception for %d.%d\n", sched_frame, sched_slot);
   nr_timer_start(&srs->aperiodic_sched.aperiodic_srs_timer);  // restart the timer, we are scheduling aperiodic SRS

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
@@ -592,7 +592,7 @@ static bool nr_fill_nfapi_srs(gNB_MAC_INST *nrmac,
 *********************************************************************/
 void nr_schedule_periodic_srs(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, frame_t frame, int slot)
  {
-  if (!cell->period_srs_sched)
+  if (!cell->periodic_srs_config.list)
     return;
 
   // we are sheduling SRS max_k2 slot in advance for the presence of SRS to be taken into account when scheduling PUSCH
@@ -601,19 +601,20 @@ void nr_schedule_periodic_srs(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, frame_
   const int sched_slot = (slot + n_ahead) % n_slots_frame;
   const int sched_frame = (frame + (slot + n_ahead) / n_slots_frame) % MAX_FRAME_NUMBER;
   int abs_slot = sched_frame * n_slots_frame + sched_slot;
-  int offset = abs_slot % cell->srs_period;
-
-  NR_UE_info_t *UE = cell->period_srs_sched[offset];
-  if (UE) {
-    if (!nr_mac_ue_is_active(UE) && !get_softmodem_params()->phy_test)
-      return;
+  int idx = get_ul_period_idx_from_abs_slot(&cell->frame_structure, abs_slot, false, cell->periodic_srs_config.max_period);
+  if (idx < 0) // Not an UL slot
+    return;
+  for (int i = 0; i < cell->periodic_srs_config.max_ue_per_slot; i++) {
+    NR_UE_info_t *UE = *get_periodic_ue(&cell->periodic_srs_config, idx, i);
+    if (!UE || (!nr_mac_ue_is_active(UE) && !get_softmodem_params()->phy_test))
+      continue;
     bool ret = nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, &UE->UE_sched_ctrl.sched_srs);
     AssertFatal(ret, "Cannot allocate periodic SRS\n");
     LOG_D(NR_MAC," %d.%d Scheduling SRS reception for %d.%d\n", frame, slot, sched_frame, sched_slot);
   }
 }
 
-bool nr_schedule_aperiodic_srs(gNB_MAC_INST *nrmac,nr_cell_sched_t *cell, NR_UE_info_t *UE, int sched_frame, int sched_slot, int k2, int sched_srs)
+bool nr_schedule_aperiodic_srs(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, NR_UE_info_t *UE, int sched_frame, int sched_slot, int k2, int sched_srs)
 {
   NR_UE_UL_BWP_t *current_BWP = &UE->current_UL_BWP;
   NR_SRS_Config_t *srs_config = current_BWP->srs_Config;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_srs.c
@@ -552,13 +552,13 @@ static bool nr_fill_nfapi_srs(gNB_MAC_INST *nrmac,
   uint16_t mask = SL_to_bitmap(l0, num);
   DevAssert(mask != 0);
   // comb-multiplexed UEs share a symbol without colliding, which the VRB map cannot express
-  const uint16_t claim = mask & ~*srs_symbols;
+  const uint16_t claim = mask & ~srs_symbols[beam.idx];
   for (int i = 0; i < UE->current_UL_BWP.BWPSize; ++i) {
     int rb = i + UE->current_UL_BWP.BWPStart;
     uint16_t alloc = vrb_map_UL[rb] & claim;
     // we allocate SRS regardless of prohibited UL PRBs (already present in VRB map)
     if (alloc != 0 && cell->ulprbbl[rb] == 0) {
-      LOG_W(NR_MAC, "RB %d not free for SRS: alloc 0x%02x for mask 0x%02x\n", rb, alloc, claim);
+      LOG_W(NR_MAC, "RB %d not free for SRS: alloc 0x%02x for claim 0x%02x\n", rb, alloc, claim);
       // resetting the resources allocated for SRS
       reset_beam_status(&cell->beam_info, frame, slot, UE->UE_beam_index, slots_frame, beam.new_beam);
       for (int j = UE->current_UL_BWP.BWPStart; j < rb; ++j)
@@ -567,7 +567,7 @@ static bool nr_fill_nfapi_srs(gNB_MAC_INST *nrmac,
     }
     vrb_map_UL[rb] |= mask;
   }
-  *srs_symbols |= mask;
+  srs_symbols[beam.idx] |= mask;
 
   nfapi_nr_ul_tti_request_t *future_ul_tti_req = &cell->UL_tti_req_ahead[index];
   AssertFatal(future_ul_tti_req->n_pdus <
@@ -608,13 +608,15 @@ void nr_schedule_periodic_srs(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, frame_
   int idx = get_ul_period_idx_from_abs_slot(&cell->frame_structure, abs_slot, false, cell->periodic_srs_config.max_period);
   if (idx < 0) // Not an UL slot
     return;
-  uint16_t srs_symbols = 0;
+  const int num_beams = cell->beam_info.beam_allocation ? cell->beam_info.beams_per_period : 1;
+  uint16_t srs_symbols[num_beams];
+  memset(srs_symbols, 0, sizeof(srs_symbols));
   for (int i = 0; i < cell->periodic_srs_config.max_ue_per_slot; i++) {
     NR_UE_info_t *UE = *get_periodic_ue(&cell->periodic_srs_config, idx, i);
     if (!UE || (!nr_mac_ue_is_active(UE) && !get_softmodem_params()->phy_test))
       continue;
     // PRACH and Msg3 can take the SRS symbols, nr_fill_nfapi_srs() reports it
-    if (!nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, &UE->UE_sched_ctrl.sched_srs, &srs_symbols))
+    if (!nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, &UE->UE_sched_ctrl.sched_srs, srs_symbols))
       continue;
     LOG_D(NR_MAC," %d.%d Scheduling SRS reception for %d.%d\n", frame, slot, sched_frame, sched_slot);
   }
@@ -632,8 +634,10 @@ bool nr_schedule_aperiodic_srs(gNB_MAC_INST *nrmac, nr_cell_sched_t *cell, NR_UE
     LOG_E(NR_MAC, "Aperiodic SRS offset %d for trigger state %d doesn't match with K2 %d\n", offset, sched_srs, k2);
     return false;
   }
-  uint16_t srs_symbols = 0;
-  if (!nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, srs, &srs_symbols))
+  const int num_beams = cell->beam_info.beam_allocation ? cell->beam_info.beams_per_period : 1;
+  uint16_t srs_symbols[num_beams];
+  memset(srs_symbols, 0, sizeof(srs_symbols));
+  if (!nr_fill_nfapi_srs(nrmac, cell, UE, sched_frame, sched_slot, srs, srs_symbols))
     return false;
   LOG_D(NR_MAC,"Scheduling aperiodic SRS reception for %d.%d\n", sched_frame, sched_slot);
   nr_timer_start(&srs->aperiodic_sched.aperiodic_srs_timer);  // restart the timer, we are scheduling aperiodic SRS

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -1908,8 +1908,9 @@ void update_ul_ue_R_Qm(int mcs, int mcs_table, const NR_PUSCH_Config_t *pusch_Co
   }
 }
 
-static int verify_aperiodic_srs(nr_cell_sched_t *cell, int slot, int k2, NR_timer_t *aperiodic_srs, NR_UE_UL_BWP_t *current_BWP)
+static int verify_aperiodic_srs(nr_cell_sched_t *cell, int slot, int k2, NR_timer_t *aperiodic_srs, NR_UE_info_t *UE)
 {
+  NR_UE_UL_BWP_t *current_BWP = &UE->current_UL_BWP;
   if (cell->radio_config.do_SRS != APERIODIC_SRS || current_BWP->dci_format == NR_UL_DCI_FORMAT_0_0 || !current_BWP->srs_Config)
     return 0;
 
@@ -1922,17 +1923,10 @@ static int verify_aperiodic_srs(nr_cell_sched_t *cell, int slot, int k2, NR_time
 
   // finally we check if the aperiodic SRS timer has expired
   if (nr_timer_expired(aperiodic_srs)) {
-    NR_SRS_Config_t *srs_config = current_BWP->srs_Config;
-    for(int rs = 0; rs < srs_config->srs_ResourceSetToAddModList->list.count; rs++) {
-      // Find periodic resource set
-      NR_SRS_ResourceSet_t *srs_resource_set = srs_config->srs_ResourceSetToAddModList->list.array[rs];
-      if (srs_resource_set->resourceType.present == NR_SRS_ResourceSet__resourceType_PR_aperiodic) {
-        struct NR_SRS_ResourceSet__resourceType__aperiodic *aperiodic = srs_resource_set->resourceType.choice.aperiodic;
-        int offset = aperiodic->slotOffset ? *aperiodic->slotOffset : 0;
-        if (offset == k2)
-          return aperiodic->aperiodicSRS_ResourceTrigger;
-      }
-    }
+    NR_sched_srs_t *sched_srs = &UE->UE_sched_ctrl.sched_srs;
+    int offset = sched_srs->aperiodic_slotOffset ? *sched_srs->aperiodic_slotOffset : 0;
+    if (offset == k2)
+      return sched_srs->aperiodic_ResourceTrigger;
   }
   return 0;
 }
@@ -2747,7 +2741,7 @@ static int collect_ul_candidates(gNB_MAC_INST *mac,
 
     cand.is_retx = false;
     if (!aperiodic_srs_scheduled) {
-      cand.sched_srs = verify_aperiodic_srs(cell, sched_slot, k2, &sched_ctrl->aperiodic_srs_trigger, current_BWP);
+      cand.sched_srs = verify_aperiodic_srs(cell, sched_slot, k2, &sched_ctrl->sched_srs.aperiodic_srs_timer, UE);
       aperiodic_srs_scheduled = cand.sched_srs > 0;
     } else
       cand.sched_srs = 0;

--- a/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
+++ b/openair2/LAYER2/NR_MAC_gNB/gNB_scheduler_ulsch.c
@@ -779,7 +779,7 @@ static void nr_rx_ra_sdu(gNB_MAC_INST *mac,
     UE->UE_sched_ctrl.ta_frame = (frame + 100) % MAX_FRAME_NUMBER;
     if (!transition_ra_connected_nr_ue(mac, UE)) {
       LOG_E(NR_MAC, "cannot add UE %04x: list is full\n", UE->rnti);
-      delete_nr_ue_data(UE, &mac->UE_info.uid_allocator);
+      delete_nr_ue_data(mac, UE);
     } else {
       LOG_A(NR_MAC, "(rnti 0x%04x) CFRA procedure succeeded!\n", UE->rnti);
     }
@@ -1924,9 +1924,9 @@ static int verify_aperiodic_srs(nr_cell_sched_t *cell, int slot, int k2, NR_time
   // finally we check if the aperiodic SRS timer has expired
   if (nr_timer_expired(aperiodic_srs)) {
     NR_sched_srs_t *sched_srs = &UE->UE_sched_ctrl.sched_srs;
-    int offset = sched_srs->aperiodic_slotOffset ? *sched_srs->aperiodic_slotOffset : 0;
+    int offset = sched_srs->aperiodic_sched.aperiodic_slotOffset ? *sched_srs->aperiodic_sched.aperiodic_slotOffset : 0;
     if (offset == k2)
-      return sched_srs->aperiodic_ResourceTrigger;
+      return sched_srs->aperiodic_sched.aperiodic_ResourceTrigger;
   }
   return 0;
 }
@@ -2741,7 +2741,7 @@ static int collect_ul_candidates(gNB_MAC_INST *mac,
 
     cand.is_retx = false;
     if (!aperiodic_srs_scheduled) {
-      cand.sched_srs = verify_aperiodic_srs(cell, sched_slot, k2, &sched_ctrl->sched_srs.aperiodic_srs_timer, UE);
+      cand.sched_srs = verify_aperiodic_srs(cell, sched_slot, k2, &sched_ctrl->sched_srs.aperiodic_sched.aperiodic_srs_timer, UE);
       aperiodic_srs_scheduled = cand.sched_srs > 0;
     } else
       cand.sched_srs = 0;

--- a/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
@@ -28,7 +28,7 @@ int get_dl_slots_per_period(const frame_structure_t *fs);
 int get_full_ul_slots_per_period(const frame_structure_t *fs);
 int get_full_dl_slots_per_period(const frame_structure_t *fs);
 int get_ul_slot_offset(const frame_structure_t *fs, int idx, bool count_mixed);
-void delete_nr_ue_data(NR_UE_info_t *UE, uid_allocator_t *uia);
+void delete_nr_ue_data(gNB_MAC_INST *mac, NR_UE_info_t *UE);
 
 void mac_top_init_gNB(ngran_node_t node_type,
                       NR_ServingCellConfigCommon_t *scc,
@@ -543,7 +543,7 @@ void nr_mac_trigger_release_complete(gNB_MAC_INST *mac, int rnti);
 void nr_mac_release_ue(gNB_MAC_INST *mac, int rnti);
 bool nr_mac_request_release_ue(const gNB_MAC_INST *nrmac, int rnti);
 void clean_bwp_structures(NR_SpCellConfig_t *spCellConfig);
-
+int set_ideal_period(const nr_cell_sched_t *cell, nr_periodic_channel_t channel_type, int num_pucch_slot);
 bool nr_mac_ue_is_active(const NR_UE_info_t *ue);
 
 void nr_mac_trigger_ul_failure(NR_UE_sched_ctrl_t *sched_ctrl, NR_SubcarrierSpacing_t subcarrier_spacing);

--- a/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
@@ -28,8 +28,9 @@ int get_dl_slots_per_period(const frame_structure_t *fs);
 int get_full_ul_slots_per_period(const frame_structure_t *fs);
 int get_full_dl_slots_per_period(const frame_structure_t *fs);
 int get_ul_slot_offset(const frame_structure_t *fs, int idx, bool count_mixed);
+int get_ul_period_idx_from_abs_slot(const frame_structure_t *fs, int slot, bool count_mixed, int max_period);
 void delete_nr_ue_data(gNB_MAC_INST *mac, NR_UE_info_t *UE);
-
+NR_UE_info_t **get_periodic_ue(periodic_ue_sched_t *p, int ul_idx, int index);
 void mac_top_init_gNB(ngran_node_t node_type,
                       NR_ServingCellConfigCommon_t *scc,
                       const nr_mac_config_t *conf,

--- a/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_proto.h
@@ -29,6 +29,7 @@ int get_full_ul_slots_per_period(const frame_structure_t *fs);
 int get_full_dl_slots_per_period(const frame_structure_t *fs);
 int get_ul_slot_offset(const frame_structure_t *fs, int idx, bool count_mixed);
 int get_ul_period_idx_from_abs_slot(const frame_structure_t *fs, int slot, bool count_mixed, int max_period);
+int nr_srs_ue_per_slot(const nr_mac_config_t *rc);
 void delete_nr_ue_data(gNB_MAC_INST *mac, NR_UE_info_t *UE);
 NR_UE_info_t **get_periodic_ue(periodic_ue_sched_t *p, int ul_idx, int index);
 void mac_top_init_gNB(ngran_node_t node_type,

--- a/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/mac_rrc_dl_handler.c
@@ -574,7 +574,7 @@ static NR_UE_info_t *create_new_UE(gNB_MAC_INST *mac, nr_cell_sched_t *cell, uin
     DevAssert(res);
   } else {
     if (!add_new_UE_RA(mac, UE)) {
-      delete_nr_ue_data(UE, &mac->UE_info.uid_allocator);
+      delete_nr_ue_data(mac, UE);
       LOG_E(NR_MAC, "UE list full while creating new UE\n");
       return NULL;
     }

--- a/openair2/LAYER2/NR_MAC_gNB/main.c
+++ b/openair2/LAYER2/NR_MAC_gNB/main.c
@@ -362,14 +362,15 @@ void mac_top_destroy_gNB(gNB_MAC_INST *mac)
     ASN_STRUCT_FREE(asn_DEF_NR_BCCH_BCH_Message, cc->mib);
     ASN_STRUCT_FREE(asn_DEF_NR_BCCH_DL_SCH_Message, cc->sib1);
     ASN_STRUCT_FREE(asn_DEF_NR_ServingCellConfigCommon, cc->ServingCellConfigCommon);
+    free(cell->period_srs_sched);
   }
   NR_UEs_t *UE_info = &mac->UE_info;
   for (int i = 0; i < sizeofArray(UE_info->connected_ue_list); ++i)
     if (UE_info->connected_ue_list[i])
-      delete_nr_ue_data(UE_info->connected_ue_list[i], &UE_info->uid_allocator);
+      delete_nr_ue_data(mac, UE_info->connected_ue_list[i]);
   for (int i = 0; i < sizeofArray(UE_info->access_ue_list); ++i)
     if (UE_info->access_ue_list[i])
-      delete_nr_ue_data(UE_info->access_ue_list[i], &UE_info->uid_allocator);
+      delete_nr_ue_data(mac, UE_info->access_ue_list[i]);
   if (mac->f1_config.setup_resp)
     free_f1ap_setup_response(mac->f1_config.setup_resp);
   free(mac->f1_config.setup_resp);

--- a/openair2/LAYER2/NR_MAC_gNB/main.c
+++ b/openair2/LAYER2/NR_MAC_gNB/main.c
@@ -351,6 +351,11 @@ void mac_top_init_gNB(ngran_node_t node_type,
   srand48(0);
 }
 
+static void destroy_periodic_sched(periodic_ue_sched_t p)
+{
+  free(p.list);
+}
+
 void mac_top_destroy_gNB(gNB_MAC_INST *mac)
 {
   for (size_t i = 0; i < sizeofArray(mac->cells); i++) {
@@ -362,7 +367,6 @@ void mac_top_destroy_gNB(gNB_MAC_INST *mac)
     ASN_STRUCT_FREE(asn_DEF_NR_BCCH_BCH_Message, cc->mib);
     ASN_STRUCT_FREE(asn_DEF_NR_BCCH_DL_SCH_Message, cc->sib1);
     ASN_STRUCT_FREE(asn_DEF_NR_ServingCellConfigCommon, cc->ServingCellConfigCommon);
-    free(cell->period_srs_sched);
   }
   NR_UEs_t *UE_info = &mac->UE_info;
   for (int i = 0; i < sizeofArray(UE_info->connected_ue_list); ++i)
@@ -375,6 +379,11 @@ void mac_top_destroy_gNB(gNB_MAC_INST *mac)
     free_f1ap_setup_response(mac->f1_config.setup_resp);
   free(mac->f1_config.setup_resp);
   free(mac->positioning_config);
+
+  for (size_t i = 0; i < sizeofArray(mac->cells); i++) {
+    nr_cell_sched_t *cell = &mac->cells[i];
+    destroy_periodic_sched(cell->periodic_srs_config);
+  }
 }
 
 void nr_mac_send_f1_setup_req(void)

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -645,6 +645,14 @@ typedef struct nr_power_control {
   float tpc_in_flight; /// TPCs applied by UE but not yet in average SNR
 } nr_power_control_t;
 
+typedef struct {
+  long usage;
+  NR_SRS_Resource_t *srs_resource;
+  long *aperiodic_slotOffset;
+  long aperiodic_ResourceTrigger;
+  NR_timer_t aperiodic_srs_timer;
+} NR_sched_srs_t;
+
 /*! \brief scheduling control information set through an API */
 typedef struct {
   /// CCE index and aggregation, should be coherent with cce_list
@@ -727,9 +735,9 @@ typedef struct {
   /// "TransmissionActionIndicator" handling
   NR_timer_t transm_timeout;
 
+  NR_sched_srs_t sched_srs;
   /// sri, ul_ri and tpmi based on SRS
   nr_srs_feedback_t srs_feedback;
-  NR_timer_t aperiodic_srs_trigger;
 
   /// per-LC configuration
   seq_arr_t lc_config;

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -1238,6 +1238,12 @@ typedef struct NR_du_stats {
 } NR_du_stats_t;
 
 typedef struct {
+  NR_UE_info_t **list;
+  int max_period; // common multiple of periodicities sharing the table
+  int max_ue_per_slot; // UE capacity per slot instance
+} periodic_ue_sched_t;
+
+typedef struct {
   bool active;
   f1ap_positioning_measurement_req_t meas_req;
 } positioning_measurement_info_t;
@@ -1312,8 +1318,7 @@ typedef struct nr_cell_sched_s {
   NR_Type0_PDCCH_CSS_config_t type0_PDCCH_CSS_config[MAX_NUM_OF_SSB];
   bool first_MIB;
   NR_sched_pdsch_t sib1_pdsch[MAX_NUM_OF_SSB];
-  NR_UE_info_t **period_srs_sched;
-  int srs_period;
+  periodic_ue_sched_t periodic_srs_config;
 
   /// Dedicated UL TDA list, built from frame_structure at config time
   seq_arr_t ul_tda;

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -93,6 +93,12 @@ typedef enum {
   nrRA_WAIT_Msg4_MsgB_ACK,
 } RA_gNB_state_t;
 
+typedef enum {
+  CSI_RS,
+  CSI_MEASUREMENTS,
+  SRS
+} nr_periodic_channel_t;
+
 static const char *const nrra_text[] =
     {"IDLE", "Msg2", "WAIT_MsgA_PUSCH", "WAIT_Msg3", "Msg3_retransmission", "Msg4", "MsgB", "WAIT_Msg4_MsgB_ACK"};
 
@@ -646,11 +652,22 @@ typedef struct nr_power_control {
 } nr_power_control_t;
 
 typedef struct {
-  long usage;
-  NR_SRS_Resource_t *srs_resource;
   long *aperiodic_slotOffset;
   long aperiodic_ResourceTrigger;
   NR_timer_t aperiodic_srs_timer;
+} NR_sched_aperiodic_srs_t;
+
+typedef struct {
+  int periodic_offset;
+} NR_sched_periodic_srs_t;
+
+typedef struct {
+  long usage;
+  NR_SRS_Resource_t *srs_resource;
+  union {
+    NR_sched_aperiodic_srs_t aperiodic_sched;
+    NR_sched_periodic_srs_t periodic_sched;
+  };
 } NR_sched_srs_t;
 
 /*! \brief scheduling control information set through an API */
@@ -1295,6 +1312,8 @@ typedef struct nr_cell_sched_s {
   NR_Type0_PDCCH_CSS_config_t type0_PDCCH_CSS_config[MAX_NUM_OF_SSB];
   bool first_MIB;
   NR_sched_pdsch_t sib1_pdsch[MAX_NUM_OF_SSB];
+  NR_UE_info_t **period_srs_sched;
+  int srs_period;
 
   /// Dedicated UL TDA list, built from frame_structure at config time
   seq_arr_t ul_tda;

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -192,6 +192,19 @@ typedef enum nr_srs_type_e {
   APERIODIC_SRS,
 } nr_srs_type_t;
 
+typedef struct nr_srs_config {
+  /// transmission comb, 2 or 4
+  int comb;
+  /// UEs sharing one symbol through comb offsets, at most comb
+  int ue_per_symbol;
+  /// symbols reserved at the end of a full UL slot
+  int symbols_per_slot;
+  /// last symbol of a full UL slot that SRS may occupy
+  int last_symbol;
+  /// period in slots, 0 to derive it from the cell capacity
+  int periodicity;
+} nr_srs_config_t;
+
 /// Max number of physical RU antenna ports the gNB can be configured with.
 /// Independent of MAX_NUM_SPATIAL_STREAMS (the NFAPI per-PDU wire limit).
 #define NR_MAC_MAX_RU_ANTENNA_PORTS 64
@@ -212,16 +225,7 @@ typedef struct nr_mac_config_s {
   nr_power_config_t pusch;
   /// SNR threshold needed to put or not a PRB in the black list
   int ul_prbblack_SNR_threshold;
-  /// SRS transmission comb, 2 or 4
-  int srs_comb;
-  /// UEs sharing one periodic SRS symbol through comb offsets, at most srs_comb
-  int srs_ue_per_symbol;
-  /// symbols reserved for periodic SRS at the end of a full UL slot
-  int srs_symbols_per_slot;
-  /// last symbol of a full UL slot that periodic SRS may occupy
-  int srs_last_symbol;
-  /// periodic SRS period in slots, 0 to derive it from the cell capacity
-  int srs_periodicity;
+  nr_srs_config_t srs;
   nr_power_config_t pucch;
   nr_mac_timers_t timer_config;
   int num_dlharq;

--- a/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_mac_gNB.h
@@ -212,6 +212,16 @@ typedef struct nr_mac_config_s {
   nr_power_config_t pusch;
   /// SNR threshold needed to put or not a PRB in the black list
   int ul_prbblack_SNR_threshold;
+  /// SRS transmission comb, 2 or 4
+  int srs_comb;
+  /// UEs sharing one periodic SRS symbol through comb offsets, at most srs_comb
+  int srs_ue_per_symbol;
+  /// symbols reserved for periodic SRS at the end of a full UL slot
+  int srs_symbols_per_slot;
+  /// last symbol of a full UL slot that periodic SRS may occupy
+  int srs_last_symbol;
+  /// periodic SRS period in slots, 0 to derive it from the cell capacity
+  int srs_periodicity;
   nr_power_config_t pucch;
   nr_mac_timers_t timer_config;
   int num_dlharq;

--- a/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
@@ -204,7 +204,7 @@ static int get_pucch2_size(const int num_ant_ports)
   return (num_ant_ports <= 4 ? 8 : 12);
 }
 
-static int get_nb_pucch2_per_slot(const NR_ServingCellConfigCommon_t *scc, int bwp_size, const nr_pdsch_AntennaPorts_t *ap)
+static int get_nb_pucch2_per_slot(const NR_ServingCellConfigCommon_t *scc, int bwp_size, int num_ap)
 {
   const NR_TDD_UL_DL_Pattern_t *tdd = scc->tdd_UL_DL_ConfigurationCommon ? &scc->tdd_UL_DL_ConfigurationCommon->pattern1 : NULL;
   const int n_slots_frame = slotsperframe[*scc->ssbSubcarrierSpacing];
@@ -214,7 +214,7 @@ static int get_nb_pucch2_per_slot(const NR_ServingCellConfigCommon_t *scc, int b
   int max_csi_reports = MAX_MOBILES_PER_GNB << 1; // 2 reports per UE (RSRP and RI-PMI-CQI)
   int available_report_occasions = max_meas_report_period * ul_slots_period / n_slots_period;
   int nb_pucch2 = (max_csi_reports / (available_report_occasions + 1)) + 1;
-  int pucch2_size = get_pucch2_size(ap->N1 * ap->N2 * ap->XP);
+  int pucch2_size = get_pucch2_size(num_ap);
   // in current implementation we need (nb_pucch2 * pucch2_size) prbs for PUCCH2
   // and MAX_MOBILES_PER_GNB prbs for PUCCH1
   // checked for validity in verify_radio_configuration
@@ -359,7 +359,7 @@ static bool check_periodicity(int val, int ideal_period, const frame_structure_t
   return (ideal_period < val + 1) && valid_periodicity_for_tdd_period;
 }
 
-static int set_ideal_period(const nr_cell_sched_t *cell, nr_periodic_channel_t channel_type)
+static int set_ideal_period(const nr_cell_sched_t *cell, nr_periodic_channel_t channel_type, int num_pucch_slot)
 {
   const frame_structure_t *fs = &cell->frame_structure;
   const int nb_slots_per_period = fs->numb_slots_period;
@@ -378,7 +378,7 @@ static int set_ideal_period(const nr_cell_sched_t *cell, nr_periodic_channel_t c
     case CSI_RS:
     case CSI_MEASUREMENTS: {
       int csi_periodicities[10] = {4, 5, 8, 10, 16, 20, 40, 80, 160, 320};
-      int csi_ideal_period = MAX_MOBILES_PER_GNB * 2 * nb_slots_per_period / n_ul_slots_per_period;
+      int csi_ideal_period = MAX_MOBILES_PER_GNB * 2 * nb_slots_per_period / (n_ul_slots_per_period * num_pucch_slot);
       for (int i = 0; i < 10; i++) {
         if (check_periodicity(csi_periodicities[i], csi_ideal_period, fs))
           return csi_periodicities[i];
@@ -440,7 +440,7 @@ static NR_NZP_CSI_RS_Resource_t *get_nzp_csi_rs_resource(int id,
                                                          int num_dl_antenna_ports,
                                                          int curr_bwp,
                                                          int symbol_index,
-                                                         long scramblingID,
+                                                         const NR_ServingCellConfigCommon_t *scc,
                                                          const nr_cell_sched_t *cell)
 {
   NR_NZP_CSI_RS_Resource_t *nzpcsi = calloc(1, sizeof(*nzpcsi));
@@ -508,8 +508,9 @@ static NR_NZP_CSI_RS_Resource_t *get_nzp_csi_rs_resource(int id,
   nzpcsi->powerControlOffset = 0;
   nzpcsi->powerControlOffsetSS = calloc(1, sizeof(*nzpcsi->powerControlOffsetSS));
   *nzpcsi->powerControlOffsetSS = NR_NZP_CSI_RS_Resource__powerControlOffsetSS_db0;
-  nzpcsi->scramblingID = scramblingID;
-  const int ideal_period = set_ideal_period(cell, CSI_RS); // same periodicity as CSI measurement report
+  nzpcsi->scramblingID = *scc->physCellId;
+  const int num_pucch2 = get_nb_pucch2_per_slot(scc, curr_bwp, num_dl_antenna_ports);
+  const int ideal_period = set_ideal_period(cell, CSI_RS, num_pucch2); // same periodicity as CSI measurement report
   const frame_structure_t *fs = &cell->frame_structure;
   set_csirs_periodicity(nzpcsi, id, ideal_period, fs);
   nzpcsi->qcl_InfoPeriodicCSI_RS = calloc(1, sizeof(*nzpcsi->qcl_InfoPeriodicCSI_RS));
@@ -543,7 +544,7 @@ static void config_csirs(const NR_ServingCellConfigCommon_t *servingcellconfigco
     if (!csi_MeasConfig->nzp_CSI_RS_ResourceToAddModList)
       csi_MeasConfig->nzp_CSI_RS_ResourceToAddModList = calloc(1, sizeof(*csi_MeasConfig->nzp_CSI_RS_ResourceToAddModList));
     NR_NZP_CSI_RS_Resource_t *nzpcsi0 =
-        get_nzp_csi_rs_resource(id, num_dl_antenna_ports, curr_bwp, symbol_index, *servingcellconfigcommon->physCellId, cell);
+        get_nzp_csi_rs_resource(id, num_dl_antenna_ports, curr_bwp, symbol_index, servingcellconfigcommon, cell);
     asn1cSeqAdd(&csi_MeasConfig->nzp_CSI_RS_ResourceToAddModList->list, nzpcsi0);
 
     // Add NZP CSI-RS Resource ID: identifier used to reference one NZP-CSI-RS-Resource
@@ -708,7 +709,7 @@ static struct NR_SRS_Resource__resourceType__periodic *configure_periodic_srs(co
   int offset = get_ul_slot_offset(fs, uid, false); // only full UL slots for SRS
   // checked for validity in verify_radio_configuration
   AssertFatal(offset < 2560, "Cannot allocate SRS configuration for uid %d, not enough resources\n", uid);
-  const int ideal_period = set_ideal_period(cell, SRS);
+  const int ideal_period = set_ideal_period(cell, SRS, 0);
 
   struct NR_SRS_Resource__resourceType__periodic *periodic_srs = calloc(1,sizeof(*periodic_srs));
   if (ideal_period == 4) {
@@ -1261,11 +1262,11 @@ static void config_pucch_resset0(const NR_ServingCellConfigCommon_t *scc,
     long *pucch_F0_2WithoutFH = uecap->phy_Parameters.phy_ParametersFRX_Diff->pucch_F0_2WithoutFH;
     AssertFatal(pucch_F0_2WithoutFH == NULL,"UE does not support PUCCH F0 without frequency hopping. Current configuration is without FH\n");
   }
-
-  int pucch2_size = get_pucch2_size(ap->N1 * ap->N2 * ap->XP);
+  int num_ap = ap->N1 * ap->N2 * ap->XP;
+  int pucch2_size = get_pucch2_size(num_ap);
   NR_PUCCH_Resource_t *pucchres0 = calloc(1,sizeof(*pucchres0));
   pucchres0->pucch_ResourceId = *pucchid;
-  int num_pucch2 = get_nb_pucch2_per_slot(scc, curr_bwp, ap);
+  int num_pucch2 = get_nb_pucch2_per_slot(scc, curr_bwp, num_ap);
   pucchres0->startingPRB = (pucch2_size * num_pucch2) + uid;
   // checked for validity in verify_radio_configuration
   AssertFatal(pucchres0->startingPRB < curr_bwp, "Not enough resources in current BWP (size %d) to allocate uid %d\n", curr_bwp, uid);
@@ -1301,11 +1302,11 @@ static void config_pucch_resset1(const NR_ServingCellConfigCommon_t *scc,
     long *pucch_F0_2WithoutFH = uecap->phy_Parameters.phy_ParametersFRX_Diff->pucch_F0_2WithoutFH;
     AssertFatal(pucch_F0_2WithoutFH == NULL,"UE does not support PUCCH F2 without frequency hopping. Current configuration is without FH\n");
   }
-
-  int pucch2_size = get_pucch2_size(ap->N1 * ap->N2 * ap->XP);
+  int num_ap = ap->N1 * ap->N2 * ap->XP;
+  int pucch2_size = get_pucch2_size(num_ap);
   NR_PUCCH_Resource_t *pucchres2 = calloc(1,sizeof(*pucchres2));
   pucchres2->pucch_ResourceId = *pucchressetid;
-  int num_pucch2 = get_nb_pucch2_per_slot(scc, curr_bwp, ap);
+  int num_pucch2 = get_nb_pucch2_per_slot(scc, curr_bwp, num_ap);
   pucchres2->startingPRB = pucch2_size * (uid % num_pucch2);
   pucchres2->intraSlotFrequencyHopping = NULL;
   pucchres2->secondHopPRB = NULL;
@@ -1979,8 +1980,8 @@ static void set_csi_meas_periodicity(const nr_cell_sched_t *cell,
                                      const nr_pdsch_AntennaPorts_t *antennaports,
                                      bool is_rsrp)
 {
-  const int ideal_period = set_ideal_period(cell, CSI_MEASUREMENTS);
-  const int num_pucch2 = get_nb_pucch2_per_slot(scc, curr_bwp, antennaports);
+  const int num_pucch2 = get_nb_pucch2_per_slot(scc, curr_bwp, antennaports->N1 * antennaports->N2 * antennaports->XP);
+  const int ideal_period = set_ideal_period(cell, CSI_MEASUREMENTS, num_pucch2);
   const int idx = (uid * 2 / num_pucch2) + is_rsrp;
   const frame_structure_t *fs = &cell->frame_structure;
   int offset = get_ul_slot_offset(fs, idx, true);
@@ -3817,9 +3818,10 @@ static bool verify_radio_configuration(int uid,
   }
 
   const nr_pdsch_AntennaPorts_t *ap = &configuration->pdsch_AntennaPorts;
-  int pucch2_size = get_pucch2_size(ap->N1 * ap->N2 * ap->XP);
+  int num_ap = ap->N1 * ap->N2 * ap->XP;
+  int pucch2_size = get_pucch2_size(num_ap);
   int curr_bwp = NRRIV2BW(scc->downlinkConfigCommon->initialDownlinkBWP->genericParameters.locationAndBandwidth, MAX_BWP_SIZE);
-  int num_pucch2 = get_nb_pucch2_per_slot(scc, curr_bwp, ap);
+  int num_pucch2 = get_nb_pucch2_per_slot(scc, curr_bwp, num_ap);
   int pucchres0_startingPRB = (pucch2_size * num_pucch2) + uid;
   // see config_pucch_resset0
   if (pucchres0_startingPRB >= curr_bwp) {

--- a/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
@@ -347,50 +347,6 @@ uint64_t get_ssb_bitmap(const NR_ServingCellConfigCommon_t *scc)
   return bitmap;
 }
 
-typedef enum {
-  CSI_RS,
-  CSI_MEASUREMENTS,
-  SRS
-} nr_periodic_channel_t;
-
-static bool check_periodicity(int val, int ideal_period, const frame_structure_t *fs)
-{
-  bool valid_periodicity_for_tdd_period = fs->frame_type == FDD ? true : (val % fs->numb_slots_period == 0);
-  return (ideal_period < val + 1) && valid_periodicity_for_tdd_period;
-}
-
-static int set_ideal_period(const nr_cell_sched_t *cell, nr_periodic_channel_t channel_type, int num_pucch_slot)
-{
-  const frame_structure_t *fs = &cell->frame_structure;
-  const int nb_slots_per_period = fs->numb_slots_period;
-  const int n_ul_slots_per_period = get_ul_slots_per_period(fs); // full UL + mixed with UL symbols
-  // 2 reports per UE (RSRP and RI-PMI-CQI)
-  switch (channel_type) {
-    case SRS: {
-      int srs_periodicities[17] = {1, 2, 4, 5, 8, 10, 16, 20, 32, 40, 64, 80, 160, 320, 640, 1280, 2560};
-      int srs_ideal_period = nb_slots_per_period * MAX_MOBILES_PER_GNB;
-      for (int i = 0; i < 17; i++) {
-        if (check_periodicity(srs_periodicities[i], srs_ideal_period, fs))
-          return srs_periodicities[i];
-      }
-      break;
-    }
-    case CSI_RS:
-    case CSI_MEASUREMENTS: {
-      int csi_periodicities[10] = {4, 5, 8, 10, 16, 20, 40, 80, 160, 320};
-      int csi_ideal_period = MAX_MOBILES_PER_GNB * 2 * nb_slots_per_period / (n_ul_slots_per_period * num_pucch_slot);
-      for (int i = 0; i < 10; i++) {
-        if (check_periodicity(csi_periodicities[i], csi_ideal_period, fs))
-          return csi_periodicities[i];
-      }
-      break;
-    }
-    default:
-      AssertFatal(false, "Invalid periodic channel type");
-  }
-  return 0;
-}
-
 static void set_csirs_periodicity(NR_NZP_CSI_RS_Resource_t *nzpcsi0,
                                   int offset,
                                   int ideal_period,

--- a/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
@@ -347,19 +347,48 @@ uint64_t get_ssb_bitmap(const NR_ServingCellConfigCommon_t *scc)
   return bitmap;
 }
 
+typedef enum {
+  CSI_RS,
+  CSI_MEASUREMENTS,
+  SRS
+} nr_periodic_channel_t;
+
 static bool check_periodicity(int val, int ideal_period, const frame_structure_t *fs)
 {
   bool valid_periodicity_for_tdd_period = fs->frame_type == FDD ? true : (val % fs->numb_slots_period == 0);
   return (ideal_period < val + 1) && valid_periodicity_for_tdd_period;
 }
 
-static int set_ideal_period(const nr_cell_sched_t *cell, bool is_csi)
+static int set_ideal_period(const nr_cell_sched_t *cell, nr_periodic_channel_t channel_type)
 {
   const frame_structure_t *fs = &cell->frame_structure;
   const int nb_slots_per_period = fs->numb_slots_period;
   const int n_ul_slots_per_period = get_ul_slots_per_period(fs); // full UL + mixed with UL symbols
   // 2 reports per UE (RSRP and RI-PMI-CQI)
-  return is_csi ? MAX_MOBILES_PER_GNB * 2 * nb_slots_per_period / n_ul_slots_per_period : nb_slots_per_period * MAX_MOBILES_PER_GNB;
+  switch (channel_type) {
+    case SRS: {
+      int srs_periodicities[17] = {1, 2, 4, 5, 8, 10, 16, 20, 32, 40, 64, 80, 160, 320, 640, 1280, 2560};
+      int srs_ideal_period = nb_slots_per_period * MAX_MOBILES_PER_GNB;
+      for (int i = 0; i < 17; i++) {
+        if (check_periodicity(srs_periodicities[i], srs_ideal_period, fs))
+          return srs_periodicities[i];
+      }
+      break;
+    }
+    case CSI_RS:
+    case CSI_MEASUREMENTS: {
+      int csi_periodicities[10] = {4, 5, 8, 10, 16, 20, 40, 80, 160, 320};
+      int csi_ideal_period = MAX_MOBILES_PER_GNB * 2 * nb_slots_per_period / n_ul_slots_per_period;
+      for (int i = 0; i < 10; i++) {
+        if (check_periodicity(csi_periodicities[i], csi_ideal_period, fs))
+          return csi_periodicities[i];
+      }
+      break;
+    }
+    default:
+      AssertFatal(false, "Invalid periodic channel type");
+  }
+  return 0;
 }
 
 static void set_csirs_periodicity(NR_NZP_CSI_RS_Resource_t *nzpcsi0,
@@ -370,49 +399,41 @@ static void set_csirs_periodicity(NR_NZP_CSI_RS_Resource_t *nzpcsi0,
   nzpcsi0->periodicityAndOffset = calloc(1,sizeof(*nzpcsi0->periodicityAndOffset));
   // TODO ideal period to be set according to estimation by the gNB on how fast the channel changes
   AssertFatal(offset < ideal_period, "CSI-RS offset %d goes beyond the assumed period %d\n", offset, ideal_period);
-  if (check_periodicity(4, ideal_period, fs)) {
+  if (ideal_period == 4) {
     nzpcsi0->periodicityAndOffset->present = NR_CSI_ResourcePeriodicityAndOffset_PR_slots4;
     nzpcsi0->periodicityAndOffset->choice.slots4 = offset;
-  }
-  else if (check_periodicity(5, ideal_period, fs)) {
+  } else if (ideal_period == 5) {
     nzpcsi0->periodicityAndOffset->present = NR_CSI_ResourcePeriodicityAndOffset_PR_slots5;
     nzpcsi0->periodicityAndOffset->choice.slots5 = offset;
-  }
-  else if (check_periodicity(8, ideal_period, fs)) {
+  } else if (ideal_period == 8) {
     nzpcsi0->periodicityAndOffset->present = NR_CSI_ResourcePeriodicityAndOffset_PR_slots8;
     nzpcsi0->periodicityAndOffset->choice.slots8 = offset;
-  }
-  else if (check_periodicity(10, ideal_period, fs)) {
+  } else if (ideal_period == 10) {
     nzpcsi0->periodicityAndOffset->present = NR_CSI_ResourcePeriodicityAndOffset_PR_slots10;
     nzpcsi0->periodicityAndOffset->choice.slots10 = offset;
-  }
-  else if (check_periodicity(16, ideal_period, fs)) {
+  } else if (ideal_period == 16) {
     nzpcsi0->periodicityAndOffset->present = NR_CSI_ResourcePeriodicityAndOffset_PR_slots16;
     nzpcsi0->periodicityAndOffset->choice.slots16 = offset;
-  }
-  else if (check_periodicity(20, ideal_period, fs)) {
+  } else if (ideal_period == 20) {
     nzpcsi0->periodicityAndOffset->present = NR_CSI_ResourcePeriodicityAndOffset_PR_slots20;
     nzpcsi0->periodicityAndOffset->choice.slots20 = offset;
-  }
-  else if (check_periodicity(40, ideal_period, fs)) {
+  } else if (ideal_period == 40) {
     nzpcsi0->periodicityAndOffset->present = NR_CSI_ResourcePeriodicityAndOffset_PR_slots40;
     nzpcsi0->periodicityAndOffset->choice.slots40 = offset;
-  }
-  else if (check_periodicity(80, ideal_period, fs)) {
+  } else if (ideal_period == 80) {
     nzpcsi0->periodicityAndOffset->present = NR_CSI_ResourcePeriodicityAndOffset_PR_slots80;
     nzpcsi0->periodicityAndOffset->choice.slots80 = offset;
-  }
-  else if (check_periodicity(160, ideal_period, fs)) {
+  } else if (ideal_period == 160) {
     nzpcsi0->periodicityAndOffset->present = NR_CSI_ResourcePeriodicityAndOffset_PR_slots160;
     nzpcsi0->periodicityAndOffset->choice.slots160 = offset;
-  }
-  else {
+  } else if (ideal_period == 320) {
     nzpcsi0->periodicityAndOffset->present = NR_CSI_ResourcePeriodicityAndOffset_PR_slots320;
     const int nb_dl_slots_period = get_full_dl_slots_per_period(fs); // full DL slots
     // checked for validity in verify_radio_configuration
     AssertFatal(offset / 320 < nb_dl_slots_period, "Cannot allocate CSI-RS for BWP %d. Not enough resources for CSI-RS\n", offset);
     nzpcsi0->periodicityAndOffset->choice.slots320 = (offset % 320) + (offset / 320);
-  }
+  } else
+    AssertFatal(false, "Invalid CSIRS period %d\n", ideal_period);
 }
 
 static NR_NZP_CSI_RS_Resource_t *get_nzp_csi_rs_resource(int id,
@@ -488,7 +509,7 @@ static NR_NZP_CSI_RS_Resource_t *get_nzp_csi_rs_resource(int id,
   nzpcsi->powerControlOffsetSS = calloc(1, sizeof(*nzpcsi->powerControlOffsetSS));
   *nzpcsi->powerControlOffsetSS = NR_NZP_CSI_RS_Resource__powerControlOffsetSS_db0;
   nzpcsi->scramblingID = scramblingID;
-  const int ideal_period = set_ideal_period(cell, true); // same periodicity as CSI measurement report
+  const int ideal_period = set_ideal_period(cell, CSI_RS); // same periodicity as CSI measurement report
   const frame_structure_t *fs = &cell->frame_structure;
   set_csirs_periodicity(nzpcsi, id, ideal_period, fs);
   nzpcsi->qcl_InfoPeriodicCSI_RS = calloc(1, sizeof(*nzpcsi->qcl_InfoPeriodicCSI_RS));
@@ -687,69 +708,56 @@ static struct NR_SRS_Resource__resourceType__periodic *configure_periodic_srs(co
   int offset = get_ul_slot_offset(fs, uid, false); // only full UL slots for SRS
   // checked for validity in verify_radio_configuration
   AssertFatal(offset < 2560, "Cannot allocate SRS configuration for uid %d, not enough resources\n", uid);
-  const int ideal_period = set_ideal_period(cell,false);
+  const int ideal_period = set_ideal_period(cell, SRS);
 
   struct NR_SRS_Resource__resourceType__periodic *periodic_srs = calloc(1,sizeof(*periodic_srs));
-  if (check_periodicity(4, ideal_period, fs)) {
+  if (ideal_period == 4) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl4;
     periodic_srs->periodicityAndOffset_p.choice.sl4 = offset;
-  }
-  else if (check_periodicity(5, ideal_period, fs)) {
+  } else if (ideal_period == 5) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl5;
     periodic_srs->periodicityAndOffset_p.choice.sl5 = offset;
-  }
-  else if (check_periodicity(8, ideal_period, fs)) {
+  } else if (ideal_period == 8) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl8;
     periodic_srs->periodicityAndOffset_p.choice.sl8 = offset;
-  }
-  else if (check_periodicity(10, ideal_period, fs)) {
+  } else if (ideal_period == 10) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl10;
     periodic_srs->periodicityAndOffset_p.choice.sl10 = offset;
-  }
-  else if (check_periodicity(16, ideal_period, fs)) {
+  } else if (ideal_period == 16) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl16;
     periodic_srs->periodicityAndOffset_p.choice.sl16 = offset;
-  }
-  else if (check_periodicity(20, ideal_period, fs)) {
+  } else if (ideal_period == 20) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl20;
     periodic_srs->periodicityAndOffset_p.choice.sl20 = offset;
-  }
-  else if (check_periodicity(32, ideal_period, fs)) {
+  } else if (ideal_period == 32) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl32;
     periodic_srs->periodicityAndOffset_p.choice.sl32 = offset;
-  }
-  else if (check_periodicity(40, ideal_period, fs)) {
+  } else if (ideal_period == 40) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl40;
     periodic_srs->periodicityAndOffset_p.choice.sl40 = offset;
-  }
-  else if (check_periodicity(64, ideal_period, fs)) {
+  } else if (ideal_period == 64) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl64;
     periodic_srs->periodicityAndOffset_p.choice.sl64 = offset;
-  }
-  else if (check_periodicity(80, ideal_period, fs)) {
+  } else if (ideal_period == 80) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl80;
     periodic_srs->periodicityAndOffset_p.choice.sl80 = offset;
-  }
-  else if (check_periodicity(160, ideal_period, fs)) {
+  } else if (ideal_period == 160) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl160;
     periodic_srs->periodicityAndOffset_p.choice.sl160 = offset;
-  }
-  else if (check_periodicity(320, ideal_period, fs)) {
+  } else if (ideal_period == 320) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl320;
     periodic_srs->periodicityAndOffset_p.choice.sl320 = offset;
-  }
-  else if (check_periodicity(640, ideal_period, fs)) {
+  } else if (ideal_period == 640) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl640;
     periodic_srs->periodicityAndOffset_p.choice.sl640 = offset;
-  }
-  else if (check_periodicity(1280, ideal_period, fs)) {
+  } else if (ideal_period == 1280) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl1280;
     periodic_srs->periodicityAndOffset_p.choice.sl1280 = offset;
-  }
-  else {
+  } else if (ideal_period == 2560) {
     periodic_srs->periodicityAndOffset_p.present = NR_SRS_PeriodicityAndOffset_PR_sl2560;
     periodic_srs->periodicityAndOffset_p.choice.sl2560 = offset;
-  }
+  } else
+    AssertFatal(false, "Invalid SRS periodicity %d\n", ideal_period);
   return periodic_srs;
 }
 
@@ -1971,7 +1979,7 @@ static void set_csi_meas_periodicity(const nr_cell_sched_t *cell,
                                      const nr_pdsch_AntennaPorts_t *antennaports,
                                      bool is_rsrp)
 {
-  const int ideal_period = set_ideal_period(cell, true);
+  const int ideal_period = set_ideal_period(cell, CSI_MEASUREMENTS);
   const int num_pucch2 = get_nb_pucch2_per_slot(scc, curr_bwp, antennaports);
   const int idx = (uid * 2 / num_pucch2) + is_rsrp;
   const frame_structure_t *fs = &cell->frame_structure;
@@ -1979,37 +1987,38 @@ static void set_csi_meas_periodicity(const nr_cell_sched_t *cell,
   LOG_D(NR_MAC, "set_csi_meas_periodicity: uid = %d, offset = %d, ideal_period = %d", uid, offset, ideal_period);
   // checked for validity in verify_radio_configuration
   AssertFatal(offset < 320, "Not enough UL slots to accomodate all possible UEs. Need to rework the implementation\n");
-  if (check_periodicity(4, ideal_period, fs)) {
+  if (ideal_period == 4) {
     csirep->reportConfigType.choice.periodic->reportSlotConfig.present = NR_CSI_ReportPeriodicityAndOffset_PR_slots4;
     csirep->reportConfigType.choice.periodic->reportSlotConfig.choice.slots4 = offset;
-  } else if (check_periodicity(5, ideal_period, fs)) {
+  } else if (ideal_period == 5) {
     csirep->reportConfigType.choice.periodic->reportSlotConfig.present = NR_CSI_ReportPeriodicityAndOffset_PR_slots5;
     csirep->reportConfigType.choice.periodic->reportSlotConfig.choice.slots5 = offset;
-  } else if (check_periodicity(8, ideal_period, fs)) {
+  } else if (ideal_period == 8) {
     csirep->reportConfigType.choice.periodic->reportSlotConfig.present = NR_CSI_ReportPeriodicityAndOffset_PR_slots8;
     csirep->reportConfigType.choice.periodic->reportSlotConfig.choice.slots8 = offset;
-  } else if (check_periodicity(10, ideal_period, fs)) {
+  } else if (ideal_period == 10) {
     csirep->reportConfigType.choice.periodic->reportSlotConfig.present = NR_CSI_ReportPeriodicityAndOffset_PR_slots10;
     csirep->reportConfigType.choice.periodic->reportSlotConfig.choice.slots10 = offset;
-  } else if (check_periodicity(16, ideal_period, fs)) {
+  } else if (ideal_period == 16) {
     csirep->reportConfigType.choice.periodic->reportSlotConfig.present = NR_CSI_ReportPeriodicityAndOffset_PR_slots16;
     csirep->reportConfigType.choice.periodic->reportSlotConfig.choice.slots16 = offset;
-  } else if (check_periodicity(20, ideal_period, fs)) {
+  } else if (ideal_period == 20) {
     csirep->reportConfigType.choice.periodic->reportSlotConfig.present = NR_CSI_ReportPeriodicityAndOffset_PR_slots20;
     csirep->reportConfigType.choice.periodic->reportSlotConfig.choice.slots20 = offset;
-  } else if (check_periodicity(40, ideal_period, fs)) {
+  } else if (ideal_period == 40) {
     csirep->reportConfigType.choice.periodic->reportSlotConfig.present = NR_CSI_ReportPeriodicityAndOffset_PR_slots40;
     csirep->reportConfigType.choice.periodic->reportSlotConfig.choice.slots40 = offset;
-  } else if (check_periodicity(80, ideal_period, fs)) {
+  } else if (ideal_period == 80) {
     csirep->reportConfigType.choice.periodic->reportSlotConfig.present = NR_CSI_ReportPeriodicityAndOffset_PR_slots80;
     csirep->reportConfigType.choice.periodic->reportSlotConfig.choice.slots80 = offset;
-  } else if (check_periodicity(160, ideal_period, fs)) {
+  } else if (ideal_period == 160) {
     csirep->reportConfigType.choice.periodic->reportSlotConfig.present = NR_CSI_ReportPeriodicityAndOffset_PR_slots160;
     csirep->reportConfigType.choice.periodic->reportSlotConfig.choice.slots160 = offset;
-  } else {
+  } else if (ideal_period == 320) {
     csirep->reportConfigType.choice.periodic->reportSlotConfig.present = NR_CSI_ReportPeriodicityAndOffset_PR_slots320;
     csirep->reportConfigType.choice.periodic->reportSlotConfig.choice.slots320 = offset;
-  }
+  } else
+    AssertFatal(false, "Invalid CSI measurements periodicity %d\n", ideal_period);
 }
 
 static NR_CodebookConfig_t *config_csi_codebook(const nr_pdsch_AntennaPorts_t *antennaports, const int max_layers)

--- a/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
@@ -809,7 +809,7 @@ static NR_SRS_Resource_t *get_srs_resource(const NR_UE_NR_Capability_t *uecap,
   srs_res->transmissionComb.present = tx_comb;
   // UEs sharing a slot are separated by comb offset first, then moved to an earlier symbol
   const int idx_in_slot = uid % nr_srs_ue_per_slot(&cell->radio_config);
-  const int comb_offset = idx_in_slot % cell->radio_config.srs_ue_per_symbol;
+  const int comb_offset = idx_in_slot % cell->radio_config.srs.ue_per_symbol;
   switch (tx_comb) {
     case NR_SRS_Resource__transmissionComb_PR_n2:
       srs_res->transmissionComb.choice.n2 = calloc_or_fail(1, sizeof(*srs_res->transmissionComb.choice.n2));
@@ -824,9 +824,9 @@ static NR_SRS_Resource_t *get_srs_resource(const NR_UE_NR_Capability_t *uecap,
     default:
       AssertFatal(1 == 0, "Invalid transmission comb %d\n", tx_comb);
   }
-  // 38.211 counts startPosition back from symbol 13, so srs_last_symbol 12 gives startPosition 1
-  const int first_position = NR_SYMBOLS_PER_SLOT - 1 - cell->radio_config.srs_last_symbol;
-  srs_res->resourceMapping.startPosition = first_position + idx_in_slot / cell->radio_config.srs_ue_per_symbol;
+  // 38.211 counts startPosition back from symbol 13, so last_symbol 12 gives startPosition 1
+  const int first_position = NR_SYMBOLS_PER_SLOT - 1 - cell->radio_config.srs.last_symbol;
+  srs_res->resourceMapping.startPosition = first_position + idx_in_slot / cell->radio_config.srs.ue_per_symbol;
   srs_res->resourceMapping.nrofSymbols = NR_SRS_Resource__resourceMapping__nrofSymbols_n1;
   srs_res->resourceMapping.repetitionFactor = NR_SRS_Resource__resourceMapping__repetitionFactor_n1;
   srs_res->freqDomainPosition = 0;
@@ -867,7 +867,7 @@ static NR_SetupRelease_SRS_Config_t *get_config_srs(const NR_ServingCellConfigCo
   NR_SRS_Config_t *srs_Config = setup_release_srs_Config->choice.setup;
 
   srs_Config->srs_ResourceToAddModList = calloc_or_fail(1, sizeof(*srs_Config->srs_ResourceToAddModList));
-  const NR_SRS_Resource__transmissionComb_PR tx_comb = cell->radio_config.srs_comb == 4
+  const NR_SRS_Resource__transmissionComb_PR tx_comb = cell->radio_config.srs.comb == 4
                                                            ? NR_SRS_Resource__transmissionComb_PR_n4
                                                            : NR_SRS_Resource__transmissionComb_PR_n2;
   NR_SRS_Resource_t *srs_res0 = get_srs_resource(uecap, cell, curr_bwp, uid, res_id, maxMIMO_Layers, tx_comb, do_srs);

--- a/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.c
@@ -662,7 +662,7 @@ static void set_dl_maxmimolayers(NR_PDSCH_ServingCellConfig_t *pdsch_servingcell
 static struct NR_SRS_Resource__resourceType__periodic *configure_periodic_srs(const int uid, const nr_cell_sched_t *cell)
 {
   const frame_structure_t *fs = &cell->frame_structure;
-  int offset = get_ul_slot_offset(fs, uid, false); // only full UL slots for SRS
+  int offset = get_ul_slot_offset(fs, uid / nr_srs_ue_per_slot(&cell->radio_config), false); // only full UL slots for SRS
   // checked for validity in verify_radio_configuration
   AssertFatal(offset < 2560, "Cannot allocate SRS configuration for uid %d, not enough resources\n", uid);
   const int ideal_period = set_ideal_period(cell, SRS, 0);
@@ -807,21 +807,26 @@ static NR_SRS_Resource_t *get_srs_resource(const NR_UE_NR_Capability_t *uecap,
 
   srs_res->ptrs_PortIndex = NULL;
   srs_res->transmissionComb.present = tx_comb;
+  // UEs sharing a slot are separated by comb offset first, then moved to an earlier symbol
+  const int idx_in_slot = uid % nr_srs_ue_per_slot(&cell->radio_config);
+  const int comb_offset = idx_in_slot % cell->radio_config.srs_ue_per_symbol;
   switch (tx_comb) {
     case NR_SRS_Resource__transmissionComb_PR_n2:
       srs_res->transmissionComb.choice.n2 = calloc_or_fail(1, sizeof(*srs_res->transmissionComb.choice.n2));
-      srs_res->transmissionComb.choice.n2->combOffset_n2 = 0;
+      srs_res->transmissionComb.choice.n2->combOffset_n2 = comb_offset;
       srs_res->transmissionComb.choice.n2->cyclicShift_n2 = 0;
       break;
     case NR_SRS_Resource__transmissionComb_PR_n4:
       srs_res->transmissionComb.choice.n4 = calloc_or_fail(1, sizeof(*srs_res->transmissionComb.choice.n4));
-      srs_res->transmissionComb.choice.n4->combOffset_n4 = 0;
+      srs_res->transmissionComb.choice.n4->combOffset_n4 = comb_offset;
       srs_res->transmissionComb.choice.n4->cyclicShift_n4 = 0;
       break;
     default:
       AssertFatal(1 == 0, "Invalid transmission comb %d\n", tx_comb);
   }
-  srs_res->resourceMapping.startPosition = 1;
+  // 38.211 counts startPosition back from symbol 13, so srs_last_symbol 12 gives startPosition 1
+  const int first_position = NR_SYMBOLS_PER_SLOT - 1 - cell->radio_config.srs_last_symbol;
+  srs_res->resourceMapping.startPosition = first_position + idx_in_slot / cell->radio_config.srs_ue_per_symbol;
   srs_res->resourceMapping.nrofSymbols = NR_SRS_Resource__resourceMapping__nrofSymbols_n1;
   srs_res->resourceMapping.repetitionFactor = NR_SRS_Resource__resourceMapping__repetitionFactor_n1;
   srs_res->freqDomainPosition = 0;
@@ -862,8 +867,10 @@ static NR_SetupRelease_SRS_Config_t *get_config_srs(const NR_ServingCellConfigCo
   NR_SRS_Config_t *srs_Config = setup_release_srs_Config->choice.setup;
 
   srs_Config->srs_ResourceToAddModList = calloc_or_fail(1, sizeof(*srs_Config->srs_ResourceToAddModList));
-  NR_SRS_Resource_t *srs_res0 =
-      get_srs_resource(uecap, cell, curr_bwp, uid, res_id, maxMIMO_Layers, NR_SRS_Resource__transmissionComb_PR_n2, do_srs);
+  const NR_SRS_Resource__transmissionComb_PR tx_comb = cell->radio_config.srs_comb == 4
+                                                           ? NR_SRS_Resource__transmissionComb_PR_n4
+                                                           : NR_SRS_Resource__transmissionComb_PR_n2;
+  NR_SRS_Resource_t *srs_res0 = get_srs_resource(uecap, cell, curr_bwp, uid, res_id, maxMIMO_Layers, tx_comb, do_srs);
   asn1cSeqAdd(&srs_Config->srs_ResourceToAddModList->list, srs_res0);
 
   srs_Config->srs_ResourceSetToAddModList = calloc_or_fail(1, sizeof(*srs_Config->srs_ResourceSetToAddModList));
@@ -1084,7 +1091,7 @@ static int tda_cmp(const void *tda_a, const void *tda_b)
 /* \brief Set up a list of time domain allocations as suitable for the TDD
  * pattern. This will be used by get_num_ul_tda(), which requires a specific
  * ordering, hence we qsort() the list at the end according to tda_cmp(). */
-void nr_rrc_config_ul_tda(NR_ServingCellConfigCommon_t *scc, int min_fb_delay, nr_srs_type_t do_SRS)
+void nr_rrc_config_ul_tda(NR_ServingCellConfigCommon_t *scc, int min_fb_delay, nr_srs_type_t do_SRS, int pusch_symbols)
 {
   NR_PUSCH_TimeDomainResourceAllocationList_t *tda_list =
       scc->uplinkConfigCommon->initialUplinkBWP->pusch_ConfigCommon->choice.setup->pusch_TimeDomainAllocationList;
@@ -1100,7 +1107,7 @@ void nr_rrc_config_ul_tda(NR_ServingCellConfigCommon_t *scc, int min_fb_delay, n
 
   // UL TDA index 1 in case of SRS
   if (do_SRS != NO_SRS) {
-    tda = set_TimeDomainResourceAllocation(k2, get_SLIV(0, 12));
+    tda = set_TimeDomainResourceAllocation(k2, get_SLIV(0, pusch_symbols));
     asn1cSeqAdd(&tda_list->list, tda);
   }
 
@@ -1154,7 +1161,7 @@ void nr_rrc_config_ul_tda(NR_ServingCellConfigCommon_t *scc, int min_fb_delay, n
         tda = set_TimeDomainResourceAllocation(i, get_SLIV(0, 13));
         asn1cSeqAdd(&tda_list->list, tda);
         if (do_SRS != NO_SRS) {
-          tda = set_TimeDomainResourceAllocation(i, get_SLIV(0, 12));
+          tda = set_TimeDomainResourceAllocation(i, get_SLIV(0, pusch_symbols));
           asn1cSeqAdd(&tda_list->list, tda);
         }
       }
@@ -3758,9 +3765,9 @@ static bool verify_radio_configuration(int uid,
 {
   const nr_mac_config_t *configuration = &cell->radio_config;
   const frame_structure_t *fs = &cell->frame_structure;
-  int srs_offset = get_ul_slot_offset(fs, uid, false);
+  int srs_offset = get_ul_slot_offset(fs, uid / nr_srs_ue_per_slot(configuration), false);
   // see configure_periodic_srs
-  if (srs_offset >= 2560) {
+  if (configuration->do_SRS == PERIODIC_SRS && srs_offset >= set_ideal_period(cell, SRS, 0)) {
     LOG_E(NR_RRC, "UID %d, cannot allocate resources for SRS, rejecting UE\n", uid);
     return false;
   }

--- a/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.h
+++ b/openair2/LAYER2/NR_MAC_gNB/nr_radio_config.h
@@ -35,7 +35,7 @@ void nr_rrc_config_dl_tda(NR_PDSCH_TimeDomainResourceAllocationList_t *pdsch_Tim
                           const NR_TDD_UL_DL_ConfigCommon_t *tdd_UL_DL_ConfigurationCommon,
                           int csi_symbols,
                           int len_coreset);
-void nr_rrc_config_ul_tda(NR_ServingCellConfigCommon_t *scc, int min_fb_delay, nr_srs_type_t do_SRS);
+void nr_rrc_config_ul_tda(NR_ServingCellConfigCommon_t *scc, int min_fb_delay, nr_srs_type_t do_SRS, int pusch_symbols);
 NR_SearchSpace_t *rrc_searchspace_config(bool is_common,
                                          int searchspaceid,
                                          int coresetid,

--- a/openair2/LAYER2/NR_MAC_gNB/nrdc_mac_rrc_dl_handler.c
+++ b/openair2/LAYER2/NR_MAC_gNB/nrdc_mac_rrc_dl_handler.c
@@ -50,7 +50,7 @@ static NR_UE_info_t *nrdc_create_new_UE(gNB_MAC_INST *mac, nr_cell_sched_t *cell
   UE->nrdc_mode = true;
 
   if (!add_new_UE_RA(mac, UE)) {
-    delete_nr_ue_data(UE, &mac->UE_info.uid_allocator);
+    delete_nr_ue_data(mac, UE);
     LOG_E(NR_MAC, "UE list full while creating new UE\n");
     return NULL;
   }


### PR DESCRIPTION
Targets `sched_srs_period` (!420). Generalises periodic SRS from one UE per UL slot to several, multiplexed over comb offsets and symbols, and makes the relevant parameters configurable.

Two fixes first, both independent of the feature and applicable to `sched_srs_period` on their own:

- `set_periodic_info()` was called on UE reconfiguration without releasing the UE's existing entry, so the first-fit loop found the slot taken by the UE's own stale record and asserted.
- The `vrb_map_UL` rollback zeroed the whole RB rather than the bits the failed SRS allocation had claimed, clearing other channels' marks.

Then the feature. `get_srs_resource()` derives comb offset and start position from the UE's index within its slot, `set_ideal_period()` and `config_period_structure()` account for per-slot capacity, and `nr_fill_nfapi_srs()` treats a symbol already claimed by a comb-multiplexed peer as available rather than a collision. Periodic SRS allocation failure is now `LOG_W` and skip instead of `AssertFatal`, matching how PUSCH and PUCCH handle per-UE runtime contention.

New MACRLC parameters, all defaulting to current behaviour:

| parameter | default | meaning |
|---|---|---|
| `srs_comb` | 2 | transmission comb, 2 or 4 |
| `srs_ue_per_symbol` | 1 | UEs sharing a symbol via comb offsets, at most `srs_comb` |
| `srs_symbols_per_slot` | 1 | SRS symbols per UL slot |
| `srs_last_symbol` | 12 | last symbol SRS may occupy |
| `srs_periodicity` | 0 | explicit SRS period in slots; 0 keeps `set_ideal_period()` |

`srs_last_symbol` exists because the common PUCCH resources used for Msg4 HARQ occupy symbols 12 and 13, so a deployment needing SRS to clear them can move it earlier.

Tested on a DSUUU cell with 5 UEs multiplexed into one UL slot, each at its predicted symbol and comb offset, no SRS drops.