### PR TITLE
tools: add physim_sweep, exhaustive high-SINR correctness sweeps for NR PHY sims

### DIFF
--- a/tools/physim_sweep/.gitignore
+++ b/tools/physim_sweep/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tools/physim_sweep/README.md
+++ b/tools/physim_sweep/README.md
@@ -1,0 +1,142 @@
+# physim_sweep
+
+Exhaustive, high-SINR structural-parameter sweeps for the NR PHY link
+simulators (`nr_pucchsim`, `nr_dlsim`, ...), run under AddressSanitizer/UBSan.
+
+## Why this exists
+
+`openair1/SIMULATION/tests/CMakeLists.txt` registers a fast suite of point
+tests (`add_physim_test`): a handful of (SNR, config) points chosen to catch
+link-performance regressions in a few minutes of `ctest`. That suite does not
+catch a bug that only shows up at one specific structural value, e.g. a
+starting-PRB computation that is wrong only near the edge of the BWP.
+
+This tool takes the opposite approach for a smaller set of parameters: fix
+SNR at a clean, high-SINR operating point and sweep one structural parameter
+across its entire legal range, checking for bit errors, non-zero exit codes,
+and ASan/UBSan reports at every point. It is meant to run as a long,
+occasional job (nightly / on-demand), not on every commit — a full run is
+thousands of simulator invocations.
+
+For structural parameters bounded by BWP size, groups are duplicated across
+"round" (106 RB) and the max, non-power-of-two NR bandwidth (273 RB) where
+the simulator supports it.
+
+Beyond BWP-bound structural parameters (PRB offset, SSB subcarrier offset,
+MCS, NCS_config), three more dimensions are covered:
+
+- **Numerology** (`numerology_sweep` groups, μ ∈ {0, 1, 3}): every simulator
+  that exposes a numerology flag on its CLI gets one, at the
+  (numerology, bandwidth) pairs already proven by the point-test suite.
+  `nr_pucchsim` has none — it runs at a fixed internal numerology.
+- **Symbols per slot** (`*_num_symbols_sweep_*` groups): PUCCH format 1
+  (`-i`, 4..14 symbols) and PUSCH (`-b`, 1..14 symbols). PDSCH has no
+  equivalent — `nr_dlsim` doesn't expose a symbol-count CLI flag.
+- **PRACH format** (`prach_format_sweep_106rb`): format is derived from `-c`
+  (`config_index`) via the 3GPP config-index-to-format table.
+
+A failing point is a real bug the sweep found, not a configuration mistake to
+work around — leave it in `sweeps.yaml` rather than adjusting the axis to
+dodge it. Check `--log-dir` for the failing run's full output.
+
+## Quick start
+
+```sh
+# 1. Build the physim executables with ASan
+./cmake_targets/build_oai -P --sanitize-address --build-dir physim-sweep-asan
+
+# 2. Run every configured sweep
+python3 tools/physim_sweep/physim_sweep.py \
+    --build-dir cmake_targets/ran_build/physim-sweep-asan/build
+
+# Quick smoke run (1 in 8 points of every axis) while iterating on a change
+python3 tools/physim_sweep/physim_sweep.py \
+    --build-dir cmake_targets/ran_build/physim-sweep-asan/build --stride 8
+
+# Just one channel/group, verbosely
+python3 tools/physim_sweep/physim_sweep.py \
+    --build-dir cmake_targets/ran_build/physim-sweep-asan/build \
+    --channel nr_pucchsim --group format0_1bit_prb_sweep_51rb -v
+
+# CI-style run: parallel, JUnit report, logs of failures kept for triage
+python3 tools/physim_sweep/physim_sweep.py \
+    --build-dir cmake_targets/ran_build/physim-sweep-asan/build \
+    --jobs 16 --junit physim_sweep_results/junit.xml --log-dir physim_sweep_results
+```
+
+Exit code is non-zero if any point failed. Failing runs have their full
+stdout/stderr saved under `--log-dir` (default `physim_sweep_results/`).
+
+Run `--list` instead of executing to see exactly which commands a given
+selection expands to:
+
+```sh
+python3 tools/physim_sweep/physim_sweep.py --build-dir <dir> \
+    --channel nr_pucchsim --list
+```
+
+To sweep under UBSan too, build with `--sanitize-undefined` (or `--sanitize`
+for ASan+UBSan together) instead of `--sanitize-address`.
+
+## Adding a new channel or sweep
+
+Edit `sweeps.yaml`. Each channel needs the executable name (`binary`, must
+exist in the ASan build dir) and a list of `groups`. Each group is one
+simulator invocation template plus the one parameter being swept:
+
+```yaml
+channels:
+  nr_pucchsim:
+    binary: nr_pucchsim
+    groups:
+      - name: format0_1bit_prb_sweep_51rb   # must be unique within the channel
+        fixed_args: ["-R", "51", "-P", "0", "-b", "1", "-i", "1", "-n", "1000"]
+        sinr: 20                            # single SINR point; do not put -s/-S in fixed_args
+        axis: {flag: "-r", range: [0, 50]}  # inclusive; optional "step" key
+        # or: axis: {flag: "-Z", values: [0, 1, 2, 5, 10, 15]}
+```
+
+An axis is usually one flag sweeping one value. Some parameters only have a
+legal value in combination with another fixed one — numerology is the main
+example: each numerology only accepts specific 3GPP bandwidths, so `N_RB_DL`
+has to change together with `-m`/`-u`. For that, `flag` and `values` both
+become lists — each inner list is one point's values for the corresponding
+flags, in order:
+
+```yaml
+      - name: numerology_sweep
+        fixed_args: ["-n", "300"]
+        sinr: 25
+        axis: {flag: ["-u", "-R"], values: [[0, 25], [1, 106], [3, 32]]}
+        # expands to: ... -u 0 -R 25   /   -u 1 -R 106   /   -u 3 -R 32
+```
+
+`sinr` is turned into `-s <sinr> -S <sinr+0.05>` by the tool itself — do not
+put `-s`/`-S` in `fixed_args`.
+
+Guidelines for picking a sweep:
+
+- Pick a parameter with a well-defined legal range tied to another fixed
+  parameter (a PRB offset bounded by BWP size, a cyclic shift bounded by comb
+  size, an MCS index bounded by the MCS table).
+- Fix a single SINR point per group, high enough that every point in the
+  swept range passes cleanly on a correct implementation.
+- Keep `-n`/trial counts capped at 1000. Runtime is meant to come from
+  covering many configs, not from a huge trial count per run.
+- A new group is picked up automatically; no changes to `physim_sweep.py`
+  are needed.
+
+## How pass/fail is determined
+
+A run is a PASS only if all of the following hold:
+- the simulator process exits with code 0,
+- it does not time out (`--timeout`, default 120s), and
+- neither stdout nor stderr contains an ASan/LSan/UBSan report.
+
+## Relationship to `ctest`
+
+This tool is intentionally standalone rather than wired into
+`add_physim_test`/`ctest`: registering every sweep point as its own `ctest`
+test would balloon the test count into the thousands. Use
+`openair1/SIMULATION/tests/` for fast per-commit checks, and this tool for
+occasional/nightly exhaustive structural-correctness sweeps.

--- a/tools/physim_sweep/physim_sweep.py
+++ b/tools/physim_sweep/physim_sweep.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+"""
+Exhaustive parameter-space correctness sweeps for the NR PHY simulators.
+
+Fixes SNR at a single high-SINR point and sweeps one structural parameter
+(e.g. resource-block allocation offset) across its entire legal range,
+checking for bit errors, non-zero exit codes, and ASan/UBSan reports.
+
+Usage:
+  ./cmake_targets/build_oai -P --sanitize-address --build-dir physim-sweep-asan
+  python3 tools/physim_sweep/physim_sweep.py \\
+      --build-dir cmake_targets/ran_build/physim-sweep-asan/build
+
+See README.md for the configuration format and how to add new sweeps.
+"""
+import argparse
+import concurrent.futures
+import dataclasses
+import os
+import re
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import yaml
+
+# UBSan violations are a standalone "<file>:<line>: runtime error: ..." line,
+# not an "ERROR: <Sanitizer>" banner like ASan/LSan.
+SANITIZER_ERROR_RE = re.compile(r"ERROR: (AddressSanitizer|LeakSanitizer|UndefinedBehaviorSanitizer)"
+                                 r"|^.+: runtime error: .+$", re.MULTILINE)
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+DEFAULT_ASAN_OPTIONS = "abort_on_error=0:halt_on_error=1:print_stats=0"
+DEFAULT_UBSAN_OPTIONS = "halt_on_error=1:print_stacktrace=1"
+
+# Some simulators loop `SNR < snr1` (strict); snr0 == snr1 would run zero
+# trials. The epsilon guarantees exactly one iteration at the requested SINR.
+SINR_EPSILON = 0.05
+SNR_FLAG = "-s"
+SNR_END_FLAG = "-S"
+
+
+@dataclasses.dataclass
+class RunResult:
+    channel: str
+    group: str
+    argv: list
+    returncode: int
+    duration: float
+    ok: bool
+    reason: str
+    log_path: Path = None
+
+
+def expand_axis(axis: dict, stride: int) -> list:
+    if "values" in axis:
+        values = list(axis["values"])
+    elif "range" in axis:
+        start, stop = axis["range"]
+        step = axis.get("step", 1)
+        values = list(range(start, stop + 1, step))
+    else:
+        raise ValueError(f"axis must have 'values' or 'range': {axis}")
+    if stride > 1:
+        values = values[::stride]
+    return values
+
+
+def axis_args(flag, value) -> list:
+    # flag/value as lists sweeps several flags together as one point.
+    if isinstance(flag, list):
+        args = []
+        for f, v in zip(flag, value):
+            args += [f, str(v)]
+        return args
+    return [flag, str(value)]
+
+
+def axis_label(flag, value) -> str:
+    if isinstance(flag, list):
+        return "_".join(f"{f.lstrip('-')}{v}" for f, v in zip(flag, value))
+    return f"{flag.lstrip('-')}{value}"
+
+
+def build_argv(binary_path: Path, fixed_args: list, sinr: float, flag, value) -> list:
+    return ([str(binary_path)] + [str(a) for a in fixed_args]
+             + [SNR_FLAG, str(sinr), SNR_END_FLAG, str(sinr + SINR_EPSILON)]
+             + axis_args(flag, value))
+
+
+def run_one(channel: str, group: str, binary_path: Path, fixed_args: list, sinr: float, flag: str, value,
+            build_dir: Path, log_dir: Path, timeout: float) -> RunResult:
+    argv = build_argv(binary_path, fixed_args, sinr, flag, value)
+    env = os.environ.copy()
+    env["LD_LIBRARY_PATH"] = f"{build_dir}:{env.get('LD_LIBRARY_PATH', '')}"
+    env["ASAN_OPTIONS"] = env.get("ASAN_OPTIONS", DEFAULT_ASAN_OPTIONS)
+    env["UBSAN_OPTIONS"] = env.get("UBSAN_OPTIONS", DEFAULT_UBSAN_OPTIONS)
+
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(argv, env=env, cwd=build_dir, capture_output=True, text=True,
+                               timeout=timeout)
+        returncode = proc.returncode
+        output = proc.stdout + proc.stderr
+        timed_out = False
+    except subprocess.TimeoutExpired as e:
+        returncode = -1
+
+        def _to_text(x):
+            return x.decode(errors="replace") if isinstance(x, bytes) else (x or "")
+        output = _to_text(e.stdout) + _to_text(e.stderr)
+        timed_out = True
+    output = ANSI_ESCAPE_RE.sub("", output)
+    duration = time.monotonic() - start
+
+    if timed_out:
+        ok, reason = False, f"timed out after {timeout:.0f}s"
+    elif SANITIZER_ERROR_RE.search(output):
+        ok, reason = False, SANITIZER_ERROR_RE.search(output).group(0)
+    elif returncode != 0:
+        ok, reason = False, f"nonzero exit code {returncode}"
+    else:
+        ok, reason = True, "ok"
+
+    log_path = None
+    if not ok:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / f"{channel}.{group}.{axis_label(flag, value)}.log"
+        log_path.write_text("$ " + " ".join(argv) + "\n\n" + output)
+
+    return RunResult(channel, group, argv, returncode, duration, ok, reason, log_path)
+
+
+def load_config(path: Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def select_groups(config: dict, channels: list, groups: list):
+    selected = []
+    for channel, cdef in config["channels"].items():
+        if channels and channel not in channels:
+            continue
+        for g in cdef["groups"]:
+            if groups and g["name"] not in groups:
+                continue
+            selected.append((channel, cdef, g))
+    return selected
+
+
+def write_junit(results: list, out_path: Path):
+    by_group = {}
+    for r in results:
+        by_group.setdefault((r.channel, r.group), []).append(r)
+
+    testsuites = ET.Element("testsuites")
+    by_channel = {}
+    for (channel, group), rs in by_group.items():
+        by_channel.setdefault(channel, []).append((group, rs))
+
+    for channel, groups in by_channel.items():
+        n_tests = sum(len(rs) for _, rs in groups)
+        n_fail = sum(1 for _, rs in groups for r in rs if not r.ok)
+        ts = ET.SubElement(testsuites, "testsuite", name=channel,
+                            tests=str(n_tests), failures=str(n_fail))
+        for group, rs in groups:
+            n_fail_g = sum(1 for r in rs if not r.ok)
+            duration = sum(r.duration for r in rs)
+            tc = ET.SubElement(ts, "testcase", classname=f"physim_sweep.{channel}",
+                                name=group, time=f"{duration:.2f}")
+            if n_fail_g:
+                failing = [r for r in rs if not r.ok]
+                msg = f"{n_fail_g}/{len(rs)} points failed"
+                detail_lines = []
+                for r in failing[:20]:
+                    detail_lines.append(f"  {' '.join(r.argv)} -> {r.reason} ({r.log_path})")
+                if len(failing) > 20:
+                    detail_lines.append(f"  ... and {len(failing) - 20} more")
+                failure = ET.SubElement(tc, "failure", message=msg)
+                failure.text = "\n".join(detail_lines)
+    ET.ElementTree(testsuites).write(out_path, encoding="unicode", xml_declaration=True)
+
+
+def main():
+    script_dir = Path(__file__).resolve().parent
+    p = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--build-dir", type=Path, required=True,
+                    help="Directory containing the ASAN-built physim executables "
+                         "(e.g. cmake_targets/ran_build/physim-sweep-asan/build)")
+    p.add_argument("--config", type=Path, default=script_dir / "sweeps.yaml",
+                    help="Sweep configuration file (default: sweeps.yaml next to this script)")
+    p.add_argument("--channel", action="append", default=[],
+                    help="Only run this channel (repeatable). Default: all channels.")
+    p.add_argument("--group", action="append", default=[],
+                    help="Only run this group name (repeatable). Default: all groups.")
+    p.add_argument("--list", action="store_true", help="List selected channels/groups and exit")
+    p.add_argument("--stride", type=int, default=1,
+                    help="Only run every Nth point of each swept axis, for a quick smoke run "
+                         "(default: 1, i.e. exhaustive)")
+    p.add_argument("--jobs", type=int, default=os.cpu_count() or 4,
+                    help="Number of simulator runs to execute in parallel")
+    p.add_argument("--timeout", type=float, default=120.0,
+                    help="Per-run timeout in seconds")
+    p.add_argument("--log-dir", type=Path, default=Path("physim_sweep_results"),
+                    help="Directory to store logs of failing runs")
+    p.add_argument("--junit", type=Path, default=None,
+                    help="Write a JUnit XML report to this path")
+    p.add_argument("--fail-fast", action="store_true",
+                    help="Stop submitting new runs after the first failure")
+    p.add_argument("-v", "--verbose", action="store_true", help="Print every run, not just failures")
+    args = p.parse_args()
+    args.build_dir = args.build_dir.resolve()
+
+    config = load_config(args.config)
+    selection = select_groups(config, args.channel, args.group)
+    if not selection:
+        print("No channels/groups matched the given --channel/--group filters", file=sys.stderr)
+        return 1
+
+    for channel, cdef, group in selection:
+        if "sinr" not in group:
+            print(f"{channel}.{group['name']}: group is missing required 'sinr' key", file=sys.stderr)
+            return 1
+
+    jobs = []
+    for channel, cdef, group in selection:
+        binary_path = args.build_dir / cdef["binary"]
+        values = expand_axis(group["axis"], args.stride)
+        for value in values:
+            jobs.append((channel, cdef, group, binary_path, value))
+
+    if args.list:
+        for channel, cdef, group, binary_path, value in jobs:
+            argv = build_argv(binary_path, group["fixed_args"], group["sinr"], group["axis"]["flag"], value)
+            print(f"{channel}.{group['name']}: {' '.join(argv)}")
+        print(f"\n{len(jobs)} runs total", file=sys.stderr)
+        return 0
+
+    missing = sorted({str(binary_path) for _, _, _, binary_path, _ in jobs if not binary_path.is_file()})
+    if missing:
+        print("Missing simulator executables (build with --sanitize-address first):", file=sys.stderr)
+        for m in missing:
+            print(f"  {m}", file=sys.stderr)
+        return 1
+
+    print(f"Running {len(jobs)} sweep points across {len(selection)} groups "
+          f"(build-dir={args.build_dir}, jobs={args.jobs}, stride={args.stride})")
+
+    results = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        futures = {}
+        for channel, cdef, group, binary_path, value in jobs:
+            fut = ex.submit(run_one, channel, group["name"], binary_path, group["fixed_args"], group["sinr"],
+                             group["axis"]["flag"], value, args.build_dir, args.log_dir, args.timeout)
+            futures[fut] = (channel, group["name"], axis_label(group["axis"]["flag"], value))
+
+        for fut in concurrent.futures.as_completed(futures):
+            channel, group_name, label = futures[fut]
+            try:
+                r = fut.result()
+            except Exception as e:
+                r = RunResult(channel, group_name, [], -1, 0.0, False, f"tool error: {e!r}", None)
+            results.append(r)
+            if not r.ok:
+                print(f"FAIL {r.channel}.{r.group} {label}: {r.reason} "
+                      f"[{' '.join(r.argv)}]")
+                if r.log_path:
+                    print(f"     log: {r.log_path}")
+                if args.fail_fast:
+                    for other in futures:
+                        other.cancel()
+                    break
+            elif args.verbose:
+                print(f"ok   {r.channel}.{r.group} {label} ({r.duration:.1f}s)")
+
+    n_fail = sum(1 for r in results if not r.ok)
+    n_ran = len(results)
+    print(f"\n{n_ran - n_fail}/{n_ran} points passed"
+          + (f", {n_fail} FAILED" if n_fail else ""))
+
+    if args.junit:
+        write_junit(results, args.junit)
+        print(f"JUnit report written to {args.junit}")
+
+    return 1 if n_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/physim_sweep/sweeps.yaml
+++ b/tools/physim_sweep/sweeps.yaml
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: LicenseRef-CSSL-1.0
+#
+# Exhaustive, high-SINR structural-parameter sweeps for the NR PHY simulators.
+# See README.md for the schema and for how to add a new channel/group.
+
+channels:
+
+  nr_pucchsim:
+    binary: nr_pucchsim
+    groups:
+      - name: format0_1bit_prb_sweep_51rb
+        fixed_args: ["-R", "51", "-P", "0", "-b", "1", "-i", "1", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-r", range: [0, 50]}
+      - name: format0_2bit_prb_sweep_51rb
+        fixed_args: ["-R", "51", "-P", "0", "-b", "2", "-i", "1", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-r", range: [0, 50]}
+      - name: format0_1bit_prb_sweep_106rb
+        fixed_args: ["-R", "106", "-P", "0", "-b", "1", "-i", "1", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-r", range: [0, 105]}
+      - name: format0_2bit_prb_sweep_106rb
+        fixed_args: ["-R", "106", "-P", "0", "-b", "2", "-i", "1", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-r", range: [0, 105]}
+      - name: format0_1bit_prb_sweep_273rb
+        fixed_args: ["-R", "273", "-P", "0", "-b", "1", "-i", "1", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-r", range: [0, 272]}
+      - name: format1_ack_prb_sweep_51rb
+        fixed_args: ["-R", "51", "-P", "1", "-i", "4", "-b", "1", "-B", "1", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-r", range: [0, 50]}
+      - name: format1_ack_prb_sweep_106rb
+        fixed_args: ["-R", "106", "-P", "1", "-i", "4", "-b", "1", "-B", "1", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-r", range: [0, 105]}
+      - name: format1_ack_prb_sweep_273rb
+        fixed_args: ["-R", "273", "-P", "1", "-i", "4", "-b", "1", "-B", "1", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-r", range: [0, 272]}
+      - name: format0_2bit_prb_sweep_273rb
+        fixed_args: ["-R", "273", "-P", "0", "-b", "2", "-i", "1", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-r", range: [0, 272]}
+      # format 2's RX requires the PRB offset to be a multiple of 4
+      - name: format2_4bit_prb_sweep_106rb
+        fixed_args: ["-R", "106", "-P", "2", "-b", "4", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-r", range: [0, 104], step: 4}
+      - name: format2_4bit_prb_sweep_273rb
+        fixed_args: ["-R", "273", "-P", "2", "-b", "4", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-r", range: [0, 268], step: 4}
+      # format 1 supports 4..14 OFDM symbols
+      - name: format1_num_symbols_sweep_106rb
+        fixed_args: ["-R", "106", "-P", "1", "-b", "1", "-B", "1", "-r", "0", "-n", "1000"]
+        sinr: 20
+        axis: {flag: "-i", range: [4, 14]}
+      # no numerology_sweep: nr_pucchsim runs at a fixed internal mu
+
+  nr_pbchsim:
+    binary: nr_pbchsim
+    groups:
+      - name: subcarrier_offset_sweep_25rb
+        fixed_args: ["-R", "25", "-m", "0", "-n", "30"]
+        sinr: -6
+        axis: {flag: "-c", range: [0, 23]}
+      - name: subcarrier_offset_sweep_106rb
+        fixed_args: ["-R", "106", "-n", "30"]
+        sinr: -6
+        axis: {flag: "-c", range: [0, 23]}
+      - name: subcarrier_offset_sweep_273rb
+        fixed_args: ["-R", "273", "-n", "30"]
+        sinr: -6
+        axis: {flag: "-c", range: [0, 23]}
+      - name: numerology_sweep
+        fixed_args: ["-n", "30"]
+        sinr: -6
+        axis: {flag: ["-m", "-R"], values: [[0, 25], [1, 106], [3, 32]]}
+
+  nr_dlschsim:
+    binary: nr_dlschsim
+    groups:
+      - name: mcs_sweep_106rb
+        fixed_args: ["-R", "106", "-n", "300"]
+        sinr: 30
+        axis: {flag: "-m", range: [0, 27]}
+      - name: mcs_sweep_273rb
+        fixed_args: ["-R", "273", "-n", "300"]
+        sinr: 30
+        axis: {flag: "-m", range: [0, 27]}
+
+  nr_ulschsim:
+    binary: nr_ulschsim
+    groups:
+      - name: mcs_sweep_106rb
+        fixed_args: ["-R", "106", "-n", "300"]
+        sinr: 30
+        axis: {flag: "-m", range: [0, 27]}
+      - name: mcs_sweep_273rb
+        fixed_args: ["-R", "273", "-n", "300"]
+        sinr: 30
+        axis: {flag: "-m", range: [0, 27]}
+
+  nr_prachsim:
+    binary: nr_prachsim
+    groups:
+      - name: ncs_config_sweep_106rb
+        fixed_args: ["-R", "106", "-n", "50"]
+        sinr: 20
+        axis: {flag: "-Z", range: [0, 15]}
+      - name: ncs_config_sweep_273rb
+        fixed_args: ["-R", "273", "-n", "50"]
+        sinr: 20
+        axis: {flag: "-Z", range: [0, 15]}
+      - name: numerology_sweep
+        fixed_args: ["-n", "50"]
+        sinr: 20
+        axis: {flag: ["-m", "-R"], values: [[0, 25], [1, 106], [3, 32]]}
+      # PRACH format is derived from config_index (-c) via the 3GPP
+      # config-index-to-format table, looked up against this simulator's
+      # hardcoded frame=1/subframe=9 scenario. One config_index per reachable
+      # format (0/3/4/5/6/7/8/9/10); formats 1/2 are unreachable by this
+      # harness, 11/12/13 are unimplemented in the RX path. -Z 1 (a non-default
+      # NCS_config) keeps this group's axis isolated to config_index alone.
+      - name: prach_format_sweep_106rb
+        fixed_args: ["-R", "106", "-n", "50", "-Z", "1"]
+        sinr: 20
+        axis: {flag: "-c", values: [0, 40, 67, 87, 110, 133, 145, 169, 189]}
+
+  nr_dlsim:
+    binary: nr_dlsim
+    groups:
+      # no -b/-e: PDSCH size defaults to N_RB_DL - rbStart
+      - name: pdsch_start_prb_sweep_106rb
+        fixed_args: ["-R", "106", "-n", "300"]
+        sinr: 30
+        axis: {flag: "-a", range: [0, 105]}
+      - name: pdsch_start_prb_sweep_273rb
+        fixed_args: ["-R", "273", "-n", "300"]
+        sinr: 30
+        axis: {flag: "-a", range: [0, 272]}
+      - name: numerology_sweep
+        fixed_args: ["-n", "300"]
+        sinr: 30
+        axis: {flag: ["-m", "-R"], values: [[0, 25], [1, 106], [3, 32]]}
+      # no symbol-count sweep: nr_dlsim exposes no such CLI flag for PDSCH
+
+  nr_ulsim:
+    binary: nr_ulsim
+    groups:
+      - name: pusch_start_prb_sweep_106rb
+        fixed_args: ["-R", "106", "-r", "1", "-m", "9", "-n", "300"]
+        sinr: 25
+        axis: {flag: "-w", range: [0, 105]}
+      - name: pusch_start_prb_sweep_273rb
+        fixed_args: ["-R", "273", "-r", "1", "-m", "9", "-n", "300"]
+        sinr: 25
+        axis: {flag: "-w", range: [0, 272]}
+      # -r 50: a 1 RB allocation is below the minimum LDPC codeword size
+      - name: pusch_num_symbols_sweep_106rb
+        fixed_args: ["-R", "106", "-r", "50", "-m", "9", "-n", "300"]
+        sinr: 25
+        axis: {flag: "-b", range: [1, 14]}
+      - name: numerology_sweep
+        fixed_args: ["-r", "1", "-m", "9", "-n", "300"]
+        sinr: 25
+        axis: {flag: ["-u", "-R"], values: [[0, 25], [1, 106], [3, 32]]}
+
+  nr_srssim:
+    binary: nr_srssim
+    groups:
+      - name: cyclic_shift_sweep_106rb
+        fixed_args: ["-R", "106", "-n", "300"]
+        sinr: 25
+        axis: {flag: "-i", range: [0, 7]}
+      - name: numerology_sweep
+        fixed_args: ["-n", "300"]
+        sinr: 25
+        axis: {flag: ["-u", "-R"], values: [[0, 25], [1, 106], [3, 32]]}
+      - name: cyclic_shift_sweep_273rb
+        fixed_args: ["-R", "273", "-n", "300"]
+        sinr: 25
+        axis: {flag: "-i", range: [0, 7]}


### PR DESCRIPTION
Tests in openair1/SIMULATION/tests/CMakeLists.txt check a handful of representative (SNR, config) points, which cannot catch a bug that only shows up at one specific structural value (e.g. a PRB offset wrong only at the edge of the BWP). physim_sweep fixes SNR at a single high-SINR point and exhaustively sweeps a structural parameter (PRB/RB offset, MCS, SSB subcarrier offset, NCS_config, PRACH format, numerology, symbols per slot) across its legal range under ASan/UBSan, for all eight NR physim simulators.

Assisted-by: Claude:claude-sonnet-5

This tool has found 3 bugs in the code.