### PR TITLE
Consume the Aerial SRS report TLV offset when unpacking

### DIFF
--- a/nfapi/open-nFAPI/fapi/src/nr_fapi_p7.c
+++ b/nfapi/open-nFAPI/fapi/src/nr_fapi_p7.c
@@ -2470,7 +2470,7 @@ static uint8_t unpack_nr_srs_report_tlv(nfapi_srs_report_tlv_t *report_tlv, uint
     return 0;
   }
 #else
-  // Aerial sends a data_buf offset instead of the report; unread, the next PDU starts 4 bytes early
+  // Aerial sends a data_buf offset instead of the report; If left unread, the next PDU starts 4 bytes early
   uint32_t data_buf_offset;
   if (!pull32(ppReadPackedMsg, &data_buf_offset, end)) {
     return 0;

--- a/nfapi/open-nFAPI/fapi/src/nr_fapi_p7.c
+++ b/nfapi/open-nFAPI/fapi/src/nr_fapi_p7.c
@@ -2469,6 +2469,12 @@ static uint8_t unpack_nr_srs_report_tlv(nfapi_srs_report_tlv_t *report_tlv, uint
   if (!unpack_nr_srs_report_tlv_value(report_tlv, ppReadPackedMsg, end)) {
     return 0;
   }
+#else
+  // Aerial sends a data_buf offset instead of the report; unread, the next PDU starts 4 bytes early
+  uint32_t data_buf_offset;
+  if (!pull32(ppReadPackedMsg, &data_buf_offset, end)) {
+    return 0;
+  }
 #endif
   return 1;
 }


### PR DESCRIPTION
Under ENABLE_AERIAL the unpacker reads tag and length but not the four-byte data buffer offset Aerial sends in place of the report. With several PDUs in one SRS.indication, every report after the first is then decoded four bytes early.