### PR TITLE
BUGFIX: rework pthread_setname_np() ASSERT and add LOG_W

### DIFF
--- a/common/utils/system.c
+++ b/common/utils/system.c
@@ -279,7 +279,16 @@ void threadCreate(pthread_t* t, void * (*func)(void*), void * param, char* name,
   strncpy(short_name, name, sizeof(short_name) - 1);
   short_name[sizeof(short_name) - 1] = '\0';
   ret = pthread_setname_np(*t, short_name);
-  AssertFatal(ret == 0, "Error in pthread_setname_np(): ret: %d, errno: %d\n", ret, errno);
+  // pthread_create() can initialize and complete before setting a name
+  AssertFatal(ret == 0 || ret == ENOENT || ret == ESRCH, "Error in pthread_setname_np(): ret: %d, errno: %d\n", ret, errno);
+  if (ret != 0) {
+    LOG_W(UTIL,
+          "pthread_setname_np() failed with ret: %d (%s) when naming %s - \
+                thread likely already exited, continuing\n",
+          ret,
+          strerror(ret),
+          name);
+  }
 
   pthread_attr_destroy(&attr);
 }


### PR DESCRIPTION
In resource constrained machines, pthread_create() can complete before the naming attribute can be set. 
Converting ASSERT to handle expected early completion and adding logged warning.
This allows the sim to continue progressing.

Initially found while running 7.2 split on Falcon server.