### PR TITLE
Fix pdsch nvar

### DIFF
--- a/openair1/PHY/NR_UE_ESTIMATION/nr_dl_channel_estimation.c
+++ b/openair1/PHY/NR_UE_ESTIMATION/nr_dl_channel_estimation.c
@@ -2,13 +2,13 @@
  * SPDX-License-Identifier: LicenseRef-CSSL-1.0
  */
 
+#include "assertions.h"
 #include "nr_common.h"
+#include "platform_types.h"
+#include <stdint.h>
 #include <string.h>
-#include "SCHED_NR_UE/defs.h"
 #include "nr_estimation.h"
 #include "PHY/NR_REFSIG/nr_refsig.h"
-#include "PHY/NR_REFSIG/dmrs_nr.h"
-#include "PHY/NR_REFSIG/ptrs_nr.h"
 #include "PHY/NR_REFSIG/nr_mod_table.h"
 #include "PHY/NR_TRANSPORT/nr_sch_dmrs.h"
 #include "nr_phy_common.h"
@@ -17,7 +17,6 @@
 #include <openair1/PHY/TOOLS/phy_scope_interface.h>
 #include "nfapi/open-nFAPI/nfapi/public_inc/nfapi_nr_interface.h"
 #include "instrumentation.h"
-#include "executables/nr-softmodem-common.h"
 // #define DEBUG_PDSCH
 // #define DEBUG_PDCCH
 // #define DEBUG_PBCH(a...) printf(a)
@@ -773,6 +772,27 @@ void nr_pdcch_channel_estimation(const NR_DL_FRAME_PARMS *frame_parms,
   }
 }
 
+static void revert_delay(c16_t *dl_ch, uint num_dl_ch, const delay_t *delay, const c16_t delay_table[][NR_MAX_OFDM_SYMBOL_SIZE])
+{
+  int inv_delay_idx = get_delay_idx(-delay->est_delay, MAX_DELAY_COMP);
+  const c16_t *dl_inv_delay_table = delay_table[inv_delay_idx];
+  mult_complex_vectors(dl_ch, dl_inv_delay_table, dl_ch, num_dl_ch, 8);
+}
+
+static inline uint32_t estimate_noise_var(const c16_t *dl_ls_est, const c16_t *dl_ch, uint num_dl_ch)
+{
+  if (num_dl_ch == 0) {
+    LOG_E(NR_PHY, "Couldn't estimate PDSCH N_0\n");
+    return UINT32_MAX;
+  }
+
+  uint64_t noise_amp2 = 0;
+  for (uint k = 0; k < num_dl_ch; k++)
+    noise_amp2 += c16amp2(c16sub(dl_ls_est[k], dl_ch[k]));
+
+  return (uint32_t)(noise_amp2 / num_dl_ch);
+}
+
 static void NFAPI_NR_DMRS_TYPE1_linear_interp(const NR_DL_FRAME_PARMS *frame_parms,
                                               c16_t *rxF,
                                               int delta,
@@ -842,20 +862,11 @@ static void NFAPI_NR_DMRS_TYPE1_linear_interp(const NR_DL_FRAME_PARMS *frame_par
   }
 
   // Revert delay
-  dl_ch = dl_ch0;
-  int nest_count = 0;
-  uint64_t noise_amp2 = 0;
-  int inv_delay_idx = get_delay_idx(-delay.est_delay, MAX_DELAY_COMP);
-  const c16_t *dl_inv_delay_table = frame_parms->delay_table[inv_delay_idx];
-  for (int k = 0; k < idx; k++) {
-    dl_ch[k] = c16mulShift(dl_ch[k], dl_inv_delay_table[k], 8);
-    noise_amp2 += c16amp2(c16sub(dl_ls_est[k], dl_ch[k]));
-    nest_count++;
-  }
+  revert_delay(dl_ch0, idx, &delay, frame_parms->delay_table);
 
-  if (nvar && nest_count > 0) {
-    *nvar = (uint32_t)(noise_amp2 / (nest_count * frame_parms->nb_antennas_rx));
-  }
+  // Estimate noise var
+  if (nvar)
+    *nvar += estimate_noise_var(dl_ls_est, dl_ch0, idx);
 }
 
 static void NFAPI_NR_DMRS_TYPE1_average_prb(const int symb_sz,
@@ -1011,20 +1022,11 @@ static void NFAPI_NR_DMRS_TYPE2_linear_interp(const NR_DL_FRAME_PARMS *frame_par
   }
 
   // Revert delay
-  dl_ch = dl_ch0;
-  int nest_count = 0;
-  uint64_t noise_amp2 = 0;
-  int inv_delay_idx = get_delay_idx(-delay.est_delay, MAX_DELAY_COMP);
-  const c16_t *dl_inv_delay_table = frame_parms->delay_table[inv_delay_idx];
-  for (int k = 0; k < idx; k++) {
-    dl_ch[k] = c16mulShift(dl_ch[k], dl_inv_delay_table[k], 8);
-    noise_amp2 += c16amp2(c16sub(dl_ls_est[k], dl_ch[k]));
-    nest_count++;
-  }
+  revert_delay(dl_ch0, idx, &delay, frame_parms->delay_table);
 
-  if (nvar && nest_count > 0) {
-    *nvar = (uint32_t)(noise_amp2 / (nest_count * frame_parms->nb_antennas_rx));
-  }
+  // Estimate noise var
+  if (nvar)
+    *nvar += estimate_noise_var(dl_ls_est, dl_ch0, idx);
 }
 
 static void NFAPI_NR_DMRS_TYPE2_average_prb(const int symb_sz,

--- a/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
+++ b/openair1/PHY/NR_UE_TRANSPORT/nr_dlsch_demodulation.c
@@ -562,11 +562,12 @@ static void nr_dlsch_mmse(uint32_t pdsch_buf_size_max,
 
   // Add noise_var such that: H^h * H + noise_var * I
   if (noise_var != 0) {
-    simde__m128i nvar_128i = simde_mm_set1_epi32(noise_var >> 3);
+    const uint16_t noise_var_q15 = noise_var >> shift;
+    simde__m128i nvar_128i = simde_mm_set_epi16(0, noise_var_q15, 0, noise_var_q15, 0, noise_var_q15, 0, noise_var_q15);
     for (int p = 0; p < nl; p++) {
       simde__m128i *conjH_H_128i = (simde__m128i *)conjH_H_elements[0][p][p];
       for (int k = 0; k < 3 * nb_rb_0; k++) {
-        conjH_H_128i[0] = simde_mm_add_epi32(conjH_H_128i[0], nvar_128i);
+        conjH_H_128i[0] = simde_mm_add_epi16(conjH_H_128i[0], nvar_128i);
         conjH_H_128i++;
       }
     }

--- a/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
+++ b/openair1/SCHED_NR_UE/phy_procedures_nr_ue.c
@@ -409,6 +409,7 @@ static int nr_ue_pdsch_procedures(PHY_VARS_NR_UE *ue,
   }
 
   int harq_pid = dlschCfg->harq_process_nbr;
+  const uint32_t dmrs_symb_bitmap = dlschCfg->dlDmrsSymbPos;
 
   LOG_D(PHY,
         "[UE %d] frame_rx %d, nr_slot_rx %d, harq_pid %d (%d), BWP start %d, start RB %d, end RB %d, symbol_start %d, nb_symbols "
@@ -424,7 +425,7 @@ static int nr_ue_pdsch_procedures(PHY_VARS_NR_UE *ue,
         freq_alloc->last_rb,
         dlschCfg->start_symbol,
         dlschCfg->number_symbols,
-        dlschCfg->dlDmrsSymbPos,
+        dmrs_symb_bitmap,
         dlsch->cw_info.Nl);
 
   const int actor_idx = proc->nr_slot_rx % ue->pdsch_num_actors;
@@ -443,7 +444,7 @@ static int nr_ue_pdsch_procedures(PHY_VARS_NR_UE *ue,
 
   start_meas_nr_ue_phy(ue, DLSCH_CHANNEL_ESTIMATION_STATS);
   for (int m = dlschCfg->start_symbol; m < (dlschCfg->start_symbol + dlschCfg->number_symbols); m++) {
-    if (dlschCfg->dlDmrsSymbPos & (1 << m)) {
+    if (dmrs_symb_bitmap & (1 << m)) {
       for (int nl = 0; nl < dlsch->cw_info.Nl; nl++) { // for MIMO Config: it shall loop over no_layers
         LOG_D(PHY, "PDSCH Channel estimation layer %d, slot %d, symbol %d\n", nl, nr_slot_rx, m);
         uint32_t nvar_tmp = 0;
@@ -464,9 +465,8 @@ static int nr_ue_pdsch_procedures(PHY_VARS_NR_UE *ue,
     }
   }
   stop_meas_nr_ue_phy(ue, DLSCH_CHANNEL_ESTIMATION_STATS);
-  nvar /= (dlschCfg->number_symbols * dlsch->cw_info.Nl * frame_parms->nb_antennas_rx);
-  uint32_t dmrs_mask = dlschCfg->dlDmrsSymbPos;
-  int first_dmrs_symbol = get_first_bit_index_mask(&dmrs_mask, 1, 0, NR_SYMBOLS_PER_SLOT);
+  nvar /= (count_bits(&dmrs_symb_bitmap, 1) * dlsch->cw_info.Nl * frame_parms->nb_antennas_rx);
+  int first_dmrs_symbol = get_first_bit_index_mask(&dmrs_symb_bitmap, 1, 0, NR_SYMBOLS_PER_SLOT);
   nr_ue_measurement_procedures(first_dmrs_symbol, ue, proc, freq_alloc->num_rbs, pdsch_est_size, pdsch_dl_ch_estimates);
 
   // PTRS processing.
@@ -489,7 +489,7 @@ static int nr_ue_pdsch_procedures(PHY_VARS_NR_UE *ue,
                        .N_RB = fp->N_RB_DL,
                        .start_symb = dlschCfg->start_symbol,
                        .num_symb = dlschCfg->number_symbols,
-                       .dmrs_symb_pos = dlschCfg->dlDmrsSymbPos,
+                       .dmrs_symb_pos = dmrs_symb_bitmap,
                        .nid = fp->Nid_cell,
                        .nscid = dlschCfg->nscid,
                        .first_carrier_offset = fp->first_carrier_offset,
@@ -511,7 +511,7 @@ static int nr_ue_pdsch_procedures(PHY_VARS_NR_UE *ue,
                              ch_est_p,
                              dlschCfg->number_symbols,
                              dlschCfg->start_symbol,
-                             dlschCfg->dlDmrsSymbPos,
+                             dmrs_symb_bitmap,
                              freq_alloc->num_rbs,
                              dlsch->cw_info.Nl,
                              frame_parms->nb_antennas_rx);
@@ -525,7 +525,7 @@ static int nr_ue_pdsch_procedures(PHY_VARS_NR_UE *ue,
   else
     dmrs_data_re = 12 - 4 * dlschCfg->n_dmrs_cdm_groups;
 
-  while ((dmrs_data_re == 0) && (dlschCfg->dlDmrsSymbPos & (1 << first_symbol_with_data))) {
+  while ((dmrs_data_re == 0) && (dmrs_symb_bitmap & (1 << first_symbol_with_data))) {
     first_symbol_with_data++;
   }
 


### PR DESCRIPTION
| develop | this PR |
| --- | --- |
| `nr_pdsch_channel_estimation()` sets `nvar` for every call. So, when the function is called for multiple antennas only the last antenna's nvar is retained in the caller. | `nr_pdsch_channel_estimation()` accumulates the nvar on every call. |
| In `nr_ue_pdsch_procedures()`, channel estimation is called for every dmrs symbols but the number of pdsch symbols are used in computing the nvar mean | use only the number of dmrs symbols as nvar is sum over dmrs symbols
| In `nr_dlsch_mmse()` the nvar is still q30. but the diagonal entries in the Gramian matrix is q15 because of the `shift` in `mult_cpx_conj_vector()` | shift nvar by same amount as gramian entries before summing |